### PR TITLE
Video player not loading after error

### DIFF
--- a/src/js/html5/jwplayer.html5.model.js
+++ b/src/js/html5/jwplayer.html5.model.js
@@ -146,7 +146,7 @@
                 });
             } else {
                 _model.sendEvent(events.JWPLAYER_PLAYLIST_LOADED, {
-                    playlist: jwplayer(_model.id).getPlaylist()
+                    playlist: jwplayer(_model.id).getPlaylist && jwplayer(_model.id).getPlaylist() || []
                 });
                 _model.item = -1;
                 _model.setItem(0);


### PR DESCRIPTION
After a jwplayer instance encounters an error during initialisation (for
example if remove is called before it is ready), then any further
jwplayer instances will not load.