### PR TITLE
[jwplayer] fixed controlbar doesn't fade out after mouseout with SMIL [Delivers #67439788]

### DIFF
--- a/src/flash/com/longtailvideo/jwplayer/media/RTMPMediaProvider.as
+++ b/src/flash/com/longtailvideo/jwplayer/media/RTMPMediaProvider.as
@@ -163,7 +163,6 @@
 			} else {
 				_loader.load(_item.file, XML);
 			}
-			setState(PlayerState.BUFFERING);
 		}
 
 
@@ -261,6 +260,10 @@
 			} else if (!media) {
 				media = _video;
 			}
+
+			//If you send buffering events before the provider's media is set
+			//The view will think that the controls should be locked because the provider doesn't have a display.
+			setState(PlayerState.BUFFERING);
 			
 			var level:Number = 0;
 			


### PR DESCRIPTION
[jwplayer] fixed controlbar doesn't fade out after mouseout with SMIL [Delivers #67439788]

If you're send buffering events before the provider's media is set the view will think that the controls should be locked because the provider doesn't have a display.
