### PR TITLE
IE8 remove swf [Delivers #87567416]

### DIFF
--- a/src/flash/com/longtailvideo/jwplayer/player/JavascriptAPI.as
+++ b/src/flash/com/longtailvideo/jwplayer/player/JavascriptAPI.as
@@ -310,12 +310,14 @@ package com.longtailvideo.jwplayer.player {
 		public static function dispatch(type:String, callbacks:Array, args:Object):void {
 			if (callbacks) {
 				// Not a great workaround, but the JavaScript API competes with the Controller when dealing with certain events
-				var asyncCallbacks:Array;
+				var asyncCallbacks:Array = null;
 				for each (var call:String in callbacks) {
 					if (javaScriptEventLoop === null || SYNCHRONOUS_EVENTS.indexOf(type) > -1) {
 						callJS(call, args, type);
 					} else {
-						if (asyncCallbacks === null) asyncCallbacks = [];
+						if (asyncCallbacks === null) {
+							asyncCallbacks = [];
+						}
 						asyncCallbacks.push(call);
 					}
 				}
@@ -415,9 +417,9 @@ package com.longtailvideo.jwplayer.player {
 		 **                 GETTERS                   **
 		 ***********************************************/
 		
-		private static function js_getBandwidth():Number {
-			return _player.config.bandwidth;
-		}
+		// private static function js_getBandwidth():Number {
+		// 	return _player.config.bandwidth;
+		// }
 
 		private static function js_getBuffer():Number {
 			return _playerBuffer;
@@ -435,13 +437,13 @@ package com.longtailvideo.jwplayer.player {
 			return RootReference.stage.stageHeight;
 		}
 		
-		private static function js_getLevel():Number {
-			return _player.playlist.currentItem ? _player.playlist.currentItem.currentLevel : 0;
-		}
+		// private static function js_getLevel():Number {
+		// 	return _player.playlist.currentItem ? _player.playlist.currentItem.currentLevel : 0;
+		// }
 		
-		private static function js_getLockState():Boolean {
-			return _player.locked;
-		}
+		// private static function js_getLockState():Boolean {
+		// 	return _player.locked;
+		// }
 		
 		private static function js_getMute():Boolean {
 			return _player.config.mute;

--- a/src/flash/com/longtailvideo/jwplayer/utils/Strings.as
+++ b/src/flash/com/longtailvideo/jwplayer/utils/Strings.as
@@ -230,7 +230,7 @@ package com.longtailvideo.jwplayer.utils {
 				}
 			}
 			return protocol + domain + "/" + result.join("/");
-		};
+		}
 		
 		public static function isAbsolutePath(path:String):Boolean {
 			var protocol:int = path.indexOf("://");

--- a/src/flash/com/longtailvideo/jwplayer/view/View.as
+++ b/src/flash/com/longtailvideo/jwplayer/view/View.as
@@ -11,7 +11,6 @@ package com.longtailvideo.jwplayer.view {
 	import com.longtailvideo.jwplayer.model.Model;
 	import com.longtailvideo.jwplayer.player.IInstreamPlayer;
 	import com.longtailvideo.jwplayer.player.IPlayer;
-	import com.longtailvideo.jwplayer.player.InstreamPlayer;
 	import com.longtailvideo.jwplayer.player.PlayerState;
 	import com.longtailvideo.jwplayer.plugins.IPlugin;
 	import com.longtailvideo.jwplayer.plugins.IPlugin6;
@@ -32,7 +31,6 @@ package com.longtailvideo.jwplayer.view {
 	import flash.display.DisplayObjectContainer;
 	import flash.display.Loader;
 	import flash.display.MovieClip;
-	import flash.display.Stage;
 	import flash.display.StageAlign;
 	import flash.display.StageDisplayState;
 	import flash.display.StageScaleMode;
@@ -357,7 +355,7 @@ package com.longtailvideo.jwplayer.view {
 
 
 		protected function resizeHandler(event:Event):void {
-			_fullscreen = (RootReference.stage.displayState == StageDisplayState.FULL_SCREEN);
+			_fullscreen = (RootReference.stage.displayState === StageDisplayState.FULL_SCREEN);
 			if (_model.media.display) _preventFade = false;
 			if (_model.fullscreen != _fullscreen) {
 				dispatchEvent(new ViewEvent(ViewEvent.JWPLAYER_VIEW_FULLSCREEN, _fullscreen));

--- a/src/js/api/jwplayer.api.js
+++ b/src/js/api/jwplayer.api.js
@@ -359,6 +359,18 @@
                 if (_this.renderingMode === 'html5') {
                     // calls jwPlayerDestroy()
                     _this.destroyPlayer();
+                } else if (utils.isMSIE(8)) {
+                    // remove flash object safely, setting flash external interface methods to null for ie8
+                    var swf = document.getElementById(_this.id);
+                    if (swf && swf.parentNode) {
+                        swf.style.display = 'none';
+                        for (var i in swf) {
+                            if (typeof swf[i] === 'function') {
+                                swf[i] = null;
+                            }
+                        }
+                        swf.parentNode.removeChild(swf);
+                    }
                 }
 
                 // If the tag is reused by another player, do not destroy the div

--- a/src/js/events/jwplayer.events.js
+++ b/src/js/events/jwplayer.events.js
@@ -21,8 +21,6 @@
         // Media Events
         JWPLAYER_MEDIA_BEFOREPLAY: 'jwplayerMediaBeforePlay',
         JWPLAYER_MEDIA_BEFORECOMPLETE: 'jwplayerMediaBeforeComplete',
-        JWPLAYER_COMPONENT_SHOW: 'jwplayerComponentShow',
-        JWPLAYER_COMPONENT_HIDE: 'jwplayerComponentHide',
         JWPLAYER_MEDIA_BUFFER: 'jwplayerMediaBuffer',
         JWPLAYER_MEDIA_BUFFER_FULL: 'jwplayerMediaBufferFull',
         JWPLAYER_MEDIA_ERROR: 'jwplayerMediaError',


### PR DESCRIPTION
First commit removes the swf safely for ie8 based on https://code.google.com/p/swfobject/source/browse/trunk/swfobject/src/swfobject.js#474

The second does some safe code cleanup.