### PR TITLE
Don't look for webkitEnterFullscreen/webkitEnterFullScreen on <div>

### DIFF
--- a/src/js/html5/jwplayer.html5.view.js
+++ b/src/js/html5/jwplayer.html5.view.js
@@ -108,8 +108,6 @@
                 _playerElement.requestFullscreen ||
                 _playerElement.webkitRequestFullscreen ||
                 _playerElement.webkitRequestFullScreen ||
-                _playerElement.webkitEnterFullscreen ||
-                _playerElement.webkitEnterFullScreen ||
                 _playerElement.mozRequestFullScreen ||
                 _playerElement.msRequestFullscreen;
             _exitFullscreen =


### PR DESCRIPTION
These two functions have never been exposed on HTMLDivElement, only
on HTMLMediaElement/HTMLVideoElement:
http://trac.webkit.org/changeset/50893
http://trac.webkit.org/changeset/54143

Looking for it on the _playerElement &lt;div> is useless, but harmless.
