### PR TITLE
Fix bug from setting mute before media item available

### DIFF
--- a/src/flash/com/longtailvideo/jwplayer/controller/Controller.as
+++ b/src/flash/com/longtailvideo/jwplayer/controller/Controller.as
@@ -162,9 +162,11 @@ public class Controller extends GlobalEventDispatcher {
     }
 
     public function mute(muted:Boolean):Boolean {
-        if (muted !== _model.mute) {
-            _model.mute = muted;
-            return true;
+        if (_model.media) {
+            if (muted !== _model.mute) {
+                _model.mute = muted;
+                return true;
+            }
         }
         return false;
     }


### PR DESCRIPTION
This bug could be reproduced locally, but not from jenkins. It originated here :
https://github.com/jwplayer/jwplayer/commit/780fb5fd5c27b573c814cdce0ed221f202948b2e