### PR TITLE
YouTube HTML5 Repeat Broken [Finishes #87674774]

### DIFF
--- a/src/js/html5/providers/jwplayer.html5.youtube.js
+++ b/src/js/html5/providers/jwplayer.html5.youtube.js
@@ -291,7 +291,9 @@
             // This event is where the Youtube player and media is actually ready and can be played
 
             // make sure playback starts/resumes
-            _this.play();
+            if (_youtubeState !== _youtubeAPI.PlayerState.ENDED) {
+                _this.play();
+            }
 
             _this.sendEvent(events.JWPLAYER_MEDIA_LEVEL_CHANGED, {
                 currentQuality: _this.getCurrentQuality(),


### PR DESCRIPTION
Prevent videos from repeating by not allowing them to play on quality change once the video has already ended. [Finishes #87674774]