### PR TITLE
Create mutators on the Model

### DIFF
--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -238,6 +238,15 @@ define([
         };
     };
 
+    _.extend(Model.prototype, {
+        'get' : function(attr) {
+            return this[attr];
+        },
+        'set' : function(attr, val) {
+            this[attr] = val;
+        }
+    });
+
     return Model;
 
 });

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -110,7 +110,7 @@ define([
             document.msExitFullscreen;
         _elementSupportsFullscreen = _requestFullscreen && _exitFullscreen;
 
-        if (_model.aspectratio) {
+        if (_model.get('aspectratio')) {
             cssUtils.style(_playerElement, {
                 display: 'inline-block'
             });


### PR DESCRIPTION
In order to reduce scope, this change does not change any Model functionality.
Instead it allows us to begin using get/set in the correct syntax, which will hopefully ease the transition away from using data on the root Model object.
[#90646580]