### PR TITLE
Bug/flash HD and CC buttons show incorrect state during mouse over when it should be a toggle

### DIFF
--- a/src/flash/com/longtailvideo/jwplayer/view/components/ControlbarComponent.as
+++ b/src/flash/com/longtailvideo/jwplayer/view/components/ControlbarComponent.as
@@ -797,7 +797,7 @@ package com.longtailvideo.jwplayer.view.components {
 			var button:ComponentButton = new ComponentButton();
 			button.name = name;
 
-            // If no overIcon is defined, only the outIcon will ever appear.  This allows the CC and HD buttons to be displayed as toggles based on the logic in captionChanged and levelChanged.
+			// If no overIcon is defined, only the outIcon will ever appear.  This allows the CC and HD buttons to be displayed as toggles based on the logic in captionChanged and levelChanged.
 			var outIcon:DisplayObject  = getSkinElement(name + "Button");
 			var overIcon:DisplayObject = getSkinElement(name + "ButtonOver");
 


### PR DESCRIPTION
Fixes the issue by allowing the overIcon to be undefined.  This allows the outIcon to be constantly visible, even in the "over" state.  Since the skin for this icon swaps based on the status of the player, it will correctly display itself as a toggle button to the user. [Fixes #82432282]
