### PR TITLE
Analytics - Disabling Analytics - Player does not appear when in ads mode while analytics is disabled

### DIFF
--- a/src/js/plugins/jwplayer.plugins.pluginloader.js
+++ b/src/js/plugins/jwplayer.plugins.pluginloader.js
@@ -39,7 +39,7 @@
 		
 		// This is not entirely efficient, but it's simple
 		function _checkComplete() {
-			if (!_config) {
+			if (!_config || _.keys(_config).length === 0) {
 				_complete();
 			}
 			if (!_iscomplete) {


### PR DESCRIPTION
This issue was caused by the _checkComplete function in the plugin loader not checking if the _config object was empty in addition to whether it is undefined. Since there was no plugins due to the tracking plugin being removed, it would never trigger the onComplete and embed the player.
