### PR TITLE
Seek faster while scrubbing through media

### DIFF
--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -492,6 +492,9 @@ define([
                 _eventListener(val[0], val[1]);
             }
 
+            // Required to force api to forward events from the controller
+            _eventListener(events.JWPLAYER_MEDIA_SEEKED, utils.noop);
+
             _eventListener(events.JWPLAYER_PLAYLIST_ITEM, function () {
                 _itemMeta = {};
             });


### PR DESCRIPTION
A provider can trigger the JWPLAYER_MEDIA_SEEKED event to alert the player that a seek has completed. This allows us to seek more frequently when scrubbing through the media.
[#88941076]