### PR TITLE
Implemented 'canSeek' in Flash providers, moving logic that delays seeking...

### DIFF
--- a/src/flash/com/longtailvideo/jwplayer/controller/Controller.as
+++ b/src/flash/com/longtailvideo/jwplayer/controller/Controller.as
@@ -505,12 +505,6 @@ import flash.utils.setTimeout;
 		public function seek(pos:Number):Boolean {
 			if (!locking && pos !== -1 && _model.media) {
 				switch (_model.media.state) {
-					case PlayerState.PAUSED:
-						play();
-						/* fallthrough */
-					case PlayerState.PLAYING:
-						_model.seek(pos);
-						return true;
 					case PlayerState.IDLE:
 						_model.playlist.currentItem.start = pos;
 						_idleSeek = pos;
@@ -518,7 +512,15 @@ import flash.utils.setTimeout;
 							play();
 						}
 						return true;
+                    case PlayerState.PAUSED:
+                        play();
+                    /* fallthrough */
+                    case PlayerState.PLAYING:
 					case PlayerState.BUFFERING:
+                        if (_model.media.canSeek) {
+                            _model.seek(pos);
+                            return true;
+                        }
 						_queuedSeek = pos;
 				}
 			}

--- a/src/flash/com/longtailvideo/jwplayer/media/IMediaProvider.as
+++ b/src/flash/com/longtailvideo/jwplayer/media/IMediaProvider.as
@@ -92,5 +92,6 @@ package com.longtailvideo.jwplayer.media
 		function get qualityLevels():Array;
 		function get currentQuality():Number;
 		function set currentQuality(quality:Number):void;
+        function get canSeek():Boolean;
 	}
 }

--- a/src/flash/com/longtailvideo/jwplayer/media/MediaProvider.as
+++ b/src/flash/com/longtailvideo/jwplayer/media/MediaProvider.as
@@ -239,6 +239,12 @@ package com.longtailvideo.jwplayer.media {
 		}
 		
 		
+        /** Determine if seek can be called or should be delayed **/
+        public function get canSeek():Boolean {
+            return state !== PlayerState.BUFFERING;
+        }
+
+		
 		/**
 		 * The current volume of the playing media
 		 * <p>Range: 0-100</p>


### PR DESCRIPTION
 while buffering out of Controller.as [#Delivers 79654140]

Providers can override 'canSeek' to allow seeking while buffering, or delay it until calling play or sending bufferFull.
