### PR TITLE
Adding start and len functionality for RTMP clipping

### DIFF
--- a/src/flash/com/longtailvideo/jwplayer/media/RTMPMediaProvider.as
+++ b/src/flash/com/longtailvideo/jwplayer/media/RTMPMediaProvider.as
@@ -312,9 +312,18 @@
 						// Only send initial metadata
 						_metadata = true;
 						if (data.duration) {
+							
+							if(data.duration != _item.len && _item.len > -1)
+							{
+								data.duration = _item.len;
+							}
+							
 							_item.duration = data.duration;
+							
 							// Support old item.start call
-							if(_item.start) { seek(_item.start); }
+							// I'm removing this feature in place of the clipping to the start because they can do this 
+							// By listening to the Player's events per the API docs
+							//if(_item.start) { seek(_item.start); }
 						}
 						if (data.width) {
 							_video.width = data.width;
@@ -378,12 +387,12 @@
 				if(_item.duration > 0) {
 					_stream.resume();
 				} else {
-					_stream.play(_levels[_level].id);
+					_stream.play(_levels[_level].id, _item.start, _item.len );
 					setState(PlayerState.BUFFERING);
 				}
 			} else {
 				// Start stream.
-				_stream.play(_levels[_level].id);
+				_stream.play(_levels[_level].id, _item.start, _item.len);
 			}
 			clearInterval(_interval);
 			_interval = setInterval(positionInterval, 100);
@@ -661,7 +670,7 @@
 				_interval = setInterval(positionInterval, 100);
 				_transition = false;
 				_stream.close();
-				_stream.play(_levels[index].id);
+				_stream.play(_levels[index].id, _item.start, _item.len);
 				_stream.seek(_position);
 				setState(PlayerState.BUFFERING);
 			 } else {
@@ -670,6 +679,9 @@
 				var nso:NetStreamPlayOptions = new NetStreamPlayOptions();
 				nso.streamName = _levels[_level].id;
 				nso.transition = NetStreamPlayTransitions.SWITCH;
+				nso.offset = _item.start;
+				nso.len = _item.len;//_item.len;
+				
 				_stream.play2(nso);
 			}
 		}

--- a/src/flash/com/longtailvideo/jwplayer/model/PlayerConfig.as
+++ b/src/flash/com/longtailvideo/jwplayer/model/PlayerConfig.as
@@ -137,6 +137,9 @@ package com.longtailvideo.jwplayer.model {
 
 		/** Duration of the file in seconds. **/
 		public function get duration():String { return playlistItem('duration'); }
+		
+		/** Duration of the file in seconds. **/
+		public function get len():String { return playlistItem('len'); }
 
 		/** Location of the mediafile or playlist to play. **/
 		public function get file():String { return playlistItem('file'); }

--- a/src/flash/com/longtailvideo/jwplayer/model/PlaylistItem.as
+++ b/src/flash/com/longtailvideo/jwplayer/model/PlaylistItem.as
@@ -14,6 +14,7 @@ package com.longtailvideo.jwplayer.model {
 		public var title:String			= "";
 		
 		protected var _duration:Number		= -1;
+		protected var _len:Number		    = -1;
 		protected var _provider:String		= "";
 		protected var _start:Number			= 0;
 		protected var _streamer:String		= "";
@@ -239,17 +240,16 @@ package com.longtailvideo.jwplayer.model {
 		public function get start():Number { return _start; }
 		public function set start(s:*):void { 
 			_start = Strings.seconds(String(s));
-			if (_start > _duration && _duration > 0) {
-				_duration += _start;
-			}
 		}
 
 		public function get duration():Number { return _duration; }
 		public function set duration(d:*):void { 
 			_duration = Strings.seconds(String(d));
-			if (_start > _duration && _duration > 0) {
-				_duration += _start;
-			}
+		}
+		
+		public function get len():Number { return _len; }
+		public function set len(l:*):void { 
+			_len = Strings.seconds(String(l));
 		}
 
 		private function levelType(level:Object):String {


### PR DESCRIPTION
I've implemented the start and len features per http://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/net/NetStream.html#play() for a personal project to allow a user to supply those parameters and only get that part of the stream.  The start param will cut off the stream content prior to that point and the len will clip the end of the stream after the duration length is met.  I saw that start and duration were already implemented to seek forward and really duration didn't seem to do anything for me.  I didn't know where to post this so i'm just submitting this as a pull-request if the project is interested in this functionality.

My example would be like
jwplayer("myElement").setup({
               primary: 'flash',
               playlist: [
                   {
                       start: start,
                       len: len,
                       sources: [
                           {file: "rtmp://myserver/void/mystream"}
                       ]
                   }
               ]
           });