### PR TITLE
Fix IE8 issue embedding jwplayer

### DIFF
--- a/src/js/embed/jwplayer.embed.flash.js
+++ b/src/js/embed/jwplayer.embed.flash.js
@@ -150,14 +150,14 @@
             storedFlashvars[_container.id] = params;
 
             if (utils.isMSIE()) {
-                var html = '<object classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000" ' +
-                    '" width="100%" height="100%"' +
-                    'id="' +
+                var html = '<object classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000"' +
+                    ' width="100%" height="100%"' +
+                    ' id="' +
                     _container.id +
                     '" name="' +
                     _container.id +
-                    '" tabindex=0"' +
-                    '">';
+                    '" tabindex="0"' +
+                    '>';
                 html += '<param name="movie" value="' + _player.src + '">';
                 html += '<param name="allowfullscreen" value="true">';
                 html += '<param name="allowscriptaccess" value="always">';
@@ -166,7 +166,7 @@
                 html += '<param name="bgcolor" value="' + bgcolor + '">';
                 html += '</object>';
 
-                _container.outerHTML = html;
+                $(_container).replaceWith(html);
 
                 flashPlayer = document.getElementById(_container.id);
             } else {


### PR DESCRIPTION
When JWPlayer is initialised as a descendant of a p tag the call to _container.outerHTML = html; causes an error to be thrown (Unknown runtime error).

See support question for details:
http://support.jwplayer.com/customer/en/portal/questions/11392466-ie8-and-p-tags?new=11392466