### PR TITLE
Don't call stripDots that much [#82006712]

### DIFF
--- a/src/flash/com/longtailvideo/jwplayer/player/JavascriptAPI.as
+++ b/src/flash/com/longtailvideo/jwplayer/player/JavascriptAPI.as
@@ -343,11 +343,13 @@ package com.longtailvideo.jwplayer.player {
 			if (evt.bufferPercent >= 0) 		returnObj.bufferPercent = evt.bufferPercent;
 			if (evt.duration >= 0)		 		returnObj.duration = evt.duration;
 			if (evt.message)					returnObj.message = evt.message;
-			if (evt.metadata != null)	 		returnObj.metadata = JavascriptSerialization.stripDots(evt.metadata);
+			if (evt.metadata != null) {
+                returnObj.metadata = JavascriptSerialization.stripDots(evt.metadata);
+            }
 			if (evt.offset > 0)					returnObj.offset = evt.offset;
 			if (evt.position >= 0)				returnObj.position = evt.position;
 			if (evt.currentQuality >= 0)		returnObj.currentQuality = evt.currentQuality;
-			if (evt.levels)						returnObj.levels = JavascriptSerialization.stripDots(evt.levels);
+			if (evt.levels)						returnObj.levels = evt.levels;
 			if (evt.type == MediaEvent.JWPLAYER_MEDIA_MUTE) {
 				returnObj.mute = evt.mute;
 			}
@@ -359,7 +361,7 @@ package com.longtailvideo.jwplayer.player {
 
         private static function listenerCallbackTrack(evt:TrackEvent):Object {
             return {
-                tracks: JavascriptSerialization.stripDots(evt.tracks),
+                tracks: evt.tracks,
                 currentTrack: evt.currentTrack
             };
         }
@@ -371,7 +373,7 @@ package com.longtailvideo.jwplayer.player {
 				returnObj.track = evt.currentTrack;
 			}
 			if (evt.tracks) {
-				returnObj.tracks = JavascriptSerialization.stripDots(evt.tracks);
+				returnObj.tracks = evt.tracks;
 			}
 			return returnObj;
 		}

--- a/src/flash/com/longtailvideo/jwplayer/utils/JavascriptSerialization.as
+++ b/src/flash/com/longtailvideo/jwplayer/utils/JavascriptSerialization.as
@@ -70,29 +70,34 @@ package com.longtailvideo.jwplayer.utils
 		//function normalizes event data btwn js and as3, having to do with reserved keywords and operators.
 		//an equivalent function in js should translate back after sending through ExternalInterface
 		public static function stripDots(obj:*):* {
-			var type:String = getQualifiedClassName(obj); 
-			switch(type) {
-				case "Object":
-				case "com.longtailvideo.jwplayer.model::PlaylistItem":
-				case "com.longtailvideo.jwplayer.model::PlaylistItemLevel":
-				case "com.longtailvideo.jwplayer.plugins::PluginConfig":
-					var newObj:Object = {};
-					for (var key:String in obj) {
-						var newkey:String = key.replace(/\./g, "__dot__");
-						newkey = newkey.replace(/\ /g, "__spc__");
-						newkey = newkey.replace(/\-/g, "__dsh__");
-						newkey = newkey.replace(/[^A-Za-z0-9\_]/g, "");
-						newkey = newkey.replace(/^default$/g, "__default__");
-						newObj[newkey] = stripDots(obj[key]);
-					}
-					return newObj;
-				case "Array":
-					var newArr:Array = [];
-					for (var i:uint = 0, l:uint = (obj as Array).length; i < l; i++) {
-						newArr[i] = stripDots(obj[i]);
-					}
-					return newArr;
-			}
+			if (obj is Array && obj.length) {
+                var newArr:Array = (obj as Array).slice(0);
+                for (var i:uint = 0, len:uint = newArr.length; i < len; i++) {
+                    newArr[i] = stripDots(newArr[i]);
+                }
+                return newArr;
+            } else {
+                var type:String = getQualifiedClassName(obj);
+                switch(type) {
+                    case "Object":
+                    case "com.longtailvideo.jwplayer.model::PlaylistItem":
+                    case "com.longtailvideo.jwplayer.model::PlaylistItemLevel":
+                    case "com.longtailvideo.jwplayer.plugins::PluginConfig":
+                        var newObj:Object = {};
+                        for (var key:String in obj) {
+                            if (/^(?!(?:default)$)[A-Za-z0-9\_]*$/.test(key)) {
+                                newObj[key] = stripDots(obj[key]);
+                            } else {
+                                newObj[key.replace(/\./g, "__dot__")
+                                        .replace(/\ /g, "__spc__")
+                                        .replace(/\-/g, "__dsh__")
+                                        .replace(/[^A-Za-z0-9\_]/g, "")
+                                        .replace(/^default$/g, "__default__")] = stripDots(obj[key]);
+                            }
+                        }
+                        return newObj;
+                }
+            }
 			return obj;
 		}
 		


### PR DESCRIPTION
Profiling in Scout shows that the String allocations caused by recursive calls to `stripDots` are a huge bottleneck in performance when we dispatch certain events or respond to methods like getPlaylist(). Until we remove the need, these changes are safe and should give us a boost.
