### PR TITLE
[jwplayer] fixed youtube html5 ie issues [Fixes #83957180]

### DIFF
--- a/src/js/html5/providers/jwplayer.html5.youtube.js
+++ b/src/js/html5/providers/jwplayer.html5.youtube.js
@@ -185,6 +185,7 @@
                 width: '100%',
                 videoId: videoId,
                 playerVars: utils.extend({
+                    html5: 1,
                     autoplay: 0,
                     controls: 0,
                     showinfo: 0,


### PR DESCRIPTION
[jwplayer] fixed youtube html5 ie issues [Fixes #83957180]

When using a Youtube embed in HTML5 mode, the skin/control bar gets removed in IE10/IE11 (in both JW6.10 & JW6.11)

It seems that as soon as the player loads, the jwplayer skin disappears and it just looks like a standard YouTube embed without JW.

In the YouTube HTML5 (iFrame) API, there is a flash to force HTML5 mode whenever possible. It is:

html5: 1,

We had this value totally omitted, so the player was falling back to flash in IE, but since we were also setting options like controls=0, it was basically unusable, since the player couldn't be scrubbed/seeked at all.