### PR TITLE
Revert "Don't fall back to download if on a desktop"

### DIFF
--- a/src/js/api/jwplayer.api.js
+++ b/src/js/api/jwplayer.api.js
@@ -116,6 +116,10 @@
         _this.setup = function(options) {
             if (jwplayer.embed) {
                 // Destroy original API on setup() to remove existing listeners
+                var fallbackDiv = document.getElementById(_this.id);
+                if (fallbackDiv) {
+                    options.fallbackDiv = fallbackDiv;
+                }
                 _remove(_this);
                 var newApi = jwplayer(_this.id);
                 newApi.config = options;

--- a/src/js/embed/jwplayer.embed.js
+++ b/src/js/embed/jwplayer.embed.js
@@ -15,8 +15,13 @@
             _playlistLoading = false,
             _errorOccurred = false,
             _setupErrorTimer = -1,
+            _fallbackDiv = null,
             _this = this;
 
+        if (_config.fallbackDiv) {
+            _fallbackDiv = _config.fallbackDiv;
+            delete _config.fallbackDiv;
+        }
         _config.id = playerApi.id;
         if (_config.aspectratio) {
             playerApi.config.aspectratio = _config.aspectratio;
@@ -59,7 +64,6 @@
             }
 
             var playlist = _config.playlist;
-            var message;
 
             // Check for common playlist errors
             if (_.isArray(playlist)) {
@@ -116,19 +120,23 @@
                     }
                 }
 
-                // Only fallback to download if on mobile device
-                if (_config.fallback && utils.isMobile()) {
+                var message;
+                if (_config.fallback) {
                     message = 'No suitable players found and fallback enabled';
                     _dispatchSetupError(message, true);
                     utils.log(message);
                     new embed.download(_container, _config, _sourceError);
-                    return;
+                } else {
+                    message = 'No suitable players found and fallback disabled';
+                    _dispatchSetupError(message, false);
+                    utils.log(message);
+                    _replaceContainer();
                 }
-
-                message = 'No suitable players found and fallback ' + (_config.fallback ? 'enabled' : 'disabled');
-                utils.log(message);
-                _sourceError();
             }
+        }
+
+        function _replaceContainer() {
+            _container.parentNode.replaceChild(_fallbackDiv, _container);
         }
 
         function _embedError(evt) {


### PR DESCRIPTION
This reverts commit dfe22f454e9b32bf0b170bd12b500b7d647014ce.
[Fixes #80904730 #82854472]

Due to a customer reported problem with fallback to download on an android device, we are going to delay this fix temporarily.

This bug is due to utils.isMobile() returning incorrectly for certain mobile devices. To solve this we will want to deactivate fallback for known desktop browsers, instead of activating it for known mobile browsers.
