### PR TITLE
Two Flash casting bugfixes [Delivers #86664424]

### DIFF
--- a/src/flash/com/longtailvideo/jwplayer/view/components/ControlbarComponent.as
+++ b/src/flash/com/longtailvideo/jwplayer/view/components/ControlbarComponent.as
@@ -144,6 +144,7 @@ package com.longtailvideo.jwplayer.view.components {
 
 		public function ControlbarComponent(player:IPlayer) {
 			super(player, "controlbar");
+
 			animations = new Animations(this);
 			alpha = 0;
 			_instreamMode = false;
@@ -382,7 +383,6 @@ package com.longtailvideo.jwplayer.view.components {
 			return layout;
 		}
 
-
 		private static function removeButtonFromLayout(button:String, layout:String):String {
 			return layout.replace(button, "");
 		}
@@ -415,7 +415,10 @@ package com.longtailvideo.jwplayer.view.components {
                     setPositionAndDuration(evt.position, evt.duration);
                     if (isLive && evt.type == MediaEvent.JWPLAYER_MEDIA_TIME) {
 						if (!_instreamMode) {
-							setText(player.playlist.currentItem.title || "Live broadcast");
+                            // In between items, the cast plugin sets duration to 0, this does not mean the video
+                            //   is a live broadcast
+                            var backup:String = (_casting ? "" : "Live broadcast");
+							setText(player.playlist.currentItem.title || backup);
 						}
 					} else {
                         if (_timeSlider) {
@@ -429,7 +432,7 @@ package com.longtailvideo.jwplayer.view.components {
 							if (evt.bufferPercent > 0) {
                                 var offsetPercent:Number = (evt.offset / _lastDur) * 100;
                                 _timeSlider.setBuffer(evt.bufferPercent / (1-offsetPercent/100), offsetPercent);
-						}
+                            }
 
                             _timeSlider.setDuration(_lastDur);
                             _timeSlider.live = isLive;

--- a/src/js/html5/jwplayer.html5.instream.js
+++ b/src/js/html5/jwplayer.html5.instream.js
@@ -74,11 +74,14 @@
             // Keep track of the original player state
             _oldpos = _video.currentTime;
 
-            if (_controller.checkBeforePlay() || _oldpos === 0) {
+            if (_model.getVideo().checkComplete()) {
+                // AKA postroll
+                _oldstate = _states.IDLE;
+            } else if (_controller.checkBeforePlay() || _oldpos === 0) {
                 // make sure video restarts after preroll
                 _oldpos = 0;
                 _oldstate = _states.PLAYING;
-            } else if (_api.jwGetState() === _states.IDLE || _model.getVideo().checkComplete()) {
+            } else if (_api.jwGetState() === _states.IDLE) {
                 _oldstate = _states.IDLE;
             } else {
                 _oldstate = _states.PLAYING;


### PR DESCRIPTION
1. Receiver was repeating HLS items after postroll, because the position was 0 causing a seek to the beginning [#87573028]
2. Sender was displaying "Live Broadcast" because duration was 0, which typically indicates a live file.