### PR TITLE
remove code that prevents controlbar from displaying on iPhone [Delivers #74735688]

### DIFF
--- a/src/js/html5/jwplayer.html5.view.js
+++ b/src/js/html5/jwplayer.html5.view.js
@@ -904,10 +904,6 @@
 		}
 		
 		function _showControlbar() {
-            if (_isIPod && !_audioMode) {
-                 return;
-            }
-
             if (_controlbar && _model.controls) {
                 if(_instreamMode) {
                     _instreamControlbar.show();


### PR DESCRIPTION
Restores Chromecast ability on iPhone
