### PR TITLE
Fixed detection of Azure HLS streams [Delivers #77710782 #70534306]

### DIFF
--- a/src/flash/com/longtailvideo/jwplayer/utils/Strings.as
+++ b/src/flash/com/longtailvideo/jwplayer/utils/Strings.as
@@ -126,13 +126,11 @@ package com.longtailvideo.jwplayer.utils {
 		 */
 
         public static function getAzureFileFormat(path:String):String {
-            var match:Array = path.match(/manifest\(format=(.*),audioTrack/);
-            if (!match || !match[1]) {
-                // not an azure file
-                return "";
+            if (path.indexOf('(format=m3u8-') > -1) {
+                return 'm3u8';
+            } else { 
+                return '';
             }
-
-            return match[1].split('-')[0];
         }
 
         public static function extension(filename:String):String {

--- a/src/js/utils/jwplayer.utils.strings.js
+++ b/src/js/utils/jwplayer.utils.strings.js
@@ -44,13 +44,11 @@
      * This does not return the file extension, instead it returns a media type extension
      */
     function getAzureFileFormat(path) {
-        var match = path.match(/manifest\(format=(.*),audioTrack/);
-        if (!match || !match[1]) {
-            // not an azure file
+        if (path.indexOf('(format=m3u8-') > -1) {
+            return 'm3u8';
+        } else { 
             return false;
         }
-
-        return match[1].split('-')[0];
     }
 
     utils.extension = function(path) {


### PR DESCRIPTION
Simplified the detection of Azure HLS streams, which to date only detects v4-multi-audio-in-v3 streams. I also trimmed it down to just HLS streams, as other formats (DASH, Smooth) can be detected by the providers. 

Here is the full set of URLs that Azure can support:

Smooth: _.ism/manifest
HLS v4: *.ism/manifest(format=m3u8-aapl)
HLS v4:_.ism/manifest(format=m3u8-aapl-v4)
HLS v3:*.ism/manifest(format=m3u8-aapl-v3)
HLS v3+audio: *.ism/manifest(format=m3u8-aapl-v3,audioTrack=trackID)
DASH: *.ism/manifest(format=mpd-time-csf)
Smooth (latest manifest): *.ism/manifest(format=fmp4)
Smooth (no repeat tags): *.ism/manifest(format=fmp4-v20)
