### PR TITLE
Remove tests for requestFullScreen() and cancelFullScreen()

### DIFF
--- a/src/js/html5/jwplayer.html5.view.js
+++ b/src/js/html5/jwplayer.html5.view.js
@@ -107,7 +107,6 @@
 
             _requestFullscreen =
                 _playerElement.requestFullscreen ||
-                _playerElement.requestFullScreen ||
                 _playerElement.webkitRequestFullscreen ||
                 _playerElement.webkitRequestFullScreen ||
                 _playerElement.webkitEnterFullscreen ||
@@ -116,7 +115,6 @@
                 _playerElement.msRequestFullscreen;
             _exitFullscreen =
                 DOCUMENT.exitFullscreen ||
-                DOCUMENT.cancelFullScreen ||
                 DOCUMENT.webkitExitFullscreen ||
                 DOCUMENT.webkitCancelFullScreen ||
                 DOCUMENT.mozCancelFullScreen ||


### PR DESCRIPTION
The only unprefixed names are requestFullscreen() and exitFullscreen():
http://fullscreen.spec.whatwg.org/#api

Checking for non-existent functions is harmless, but useless.
