### PR TITLE
changing http to use // prevent mixed content messages for html5 player

### DIFF
--- a/src/js/html5/providers/jwplayer.html5.youtube.js
+++ b/src/js/html5/providers/jwplayer.html5.youtube.js
@@ -350,7 +350,7 @@
             var videoId = utils.youTubeID(url);
 
             if (!item.image) {
-                item.image = 'http://i.ytimg.com/vi/' + videoId + '/0.jpg';
+                item.image = '//i.ytimg.com/vi/' + videoId + '/0.jpg';
             }
 
             _this.setVisibility(true);


### PR DESCRIPTION
Found this was cause for https / SSL secure site to go to mixed content and have a broken poster image when using SSL.
