### PR TITLE
[jwplayer] fixed infinite buffering issue on mobile [Delivers #83128276]

### DIFF
--- a/src/js/html5/providers/jwplayer.html5.video.js
+++ b/src/js/html5/providers/jwplayer.html5.video.js
@@ -331,10 +331,6 @@
 
             _source = _levels[_currentQuality];
 
-            if (!_isMobile) {
-                _this.setState(states.BUFFERING);
-            }
-
             clearInterval(_bufferInterval);
             _bufferInterval = setInterval(_sendBufferUpdate, 100);
 


### PR DESCRIPTION
If you try to chain play() after onReady(), the player will get stuck in an infinite buffering state on mobile browsers. This small patch fixes it. By not putting the player into a buffering state during __completeLoad() for mobile, the player doesn't need to try to buffer, and do something that can't be done (autostart on mobile).
