### PR TITLE
Rewrite of drag seeking functionality

### DIFF
--- a/src/css/imports/display.less
+++ b/src/css/imports/display.less
@@ -66,6 +66,9 @@
     font-size: 2em;
 }
 
+.jwplayer.jw-flag-dragging .jw-display-icon {
+    display:none;
+}
 .jwplayer .jwpreview {
     opacity: 1;
     visibility: visible;

--- a/src/flash/com/longtailvideo/jwplayer/controller/Controller.as
+++ b/src/flash/com/longtailvideo/jwplayer/controller/Controller.as
@@ -239,13 +239,8 @@ public class Controller extends GlobalEventDispatcher {
                 case PlayerState.IDLE:
                     _model.item.start = pos;
                     _idleSeek = pos;
-                    if (!_preplay) {
-                        play();
-                    }
                     return true;
                 case PlayerState.PAUSED:
-                    play();
-                /* fallthrough */
                 case PlayerState.PLAYING:
                 case PlayerState.BUFFERING:
                     if (_model.media.canSeek) {

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -231,7 +231,7 @@ define([
         }
 
         function _seek(pos) {
-            if (_model.state !== states.PLAYING) {
+            if (!_model.dragging && _model.state !== states.PLAYING) {
                 _play(true);
             }
             _video().seek(pos);

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -13,6 +13,7 @@ define([
     var _defaults = {
         autostart: false,
         controls: true,
+        dragging : false,
         // debug: undefined,
         fullscreen: false,
         height: 320,
@@ -122,7 +123,12 @@ define([
         };
 
         _this.seekDrag = function(state) {
-            _provider.seekDrag(state);
+            _this.dragging = state;
+            if (state) {
+                _provider.pause();
+            } else {
+                _provider.play();
+            }
         };
 
         _this.setFullscreen = function(state) {

--- a/src/js/events/events.js
+++ b/src/js/events/events.js
@@ -57,6 +57,7 @@ define([], function() {
         // Controls show/hide 
         JWPLAYER_CONTROLS: 'jwplayerViewControls',
         JWPLAYER_USER_ACTION: 'jwplayerUserAction',
+        JWPLAYER_CONTROLBAR_DRAGGING: 'jwplayerControlbarDragging',
 
         // Instream events
         JWPLAYER_INSTREAM_CLICK: 'jwplayerInstreamClicked',

--- a/src/js/providers/default.js
+++ b/src/js/providers/default.js
@@ -19,7 +19,6 @@ define([
         volume : noop,
         mute : noop,
         seek : noop,
-        seekDrag : noop, // only for html5 ?
         resize : noop,
         remove : noop,  // removes from page
         destroy : noop, // frees memory

--- a/src/js/providers/flash.js
+++ b/src/js/providers/flash.js
@@ -21,7 +21,6 @@ define([
         var _swf;
         var _clickOverlay;
         var _item = null;
-        var _dragging = false;
         var _volume;
         var _muted = false;
         var _beforecompleted = false;
@@ -50,8 +49,7 @@ define([
 
         var _eventDispatcher = new eventdispatcher('flash.provider');
 
-        _.extend(this, _eventDispatcher,
-            {
+        _.extend(this, _eventDispatcher, {
                 load: function(item) {
                     _item = item;
                     this.setState(states.BUFFERING);
@@ -69,10 +67,6 @@ define([
                     _currentQuality = -1;
                     _item = null;
                     this.setState(states.IDLE);
-                },
-                seekDrag: function(state) {
-                    // toggle scrubbing state
-                    _dragging = state;
                 },
                 seek: function(seekPos) {
                     /*
@@ -93,8 +87,8 @@ define([
                     _muted = utils.exists(muted) ? muted : !_muted;
                     _flashCommand('mute', muted);
                 },
-                setState: function(/* state */) {
-                    DefaultProvider.setState.apply(this, arguments);
+                setState: function() {
+                    return DefaultProvider.setState.apply(this, arguments);
                 },
                 checkComplete: function() {
                     return _beforecompleted;
@@ -311,10 +305,9 @@ define([
                     _eventDispatcher.resetEventListeners();
                     _eventDispatcher = null;
                 }
-            }
-        );
-
+        });
     }
+
 
     var flashExtensions = {
         'flv': 'video',

--- a/src/js/utils/underscore.js
+++ b/src/js/utils/underscore.js
@@ -323,6 +323,44 @@ define([], function() {
         return _.delay.apply(_, [func, 1].concat(slice.call(arguments, 1)));
     };
 
+
+
+    // Returns a function, that, when invoked, will only be triggered at most once
+    // during a given window of time. Normally, the throttled function will run
+    // as much as it can, without ever going more than once per `wait` duration;
+    // but if you'd like to disable the execution on the leading edge, pass
+    // `{leading: false}`. To disable execution on the trailing edge, ditto.
+    _.throttle = function(func, wait, options) {
+        var context, args, result;
+        var timeout = null;
+        var previous = 0;
+        options || (options = {});
+        var later = function() {
+            previous = options.leading === false ? 0 : _.now();
+            timeout = null;
+            result = func.apply(context, args);
+            context = args = null;
+        };
+        return function() {
+            var now = _.now();
+            if (!previous && options.leading === false) previous = now;
+            var remaining = wait - (now - previous);
+            context = this;
+            args = arguments;
+            if (remaining <= 0) {
+                clearTimeout(timeout);
+                timeout = null;
+                previous = now;
+                result = func.apply(context, args);
+                context = args = null;
+            } else if (!timeout && options.trailing !== false) {
+                timeout = setTimeout(later, remaining);
+            }
+            return result;
+        };
+    };
+
+
     // Retrieve the names of an object's properties.
     // Delegates to **ECMAScript 5**'s native `Object.keys`
     _.keys = function (obj) {
@@ -477,7 +515,8 @@ define([], function() {
     };
 
 
-
+    // A (possibly faster) way to get the current timestamp as an integer.
+    _.now = Date.now || function() { return new Date().getTime(); };
 
     // If the value of the named `property` is a function then invoke it with the
     // `object` as context; otherwise, return it.

--- a/src/js/view/displayicon.js
+++ b/src/js/view/displayicon.js
@@ -99,7 +99,7 @@ define([
                 style['float'] = 'none';
 
                 cssUtils.style(_container, {
-                    display: 'table'
+                    display: ''
                 });
             } else {
                 cssUtils.style(_container, {
@@ -262,6 +262,10 @@ define([
     _css(DI_CLASS + ' div', {
         'vertical-align': 'middle'
     }, true);
+
+    _css('.jwplayer.jw-flag-dragging .jwdisplayIcon', {
+        'display':'none'
+    });
 
     _css(DI_CLASS + ' .jwtext', {
         color: '#fff',

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -560,6 +560,7 @@ define([
 
             _controlbar = new Controlbar(_skin, _api, _model);
             _controlbar.addEventListener(events.JWPLAYER_USER_ACTION, _resetTapTimer);
+            _controlbar.addEventListener(events.JWPLAYER_CONTROLBAR_DRAGGING, _dragging);
 
             _controlsLayer.appendChild(_controlbar.element());
 
@@ -576,6 +577,14 @@ define([
             _playerElement.onfocusout = handleBlur;
             _playerElement.addEventListener('blur', handleBlur);
             _playerElement.addEventListener('keydown', handleKeydown);
+        }
+
+        function _dragging(evt) {
+            if (evt.dragging) {
+                utils.addClass(_playerElement, 'jw-flag-dragging');
+            } else {
+                utils.removeClass(_playerElement, 'jw-flag-dragging');
+            }
         }
 
         function _castAdChanged(evt) {


### PR DESCRIPTION
This change moves the logic for drag seeking (when you click down and slide the cursor along the seekbar)
out of the individual providers and into the javascript controller. This required a few functional changes.
    1. Providers will no longer begin playback after a seek. Instead the controller will decide the correct time to do this.
    2. The "dragging" state is no longer stored in the provider, it is stored in the model.
    3. Since dragging occurs during the "pause" state, we add a visual style flag "jw-flag-dragging" to hide the center play icon.

This fix was required for flash seek dragging to work, but also improves the UX for html5 due to improvements in how
events are being throttled.

[Fixes #89827172]