### PR TITLE
Fixed instream

### DIFF
--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -249,7 +249,7 @@ define([
             return _this;
         };
         _this.createInstream = function () {
-            return new Instream(this, _controller);
+            return new Instream(_controller);
         };
         _this.setInstream = function (instream) {
             _instream = instream;

--- a/src/js/api/instream.js
+++ b/src/js/api/instream.js
@@ -6,7 +6,7 @@ define([
     'events/states'
 ], function(Events, EVENTS, _, utils, states) {
 
-    var Instream = function(_api, _player) {
+    var Instream = function(_controller) {
 
         var events = utils.extend({}, Events);
 
@@ -17,41 +17,41 @@ define([
         this.type = 'instream';
 
         _this.init = function() {
-            _api.callInternal('jwInitInstream');
+            _controller.jwInitInstream();
             return _this;
         };
         _this.loadItem = function(item, options) {
             _item = item;
             _options = options || {};
             if (utils.typeOf(item) === 'array') {
-                _api.callInternal('jwLoadArrayInstream', _item, _options);
+                _controller.jwLoadArrayInstream(_item, _options);
             } else {
-                _api.callInternal('jwLoadItemInstream', _item, _options);
+                _controller.jwLoadItemInstream(_item, _options);
             }
         };
         _this.play = function(state) {
-            _player.jwInstreamPlay(state);
+            _controller.jwInstreamPlay(state);
         };
         _this.pause = function(state) {
-            _player.jwInstreamPause(state);
+            _controller.jwInstreamPause(state);
         };
         _this.hide = function() {
-            _api.callInternal('jwInstreamHide');
+            _controller.jwInstreamHide();
         };
         _this.destroy = function() {
             _this.removeEvents();
-            _api.callInternal('jwInstreamDestroy');
+            _controller.jwInstreamDestroy();
         };
         _this.setText = function(text) {
-            _player.jwInstreamSetText(text ? text : '');
+            _controller.jwInstreamSetText(text ? text : '');
         };
         _this.getState = function() {
-            return _player.jwInstreamState();
+            return _controller.jwInstreamState();
         };
         _this.setClick = function(url) {
             //only present in flashMode
-            if (_player.jwInstreamClick) {
-                _player.jwInstreamClick(url);
+            if (_controller.jwInstreamClick) {
+                _controller.jwInstreamClick(url);
             }
         };
 
@@ -78,7 +78,7 @@ define([
 
         _.each(legacyMaps, function(event, api) {
             _this[api] = function(callback) {
-                _player.jwInstreamAddEventListener(event, callback);
+                _controller.jwInstreamAddEventListener(event, callback);
                 events.on(event, callback);
                 return _this;
             };

--- a/src/js/api/internal-api.js
+++ b/src/js/api/internal-api.js
@@ -1,5 +1,5 @@
 define([
-    'api/instream'
+    'controller/instream'
 ], function(Instream) {
 
     return function (_controller, _model, _view) {
@@ -10,6 +10,17 @@ define([
             };
         };
 
+        // add to controller
+        _controller.jwResize = _view.resize;
+        _controller.jwSeekDrag = _model.seekDrag;
+        _controller.jwGetSafeRegion = _view.getSafeRegion;
+        _controller.jwForceState = _view.forceState;
+        _controller.jwReleaseState = _view.releaseState;
+        _controller.jwSetCues = _view.addCues;
+        _controller.jwDockAddButton = _view.addButton;
+        _controller.jwDockRemoveButton = _view.removeButton;
+
+        // // TODO: remove redundancies
         _controller.jwPlay = _controller.play;
         _controller.jwPause = _controller.pause;
         _controller.jwStop = _controller.stop;
@@ -21,8 +32,6 @@ define([
         _controller.jwPlaylistPrev = _controller.prev;
         _controller.jwPlaylistItem = _controller.item;
         _controller.jwSetFullscreen = _controller.setFullscreen;
-        _controller.jwResize = _view.resize;
-        _controller.jwSeekDrag = _model.seekDrag;
         _controller.jwGetQualityLevels = _controller.getQualityLevels;
         _controller.jwGetCurrentQuality = _controller.getCurrentQuality;
         _controller.jwSetCurrentQuality = _controller.setCurrentQuality;
@@ -32,11 +41,12 @@ define([
         _controller.jwGetCaptionsList = _controller.getCaptionsList;
         _controller.jwGetCurrentCaptions = _controller.getCurrentCaptions;
         _controller.jwSetCurrentCaptions = _controller.setCurrentCaptions;
+        _controller.jwDetachMedia = _controller.detachMedia;
+        _controller.jwAttachMedia = _controller.attachMedia;
+        _controller.jwAddEventListener = _controller.on;
+        _controller.jwRemoveEventListener = _controller.off;
 
-        _controller.jwGetSafeRegion = _view.getSafeRegion;
-        _controller.jwForceState = _view.forceState;
-        _controller.jwReleaseState = _view.releaseState;
-
+        // getters
         _controller.jwGetPlaylistIndex = _statevarFactory('item');
         _controller.jwGetPosition = _statevarFactory('position');
         _controller.jwGetDuration = _statevarFactory('duration');
@@ -51,9 +61,7 @@ define([
         _controller.jwGetControls = _statevarFactory('controls');
         _controller.jwGetPlaylist = _statevarFactory('playlist');
 
-        _controller.jwDetachMedia = _controller.detachMedia;
-        _controller.jwAttachMedia = _controller.attachMedia;
-
+        // TODO: move to commercial controller
         _controller.jwPlayAd = function (ad) {
             // THIS SHOULD NOT BE USED!
             var plugins = jwplayer(_controller.id).plugins;
@@ -82,7 +90,7 @@ define([
 
         _controller.jwInitInstream = function () {
             _controller.jwInstreamDestroy();
-            _controller._instreamPlayer = new Instream(_controller, _model, _view, _controller);
+            _controller._instreamPlayer = new Instream(_controller, _model, _view);
             _controller._instreamPlayer.init();
         };
 
@@ -178,13 +186,5 @@ define([
         _controller.jwIsBeforeComplete = function () {
             return _model.getVideo().checkComplete();
         };
-
-        _controller.jwSetCues = _view.addCues;
-
-        _controller.jwAddEventListener = _controller.on;
-        _controller.jwRemoveEventListener = _controller.off;
-
-        _controller.jwDockAddButton = _view.addButton;
-        _controller.jwDockRemoveButton = _view.removeButton;
     };
 });

--- a/src/js/playlist/playlist.js
+++ b/src/js/playlist/playlist.js
@@ -4,7 +4,7 @@ define([
     'playlist/item',
     'playlist/source',
     'utils/underscore'
-], function(chooseProvider, utils, PlaylistItem, Source,  _) {
+], function(chooseProvider, utils, PlaylistItem, Source, _) {
 
     var Playlist = function (playlist) {
         // Can be either an array of items or a single item.

--- a/src/js/view/adskipbutton.js
+++ b/src/js/view/adskipbutton.js
@@ -7,8 +7,7 @@ define([
     'utils/eventdispatcher'
 ], function(utils, cssUtils, Touch, events, eventdispatcher) {
 
-    var _css = cssUtils.css,
-        VIEW_INSTREAM_SKIP_CLASS = 'jwskip',
+    var VIEW_INSTREAM_SKIP_CLASS = 'jwskip',
         VIEW_INSTREAM_IMAGE = 'jwskipimage',
         VIEW_INSTREAM_OVER = 'jwskipover',
         VIEW_INSTREAM_OUT = 'jwskipout',
@@ -44,7 +43,7 @@ define([
             _this.height = _instreamSkip.height = _SKIP_HEIGHT;
             _instreamSkipContainer.appendChild(_skip_image_over);
             _instreamSkipContainer.appendChild(_skip_image);
-            _css.style(_instreamSkipContainer, {
+            cssUtils.style(_instreamSkipContainer, {
                 'visibility': 'hidden',
                 'bottom': _bottom
             });
@@ -86,7 +85,7 @@ define([
         _this.updateSkipTime = function(time, duration) {
             _updateOffset(time, duration);
             if (_offsetTime >= 0) {
-                _css.style(_instreamSkipContainer, {
+                cssUtils.style(_instreamSkipContainer, {
                     'visibility': _controls ? 'visible' : 'hidden'
                 });
                 if (_offsetTime - time > 0) {
@@ -209,7 +208,7 @@ define([
         _this.show = function() {
             _controls = true;
             if (_offsetTime > 0) {
-                _css.style(_instreamSkipContainer, {
+                cssUtils.style(_instreamSkipContainer, {
                     'visibility': 'visible'
                 });
             }
@@ -217,7 +216,7 @@ define([
 
         _this.hide = function() {
             _controls = false;
-            _css.style(_instreamSkipContainer, {
+            cssUtils.style(_instreamSkipContainer, {
                 'visibility': 'hidden'
             });
         };
@@ -237,7 +236,7 @@ define([
         _init();
     };
 
-    _css('.' + VIEW_INSTREAM_SKIP_CLASS, {
+    cssUtils.css('.' + VIEW_INSTREAM_SKIP_CLASS, {
         'position': 'absolute',
         'float': 'right',
         'display': 'inline-block',
@@ -246,7 +245,7 @@ define([
         'right': 10
     });
 
-    _css('.' + VIEW_INSTREAM_IMAGE, {
+    cssUtils.css('.' + VIEW_INSTREAM_IMAGE, {
         'position': 'relative',
         'display': 'none'
     });

--- a/src/js/view/display.js
+++ b/src/js/view/display.js
@@ -26,8 +26,8 @@ define([
         fontweight: ''
     };
 
-    var Display = function(_api, config) {
-        var _skin = _api.skin,
+    var Display = function(_controller, config) {
+        var _skin = _controller.skin,
             _display, _preview,
             _displayTouch,
             _item,
@@ -52,19 +52,19 @@ define([
 
         function _init() {
             _display = document.createElement('div');
-            _display.id = _api.id + '_display';
+            _display.id = _controller.id + '_display';
             _display.className = 'jwdisplay';
 
             _preview = document.createElement('div');
-            _preview.className = 'jwpreview jw' + _api.jwGetStretching();
+            _preview.className = 'jwpreview jw' + _controller.jwGetStretching();
             _display.appendChild(_preview);
 
-            _api.jwAddEventListener(events.JWPLAYER_PLAYER_STATE, _stateHandler);
-            _api.jwAddEventListener(events.JWPLAYER_PLAYLIST_ITEM, _itemHandler);
-            _api.jwAddEventListener(events.JWPLAYER_PLAYLIST_COMPLETE, _playlistCompleteHandler);
-            _api.jwAddEventListener(events.JWPLAYER_MEDIA_ERROR, _errorHandler);
-            _api.jwAddEventListener(events.JWPLAYER_ERROR, _errorHandler);
-            _api.jwAddEventListener(events.JWPLAYER_PROVIDER_CLICK, _clickHandler);
+            _controller.jwAddEventListener(events.JWPLAYER_PLAYER_STATE, _stateHandler);
+            _controller.jwAddEventListener(events.JWPLAYER_PLAYLIST_ITEM, _itemHandler);
+            _controller.jwAddEventListener(events.JWPLAYER_PLAYLIST_COMPLETE, _playlistCompleteHandler);
+            _controller.jwAddEventListener(events.JWPLAYER_MEDIA_ERROR, _errorHandler);
+            _controller.jwAddEventListener(events.JWPLAYER_ERROR, _errorHandler);
+            _controller.jwAddEventListener(events.JWPLAYER_PROVIDER_CLICK, _clickHandler);
 
             if (!_isMobile) {
                 _display.addEventListener('click', _clickHandler, false);
@@ -82,16 +82,17 @@ define([
 
         function _clickHandler(evt) {
 
-            if (_alternateClickHandler && (_api.jwGetControls() || _api.jwGetState() === states.PLAYING)) {
+            if (_alternateClickHandler &&
+                    (_controller.jwGetControls() || _controller.jwGetState() === states.PLAYING)) {
                 _alternateClickHandler(evt);
                 return;
             }
 
-            if (!_isMobile || !_api.jwGetControls()) {
+            if (!_isMobile || !_controller.jwGetControls()) {
                 _eventDispatcher.sendEvent(events.JWPLAYER_DISPLAY_CLICK);
             }
 
-            if (!_api.jwGetControls()) {
+            if (!_controller.jwGetControls()) {
                 return;
             }
 
@@ -99,7 +100,7 @@ define([
             // Handle double-clicks for fullscreen toggle
             var currentClick = _getCurrentTime();
             if (_lastClick && currentClick - _lastClick < 500) {
-                _api.jwSetFullscreen();
+                _controller.jwSetFullscreen();
                 _lastClick = undefined;
             } else {
                 _lastClick = _getCurrentTime();
@@ -124,7 +125,7 @@ define([
                 if (_inside(playSquare, evt.x, evt.y)) {
                     // Perform play/pause toggle below
                 } else if (_inside(fsSquare, evt.x, evt.y)) {
-                    _api.jwSetFullscreen();
+                    _controller.jwSetFullscreen();
                     return;
                 } else {
                     _eventDispatcher.sendEvent(events.JWPLAYER_DISPLAY_CLICK);
@@ -134,13 +135,13 @@ define([
                 }
             }
 
-            switch (_api.jwGetState()) {
+            switch (_controller.jwGetState()) {
                 case states.PLAYING:
                 case states.BUFFERING:
-                    _api.jwPause();
+                    _controller.jwPause();
                     break;
                 default:
-                    _api.jwPlay();
+                    _controller.jwPlay();
                     break;
             }
 
@@ -166,7 +167,7 @@ define([
                 overStyle = {
                     color: _config.overcolor
                 };
-            _button = new DisplayIcon(_display.id + '_button', _api, outStyle, overStyle);
+            _button = new DisplayIcon(_display.id + '_button', _controller, outStyle, overStyle);
             _display.appendChild(_button.element());
         }
 
@@ -189,7 +190,7 @@ define([
 
         function _itemHandler() {
             _clearError();
-            _item = _api.jwGetPlaylist()[_api.jwGetPlaylistIndex()];
+            _item = _controller.jwGetPlaylist()[_controller.jwGetPlaylistIndex()];
             var newImage = _item ? _item.image : '';
             _previousState = undefined;
             _loadImage(newImage);
@@ -205,20 +206,20 @@ define([
             } else if (_image && !_hiding) {
                 _setVisibility(D_PREVIEW_CLASS, true);
             }
-            _updateDisplay(_api.jwGetState());
+            _updateDisplay(_controller.jwGetState());
         }
 
         function _playlistCompleteHandler() {
             _completedState = true;
             _setIcon('replay');
-            var item = _api.jwGetPlaylist()[0];
+            var item = _controller.jwGetPlaylist()[0];
             _loadImage(item.image);
         }
 
         var _stateTimeout;
 
         function _getState() {
-            return _forced ? _forced : (_api ? _api.jwGetState() : states.IDLE);
+            return _forced ? _forced : (_controller ? _controller.jwGetState() : states.IDLE);
         }
 
         function _stateHandler(evt) {
@@ -242,7 +243,7 @@ define([
                                 _setVisibility(D_PREVIEW_CLASS, true);
                             }
                             var disp = true;
-                            if (_api._model && _api._model.config.displaytitle === false) {
+                            if (_controller._model && _controller._model.config.displaytitle === false) {
                                 disp = false;
                             }
                             _setIcon('play', (_item && disp) ? _item.title : '');
@@ -315,7 +316,7 @@ define([
         function _imageLoaded() {
             _imageWidth = this.width;
             _imageHeight = this.height;
-            _updateDisplay(_api.jwGetState());
+            _updateDisplay(_controller.jwGetState());
             _redraw();
             if (_image) {
                 _css(_internalSelector(D_PREVIEW_CLASS), {
@@ -339,7 +340,7 @@ define([
 
         function _redraw() {
             if (_display.clientWidth * _display.clientHeight > 0) {
-                stretchUtils.stretch(_api.jwGetStretching(),
+                stretchUtils.stretch(_controller.jwGetStretching(),
                     _preview, _display.clientWidth, _display.clientHeight, _imageWidth, _imageHeight);
             }
         }

--- a/src/js/view/displayicon.js
+++ b/src/js/view/displayicon.js
@@ -1,10 +1,8 @@
 define([
     'utils/helpers',
     'utils/css',
-    'controller/instream',
     'events/events'
-], function(utils, cssUtils, Instream, events) {
-    /*jshint maxparams:5*/
+], function(utils, cssUtils, events) {
     /*jshint -W069 */
 
     var _css = cssUtils.css,
@@ -16,9 +14,9 @@ define([
         JW_CSS_100PCT = '100%',
         JW_CSS_CENTER = 'center';
 
-    var DisplayIcon = function(_id, _api, textStyle, textStyleOver) {
-        var _skin = _api.skin,
-            _playerId = _api.id,
+    var DisplayIcon = function(_id, _controller, textStyle, textStyleOver) {
+        var _skin = _controller.skin,
+            _playerId = _controller.id.replace(/_instream$/, ''),
             _container,
             _bgSkin,
             _capLeftSkin,
@@ -32,10 +30,6 @@ define([
             _setWidthTimeout = -1,
             _repeatCount = 0;
 
-        if (_api instanceof Instream) {
-            _playerId = _playerId.replace('_instream', '');
-        }
-
         function _init() {
             _container = _createElement('jwdisplayIcon');
             _container.id = _id;
@@ -44,7 +38,7 @@ define([
             _text = _createElement('jwtext', _container, textStyle, textStyleOver);
             _icon = _createElement('jwicon', _container);
 
-            _api.jwAddEventListener(events.JWPLAYER_RESIZE, _setWidth);
+            _controller.jwAddEventListener(events.JWPLAYER_RESIZE, _setWidth);
 
             _hide();
             _redraw();

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -1168,12 +1168,16 @@ define([
             _instreamControlbar = instreamControlbar;
             _instreamDisplay = instreamDisplay;
             _instreamModel = instreamModel;
-            _stateHandler({
-                newstate: states.PLAYING
-            });
             _instreamMode = true;
             _instreamLayer.addEventListener('mousemove', _startFade);
             _instreamLayer.addEventListener('mouseout', _mouseoutHandler);
+        };
+
+        this.showInstream = function() {
+            // adds video tag to video layer
+            _instreamModel.getVideo().setContainer(_videoLayer);
+            _instreamModel.getVideo().setVisibility(true);
+            _instreamDisplay.show();
         };
 
         this.destroyInstream = function() {


### PR DESCRIPTION
- Renamed controller and provider instances for clarity
- Replaced callInternal calls by using controller methods
- Instream ad player model will select a provider on setItem instead or only using one default html5 provider
- Fixed some player/instream view show/hide dependencies
- Removed model state tampering from Instream controller

Note: Instream API and Instream controller have the same name and this is confusing. While we hope to remove and refactor this code completely, maintaining ad functionality is important for testing core player changes and legacy plugin support.