### PR TITLE
Ensure play button displays when no display text is sent [Delivers #87223960]

### DIFF
--- a/src/flash/com/longtailvideo/jwplayer/view/components/DisplayIcon.as
+++ b/src/flash/com/longtailvideo/jwplayer/view/components/DisplayIcon.as
@@ -169,6 +169,7 @@ package com.longtailvideo.jwplayer.view.components {
 			if (!_text || _noText) {
 				_textField.visible = false;
 				_textField.width = _textField.height = 0;
+				_textField.text = "";
 				redraw();
 				return;
 			}


### PR DESCRIPTION
Getting a null value for a text field broke the text layout of the button on Pepper Flash on Mac Chrome by making it impossibly large (height > 1,000,000).  Setting the text field to have a blank string for its content when we're getting falsy text values (such as when we get null) will not cause this issue to happen.  Seems like a wrapping issue when we set the width and height of the text field to 0. [Delivers #87223960]