### PR TITLE
Adding css reset for line-height

### DIFF
--- a/src/js/html5/jwplayer.html5.js
+++ b/src/js/html5/jwplayer.html5.js
@@ -24,6 +24,7 @@
         'background-color': 'transparent',
         'text-align': 'left',
         'direction': 'ltr',
+        'line-height': 20,
         '-webkit-tap-highlight-color': 'rgba(255, 255, 255, 0)'
     });
 


### PR DESCRIPTION
Fixes an issue where setting line-height would break the height of the right-click menu
