### PR TITLE
Audio Panning support (Flash only)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules
 bin-debug
 bin-release
 examples/panning/cheetah.mp4
+examples/panning/server.go

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ bin-debug
 bin-release
 examples/panning/cheetah.mp4
 examples/panning/server.go
+examples/panning/server
+examples/panning/.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 *.iml
 bin-debug
 bin-release
+examples/panning/cheetah.mp4

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,4 @@ node_modules
 *.iml
 bin-debug
 bin-release
-examples/panning/cheetah.mp4
-examples/panning/server.go
-examples/panning/server
 examples/panning/.DS_Store

--- a/build/build.properties
+++ b/build/build.properties
@@ -8,7 +8,7 @@
 # flexsdk = C:/Program Files/Adobe/Flash Builder 4/sdks/4.1.0
 # Replace the above line with the following for unix / OS X, replacing the path
 # flexsdk = /Applications/Adobe-Flash-Builder-4/sdks/4.1.0
-flexsdk = /Users/adinapoli/work/flex_sdk_4.1
+flexsdk = /Developer/SDKs/flex_sdk_4
 
 # Extension for Windows setups
 # execextension = .exe

--- a/build/build.properties
+++ b/build/build.properties
@@ -8,7 +8,7 @@
 # flexsdk = C:/Program Files/Adobe/Flash Builder 4/sdks/4.1.0
 # Replace the above line with the following for unix / OS X, replacing the path
 # flexsdk = /Applications/Adobe-Flash-Builder-4/sdks/4.1.0
-flexsdk = /Developer/SDKs/flex_sdk_4
+flexsdk = /Users/adinapoli/work/flex_sdk_4.1
 
 # Extension for Windows setups
 # execextension = .exe

--- a/examples/panning/index.html
+++ b/examples/panning/index.html
@@ -2,18 +2,20 @@
 <html>
   <head>
     <title>JW Audio Panning</title>
-    <script type="text/javascript" src="../../bin-release/jwplayer.js"></script>
+    <script type="text/javascript" src="static/jwplayer.js"></script>
   </head>
   <body>
     <p> Audio panning Test </p>
     <div id="playerContainer">Loading the player ...</div>
     <a onclick="jwplayer().play()">Toggle playback</a> |
+    <a onclick="jwplayer().myTest()">My custom mute</a> |
     <a onclick="console.log(jwplayer().getVolume())">Report volume</a>
   </body>
 
   <script type='text/javascript'>
     jwplayer("playerContainer").setup({
-      file: "cheetah.mp4",
+      file: "video/cheetah.mp4",
+      primary: "flash",
       height: 360,
       width: 640
     });

--- a/examples/panning/index.html
+++ b/examples/panning/index.html
@@ -7,16 +7,14 @@
   <body>
     <p> Audio panning Test </p>
     <div id="playerContainer">Loading the player ...</div>
-    <a onclick="jwplayer().play()">Toggle playback</a> |
     <a onclick="jwplayer().setPan(-100)">Pan left</a> |
     <a onclick="jwplayer().setPan(0)">Pan middle</a> |
