### PR TITLE
fixes and cleanup from decoupling and instream support

### DIFF
--- a/src/js/controller/instream.js
+++ b/src/js/controller/instream.js
@@ -95,7 +95,7 @@ define([
             }
 
             // Instream display
-            _instreamDisplay = new Display(_this);
+            _instreamDisplay = new Display(_view._skin, jwplayer(_controller.id), _adModel);
             _instreamDisplay.forceState(states.BUFFERING);
             // Create the container in which the controls will be placed
             _instreamContainer = document.createElement('div');
@@ -108,10 +108,7 @@ define([
             _instreamContainer.appendChild(_instreamDisplay.element());
 
             // Instream controlbar
-            var cbarConfig = {
-                fullscreen : _model.fullscreen
-            };
-            _cbar = new Controlbar(_this, cbarConfig);
+            _cbar = new Controlbar(_view._skin, jwplayer(_controller.id), _adModel);
             _cbar.instreamMode(true);
             _instreamContainer.appendChild(_cbar.element());
 
@@ -557,7 +554,7 @@ define([
             return _controller.jwGetControls();
         };
 
-        _this.skin = _controller.skin;
+        _this.skin = _view._skin;
         _this.id = _controller.id + '_instream';
 
         return _this;

--- a/src/js/view/captions.js
+++ b/src/js/view/captions.js
@@ -25,11 +25,18 @@ define([
         JW_CSS_WHITE = '#FFFFFF';
 
     /** Displays closed captions or subtitles on top of the video. **/
-    var Captions = function(api, model) {
-        var _api = api,
-            _model = model,
-            options = _model.captions,
-            _display,
+    var Captions = function(_api, _model) {
+        _api.onReady(_setup);
+        _api.onPlaylistItem(_itemHandler);
+        _api.onFullscreen(_fullscreenHandler);
+        _api.onResize(_resizeHandler);
+        _api.onError(_errorHandler);
+
+        _model.addEventListener(events.JWPLAYER_PLAYER_STATE, _stateHandler);
+        _model.addEventListener(events.JWPLAYER_MEDIA_ERROR, _errorHandler);
+        _model.addEventListener(events.JWPLAYER_MEDIA_TIME, _timeHandler);
+
+        var _display,
             _defaults = {
                 back: true,
                 color: JW_CSS_WHITE,
@@ -73,22 +80,9 @@ define([
 
         _.extend(this, _eventDispatcher);
 
-        function _init() {
-
-            _display = document.createElement('div');
-            _display.id = _api.getContainer().id + '_caption';
-            _display.className = 'jwcaptions';
-
-            _api.onReady(_setup);
-            _api.onPlaylistItem(_itemHandler);
-            _api.onFullscreen(_fullscreenHandler);
-            _api.onResize(_resizeHandler);
-            _api.onError(_errorHandler);
-
-            _model.addEventListener(events.JWPLAYER_PLAYER_STATE, _stateHandler);
-            _model.addEventListener(events.JWPLAYER_MEDIA_ERROR, _errorHandler);
-            _model.addEventListener(events.JWPLAYER_MEDIA_TIME, _timeHandler);
-        }
+        _display = document.createElement('div');
+        _display.id = _model.id + '_caption';
+        _display.className = 'jwcaptions';
 
         function _resizeHandler() {
             _redraw(false);
@@ -146,8 +140,8 @@ define([
             var item = _model.playlist[_model.item],
                 tracks = item.tracks,
                 captions = [],
-                i = 0,
-                label = '',
+                i,
+                label,
                 defaultTrack = 0,
                 file = '',
                 cookies;
@@ -306,12 +300,13 @@ define([
 
         /** Setup captions when player is ready. **/
         function _setup() {
+            var captions = _model.captions;
             utils.foreach(_defaults, function(rule, val) {
-                if (options) {
-                    if (options[rule] !== undefined) {
-                        val = options[rule];
-                    } else if (options[rule.toLowerCase()] !== undefined) {
-                        val = options[rule.toLowerCase()];
+                if (captions) {
+                    if (captions[rule] !== undefined) {
+                        val = captions[rule];
+                    } else if (captions[rule.toLowerCase()] !== undefined) {
+                        val = captions[rule.toLowerCase()];
                     }
                 }
                 _options[rule] = val;
@@ -401,8 +396,6 @@ define([
                 _sendEvent(events.JWPLAYER_CAPTIONS_CHANGED, tracks, _selectedTrack);
             }
         };
-
-        _init();
     };
 
     cssUtils.css(D_CLASS, {

--- a/src/js/view/display.js
+++ b/src/js/view/display.js
@@ -27,7 +27,8 @@ define([
         fontweight: ''
     };
 
-    var Display = function(_skin, _api, _model) { // TODO: Make this only _api and _model as config and _skin are stripped out
+    // TODO: Make this only _api and _model as config and _skin are stripped out
+    var Display = function(_skin, _api, _model) {
         var _display, _preview,
             _displayTouch,
             _item,
@@ -50,36 +51,44 @@ define([
 
         _.extend(this, _eventDispatcher);
 
-        function _init() {
-            _display = document.createElement('div');
-            _display.id = _api.getContainer().id;
-            _display.className = 'jwdisplay';
+        _display = document.createElement('div');
+        _display.id = _model.id + '_display';
+        _display.className = 'jwdisplay';
 
-            _preview = document.createElement('div');
-            _preview.className = 'jwpreview jw' + _model.stretching;
-            _display.appendChild(_preview);
+        _preview = document.createElement('div');
+        _preview.className = 'jwpreview jw' + _model.stretching;
+        _display.appendChild(_preview);
 
-			_api.onPlaylistItem(_itemHandler);
-			_api.onPlaylistComplete(_playlistCompleteHandler);
-            _api.onError(_errorHandler);
+        _api.onPlaylistItem(_itemHandler);
+        _api.onPlaylistComplete(_playlistCompleteHandler);
+        _api.onError(_errorHandler);
 
-            _model.addEventListener(events.JWPLAYER_PLAYER_STATE, _stateHandler);
-			_model.addEventListener(events.JWPLAYER_MEDIA_ERROR, _errorHandler); // TODO: is there a more up-to-date event to listen to?  Do we listen to the provider via the model?
-            _model.addEventListener(events.JWPLAYER_PROVIDER_CLICK, _clickHandler);   // TODO: Who sends this event?  Do we listen to the provider via the model?
+        _model.addEventListener(events.JWPLAYER_PLAYER_STATE, _stateHandler);
+        // ???: is there a more up-to-date event to listen to?  Do we listen to the provider via the model?
+        _model.addEventListener(events.JWPLAYER_MEDIA_ERROR, _errorHandler);
+        // Kyle: Who sends this event?  Do we listen to the provider via the model?
+        // Rob: Yes the provider.
+        _model.addEventListener(events.JWPLAYER_PROVIDER_CLICK, _clickHandler);
 
-            if (!_isMobile) {
-                _display.addEventListener('click', _clickHandler, false);
-            } else {
-                _displayTouch = new Touch(_display);
-                _displayTouch.addEventListener(events.touchEvents.TAP, _clickHandler);
-            }
-
-            _createIcons();
-
-            _stateHandler({
-                newstate: states.IDLE
-            });
+        if (!_isMobile) {
+            _display.addEventListener('click', _clickHandler, false);
+        } else {
+            _displayTouch = new Touch(_display);
+            _displayTouch.addEventListener(events.touchEvents.TAP, _clickHandler);
         }
+
+        _button = new DisplayIcon(_model.id, _display.id + '_button', _skin, _api, {
+            font: _config.fontweight + ' ' + _config.fontsize + 'px/' +
+                (parseInt(_config.fontsize, 10) + 3) + 'px Arial, Helvetica, sans-serif',
+            color: _config.fontcolor
+        }, {
+            color: _config.overcolor
+        });
+        _display.appendChild(_button.element());
+
+        _stateHandler({
+            newstate: states.IDLE
+        });
 
         function _clickHandler(evt) {
 
@@ -158,20 +167,6 @@ define([
         }
 
         this.clickHandler = _clickHandler;
-
-        function _createIcons() {
-            var outStyle = {
-                    font: _config.fontweight + ' ' + _config.fontsize + 'px/' +
-                        (parseInt(_config.fontsize, 10) + 3) + 'px Arial, Helvetica, sans-serif',
-                    color: _config.fontcolor
-                },
-                overStyle = {
-                    color: _config.overcolor
-                };
-            _button = new DisplayIcon(_display.id + '_button', _skin, _api, outStyle, overStyle);
-            _display.appendChild(_button.element());
-        }
-
 
         function _setIcon(name, text) {
             if (!_config.showicons) {
@@ -384,8 +379,6 @@ define([
         this.revertAlternateClickHandler = function() {
             _alternateClickHandler = null;
         };
-
-        _init();
     };
 
     _css(D_CLASS, {

--- a/src/js/view/displayicon.js
+++ b/src/js/view/displayicon.js
@@ -1,9 +1,8 @@
 define([
     'utils/helpers',
     'utils/css',
-    'events/events',
     'underscore'
-], function(utils, cssUtils, events, _) {
+], function(utils, cssUtils, _) {
     /*jshint -W069 */
 
     var _css = cssUtils.css,
@@ -15,34 +14,25 @@ define([
         JW_CSS_100PCT = '100%',
         JW_CSS_CENTER = 'center';
 
-    var DisplayIcon = function(_id, _skin, _api, textStyle, textStyleOver) {
-        var _playerId = _api.getContainer().id,
-            _container,
+    var DisplayIcon = function(_playerId, _id, _skin, _api, textStyle, textStyleOver) {
+        _api.onResize(_setWidth);
+
+        var _container = _createElement('jwdisplayIcon'),
             _bgSkin,
             _capLeftSkin,
             _capRightSkin,
             _hasCaps,
-            _text,
-            _icon,
+            _text = _createElement('jwtext', _container, textStyle, textStyleOver),
+            _icon = _createElement('jwicon', _container),
             _iconCache = {},
             _iconElement,
             _iconWidth = 0,
             _setWidthTimeout = -1,
             _repeatCount = 0;
 
-        function _init() {
-            _container = _createElement('jwdisplayIcon');
-            _container.id = _id;
+        _container.id = _id;
 
-            _createBackground();
-            _text = _createElement('jwtext', _container, textStyle, textStyleOver);
-            _icon = _createElement('jwicon', _container);
-
-            _api.onResize(_setWidth);
-
-            _hide();
-            _redraw();
-        }
+        _createBackground();
 
         function _internalSelector() {
             return '#' + _id;
@@ -248,7 +238,8 @@ define([
             _container.style.cursor = 'pointer';
         };
 
-        _init();
+        _hide();
+        _redraw();
     };
 
     _css(DI_CLASS, {

--- a/src/js/view/dock.js
+++ b/src/js/view/dock.js
@@ -15,17 +15,13 @@ define([
         D_CLASS = '.jwdock',
         DB_CLASS = '.jwdockbuttons';
 
-    var Dock = function(skin, api, model) {
-        var _skin = skin,
-            _api = api,
-            _defaults = {
+    var Dock = function(_id, config, _api, _skin) {
+        var _config = _.extend({
                 iconalpha: 0.75,
                 iconalphaactive: 0.5,
                 iconalphaover: 1,
                 margin: 8
-            },
-            _config = _.extend({}, _defaults, model.componentConfig('dock')),
-            _id = _api.getContainer().id + '_dock',
+            }, config),
             _buttonCount = 0,
             _buttons = {},
             _tooltips = {},
@@ -35,30 +31,27 @@ define([
             _fadeTimeout,
             _this = this;
 
-        function _init() {
-            _this.visible = false;
+        _this.visible = false;
 
-            _container = _createElement('div', 'jwdock');
-            _buttonContainer = _createElement('div', 'jwdockbuttons');
-            _container.appendChild(_buttonContainer);
-            _container.id = _id;
+        _container = _createElement('div', 'jwdock');
+        _buttonContainer = _createElement('div', 'jwdockbuttons');
+        _container.appendChild(_buttonContainer);
+        _container.id = _id;
 
-            _setupElements();
+        _setupElements();
 
-            setTimeout(function() {
-                _dockBounds = _bounds(_container);
-            });
-
-        }
+        setTimeout(function() {
+            _dockBounds = _bounds(_container);
+        });
 
         function _setupElements() {
-            var button = _getSkinElement('button'),
-                buttonOver = _getSkinElement('buttonOver'),
-                buttonActive = _getSkinElement('buttonActive');
-
+            var button = _getSkinElement('button');
             if (!button) {
                 return;
             }
+
+            var buttonOver = _getSkinElement('buttonOver'),
+                buttonActive = _getSkinElement('buttonActive');
 
             _css(_internalSelector(), {
                 height: button.height,
@@ -313,8 +306,6 @@ define([
                 display: _buttonCount ? 'block' : 'none'
             });
         }
-
-        _init();
     };
 
     _css(D_CLASS, {

--- a/src/js/view/logo.js
+++ b/src/js/view/logo.js
@@ -3,9 +3,8 @@ define([
     'utils/helpers',
     'utils/css',
     'events/events',
-    'events/states',
     'underscore'
-], function(Touch, utils, cssUtils, events, states, _) {
+], function(Touch, utils, cssUtils, events, _) {
 
     var _css = cssUtils.css,
 
@@ -18,9 +17,8 @@ define([
         LOGO_CLASS = '.jwlogo';
 
 
-    var Logo = function(api, _model) {
-        var _api = api,
-            _id = _api.getContainer().id + '_logo',
+    var Logo = function(_api, _model) {
+        var _id = _model.id + '_logo',
             _settings,
             _logo,
             _logoConfig = _.extend({}, _model.componentConfig('logo')),
@@ -34,7 +32,7 @@ define([
 
         function _setupConfig() {
             var linkFlag = 'o';
-            if ( _model.edition && _model.edition() ) { // TODO: Figure out how to determine edition from the model.
+            if ( _model.edition && _model.edition() ) {
                 linkFlag = _getLinkFlag(_model.edition());
             }
 

--- a/src/js/view/menu.js
+++ b/src/js/view/menu.js
@@ -12,9 +12,8 @@ define([
         OPTION_CLASS = 'jwoption';
 
     /** HTML5 Overlay class **/
-    var Menu = function(name, id, skin, changeHandler) {
-        var _id = id,
-            _changeHandler = changeHandler,
+    var Menu = function(name, _id, skin, changeHandler) {
+        var _changeHandler = changeHandler,
             _overlay = new Overlay(_id + '_overlay', skin),
             _settings = _.extend({
                 fontcase: undefined,
@@ -24,46 +23,43 @@ define([
                 activecolor: '#ffffff',
                 overcolor: '#ffffff'
             }, skin.getComponentSettings('tooltip')),
-            _container,
+            _container = _createElement(MENU_CLASS),
             _options = [];
 
-        function _init() {
-            _container = _createElement(MENU_CLASS);
-            _container.id = _id;
+        _container.id = _id;
 
-            var top = _getSkinElement('menuTop' + name),
-                menuOption = _getSkinElement('menuOption'),
-                menuOptionOver = _getSkinElement('menuOptionOver'),
-                menuOptionActive = _getSkinElement('menuOptionActive');
+        var top = _getSkinElement('menuTop' + name),
+            menuOption = _getSkinElement('menuOption'),
+            menuOptionOver = _getSkinElement('menuOptionOver'),
+            menuOptionActive = _getSkinElement('menuOptionActive');
 
-            if (top && top.image) {
-                var topImage = new Image();
-                topImage.src = top.src;
-                topImage.width = top.width;
-                topImage.height = top.height;
-                _container.appendChild(topImage);
-            }
-
-            if (menuOption) {
-                var selector = '#' + id + ' .' + OPTION_CLASS;
-
-                _css(selector, _.extend(_formatBackground(menuOption), {
-                    height: menuOption.height,
-                    color: _settings.fontcolor,
-                    'padding-left': menuOption.width,
-                    font: _settings.fontweight + ' ' + _settings.fontsize + 'px Arial,Helvetica,sans-serif',
-                    'line-height': menuOption.height,
-                    'text-transform': (_settings.fontcase === 'upper') ? 'uppercase' : undefined
-                }));
-                _css(selector + ':hover', _.extend(_formatBackground(menuOptionOver), {
-                    color: _settings.overcolor
-                }));
-                _css(selector + '.active', _.extend(_formatBackground(menuOptionActive), {
-                    color: _settings.activecolor
-                }));
-            }
-            _overlay.setContents(_container);
+        if (top && top.image) {
+            var topImage = new Image();
+            topImage.src = top.src;
+            topImage.width = top.width;
+            topImage.height = top.height;
+            _container.appendChild(topImage);
         }
+
+        if (menuOption) {
+            var selector = '#' + _id + ' .' + OPTION_CLASS;
+
+            _css(selector, _.extend(_formatBackground(menuOption), {
+                height: menuOption.height,
+                color: _settings.fontcolor,
+                'padding-left': menuOption.width,
+                font: _settings.fontweight + ' ' + _settings.fontsize + 'px Arial,Helvetica,sans-serif',
+                'line-height': menuOption.height,
+                'text-transform': (_settings.fontcase === 'upper') ? 'uppercase' : undefined
+            }));
+            _css(selector + ':hover', _.extend(_formatBackground(menuOptionOver), {
+                color: _settings.overcolor
+            }));
+            _css(selector + '.active', _.extend(_formatBackground(menuOptionActive), {
+                color: _settings.activecolor
+            }));
+        }
+        _overlay.setContents(_container);
 
         function _formatBackground(elem) {
             if (!(elem && elem.src)) {
@@ -144,8 +140,6 @@ define([
         this.offsetX = _overlay.offsetX;
         this.positionX = _overlay.positionX;
         this.constrainX = _overlay.constrainX;
-
-        _init();
     };
 
     function _class(className) {

--- a/src/js/view/overlay.js
+++ b/src/js/view/overlay.js
@@ -26,72 +26,66 @@ define([
         };
 
     /** HTML5 Overlay class **/
-    var Overlay = function(id, skin, inverted) {
+    var Overlay = function(_id, _skin, _inverted) {
         var _this = this,
-            _id = id,
-            _skin = skin,
-            _inverted = inverted,
-            _container,
+            _container = _createElement(OVERLAY_CLASS.replace('.', '')),
             _contents,
             _arrow,
             _arrowElement,
             _settings = _.extend({}, _defaults, _skin.getComponentSettings('tooltip')),
             _borderSizes = {};
 
-        function _init() {
-            _container = _createElement(OVERLAY_CLASS.replace('.', ''));
-            _container.id = _id;
+        _container.id = _id;
 
-            var arrow = _createSkinElement('arrow', 'jwarrow');
-            _arrowElement = arrow[0];
-            _arrow = arrow[1];
+        var arrow = _createSkinElement('arrow', 'jwarrow');
+        _arrowElement = arrow[0];
+        _arrow = arrow[1];
 
-            cssUtils.style(_arrowElement, {
-                position: 'absolute',
-                //bottom: _inverted ? undefined : -1 * _arrow.height,
-                bottom: _inverted ? undefined : 0,
-                top: _inverted ? 0 : undefined,
-                width: _arrow.width,
-                height: _arrow.height,
-                left: '50%'
-            });
+        cssUtils.style(_arrowElement, {
+            position: 'absolute',
+            //bottom: _inverted ? undefined : -1 * _arrow.height,
+            bottom: _inverted ? undefined : 0,
+            top: _inverted ? 0 : undefined,
+            width: _arrow.width,
+            height: _arrow.height,
+            left: '50%'
+        });
 
-            _createBorderElement(TOP, LEFT);
-            _createBorderElement(BOTTOM, LEFT);
-            _createBorderElement(TOP, RIGHT);
-            _createBorderElement(BOTTOM, RIGHT);
-            _createBorderElement(LEFT);
-            _createBorderElement(RIGHT);
-            _createBorderElement(TOP);
-            _createBorderElement(BOTTOM);
+        _createBorderElement(TOP, LEFT);
+        _createBorderElement(BOTTOM, LEFT);
+        _createBorderElement(TOP, RIGHT);
+        _createBorderElement(BOTTOM, RIGHT);
+        _createBorderElement(LEFT);
+        _createBorderElement(RIGHT);
+        _createBorderElement(TOP);
+        _createBorderElement(BOTTOM);
 
-            var back = _createSkinElement('background', 'jwback');
-            cssUtils.style(back[0], {
-                left: _borderSizes.left,
-                right: _borderSizes.right,
-                top: _borderSizes.top,
-                bottom: _borderSizes.bottom
-            });
+        var back = _createSkinElement('background', 'jwback');
+        cssUtils.style(back[0], {
+            left: _borderSizes.left,
+            right: _borderSizes.right,
+            top: _borderSizes.top,
+            bottom: _borderSizes.bottom
+        });
 
-            _contents = _createElement(CONTENTS_CLASS, _container);
-            _css(_internalSelector(CONTENTS_CLASS) + ' *', {
-                color: _settings.fontcolor,
-                font: _settings.fontweight + ' ' + (_settings.fontsize) + 'px Arial,Helvetica,sans-serif',
-                'text-transform': (_settings.fontcase === 'upper') ? 'uppercase' : undefined
-            });
+        _contents = _createElement(CONTENTS_CLASS, _container);
+        _css(_internalSelector(CONTENTS_CLASS) + ' *', {
+            color: _settings.fontcolor,
+            font: _settings.fontweight + ' ' + (_settings.fontsize) + 'px Arial,Helvetica,sans-serif',
+            'text-transform': (_settings.fontcase === 'upper') ? 'uppercase' : undefined
+        });
 
 
-            if (_inverted) {
-                cssUtils.transform(_internalSelector('jwarrow'), 'rotate(180deg)');
-            }
-
-            cssUtils.style(_container, {
-                padding: (_borderSizes.top + 1) + 'px ' + _borderSizes.right +
-                    'px ' + (_borderSizes.bottom + 1) + 'px ' + _borderSizes.left + 'px'
-            });
-
-            _this.showing = false;
+        if (_inverted) {
+            cssUtils.transform(_internalSelector('jwarrow'), 'rotate(180deg)');
         }
+
+        cssUtils.style(_container, {
+            padding: (_borderSizes.top + 1) + 'px ' + _borderSizes.right +
+                'px ' + (_borderSizes.bottom + 1) + 'px ' + _borderSizes.left + 'px'
+        });
+
+        _this.showing = false;
 
         function _internalSelector(name) {
             return '#' + _id + (name ? ' .' + name : '');
@@ -253,10 +247,6 @@ define([
                 visibility: 'hidden'
             });
         };
-
-        // Call constructor
-        _init();
-
     };
 
     /*************************************************************

--- a/src/js/view/rightclick.js
+++ b/src/js/view/rightclick.js
@@ -21,37 +21,38 @@ define([
         JW_CSS_NONE = 'none',
         JW_CSS_WHITE = '#FFF';
 
-    var Rightclick = function(api, model, config) {
+    var Rightclick = function(_playerElement, _model) {
 
-        var _api = api,
-            _container, // = DOCUMENT.getElementById(_api.id),
-            _config = _.extend({
+        var _config = {
                 aboutlink: LINK_DEFAULT + _version + '&m=h&e=o',
                 abouttext: ABOUT_DEFAULT + _version + '...'
-            }, config),
+            },
             _mouseOverContext = false,
-            _menu,
-            _about;
-
-        function _init() {
-            _container = document.getElementById(_api.getContainer().id);   // TODO: _api.getContainer() does not return an element that is on the page.  Likely an issue with our replacing the old container on the page after the player is removed.
-            _menu = _createElement(RC_CLASS);
-            _menu.id = _container.id + '_menu';
-            _menu.style.display = JW_CSS_NONE;
-            _container.oncontextmenu = _showContext;
-            _menu.onmouseover = function() {
-                _mouseOverContext = true;
-            };
-            _menu.onmouseout = function() {
-                _mouseOverContext = false;
-            };
-            DOCUMENT.addEventListener('mousedown', _hideContext, false);
+            _menu = _createElement(RC_CLASS),
             _about = _createElement(RC_ITEM_CLASS);
-            _about.innerHTML = _config.abouttext;
-            _about.onclick = _clickHandler;
-            _menu.appendChild(_about);
-            _container.appendChild(_menu);
+
+        if (_model.edition) {
+            _.extend(_config, {
+                abouttext: _model.abouttext,
+                aboutlink: _model.aboutlink
+            });
         }
+
+        _menu.id = _playerElement.id + '_menu';
+        _menu.style.display = JW_CSS_NONE;
+        _playerElement.oncontextmenu = _showContext;
+        _menu.onmouseover = function() {
+            _mouseOverContext = true;
+        };
+        _menu.onmouseout = function() {
+            _mouseOverContext = false;
+        };
+        DOCUMENT.addEventListener('mousedown', _hideContext, false);
+
+        _about.innerHTML = _config.abouttext;
+        _about.onclick = _clickHandler;
+        _menu.appendChild(_about);
+        _playerElement.appendChild(_menu);
 
         function _createElement(className) {
             var elem = DOCUMENT.createElement('div');
@@ -77,7 +78,7 @@ define([
             target = evt.target || evt.srcElement;
 
 
-            containerBounds = utils.bounds(_container);
+            containerBounds = utils.bounds(_playerElement);
             bounds = utils.bounds(target);
 
             // hide the menu first to avoid an 'up-then-over' visual effect
@@ -104,8 +105,6 @@ define([
         this.destroy = function() {
             DOCUMENT.removeEventListener('mousedown', _hideContext, false);
         };
-
-        _init();
     };
 
     _css(RC_CLASS, {


### PR DESCRIPTION
@jw-kaurand 

- use model.id instead of api.getContainer().id or just pass in playerId or playerElement when api or model is not required
- inlined _init() functions (looks like big changes, not really)
- fixed instream (make sure all instantiation uses new contructor args)
- cleaned up comments (don't comment after end of line)
- found and removed some sidebar code
