### PR TITLE
HLS Android

### DIFF
--- a/src/js/html5/jwplayer.html5.model.js
+++ b/src/js/html5/jwplayer.html5.model.js
@@ -126,7 +126,7 @@
 		
 		// TODO: make this a synchronous action; throw error if playlist is empty
 		_model.setPlaylist = function(playlist) {
-			_model.playlist = utils.filterPlaylist(playlist);
+			_model.playlist = utils.filterPlaylist(playlist, false, _model.androidhls);
 			if (_model.playlist.length === 0) {
 				_model.sendEvent(events.JWPLAYER_ERROR, { message: "Error loading playlist: No playable sources found" });
 			} else {

--- a/src/js/html5/jwplayer.html5.setup.js
+++ b/src/js/html5/jwplayer.html5.setup.js
@@ -107,38 +107,24 @@
 		}
 
 		function _loadPlaylist() {
-			switch(utils.typeOf(_model.config.playlist)) {
-			case "string":
-//				var loader = new html5.playlistloader();
-//				loader.addEventListener(events.JWPLAYER_PLAYLIST_LOADED, _playlistLoaded);
-//				loader.addEventListener(events.JWPLAYER_ERROR, _playlistError);
-//				loader.load(_model.config.playlist);
-//				break;
-				_error("Can't load a playlist as a string anymore");
-				break;
-			case "array":
+			var type = utils.typeOf(_model.config.playlist);
+			if (type === "array") {
 				_completePlaylist(new jwplayer.playlist(_model.config.playlist));
+			} else {
+				_error("Playlist type not supported: "+ type);
 			}
 		}
 		
-		// function _playlistLoaded(evt) {
-		// 	_completePlaylist(evt.playlist);
-		// }
-		
 		function _completePlaylist(playlist) {
 			_model.setPlaylist(playlist);
-			// Support Playlist index in config?:
+			// TODO: support playlist index in config
 			// _model.setItem(_model.config.item);
-			if (_model.playlist[0].sources.length === 0) {
+			if (_model.playlist.length === 0 || _model.playlist[0].sources.length === 0) {
 				_error("Error loading playlist: No playable sources found");
 			} else {
 				_taskComplete(LOAD_PLAYLIST);
 			}
 		}
-
-		// function _playlistError(evt) {
-		// 	_error("Error loading playlist: " + evt.message);
-		// }
 		
 		function _loadPreview() {
 			var preview = _model.playlist[_model.item].image; 

--- a/src/js/utils/jwplayer.utils.extensionmap.js
+++ b/src/js/utils/jwplayer.utils.extensionmap.js
@@ -40,6 +40,7 @@
 			"oga": mimeMap[vorbis],
 			"webm": mimeMap[webm],
 			"m3u8": mimeMap.hls,
+			"m3u": mimeMap.hls,
 			"hls": mimeMap.hls
 		}, 
 		videoX = "video", 

--- a/src/js/utils/jwplayer.utils.js
+++ b/src/js/utils/jwplayer.utils.js
@@ -198,7 +198,7 @@
 	utils.translateEventResponse = function(type, eventProperties) {
 		var translated = utils.extend({}, eventProperties);
 		if (type == jwplayer.events.JWPLAYER_FULLSCREEN && !translated.fullscreen) {
-			translated.fullscreen = translated.message == "true" ? TRUE : FALSE;
+			translated.fullscreen = (translated.message === "true");
 			delete translated.message;
 		} else if (typeof translated.data == OBJECT) {
 			// Takes ViewEvent "data" block and moves it up a level
@@ -564,11 +564,11 @@
 	};
 	
 	/** Go through the playlist and choose a single playable type to play; remove sources of a different type **/
-	utils.filterPlaylist = function(playlist, checkFlash) {
+	utils.filterPlaylist = function(playlist, checkFlash, androidhls) {
 		var pl = [], i, item, j, source;
 		for (i=0; i < playlist.length; i++) {
 			item = utils.extend({}, playlist[i]);
-			item.sources = utils.filterSources(item.sources);
+			item.sources = utils.filterSources(item.sources, FALSE, androidhls);
 			if (item.sources.length > 0) {
 				for (j = 0; j < item.sources.length; j++) {
 					source = item.sources[j];
@@ -582,7 +582,7 @@
 		if (checkFlash && pl.length === 0) {
 			for (i=0; i < playlist.length; i++) {
 				item = utils.extend({}, playlist[i]);
-				item.sources = utils.filterSources(item.sources, TRUE);
+				item.sources = utils.filterSources(item.sources, TRUE, androidhls);
 				if (item.sources.length > 0) {
 					for (j = 0; j < item.sources.length; j++) {
 						source = item.sources[j];
@@ -596,7 +596,7 @@
 	};
 
 	/** Filters the sources by taking the first playable type and eliminating sources of a different type **/
-	utils.filterSources = function(sources, filterFlash) {
+	utils.filterSources = function(sources, filterFlash, androidhls) {
 		var selectedType, newSources, extensionmap = utils.extensionmap;
 		if (sources) {
 			newSources = [];
@@ -621,7 +621,7 @@
 						}
 					}
 				} else {
-					if (utils.canPlayHTML5(type)) {
+					if (jwplayer.embed.html5CanPlay(file, type, androidhls)) {
 						if (!selectedType) {
 							selectedType = type;
 						}
@@ -637,9 +637,8 @@
 	
 	/** Returns true if the type is playable in HTML5 **/
 	utils.canPlayHTML5 = function(type) {
-		if (utils.isAndroid() && (type == "hls" || type == "m3u" || type == "m3u8")) return FALSE;
 		var mime = utils.extensionmap.types[type];
-		return (!!mime && !!jwplayer.vid.canPlayType && jwplayer.vid.canPlayType(mime));
+		return (!!mime && !!jwplayer.vid.canPlayType && !!jwplayer.vid.canPlayType(mime));
 	};
 
 	/**


### PR DESCRIPTION
Had to get filterPlaylist and filterSources to use html5CanPlay in jwplayer.embed. It is now exposed as jwplayer.embed.html5CanPlay(file, type, androidhls)

Not that the androidhls option is passed in from _model.setPlaylist to utils.filterPlaylist, but not when calling utils.filterSources in the vast plugin.

Android's video.canPlayType will report empty or false for m3u8 in the native browser but true in Chrome, so we have to ignore it if androidhls is set and always try to play hls sources in Android 4.1 and up.