-    <a onclick="jwplayer().setPan(100)">Pan right</a> |
-    <a onclick="console.log(jwplayer().getVolume())">Report volume</a>
+    <a onclick="jwplayer().setPan(100)">Pan right</a>
   </body>
 
   <script type='text/javascript'>
     jwplayer("playerContainer").setup({
-      file: "video/cheetah.mp4",
+      file: "http://clips.vorwaerts-gmbh.de/big_buck_bunny.mp4",
       primary: "flash",
       height: 360,
       width: 640

--- a/examples/panning/index.html
+++ b/examples/panning/index.html
@@ -8,7 +8,9 @@
     <p> Audio panning Test </p>
     <div id="playerContainer">Loading the player ...</div>
     <a onclick="jwplayer().play()">Toggle playback</a> |
-    <a onclick="jwplayer().myTest()">My custom mute</a> |
+    <a onclick="jwplayer().setPan(-100)">Pan left</a> |
+    <a onclick="jwplayer().setPan(0)">Pan middle</a> |
+    <a onclick="jwplayer().setPan(100)">Pan right</a> |
     <a onclick="console.log(jwplayer().getVolume())">Report volume</a>
   </body>
 

--- a/examples/panning/index.html
+++ b/examples/panning/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>JW Audio Panning</title>
+    <script type="text/javascript" src="../../bin-release/jwplayer.js"></script>
+  </head>
+  <body>
+    <p> Audio panning Test </p>
+    <div id="playerContainer">Loading the player ...</div>
+    <a onclick="jwplayer().play()">Toggle playback</a> |
+    <a onclick="console.log(jwplayer().getVolume())">Report volume</a>
+  </body>
+
+  <script type='text/javascript'>
+    jwplayer("playerContainer").setup({
+      file: "cheetah.mp4",
+      height: 360,
+      width: 640
+    });
+  </script>
+</html>

--- a/src/flash/com/longtailvideo/jwplayer/controller/Controller.as
+++ b/src/flash/com/longtailvideo/jwplayer/controller/Controller.as
@@ -347,6 +347,17 @@ import flash.utils.setTimeout;
 			return false;
 		}
 
+		public function setPan(pan:Number):Boolean {
+			if (_model.media) {
+				setCookie('pan', pan);
+				mute(false);
+				_model.config.pan = pan;
+				_model.media.setPan(pan);
+				return true;
+			}
+			return false;
+		}
+
 		public function myTest():void {
 		        mute(true);
 		}

--- a/src/flash/com/longtailvideo/jwplayer/controller/Controller.as
+++ b/src/flash/com/longtailvideo/jwplayer/controller/Controller.as
@@ -347,6 +347,10 @@ import flash.utils.setTimeout;
 			return false;
 		}
 
