### PR TITLE
Webpack IE8 Fonts issue fix

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -159,15 +159,15 @@ module.exports = function(grunt) {
                         },
                         {
                             test: /\.woff(\?v=\d+\.\d+\.\d+)?$/,
-                            loader: 'url?limit=10000&minetype=application/font-woff'
+                            loader: 'url?limit=10000&mimetype=application/font-woff'
                         },
                         {
                             test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/,
-                            loader: 'url?limit=10000&minetype=application/octet-stream'
+                            loader: 'url?limit=10000&mimetype=application/octet-stream'
                         },
                         {
                             test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
-                            loader: 'url?limit=10000&minetype=image/svg+xml'
+                            loader: 'url?limit=10000&mimetype=image/svg+xml'
                         },
                         {
                             test: /\.html$/,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -128,6 +128,7 @@ module.exports = function(grunt) {
                 },
                 output: {
                     path: 'bin-debug/',
+                    publicPath: '/jwplayer/bin-debug/',
                     filename: '[name].js'
                 },
                 resolve: {
@@ -153,16 +154,16 @@ module.exports = function(grunt) {
                             loader: 'style-loader!css-loader!less-loader'
                         },
                         {
+                            test: /\.eot(\?v=\d+\.\d+\.\d+)?$/,
+                            loader: 'file'
+                        },
+                        {
                             test: /\.woff(\?v=\d+\.\d+\.\d+)?$/,
                             loader: 'url?limit=10000&minetype=application/font-woff'
                         },
                         {
                             test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/,
                             loader: 'url?limit=10000&minetype=application/octet-stream'
-                        },
-                        {
-                            test: /\.eot(\?v=\d+\.\d+\.\d+)?$/,
-                            loader: 'file'
                         },
                         {
                             test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,

--- a/src/css/imports/icons.less
+++ b/src/css/imports/icons.less
@@ -1,8 +1,14 @@
 @import "vars.less";
 
+
 @font-face {
     font-family: 'jw-six-icons';
     src: url('../../../assets/fonts/jw-six-icons.eot');
+    font-weight: normal;
+    font-style: normal;
+}
+@font-face {
+    font-family: 'jw-six-icons';
     src: url('../../../assets/fonts/jw-six-icons.eot') format('embedded-opentype'),
     url('../../../assets/fonts/jw-six-icons.woff') format('woff'),
     url('../../../assets/fonts/jw-six-icons.ttf') format('truetype'),

--- a/src/css/imports/icons.less
+++ b/src/css/imports/icons.less
@@ -1,12 +1,13 @@
 @import "vars.less";
 
-
+// This is IE8 only
 @font-face {
     font-family: 'jw-six-icons';
     src: url('../../../assets/fonts/jw-six-icons.eot');
     font-weight: normal;
     font-style: normal;
 }
+// This cascades and overwrites for non IE8 browsers
 @font-face {
     font-family: 'jw-six-icons';
     src: url('../../../assets/fonts/jw-six-icons.eot') format('embedded-opentype'),


### PR DESCRIPTION
Fixes IE8 issue where fonts weren't loading correctly in IE8 since the publicPath wasn't correctly set and the less code needed to be structured differently due to how the other fonts are being embedded so that IE8 sees them correctly.