### PR TITLE
[jwplayer] fixed form postback issue on mobile [Delivers #72548052]

### DIFF
--- a/src/js/html5/jwplayer.html5.controlbar.js
+++ b/src/js/html5/jwplayer.html5.controlbar.js
@@ -614,6 +614,8 @@
 
             button.innerHTML = '&nbsp;';
             button.tabIndex = -1;
+            //fix for postbacks on mobile devices when a <form> is used
+            button.setAttribute('type', 'button');
             _appendChild(span, button);
 
             var outSkin = _getSkinElement(name + 'Button'),


### PR DESCRIPTION
Pausing a player in a form triggers reload on Android. I will create a test page for this issue as well.
