### PR TITLE
Interactions with HTML5 player after keyboard focus

### DIFF
--- a/src/js/html5/jwplayer.html5.displayicon.js
+++ b/src/js/html5/jwplayer.html5.displayicon.js
@@ -36,14 +36,10 @@
 			_container = _createElement("jwdisplayIcon");
 			_container.id = _id;
 
-			
-			//_createElement('capLeft', _container);
-//			_bg = _createElement('background', _container);
 			_createBackground();
 			_text = _createElement('jwtext', _container, textStyle, textStyleOver);
 			_icon = _createElement('jwicon', _container);
-			//_createElement('capRight', _container);
-			
+
 			_api.jwAddEventListener(jwplayer.events.JWPLAYER_RESIZE, _setWidth);
 			
 			_hide();
@@ -86,7 +82,7 @@
 				if (_bgSkin.overSrc) {
 					style['background-image'] = "url(" + _capLeftSkin.overSrc + "), url(" + _bgSkin.overSrc + "), url(" + _capRightSkin.overSrc + ")"; 
 				}
-				_css("#"+_api.id+" .jwdisplay:hover " + _internalSelector(), style);
+				_css(".jw-tab-focus "+ _internalSelector() + ", #"+_api.id+" .jwdisplay:hover " + _internalSelector(), style);
 			}
 		}
 		

--- a/src/js/html5/jwplayer.html5.view.js
+++ b/src/js/html5/jwplayer.html5.view.js
@@ -81,7 +81,7 @@
 			_readyState,
 			_rightClickMenu,
 			_resizeMediaTimeout = -1,
-			_inCB = FALSE,
+			_inCB = FALSE, // in control bar
 			_currentState,
 
             // Used to differentiate tab focus events from click events, because when
@@ -167,26 +167,32 @@
             }
         }
 
-		function handleMouseDown(evt) {
+		function handleMouseDown() {
             _focusFromClick = true;
 
+            // After a click it no longer has "tab-focus"
             _this.sendEvent(events.JWPLAYER_VIEW_TAB_FOCUS, {
                 hasFocus : false
             });
 		}
 
-		function handleFocus(evt) {
+		function handleFocus() {
             var wasTabEvent = ! _focusFromClick;
             _focusFromClick = false;
 
             if (wasTabEvent) {
+                _controlbar.show();
+
+                // Hide controlbar after x seconds
+                _resetTapTimer();
+
                 _this.sendEvent(events.JWPLAYER_VIEW_TAB_FOCUS, {
                     hasFocus : true
                 });
             }
 		}
 
-		function handleBlur(evt) {
+		function handleBlur() {
             _focusFromClick = false;
             _this.sendEvent(events.JWPLAYER_VIEW_TAB_FOCUS, {
                 hasFocus : false


### PR DESCRIPTION
1. Play/pause button should display as if hover state
2. Control bar should fade in (and out) when tabbed into player

https://www.pivotaltracker.com/story/show/70960452
