### PR TITLE
Fix for flash toggle playback by clicking on the video [#89735192]

### DIFF
--- a/src/flash/com/longtailvideo/jwplayer/player/Player.as
+++ b/src/flash/com/longtailvideo/jwplayer/player/Player.as
@@ -199,7 +199,7 @@ public class Player extends Sprite implements IPlayer {
         this.mouseEnabled = true;
         this.mouseChildren = false;
         this.buttonMode = true;
-        this.addEventListener(MouseEvent.CLICK, function(e:MouseEvent):void {
+        this.stage.addEventListener(MouseEvent.CLICK, function(e:MouseEvent):void {
             SwfEventRouter.triggerJsEvent('click', e);
         });
 


### PR DESCRIPTION
Stage needs the click listener in order to hear click events.  Once thestage, the provider will then trigger the click events in the provider correctly. [#89735192]