### PR TITLE
Use icon hash

### DIFF
--- a/src/js/html5/jwplayer.html5.displayicon.js
+++ b/src/js/html5/jwplayer.html5.displayicon.js
@@ -197,6 +197,7 @@
             if (!icon) {
                 icon = _createElement('jwicon');
                 icon.id = _container.id + '_' + name;
+                _iconCache[name] = icon;
             }
             _styleIcon(icon, name + 'Icon', '#' + icon.id);
             if (_container.contains(_icon)) {


### PR DESCRIPTION
Reusing icon elements prevents data:image/png parsing from being repeated.
