### PR TITLE
Youtube HTML5 autoplay fix [Finishes #86721652]

### DIFF
--- a/src/js/html5/providers/jwplayer.html5.youtube.js
+++ b/src/js/html5/providers/jwplayer.html5.youtube.js
@@ -169,6 +169,19 @@
             });
         }
 
+        // Returns a function that is the composition of a list of functions, each
+        // consuming the return value of the function that follows.
+        function _composeCallbacks() {
+            var args = arguments;
+            var start = args.length - 1;
+            return function() {
+                var i = start;
+                var result = args[start].apply(this, arguments);
+                while (i--) result = args[i].call(this, result);
+                    return result;
+            };
+        }
+
         function _embedYoutubePlayer(videoId, playerVars) {
             if (!videoId) {
                 throw 'invalid Youtube ID';
@@ -371,10 +384,11 @@
             }
 
             if (!_youtubePlayer.getPlayerState) {
-                _youtubePlayerReadyCallback = function() {
+                var onStart = function() {
                     _volumeHandler();
                     _this.load(item);
                 };
+                _youtubePlayerReadyCallback = (_youtubePlayerReadyCallback) ? _composeCallbacks(onStart, _youtubePlayerReadyCallback) : onStart;
                 return;
             }
 
@@ -419,7 +433,7 @@
             if (_youtubePlayer && _youtubePlayer.playVideo) {
                 _youtubePlayer.playVideo();
             } else {    // If the _youtubePlayer isn't setup, then play when we're ready
-                _youtubePlayerReadyCallback = this.play;
+                _youtubePlayerReadyCallback = (_youtubePlayerReadyCallback) ? _composeCallbacks(this.play, _youtubePlayerReadyCallback) : this.play;
             }
         };
 

--- a/src/js/html5/providers/jwplayer.html5.youtube.js
+++ b/src/js/html5/providers/jwplayer.html5.youtube.js
@@ -177,8 +177,8 @@
             return function() {
                 var i = start;
                 var result = args[start].apply(this, arguments);
-                while (i--) result = args[i].call(this, result);
-                    return result;
+                while (i--) { result = args[i].call(this, result); }
+                return result;
             };
         }
 
@@ -388,7 +388,11 @@
                     _volumeHandler();
                     _this.load(item);
                 };
-                _youtubePlayerReadyCallback = (_youtubePlayerReadyCallback) ? _composeCallbacks(onStart, _youtubePlayerReadyCallback) : onStart;
+                if (_youtubePlayerReadyCallback) {
+                    _youtubePlayerReadyCallback = _composeCallbacks(onStart, _youtubePlayerReadyCallback);
+                } else {
+                    _youtubePlayerReadyCallback = onStart;
+                }
                 return;
             }
 
@@ -433,7 +437,11 @@
             if (_youtubePlayer && _youtubePlayer.playVideo) {
                 _youtubePlayer.playVideo();
             } else {    // If the _youtubePlayer isn't setup, then play when we're ready
-                _youtubePlayerReadyCallback = (_youtubePlayerReadyCallback) ? _composeCallbacks(this.play, _youtubePlayerReadyCallback) : this.play;
+                if (_youtubePlayerReadyCallback) {
+                    _youtubePlayerReadyCallback = _composeCallbacks(this.play, _youtubePlayerReadyCallback);
+                } else {
+                    _youtubePlayerReadyCallback = this.play;
+                }
             }
         };
 

--- a/src/js/html5/providers/jwplayer.html5.youtube.js
+++ b/src/js/html5/providers/jwplayer.html5.youtube.js
@@ -416,8 +416,10 @@
             if (_requiresUserInteraction) {
                 return;
             }
-            if (_youtubePlayer.playVideo) {
+            if (_youtubePlayer && _youtubePlayer.playVideo) {
                 _youtubePlayer.playVideo();
+            } else {    // If the _youtubePlayer isn't setup, then play when we're ready
+                _youtubePlayerReadyCallback = this.play;
             }
         };
 


### PR DESCRIPTION
Fixes the issue noted in #86721652 by checking if _youtubePlayer is set up. If it isn't then we queue up a play call once the player is ready. This issue is caused by attempting to play when the provider hasn't finished setting up, so we will just play once its finished setting up. [Finishes #86721652]
