### PR TITLE
Stop control bar from showing for ads

### DIFF
--- a/src/js/html5/jwplayer.html5.controller.js
+++ b/src/js/html5/jwplayer.html5.controller.js
@@ -16,7 +16,7 @@
 	html5.controller = function(_model, _view) {
 		var _ready = FALSE,
 			_loadOnPlay = -1,
-			_preplay, 
+			_preplay = FALSE,
 			_actionOnAttach,
 			_stopPlaylist = FALSE,
 			_interruptPlay,


### PR DESCRIPTION
but we do want all non-seeking hotkeys to work during ad playback.

[Fixes #70985360]
