### PR TITLE
Moving the "reset" css into jwplayer.html.js

### DIFF
--- a/src/js/html5/jwplayer.html5.js
+++ b/src/js/html5/jwplayer.html5.js
@@ -7,4 +7,24 @@
 (function(jwplayer) {
 	jwplayer.html5 = {};
 	jwplayer.html5.version = 'X.Y.ZZZZ';
+
+    // These "reset" styles must be included before any others
+    var _css = jwplayer.utils.css;
+    var JW_CLASS = '.jwplayer ';
+    _css(JW_CLASS.slice(0, -1) + ["", "div", "span", "a", "img", "ul", "li", "video"].join(", "+JW_CLASS) + ", .jwclick", {
+        margin: 0,
+        padding: 0,
+        border: 0,
+        color: '#000000',
+        'font-size': "100%",
+        font: 'inherit',
+        'vertical-align': 'baseline',
+        'background-color': 'transparent',
+        'text-align': 'left',
+        'direction':'ltr',
+        '-webkit-tap-highlight-color': 'rgba(255, 255, 255, 0)'
+    });
+
+    _css(JW_CLASS + "ul", { 'list-style': "none" });
+
 })(jwplayer);

--- a/src/js/html5/jwplayer.html5.view.js
+++ b/src/js/html5/jwplayer.html5.view.js
@@ -40,7 +40,6 @@
 		TRUE = true,
 		FALSE = !TRUE,
 		
-		JW_CLASS = '.jwplayer ',
 		JW_CSS_SMOOTH_EASE = "opacity .25s ease",
 		JW_CSS_100PCT = "100%",
 		JW_CSS_ABSOLUTE = "absolute",
@@ -1248,23 +1247,6 @@
 
 		_init();
 	};
-
-	// Reset CSS
-	_css(JW_CLASS.slice(0, -1) + ["", "div", "span", "a", "img", "ul", "li", "video"].join(", "+JW_CLASS) + ", .jwclick", {
-		margin: 0,
-		padding: 0,
-		border: 0,
-		color: '#000000',
-		'font-size': "100%",
-		font: 'inherit',
-		'vertical-align': 'baseline',
-		'background-color': 'transparent',
-		'text-align': 'left',
-		'direction':'ltr',
-		'-webkit-tap-highlight-color': 'rgba(255, 255, 255, 0)'
-	});
-
-	_css(JW_CLASS + "ul", { 'list-style': "none" });
 
 	// Container styles
 	_css('.' + PLAYER_CLASS, {


### PR DESCRIPTION
These styles need to be inserted before anything else in the html5 build,
this was the only way to ensure that without modifying the build script.
