### PR TITLE
Fix for playing .m4a files

### DIFF
--- a/src/js/playlist/source.js
+++ b/src/js/playlist/source.js
@@ -56,6 +56,11 @@ define([
         if (_source.type === 'smil') {
             _source.type = 'rtmp';
         }
+        // Although m4a is a container format, it is most often used for aac files
+        // http://en.wikipedia.org/w/index.php?title=MPEG-4_Part_14
+        if (_source.type === 'm4a') {
+            _source.type = 'aac';
+        }
 
         return _source;
     };

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -759,19 +759,21 @@ define([
     }
 
     var MimeTypes = {
+        'aac': 'audio/mp4',
         'mp4': 'video/mp4',
         'f4v': 'video/mp4',
         'm4v': 'video/mp4',
         'mov': 'video/mp4',
-        'm4a': 'video/aac',
-        'f4a': 'video/aac',
-        'aac': 'video/aac',
-        'mp3': 'video/mp3',
+        //'m4a': 'audio/x-m4a', // converted to aac by source.js
+        'mp3': 'audio/mp3',
         'ogv': 'video/ogg',
         'ogg': 'video/ogg',
         'oga': 'video/ogg',
         'vorbis': 'video/ogg',
         'webm': 'video/webm',
+
+        // The following are not expected to work in Chrome
+        'f4a': 'video/aac',
         'm3u8': 'application/vnd.apple.mpegurl',
         'm3u': 'application/vnd.apple.mpegurl',
         'hls': 'application/vnd.apple.mpegurl'


### PR DESCRIPTION
m4a files can be tricky because it is a container format which may contain different
formats. We make the safe assumption that they will be "aac" files, which is the most
common type.
[Fixes #90525826]