### PR TITLE
Fix for API onReady

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -149,7 +149,7 @@ define([
             //_actionOnAttach = _play;
             if (!_preplay) {
                 _preplay = true;
-                _this.trigger(events.JWPLAYER_MEDIA_BEFOREPLAY);
+                _this.trigger(events.JWPLAYER_MEDIA_BEFOREPLAY, {});
                 _preplay = false;
                 if (_interruptPlay) {
                     _interruptPlay = false;
@@ -276,7 +276,7 @@ define([
                     _loadOnPlay = 0;
                     _stop(true);
                     setTimeout(function() {
-                        _this.trigger(events.JWPLAYER_PLAYLIST_COMPLETE);
+                        _this.trigger(events.JWPLAYER_PLAYLIST_COMPLETE, {});
                     }, 0);
                 } else {
                     _next();

--- a/src/js/embed/embed.js
+++ b/src/js/embed/embed.js
@@ -141,7 +141,7 @@ define([
         }
 
         function _pluginError(evt) {
-            api.dispatchEvent(events.JWPLAYER_ERROR, {
+            api.trigger(events.JWPLAYER_ERROR, {
                 message: 'Could not load plugin: ' + evt.message
             });
         }
@@ -158,7 +158,7 @@ define([
             // Throttle this so that it runs once if called twice in the same callstack
             clearTimeout(_setupErrorTimer);
             _setupErrorTimer = setTimeout(function() {
-                api.dispatchEvent(events.JWPLAYER_SETUP_ERROR, {
+                api.trigger(events.JWPLAYER_SETUP_ERROR, {
                     message: message
                 });
             }, 0);


### PR DESCRIPTION
This commit cleans up an extra layer of event passing between the controller and api.
Previously, api.js was re-implementing the event handler, with a minor change in how it normalizes
the event object before passing it outside. Now, it uses the default dispatcher with an overridden trigger method.
[Fixes #90534574]