### PR TITLE
Added rtmp.proxytype config option [Delivers #77110386]

### DIFF
--- a/src/flash/com/longtailvideo/jwplayer/media/RTMPMediaProvider.as
+++ b/src/flash/com/longtailvideo/jwplayer/media/RTMPMediaProvider.as
@@ -90,6 +90,9 @@
 			_connection.addEventListener(IOErrorEvent.IO_ERROR, errorHandler);
 			_connection.addEventListener(AsyncErrorEvent.ASYNC_ERROR, errorHandler);
 			_connection.objectEncoding = ObjectEncoding.AMF0;
+			if (getConfigProperty('proxytype')) {
+				_connection.proxyType = getConfigProperty('proxytype');
+			}
 			_connection.client = new NetClient(this);
 			_loader = new AssetLoader();
 			_loader.addEventListener(Event.COMPLETE, loaderComplete);


### PR DESCRIPTION
We have what should be a small change needed to latest JW Player so that it can work better with RTMPS. We need some way for the user to be able to set the NetConnection.proxyType:

NetConnection.proxyType="best"

For RTMPS it will then do RTMP over SSL rather than RTMPT over SSL which as you know works much better. The docs are here:

http://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/net/NetConnection.html#proxyType

The default is "none". With this value set any RTMPS connection will be RTMPT over SSL. If proxyType is set to "best" then it will try to negotiate a RTMP over SSL connection. Which is much better. I am pretty sure if it can't it will default back to RTMPT over SSL. We just need some way for the customer to set the proxyType value through the player code.
