### PR TITLE
Styling for tab focus

### DIFF
--- a/src/js/api/jwplayer.api.js
+++ b/src/js/api/jwplayer.api.js
@@ -624,10 +624,14 @@
 		if (api) {
 			api.playerReady(obj);	
 			api.onFocus(function(evt) {
-				if (evt.hasFocus)
-					console.log("player :" + api.id + " has focus");
-				else
-					console.log("player :" + api.id + " lost focus");
+				var container = this.getContainer();
+				if (evt.hasFocus) {
+					container.className = container.className + ' jw-tab-focus';
+				}
+				else {
+					// Lost focus, remove the class
+					container.className = container.className.replace(/ *jw-tab-focus/g, '');
+				}
 			});
 		} else {
 			jwplayer.api.selectPlayer(obj.id).playerReady(obj);

--- a/src/js/embed/jwplayer.embed.js
+++ b/src/js/embed/jwplayer.embed.js
@@ -7,22 +7,23 @@
 (function(jwplayer) {
 	var utils = jwplayer.utils,
 		events = jwplayer.events,
-		
 		TRUE = true,
 		FALSE = false,
 		DOCUMENT = document;
 	
 	var embed = jwplayer.embed = function(playerApi) {
 //		var mediaConfig = utils.mediaparser.parseMedia(playerApi.container);
-		var _config = new embed.config(playerApi.config),
-			_container, _oldContainer, _fallbackDiv,
-			_width = _config.width,
-			_height = _config.height,
+
+		var _config    = new embed.config(playerApi.config),
+			_width     = _config.width,
+			_height    = _config.height,
 			_errorText = "Error loading player: ",
-			_pluginloader = jwplayer.plugins.loadPlugins(playerApi.id, _config.plugins),
+			_oldContainer    = DOCUMENT.getElementById(playerApi.id),
+			_pluginloader    = jwplayer.plugins.loadPlugins(playerApi.id, _config.plugins),
 			_playlistLoading = FALSE,
-			_errorOccurred = FALSE,
+			_errorOccurred   = FALSE,
 			_setupErrorTimer = null,
+			_fallbackDiv     = null,
 			_this = this;
 
 		if (_config.fallbackDiv) {
@@ -30,14 +31,13 @@
 			delete _config.fallbackDiv;
 		}
 		_config.id = playerApi.id;
-		_oldContainer = DOCUMENT.getElementById(playerApi.id);
 		if (_config.aspectratio) {
 			playerApi.config.aspectratio = _config.aspectratio;
 		}
 		else {
 			delete playerApi.config.aspectratio;
 		}
-		_container = DOCUMENT.createElement("div");
+		var _container = DOCUMENT.createElement("div");
 		_container.id = _oldContainer.id;
 		_container.style.width = _width.toString().indexOf("%") > 0 ? _width : (_width + "px");
 		_container.style.height = _height.toString().indexOf("%") > 0 ? _height : (_height + "px");
@@ -60,18 +60,18 @@
 		};
 		
 		function _doEmbed() {
-			if (_errorOccurred) return;
+			if (_errorOccurred) { return; }
 
-			if (utils.typeOf(_config.playlist) == "array" && _config.playlist.length < 2) {
+			if (utils.typeOf(_config.playlist) === "array" && _config.playlist.length < 2) {
 				if (_config.playlist.length === 0 || !_config.playlist[0].sources || _config.playlist[0].sources.length === 0) {
 					_sourceError();
 					return;
 				}
 			}
 			
-			if (_playlistLoading) return;
+			if (_playlistLoading) { return; }
 			
-			if (utils.typeOf(_config.playlist) == "string") {
+			if (utils.typeOf(_config.playlist) === "string") {
 				var loader = new jwplayer.playlist.loader();
 				loader.addEventListener(events.JWPLAYER_PLAYLIST_LOADED, function(evt) {
 					_config.playlist = evt.playlist;
@@ -96,6 +96,7 @@
 						if (embedder.supportsConfig()) {
 							embedder.addEventListener(events.ERROR, _embedError);
 							embedder.embed();
+							_insertCSS();
 							_setupEvents(playerApi, configClone.events);
 							return playerApi;
 						}
@@ -170,6 +171,12 @@
 		
 		return _this;
 	};
+
+	function _insertCSS() {
+		utils.css('.jwplayer:focus, .jw-tab-focus', {
+			outline : 'solid 2px #0B7EF4'
+		});
+	}
 
 	function _displayError(container, message, config) {
 		var style = container.style;

--- a/src/js/html5/jwplayer.html5.view.js
+++ b/src/js/html5/jwplayer.html5.view.js
@@ -40,6 +40,7 @@
 		TRUE = true,
 		FALSE = !TRUE,
 		
+		JW_CLASS = '.jwplayer ',
 		JW_CSS_SMOOTH_EASE = "opacity .25s ease",
 		JW_CSS_100PCT = "100%",
 		JW_CSS_ABSOLUTE = "absolute",
@@ -119,7 +120,6 @@
 
 
 		}
-
 
 		this.getCurrentCaptions = function() {
 			return _captions.getCurrentCaptions();
@@ -1168,6 +1168,23 @@
 
 		_init();
 	};
+
+	// Reset CSS
+	_css(JW_CLASS.slice(0, -1) + ["", "div", "span", "a", "img", "ul", "li", "video"].join(", "+JW_CLASS) + ", .jwclick", {
+		margin: 0,
+		padding: 0,
+		border: 0,
+		color: '#000000',
+		'font-size': "100%",
+		font: 'inherit',
+		'vertical-align': 'baseline',
+		'background-color': 'transparent',
+		'text-align': 'left',
+		'direction':'ltr',
+		'-webkit-tap-highlight-color': 'rgba(255, 255, 255, 0)'
+	});
+
+	_css(JW_CLASS + "ul", { 'list-style': "none" });
 
 	// Container styles
 	_css('.' + PLAYER_CLASS, {

--- a/src/js/utils/jwplayer.utils.css.js
+++ b/src/js/utils/jwplayer.utils.css.js
@@ -11,9 +11,7 @@
 		_rules = {},
 		_cssBlock = null,
 		_ruleIndexes = {},
-		_debug = false,
-				
-		JW_CLASS = '.jwplayer ';
+		_debug = false;
 
 	function _createStylesheet(debugText) {
 		var styleSheet = document.createElement('style');
@@ -326,23 +324,5 @@
 		}
 		return style +'('+ channels.join(',') +')';
 	};
-
-	(function cssReset() {
-		_css(JW_CLASS.slice(0, -1) + ["", "div", "span", "a", "img", "ul", "li", "video"].join(", "+JW_CLASS) + ", .jwclick", {
-			margin: 0,
-			padding: 0,
-			border: 0,
-			color: '#000000',
-			'font-size': "100%",
-			font: 'inherit',
-			'vertical-align': 'baseline',
-			'background-color': 'transparent',
-			'text-align': 'left',
-			'direction':'ltr',
-			'-webkit-tap-highlight-color': 'rgba(255, 255, 255, 0)'
-		});
-		
-		_css(JW_CLASS + "ul", { 'list-style': "none" });
-	})();
 	
 })(jwplayer);


### PR DESCRIPTION
Changes
1. Moving the utils.css file from html5 to shared
2. Adding a style for **.jw-tab-focus**
3. Watching for onFocus events and add/removing the **jw-tab-focus** class to enable styling of the player when it has focus.
4. Some white-space changes in jwplayer.embed.js
