### PR TITLE
python syntax error 

### DIFF
--- a/build/skin-packer.py
+++ b/build/skin-packer.py
@@ -9,4 +9,4 @@ skinText = skin.toxml()
 whiteSpace = re.compile('>(.*?)<', re.S)
 skinText = whiteSpace.sub('><', skinText)
 
-print skinText
+print(skinText) # python 3.4.2


### PR DESCRIPTION
[echo] Building html5
[java]
[java] [ERROR] 5167:63:unterminated string literal

src\js\html5\jwplayer.html5.defaultskin.js : line 5
