### PR TITLE
 VAST onBeforeComplete Fix for the vast-regressions-load test use case [Delivers #88195758]

### DIFF
--- a/src/js/html5/jwplayer.html5.instream.js
+++ b/src/js/html5/jwplayer.html5.instream.js
@@ -74,14 +74,14 @@
             // Keep track of the original player state
             _oldpos = _video.currentTime;
 
-            if (_model.getVideo().checkComplete()) {
-                // AKA postroll
-                _oldstate = _states.IDLE;
-            } else if (_controller.checkBeforePlay() || _oldpos === 0) {
+            if (_controller.checkBeforePlay() || _oldpos === 0) {
                 // make sure video restarts after preroll
                 _oldpos = 0;
                 _oldstate = _states.PLAYING;
-            } else if (_api.jwGetState() === _states.IDLE) {
+            } else if (_model.getVideo().checkComplete()) {
+                 // AKA  postroll
+                 _oldstate = _states.IDLE;
+             }  else if (_api.jwGetState() === _states.IDLE) {
                 _oldstate = _states.IDLE;
             } else {
                 _oldstate = _states.PLAYING;


### PR DESCRIPTION
Switches the order for checks so that we see if we're beforePlay before we check for the complete state so that the vast-regressions-load.html test will continue to work.  The test tests for a bizarre usage for onBeforeComplete, but changing the order in which we're checking these states shouldn't matter much since normally they'd be mostly exclusive from one another. [Finishes #88195758]