### PR TITLE
Bugfix - elapsed time displayed after vast Ad is skipped [Delivers #71716408]

### DIFF
--- a/src/js/html5/jwplayer.html5.view.js
+++ b/src/js/html5/jwplayer.html5.view.js
@@ -298,6 +298,9 @@
                 _controlbar.adMode(true);
                 _updateState(states.PLAYING);
             });
+            jwplayer(_api.id).onAdSkipped(function() {
+                _controlbar.adMode(false);
+            });
             jwplayer(_api.id).onAdComplete(function() {
                 _controlbar.adMode(false);
             });


### PR DESCRIPTION
Ensuring adMode is set to false when an Ad is skipped.
