### PR TITLE
Update player version to 7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jwplayer",
-  "version": "6.12.7000",
+  "version": "7.0.0",
   "description": "The JW Player is free for non-commerical use. To buy a license for commercial use, please visit \r http://www.jwplayer.com/pricing/",
   "repository": {
     "type": "git",

--- a/src/js/utils/helpers.js
+++ b/src/js/utils/helpers.js
@@ -3,11 +3,13 @@ define([
     'events/events',
     'underscore'
 ], function(strings, events, _) {
-
-    // This is replaced by compiler
-    var _version = __BUILD_VERSION__;
-
     /*jshint maxparams:5*/
+
+    // TODO:: the next lines are a holdover until we update our CDN w/ plugins for 7.0
+    // This is replaced by compiler
+    //var _version = __BUILD_VERSION__;
+    var _version = 6.12;
+
     var utils = {};
 
     /**
@@ -350,6 +352,7 @@ define([
         return repo;
     };
 
+    // Return true:Boolean if major and minor version of target is less than current version
     utils.versionCheck = function (target) {
         var tParts = ('0' + target).split(/\W/);
         var jParts = _version.split(/\W/);


### PR DESCRIPTION
Since our CDN does not have the correct resources yet, the repo
used for fetching logo and plugins will still be version 6.12
[Delivers #90154864]