### PR TITLE
prevent duplicate captions if YouTube video has yt:cc=on

### DIFF
--- a/src/js/html5/providers/jwplayer.html5.youtube.js
+++ b/src/js/html5/providers/jwplayer.html5.youtube.js
@@ -239,7 +239,10 @@
                     return;
 
                 case youtubeStates.PLAYING: // 1: playing
-
+                
+//prevent duplicate captions when using JW Player captions and YT video has yt:cc=on
+                    _youtubePlayer.unloadModule("captions");
+                
                     // playback has started so stop blocking api.play()
                     _requiresUserInteraction = false;
 


### PR DESCRIPTION
If YouTube video has yt:cc=on attribute when embedding the video in html5 mode, captions loads by default and can't be disabled. If you add caption via jwplayer there will be duplicate captions.
example:
http://jsfiddle.net/UAR3U/25/show/
The only way to disable YouTube captions is via javascript API:
    player.unloadModule("captions");