### PR TITLE
Additional checks for instream to fix chromecast replay issue for postrolls [Finishes #89206786]

### DIFF
--- a/src/js/html5/jwplayer.html5.instream.js
+++ b/src/js/html5/jwplayer.html5.instream.js
@@ -74,7 +74,7 @@
             // Keep track of the original player state
             _oldpos = _video.currentTime;
 
-            if ( (_controller.checkBeforePlay() || _oldpos === 0) && !_model.getVideo().checkComplete()) {
+            if ( _controller.checkBeforePlay() || (_oldpos === 0 && !_model.getVideo().checkComplete()) ) {
                 // make sure video restarts after preroll
                 _oldpos = 0;
                 _oldstate = _states.PLAYING;

--- a/src/js/html5/jwplayer.html5.instream.js
+++ b/src/js/html5/jwplayer.html5.instream.js
@@ -74,7 +74,7 @@
             // Keep track of the original player state
             _oldpos = _video.currentTime;
 
-            if (_controller.checkBeforePlay() || _oldpos === 0) {
+            if ( (_controller.checkBeforePlay() || _oldpos === 0) && !_model.getVideo().checkComplete()) {
                 // make sure video restarts after preroll
                 _oldpos = 0;
                 _oldstate = _states.PLAYING;


### PR DESCRIPTION
Change to add additional checks to more accurately represent the current state of the instream player.  This makes it so that we're more certain that we're in the before play state when we set the instream to playing after the video plays.  This fixes an issue with the chrome cast where a video with a postroll l will replay at the end of the video [Finishes #89206786]