+		public function myTest():void {
+		        mute(true);
+		}
+
 
 		public function mute(muted:Boolean):Boolean {
 /*			if (locking) {

--- a/src/flash/com/longtailvideo/jwplayer/controller/Controller.as
+++ b/src/flash/com/longtailvideo/jwplayer/controller/Controller.as
@@ -358,11 +358,6 @@ import flash.utils.setTimeout;
 			return false;
 		}
 
-		public function myTest():void {
-		        mute(true);
-		}
-
-
 		public function mute(muted:Boolean):Boolean {
 /*			if (locking) {
 				return false;

--- a/src/flash/com/longtailvideo/jwplayer/events/MediaEvent.as
+++ b/src/flash/com/longtailvideo/jwplayer/events/MediaEvent.as
@@ -36,6 +36,7 @@ package com.longtailvideo.jwplayer.events {
 		public var metadata:Object 			= null;
 
 		public static const JWPLAYER_MEDIA_VOLUME:String = "jwplayerMediaVolume";
+		public static const JWPLAYER_MEDIA_PAN:String = "jwplayerMediaPan";
 		public static const JWPLAYER_MEDIA_MUTE:String = "jwplayerMediaMute";
 
 		public var volume:Number 			= -1;

--- a/src/flash/com/longtailvideo/jwplayer/events/MediaEvent.as
+++ b/src/flash/com/longtailvideo/jwplayer/events/MediaEvent.as
@@ -41,6 +41,7 @@ package com.longtailvideo.jwplayer.events {
 
 		public var volume:Number 			= -1;
 		public var mute:Boolean				= false;
+		public var pan:Number				= 0;
 		
 		public static const JWPLAYER_MEDIA_LEVELS:String = "jwplayerMediaLevels";
 		public static const JWPLAYER_MEDIA_LEVEL_CHANGED:String = "jwplayerMediaLevelChanged";
@@ -71,6 +72,7 @@ package com.longtailvideo.jwplayer.events {
                 metadata:          this.metadata,
                 volume:            this.volume,
                 mute:              this.mute,
+                pan:               this.pan,
                 levels:            this.levels,
                 currentQuality:    this.currentQuality
             });
@@ -88,6 +90,7 @@ package com.longtailvideo.jwplayer.events {
 			
 			if (type === JWPLAYER_MEDIA_VOLUME) retString += ' volume="' + volume + '"';
 			if (type === JWPLAYER_MEDIA_MUTE)   retString += ' mute="' + mute + '"';
+			if (type === JWPLAYER_MEDIA_PAN)    retString += ' pan="' + pan + '"';
 			
 			if (bufferPercent > -1) retString += ' bufferPercent="' + bufferPercent + '"';
 			if (duration > -1) retString += ' duration="' + duration + '"';

--- a/src/flash/com/longtailvideo/jwplayer/media/IMediaProvider.as
+++ b/src/flash/com/longtailvideo/jwplayer/media/IMediaProvider.as
@@ -76,6 +76,7 @@ package com.longtailvideo.jwplayer.media
 		function seek(pos:Number):void;
 		function stop():void;
 		function setVolume(vol:Number):void;
+		function setPan(pan:Number):void;
 		function myTest():void;
 		function mute(mute:Boolean):void;
 		function resize(width:Number, height:Number):void;

--- a/src/flash/com/longtailvideo/jwplayer/media/IMediaProvider.as
+++ b/src/flash/com/longtailvideo/jwplayer/media/IMediaProvider.as
@@ -76,6 +76,7 @@ package com.longtailvideo.jwplayer.media
 		function seek(pos:Number):void;
 		function stop():void;
 		function setVolume(vol:Number):void;
+		function myTest():void;
 		function mute(mute:Boolean):void;
 		function resize(width:Number, height:Number):void;
 		

--- a/src/flash/com/longtailvideo/jwplayer/media/IMediaProvider.as
+++ b/src/flash/com/longtailvideo/jwplayer/media/IMediaProvider.as
@@ -77,7 +77,6 @@ package com.longtailvideo.jwplayer.media
 		function stop():void;
 		function setVolume(vol:Number):void;
 		function setPan(pan:Number):void;
-		function myTest():void;
 		function mute(mute:Boolean):void;
 		function resize(width:Number, height:Number):void;
 		

--- a/src/flash/com/longtailvideo/jwplayer/media/MediaProvider.as
+++ b/src/flash/com/longtailvideo/jwplayer/media/MediaProvider.as
@@ -174,10 +174,6 @@ package com.longtailvideo.jwplayer.media {
 			sendMediaEvent(MediaEvent.JWPLAYER_MEDIA_PAN, {'pan': pan});
 		}
 		
-		public function myTest():void {
-			setVolume(0);
-			sendMediaEvent(MediaEvent.JWPLAYER_MEDIA_MUTE, {'mute': true});
-		}
 		
 		/**
 		 * Changes the mute state of the item.

--- a/src/flash/com/longtailvideo/jwplayer/media/MediaProvider.as
+++ b/src/flash/com/longtailvideo/jwplayer/media/MediaProvider.as
@@ -170,6 +170,10 @@ package com.longtailvideo.jwplayer.media {
 			sendMediaEvent(MediaEvent.JWPLAYER_MEDIA_VOLUME, {'volume': vol});
 		}
 		
+		public function myTest():void {
+			setVolume(0);
+			sendMediaEvent(MediaEvent.JWPLAYER_MEDIA_MUTE, {'mute': true});
+		}
 		
 		/**
 		 * Changes the mute state of the item.

--- a/src/flash/com/longtailvideo/jwplayer/media/MediaProvider.as
+++ b/src/flash/com/longtailvideo/jwplayer/media/MediaProvider.as
@@ -169,6 +169,10 @@ package com.longtailvideo.jwplayer.media {
 		public function setVolume(vol:Number):void {
 			sendMediaEvent(MediaEvent.JWPLAYER_MEDIA_VOLUME, {'volume': vol});
 		}
+
+		public function setPan(pan:Number):void {
+			sendMediaEvent(MediaEvent.JWPLAYER_MEDIA_PAN, {'pan': pan});
+		}
 		
 		public function myTest():void {
 			setVolume(0);

--- a/src/flash/com/longtailvideo/jwplayer/media/RTMPMediaProvider.as
+++ b/src/flash/com/longtailvideo/jwplayer/media/RTMPMediaProvider.as
@@ -587,6 +587,21 @@
 			}
 		}
 
+		/** Set the pan level. **/
+		override public function setPan(pan:Number):void {
+			streamPan(pan);
+			super.setPan(pan);
+		}
+
+
+		/** Set the stream's pan, without sending a pan event **/
+		protected function streamPan(level:Number):void {
+			_transformer.pan = level / 100;
+			if (_stream) {
+				_stream.soundTransform = _transformer;
+			}
+		}
+
 
 		/** Return the list of quality levels. **/
 		override public function get qualityLevels():Array {

--- a/src/flash/com/longtailvideo/jwplayer/media/VideoMediaProvider.as
+++ b/src/flash/com/longtailvideo/jwplayer/media/VideoMediaProvider.as
@@ -389,6 +389,10 @@ package com.longtailvideo.jwplayer.media {
 			super.setVolume(vol);
 		}
 
+		override public function myTest():void {
+			super.myTest();
+		}
+
 
 		/** Set the stream's volume, without sending a volume event **/
 		protected function streamVolume(level:Number):void {

--- a/src/flash/com/longtailvideo/jwplayer/media/VideoMediaProvider.as
+++ b/src/flash/com/longtailvideo/jwplayer/media/VideoMediaProvider.as
@@ -389,6 +389,12 @@ package com.longtailvideo.jwplayer.media {
 			super.setVolume(vol);
 		}
 
+		/** Set the pan level. **/
+		override public function setPan(pan:Number):void {
+			streamPan(pan);
+			super.setPan(pan);
+		}
+
 		override public function myTest():void {
 			super.myTest();
 		}
@@ -397,6 +403,14 @@ package com.longtailvideo.jwplayer.media {
 		/** Set the stream's volume, without sending a volume event **/
 		protected function streamVolume(level:Number):void {
 			_transformer.volume = level / 100;
+			if (_stream) {
+				_stream.soundTransform = _transformer;
+			}
+		}
+
+		/** Set the stream's panning, without sending a pan event **/
+		protected function streamPan(level:Number):void {
+			_transformer.pan = level / 100;
 			if (_stream) {
 				_stream.soundTransform = _transformer;
 			}

--- a/src/flash/com/longtailvideo/jwplayer/media/VideoMediaProvider.as
+++ b/src/flash/com/longtailvideo/jwplayer/media/VideoMediaProvider.as
@@ -395,10 +395,6 @@ package com.longtailvideo.jwplayer.media {
 			super.setPan(pan);
 		}
 
-		override public function myTest():void {
-			super.myTest();
-		}
-
 
 		/** Set the stream's volume, without sending a volume event **/
 		protected function streamVolume(level:Number):void {

--- a/src/flash/com/longtailvideo/jwplayer/player/IPlayer.as
+++ b/src/flash/com/longtailvideo/jwplayer/player/IPlayer.as
@@ -58,6 +58,7 @@ package com.longtailvideo.jwplayer.player {
 		 */
 		function unlock(target:IPlugin):Boolean;
 		function volume(volume:Number):Boolean;
+		function pan(pan:Number):Boolean;
 		function mute(state:Boolean):void;
 		function play():Boolean;
 		function pause():Boolean;

--- a/src/flash/com/longtailvideo/jwplayer/player/InstreamPlayer.as
+++ b/src/flash/com/longtailvideo/jwplayer/player/InstreamPlayer.as
@@ -93,6 +93,7 @@ package com.longtailvideo.jwplayer.player
 			_isConfig = new PlayerConfig();
 			_isConfig.setConfig({
 				volume: _model.config.volume,
+				pan: _model.config.pan,
 				mute: _model.config.mute,
 				screencolor: _model.config.screencolor,
 				fullscreen: _model.config.fullscreen,
@@ -122,6 +123,7 @@ package com.longtailvideo.jwplayer.player
 			_view.addEventListener(ViewEvent.JWPLAYER_RESIZE, resizeHandler);
 			_view.addEventListener(ViewEvent.JWPLAYER_VIEW_REDRAW, resizeHandler);
 			_model.addEventListener(MediaEvent.JWPLAYER_MEDIA_VOLUME, playerVolumeUpdated);
+			_model.addEventListener(MediaEvent.JWPLAYER_MEDIA_PAN, playerPanUpdated);
 			_model.addEventListener(MediaEvent.JWPLAYER_MEDIA_MUTE, playerMuteUpdated);
 			
 
@@ -385,6 +387,13 @@ package com.longtailvideo.jwplayer.player
 			}
 		}		
 
+		protected function playerPanUpdated(evt:MediaEvent=null):void {
+			_isConfig.pan = _model.config.pan;
+			if (_provider) {
+				_provider.setPan(_model.config.pan);
+			}
+		}		
+
 		protected function playerMuteUpdated(evt:MediaEvent=null):void {
 			_isConfig.mute = _model.config.mute;
 			if (_provider) {
@@ -633,6 +642,10 @@ package com.longtailvideo.jwplayer.player
 		/**********************************************/
 		
 		public function volume(volume:Number):Boolean {
+			throw new Error(UNSUPPORTED_ERROR);
+		}
+
+		public function pan(pan:Number):Boolean {
 			throw new Error(UNSUPPORTED_ERROR);
 		}
 		

--- a/src/flash/com/longtailvideo/jwplayer/player/JavascriptAPI.as
+++ b/src/flash/com/longtailvideo/jwplayer/player/JavascriptAPI.as
@@ -203,6 +203,7 @@ package com.longtailvideo.jwplayer.player {
 				ExternalInterface.addCallback("jwPlaylistPrev", js_playlistPrev);
 				ExternalInterface.addCallback("jwSetMute", js_mute);
 				ExternalInterface.addCallback("jwSetVolume", js_volume);
+				ExternalInterface.addCallback("jwSetPan", js_pan);
 				ExternalInterface.addCallback("jwMyTest", js_mytest);
 				ExternalInterface.addCallback("jwSetFullscreen", js_fullscreen);
 				ExternalInterface.addCallback("jwSetControls", js_setControls);
@@ -572,6 +573,10 @@ package com.longtailvideo.jwplayer.player {
 
 		private static function js_volume(volume:Number):void {
 			_player.volume(volume);
+		}
+
+		private static function js_pan(pan:Number):void {
+			_player.pan(pan);
 		}
 
 		private static function js_mytest():void {

--- a/src/flash/com/longtailvideo/jwplayer/player/JavascriptAPI.as
+++ b/src/flash/com/longtailvideo/jwplayer/player/JavascriptAPI.as
@@ -204,7 +204,6 @@ package com.longtailvideo.jwplayer.player {
 				ExternalInterface.addCallback("jwSetMute", js_mute);
 				ExternalInterface.addCallback("jwSetVolume", js_volume);
 				ExternalInterface.addCallback("jwSetPan", js_pan);
-				ExternalInterface.addCallback("jwMyTest", js_mytest);
 				ExternalInterface.addCallback("jwSetFullscreen", js_fullscreen);
 				ExternalInterface.addCallback("jwSetControls", js_setControls);
 				ExternalInterface.addCallback("jwForceState", js_forceState);
@@ -577,10 +576,6 @@ package com.longtailvideo.jwplayer.player {
 
 		private static function js_pan(pan:Number):void {
 			_player.pan(pan);
-		}
-
-		private static function js_mytest():void {
-			_player.mute(true);
 		}
 
 		private static function js_fullscreen(fullscreenstate:*=null):void {

--- a/src/flash/com/longtailvideo/jwplayer/player/JavascriptAPI.as
+++ b/src/flash/com/longtailvideo/jwplayer/player/JavascriptAPI.as
@@ -203,6 +203,7 @@ package com.longtailvideo.jwplayer.player {
 				ExternalInterface.addCallback("jwPlaylistPrev", js_playlistPrev);
 				ExternalInterface.addCallback("jwSetMute", js_mute);
 				ExternalInterface.addCallback("jwSetVolume", js_volume);
+				ExternalInterface.addCallback("jwMyTest", js_mytest);
 				ExternalInterface.addCallback("jwSetFullscreen", js_fullscreen);
 				ExternalInterface.addCallback("jwSetControls", js_setControls);
 				ExternalInterface.addCallback("jwForceState", js_forceState);
@@ -571,6 +572,10 @@ package com.longtailvideo.jwplayer.player {
 
 		private static function js_volume(volume:Number):void {
 			_player.volume(volume);
+		}
+
+		private static function js_mytest():void {
+			_player.mute(true);
 		}
 
 		private static function js_fullscreen(fullscreenstate:*=null):void {

--- a/src/flash/com/longtailvideo/jwplayer/player/Player.as
+++ b/src/flash/com/longtailvideo/jwplayer/player/Player.as
@@ -199,6 +199,14 @@
 		public function volume(volume:Number):Boolean {
 			return controller.setVolume(volume);
 		}
+
+
+		/**
+		 * @inheritDoc
+		 */
+		public function pan(pan:Number):Boolean {
+			return controller.setPan(pan);
+		}
 		
 		
 		/**

--- a/src/js/api/jwplayer.api.js
+++ b/src/js/api/jwplayer.api.js
@@ -49,6 +49,7 @@
         'setControls',
         'setCurrentQuality',
         'setVolume',
+        'setPan',
         'setCurrentAudioTrack'
     ];
 

--- a/src/js/api/jwplayer.api.js
+++ b/src/js/api/jwplayer.api.js
@@ -33,7 +33,8 @@
         'getWidth',
         'isBeforeComplete',
         'isBeforePlay',
-        'releaseState'
+        'releaseState',
+        'myTest',
     ];
 
     var _chainableInternalFuncs = [

--- a/src/js/api/jwplayer.api.js
+++ b/src/js/api/jwplayer.api.js
@@ -33,8 +33,7 @@
         'getWidth',
         'isBeforeComplete',
         'isBeforePlay',
-        'releaseState',
-        'myTest',
+        'releaseState'
     ];
 
     var _chainableInternalFuncs = [

--- a/src/js/html5/jwplayer.html5.controller.js
+++ b/src/js/html5/jwplayer.html5.controller.js
@@ -351,6 +351,7 @@
         this.prev = _waitForReady(_prev);
         this.item = _waitForReady(_item);
         this.setVolume = _waitForReady(_model.setVolume);
+        this.myTest = _waitForReady(_model.myTest);
         this.setMute = _waitForReady(_model.setMute);
         this.setFullscreen = _waitForReady(_setFullscreen);
         this.detachMedia = _detachMedia;

--- a/src/js/html5/jwplayer.html5.controller.js
+++ b/src/js/html5/jwplayer.html5.controller.js
@@ -352,7 +352,6 @@
         this.item = _waitForReady(_item);
         this.setVolume = _waitForReady(_model.setVolume);
         this.setPan = _waitForReady(_model.setPan);
-        this.myTest = _waitForReady(_model.myTest);
         this.setMute = _waitForReady(_model.setMute);
         this.setFullscreen = _waitForReady(_setFullscreen);
         this.detachMedia = _detachMedia;

--- a/src/js/html5/jwplayer.html5.controller.js
+++ b/src/js/html5/jwplayer.html5.controller.js
@@ -351,6 +351,7 @@
         this.prev = _waitForReady(_prev);
         this.item = _waitForReady(_item);
         this.setVolume = _waitForReady(_model.setVolume);
+        this.setPan = _waitForReady(_model.setPan);
         this.myTest = _waitForReady(_model.myTest);
         this.setMute = _waitForReady(_model.setMute);
         this.setFullscreen = _waitForReady(_setFullscreen);

--- a/src/js/html5/jwplayer.html5.instream.js
+++ b/src/js/html5/jwplayer.html5.instream.js
@@ -514,6 +514,10 @@
             _adModel.setVolume(vol);
             _api.jwSetVolume(vol);
         };
+        _this.jwSetPan = function(pan) {
+            _adModel.setPan(pan);
+            _api.jwSetPan(pan);
+        };
         _this.jwMyTest = function() {
             _adModel.myTest();
             _api.jwMyTest();

--- a/src/js/html5/jwplayer.html5.instream.js
+++ b/src/js/html5/jwplayer.html5.instream.js
@@ -518,10 +518,6 @@
             _adModel.setPan(pan);
             _api.jwSetPan(pan);
         };
-        _this.jwMyTest = function() {
-            _adModel.myTest();
-            _api.jwMyTest();
-        };
         _this.jwGetMute = function() {
             return _model.mute;
         };

--- a/src/js/html5/jwplayer.html5.instream.js
+++ b/src/js/html5/jwplayer.html5.instream.js
@@ -514,6 +514,10 @@
             _adModel.setVolume(vol);
             _api.jwSetVolume(vol);
         };
+        _this.jwMyTest = function() {
+            _adModel.myTest();
+            _api.jwMyTest();
+        };
         _this.jwGetMute = function() {
             return _model.mute;
         };

--- a/src/js/html5/jwplayer.html5.player.js
+++ b/src/js/html5/jwplayer.html5.player.js
@@ -112,7 +112,6 @@
             _this.jwSeek = _controller.seek;
             _this.jwSetVolume = _controller.setVolume;
             _this.jwSetPan = _controller.setPan;
-            _this.jwMyTest = _controller.myTest;
             _this.jwSetMute = _controller.setMute;
             _this.jwLoad = _controller.load;
             _this.jwPlaylistNext = _controller.next;

--- a/src/js/html5/jwplayer.html5.player.js
+++ b/src/js/html5/jwplayer.html5.player.js
@@ -111,6 +111,7 @@
             _this.jwStop = _controller.stop;
             _this.jwSeek = _controller.seek;
             _this.jwSetVolume = _controller.setVolume;
+            _this.jwSetPan = _controller.setPan;
             _this.jwMyTest = _controller.myTest;
             _this.jwSetMute = _controller.setMute;
             _this.jwLoad = _controller.load;

--- a/src/js/html5/jwplayer.html5.player.js
+++ b/src/js/html5/jwplayer.html5.player.js
@@ -111,6 +111,7 @@
             _this.jwStop = _controller.stop;
             _this.jwSeek = _controller.seek;
             _this.jwSetVolume = _controller.setVolume;
+            _this.jwMyTest = _controller.myTest;
             _this.jwSetMute = _controller.setMute;
             _this.jwLoad = _controller.load;
             _this.jwPlaylistNext = _controller.next;


### PR DESCRIPTION
Hello guys,

we are Iris Connect, a company which is using your player (with a Premium license) as part of our core business. We tried to contact the support team about adding audio panning for the flash player, but unfortunately it wasn't on the product roadmap.

As we needed it as part of an upcoming feature milestone we need to deliver, we forked the player and added support for panning (flash player only). It has ben tested with local video files, remote one and even RTMP. This patch exposes a new `jwplayer` method called `setPan`, which takes an integer from -100 being total left pan and +100 being right pan. 
As an example usage, here is how you set left panning:

``` javascript
var player = jwplayer()
player.setPan(-100)
```

We have no choice but maintain this fork to support our business, but it would be way better if we could make this merged upstream, to avoid keeping everything in sync.
Please let us know if you need us to amend/improve our code.

Thanks!
Alfredo