### PR TITLE
Track stalls/loads separately in more providers

### DIFF
--- a/src/flash/com/longtailvideo/jwplayer/controller/Controller.as
+++ b/src/flash/com/longtailvideo/jwplayer/controller/Controller.as
@@ -103,7 +103,7 @@ public class Controller extends GlobalEventDispatcher {
         _lockManager.lock(plugin, callback);
 
         // If it was playing, pause playback and plan to resume when you're done
-        if (_player.state == PlayerState.PLAYING || _player.state == PlayerState.BUFFERING || _preplay) {
+        if (_player.state == PlayerState.PLAYING || PlayerState.isBuffering(_player.state) || _preplay) {
             if (!_preplay) {
                 _model.media.pause();
             }
@@ -170,7 +170,7 @@ public class Controller extends GlobalEventDispatcher {
     }
 
     public function play():Boolean {
-        if (locking || _player.state == PlayerState.PLAYING || _player.state == PlayerState.BUFFERING) {
+        if (locking || _player.state == PlayerState.PLAYING || PlayerState.isBuffering(_player.state)) {
             return false;
         }
 
@@ -210,6 +210,8 @@ public class Controller extends GlobalEventDispatcher {
             switch (_model.media.state) {
                 case PlayerState.PLAYING:
                 case PlayerState.BUFFERING:
+                case PlayerState.STALLED:
+                case PlayerState.LOADING:
                     _model.media.pause();
                     return true;
                 default:
@@ -225,6 +227,8 @@ public class Controller extends GlobalEventDispatcher {
             switch (_model.media.state) {
                 case PlayerState.PLAYING:
                 case PlayerState.BUFFERING:
+                case PlayerState.STALLED:
+                case PlayerState.LOADING:
                 case PlayerState.PAUSED:
                     _model.media.stop();
                     return true;
@@ -243,6 +247,8 @@ public class Controller extends GlobalEventDispatcher {
                 case PlayerState.PAUSED:
                 case PlayerState.PLAYING:
                 case PlayerState.BUFFERING:
+                case PlayerState.STALLED:
+                case PlayerState.LOADING:
                     if (_model.media.canSeek) {
                         _model.seek(pos);
                         return true;

--- a/src/flash/com/longtailvideo/jwplayer/media/MediaProvider.as
+++ b/src/flash/com/longtailvideo/jwplayer/media/MediaProvider.as
@@ -177,7 +177,7 @@ public class MediaProvider extends Sprite implements IMediaProvider {
 
     /** Determine if seek can be called or should be delayed **/
     public function get canSeek():Boolean {
-        return state !== PlayerState.BUFFERING;
+        return !PlayerState.isBuffering(state);
     }
 
     /**
@@ -266,8 +266,9 @@ public class MediaProvider extends Sprite implements IMediaProvider {
     /** Resume playback of the item. **/
     public function play():void {
         if (_queuedBufferFull) {
+            // This path of execution implies we were in a paused state
             _queuedBufferFull = false;
-            setState(PlayerState.BUFFERING);
+            setState(PlayerState.LOADING);
             sendMediaEvent(MediaEvent.JWPLAYER_MEDIA_BUFFER_FULL);
         } else {
             setState(PlayerState.PLAYING);

--- a/src/flash/com/longtailvideo/jwplayer/media/SoundMediaProvider.as
+++ b/src/flash/com/longtailvideo/jwplayer/media/SoundMediaProvider.as
@@ -57,7 +57,7 @@ public class SoundMediaProvider extends MediaProvider {
         _sound.addEventListener(ProgressEvent.PROGRESS, positionHandler);
         _sound.load(new URLRequest(itm.file), _context);
         sendMediaEvent(MediaEvent.JWPLAYER_MEDIA_LOADED);
-        setState(PlayerState.BUFFERING);
+        setState(PlayerState.LOADING);
         sendBufferEvent(0);
         streamVolume(config.mute ? 0 : config.volume);
     }
@@ -150,11 +150,11 @@ public class SoundMediaProvider extends MediaProvider {
             }
         }
         // Switch between playback and buffering state.
-        if (state == PlayerState.BUFFERING && !_sound.isBuffering) {
+        if (PlayerState.isBuffering(state) && !_sound.isBuffering) {
             sendMediaEvent(MediaEvent.JWPLAYER_MEDIA_BUFFER_FULL);
             setState(PlayerState.PLAYING);
         } else if (state == PlayerState.PLAYING && _sound.isBuffering) {
-            setState(PlayerState.BUFFERING);
+            setState(PlayerState.STALLED);
         }
         // Send time ticks when playing
         if (state == PlayerState.PLAYING && _item.duration > 0) {

--- a/src/flash/com/longtailvideo/jwplayer/media/VideoMediaProvider.as
+++ b/src/flash/com/longtailvideo/jwplayer/media/VideoMediaProvider.as
@@ -299,7 +299,7 @@ public class VideoMediaProvider extends MediaProvider {
             } else {
                 setState(PlayerState.STALLED);
             }
-        } else if (_stream.bufferLength > 1 && (state == PlayerState.LOADING || state == PlayerState.STALLED)) {
+        } else if (_stream.bufferLength >= 1 && PlayerState.isBuffering(state)) {
             sendMediaEvent(MediaEvent.JWPLAYER_MEDIA_BUFFER_FULL);
             setState(PlayerState.PLAYING);
         }

--- a/src/flash/com/longtailvideo/jwplayer/media/YouTubeMediaProvider.as
+++ b/src/flash/com/longtailvideo/jwplayer/media/YouTubeMediaProvider.as
@@ -127,7 +127,7 @@ public class YouTubeMediaProvider extends MediaProvider {
 
     /** Pause the YouTube movie. **/
     public override function pause():void {
-        if (state == PlayerState.PLAYING || state == PlayerState.STALLED || state == PlayerState.LOADING) {
+        if (state == PlayerState.PLAYING || PlayerState.isBuffering(state)) {
             if (_ready) {
                 _ytAPI.pauseVideo();
             }
@@ -207,7 +207,7 @@ public class YouTubeMediaProvider extends MediaProvider {
         switch (Number(Object(evt).data)) {
             case 0:
                 // "ended"
-                if (state != PlayerState.LOADING && state != PlayerState.STALLED && state != PlayerState.IDLE) {
+                if (state != PlayerState.LOADING && !PlayerState.isBuffering(state)) {
                     complete();
                     _offset = 0;
                 }

--- a/src/flash/com/longtailvideo/jwplayer/player/InstreamPlayer.as
+++ b/src/flash/com/longtailvideo/jwplayer/player/InstreamPlayer.as
@@ -102,7 +102,7 @@ public class InstreamPlayer extends GlobalEventDispatcher implements IInstreamPl
     public function play():Boolean {
         _setupView();
         if (_provider) {
-            if (_provider.state == PlayerState.PLAYING || _provider.state == PlayerState.BUFFERING) {
+            if (_provider.state == PlayerState.PLAYING || PlayerState.isBuffering(_provider.state)) {
                 _provider.pause();
             } else {
                 _provider.play();
@@ -112,7 +112,7 @@ public class InstreamPlayer extends GlobalEventDispatcher implements IInstreamPl
     }
 
     public function pause():Boolean {
-        if (_provider && _provider.state == PlayerState.PLAYING || PlayerState.BUFFERING) {
+        if (_provider && _provider.state == PlayerState.PLAYING || PlayerState.isBuffering(_provider.state)) {
             _provider.pause();
         }
         return true;

--- a/src/flash/com/longtailvideo/jwplayer/player/PlayerState.as
+++ b/src/flash/com/longtailvideo/jwplayer/player/PlayerState.as
@@ -23,7 +23,7 @@ public class PlayerState {
     public static const LOADING:String = "LOADING";
 
     public static function isBuffering(state:String):Boolean {
-        return (state === BUFFERING || state === STALLED || state === LOADING);
+        return (state === LOADING || state === STALLED || state === BUFFERING);
     }
 }
 }

--- a/src/flash/com/longtailvideo/jwplayer/player/PlayerState.as
+++ b/src/flash/com/longtailvideo/jwplayer/player/PlayerState.as
@@ -15,5 +15,15 @@ public class PlayerState {
     public static var PLAYING:String = "PLAYING";
     /** Playback is paused. **/
     public static var PAUSED:String = "PAUSED";
+
+
+    // These are specific types of buffering which a provider may use for
+    //  better QOE introspection
+    public static const STALLED:String = "STALLED";
+    public static const LOADING:String = "LOADING";
+
+    public static function isBuffering(state:String):Boolean {
+        return (state === BUFFERING || state === STALLED || state === LOADING);
+    }
 }
 }

--- a/src/js/providers/youtube.js
+++ b/src/js/providers/youtube.js
@@ -50,8 +50,9 @@ define([
                 // always run this interval when not idle because we can't trust events from iFrame
                 _playingInterval = setInterval(_checkPlaybackHandler, 250);
                 if (state === states.PLAYING) {
+                    this.seeking = false;
                     _resetViewForMobile();
-                } else if (state === states.BUFFERING) {
+                } else if (state === states.LOADING || state === states.STALLED) {
                     _bufferUpdate();
                 }
             }
@@ -283,7 +284,11 @@ define([
                     return;
 
                 case youtubeStates.BUFFERING: // 3: //buffering
-                    _this.setState(states.BUFFERING);
+                    if (_this.seeking) {
+                        _this.setState(states.LOADING);
+                    } else {
+                        _this.setState(states.STALLED);
+                    }
                     return;
 
                 case youtubeStates.CUED: // 5: //video cued (idle before playback)
@@ -361,7 +366,7 @@ define([
 
         // Video Provider API
         this.load = function(item) {
-            this.setState(states.BUFFERING);
+            this.setState(states.LOADING);
 
             _setItem(item);
             // start playback if api is ready
@@ -464,6 +469,7 @@ define([
                 return;
             }
             if (_youtubePlayer.seekTo) {
+                this.seeking = true;
                 _youtubePlayer.seekTo(position);
             }
         };


### PR DESCRIPTION
This commit adds tracking to html5 youtube player, and all Flash providers (except RTMP)
[#90699216]