### PR TITLE
Hotfix: onReady should fire after onPlaylist [#83674558]

### DIFF
--- a/src/flash/com/longtailvideo/jwplayer/controller/Controller.as
+++ b/src/flash/com/longtailvideo/jwplayer/controller/Controller.as
@@ -180,16 +180,13 @@ import flash.utils.setTimeout;
 				_model.addEventListener(MediaEvent.JWPLAYER_MEDIA_COMPLETE, completeHandler, false);
 				_model.addEventListener(MediaEvent.JWPLAYER_MEDIA_TIME, timeHandler);
 				
+				// setup listeners so playlist loaded can be dispatched (ready will be forwarded asynchronously)
 				dispatchEvent(new PlayerEvent(PlayerEvent.JWPLAYER_READY));
-
-//				playlistLoadHandler();
 
 				// Broadcast playlist loaded (which was swallowed during player setup);
 				if (_model.playlist.length > 0) {
 					_model.dispatchEvent(new PlaylistEvent(PlaylistEvent.JWPLAYER_PLAYLIST_LOADED, _model.playlist));
 				}
-
-				
 			}
 		}
 

--- a/src/flash/com/longtailvideo/jwplayer/player/JavascriptAPI.as
+++ b/src/flash/com/longtailvideo/jwplayer/player/JavascriptAPI.as
@@ -108,13 +108,9 @@ package com.longtailvideo.jwplayer.player {
 					clearQueuedEvents();
 				}
 			};
-			if (ExternalInterface.available) {
-				ready();
-			} else {
-				var timer:Timer = new Timer(0, 5);
-				timer.addEventListener(TimerEvent.TIMER_COMPLETE, ready);
-				timer.start();
-			}
+			var timer:Timer = new Timer(0, 5);
+			timer.addEventListener(TimerEvent.TIMER_COMPLETE, ready);
+			timer.start();
 		}
 
 		private static function queueEvents(evt:Event):void {


### PR DESCRIPTION
This is to provide a patched version of 6.11 to self hosted customers.
