### PR TITLE
change scale comparison from 0.95 to 0.9999 to stop 'snapping' of poster and video during resize

### DIFF
--- a/src/flash/com/longtailvideo/jwplayer/utils/Stretcher.as
+++ b/src/flash/com/longtailvideo/jwplayer/utils/Stretcher.as
@@ -15,6 +15,8 @@ package com.longtailvideo.jwplayer.utils {
 		public static var NONE:String = "none";
 		/** Stretches the clip uniform to fit the container, with bars added. **/
 		public static var UNIFORM:String = "uniform";
+		/** Stretches the clip uniform to fit the container, without snapping, with bars added. **/
+		public static var UNIFORMSMOOTH:String = "uniformsmooth";
 
 		/**
 		 * Resize a displayobject to the display, depending on the stretching.
@@ -27,6 +29,7 @@ package com.longtailvideo.jwplayer.utils {
 		public static function stretch(clp:DisplayObject, wid:Number, hei:Number, typ:String='uniform'):void {
 			var xsc:Number = wid / clp.width;
 			var ysc:Number = hei / clp.height;
+			var snap:Number = 0.95;
 			switch (typ.toLowerCase()) {
 				case Stretcher.EXACTFIT:
 					clp.width = wid;
@@ -45,18 +48,20 @@ package com.longtailvideo.jwplayer.utils {
 					clp.scaleX = 1;
 					clp.scaleY = 1;
 					break;
+				case Stretcher.UNIFORMSMOOTH:
+					snap = 0.9999;
 				case Stretcher.UNIFORM:
 				default:
 					if (xsc > ysc) {
 						clp.width *= ysc;
 						clp.height *= ysc;
-						if (clp.width/wid > 0.95) {
+						if (clp.width/wid > snap) {
 							clp.width = wid;
 						}
 					} else {
 						clp.width *= xsc;
 						clp.height *= xsc;
-						if (clp.height/hei > 0.95) {
+						if (clp.height/hei > snap) {
 							clp.height = hei;
 						}
 					}

--- a/src/js/html5/utils/jwplayer.html5.utils.stretching.js
+++ b/src/js/html5/utils/jwplayer.html5.utils.stretching.js
@@ -11,7 +11,8 @@
         NONE: "none",
         FILL: "fill",
         UNIFORM: "uniform",
-        EXACTFIT: "exactfit"
+        EXACTFIT: "exactfit",
+        UNIFORMSMOOTH: "uniformsmooth"
     };
 
     utils.scale = function(domelement, xscale, yscale, xoffset, yoffset) {
@@ -63,7 +64,8 @@
             yscale = Math.ceil(parentHeight / 2) * 2 / elementHeight,
             video = (domelement.tagName.toLowerCase() === "video"),
             scale = false,
-            stretchClass = "jw" + stretching.toLowerCase();
+            stretchClass = "jw" + stretching.toLowerCase(),
+            snap = 0.95;
 
         switch (stretching.toLowerCase()) {
             case _stretching.FILL:
@@ -80,11 +82,13 @@
             case _stretching.EXACTFIT:
                 scale = true;
                 break;
+            case _stretching.UNIFORMSMOOTH:
+                snap = 0.9999;
             case _stretching.UNIFORM:
                 /* falls through */
             default:
                 if (xscale > yscale) {
-                    if (elementWidth * yscale / parentWidth > 0.95) {
+                    if (elementWidth * yscale / parentWidth > snap) {
                         scale = true;
                         stretchClass = "jwexactfit";
                     } else {
@@ -92,7 +96,7 @@
                         elementHeight = elementHeight * yscale;
                     }
                 } else {
-                    if (elementHeight * xscale / parentHeight > 0.95) {
+                    if (elementHeight * xscale / parentHeight > snap) {
                         scale = true;
                         stretchClass = "jwexactfit";
                     } else {


### PR DESCRIPTION
When resizing a player there is a noticeable 'jump'/'snap' of poster images/video content.

See example video: http://embed.reelfeed.tv/jwplayersnapping/

By changing the size comparison in these 'Stretching' utilities, the snapping is all but gone.
