### PR TITLE
Mutliple error texts and color switch

### DIFF
--- a/src/css/styles.less
+++ b/src/css/styles.less
@@ -11,7 +11,7 @@
     -o-transition: @JW_CSS_SMOOTH_EASE;
 }
 
-.jw-errorscreen {
+.jwplayer .jw-errorscreen {
     background-color: #000;
     color: #FFF;
     width: 100%;

--- a/src/js/controller/Setup.js
+++ b/src/js/controller/Setup.js
@@ -71,7 +71,6 @@ define([
         };
 
         function _setupTimeoutHandler(){
-            this.destroy();
             _error('Setup Timeout Error: Setup took longer than '+(_errorTimeoutSeconds)+' seconds to complete.');
         }
 
@@ -163,6 +162,8 @@ define([
                 message: message
             });
             _view.setupError(message);
+            clearTimeout(_setupFailureTimeout);
+            this.destroy();
         }
 
         this.destroy = function() {


### PR DESCRIPTION
Setup timer cleared on error, and destroy called on error to cancel next tasks. Specificity for the .jw-errorscreen styles increased to ensure that white text is shown.  [Finishes #90197716]