### PR TITLE
API event flow refactor

### DIFF
--- a/src/js/api/callbacks-deprecate.js
+++ b/src/js/api/callbacks-deprecate.js
@@ -1,0 +1,67 @@
+define([
+    'utils/underscore',
+    'events/states',
+    'events/events'
+], function(_, states, events) {
+
+    return function init(_api) {
+
+        var _eventMapping = {
+            onBufferChange: events.JWPLAYER_MEDIA_BUFFER,
+            onBufferFull: events.JWPLAYER_MEDIA_BUFFER_FULL,
+            onError: events.JWPLAYER_ERROR,
+            onSetupError: events.JWPLAYER_SETUP_ERROR,
+            onFullscreen: events.JWPLAYER_FULLSCREEN,
+            onMeta: events.JWPLAYER_MEDIA_META,
+            onMute: events.JWPLAYER_MEDIA_MUTE,
+            onPlaylist: events.JWPLAYER_PLAYLIST_LOADED,
+            onPlaylistItem: events.JWPLAYER_PLAYLIST_ITEM,
+            onPlaylistComplete: events.JWPLAYER_PLAYLIST_COMPLETE,
+            onReady: events.API_READY,
+            onResize: events.JWPLAYER_RESIZE,
+            onComplete: events.JWPLAYER_MEDIA_COMPLETE,
+            onSeek: events.JWPLAYER_MEDIA_SEEK,
+            onTime: events.JWPLAYER_MEDIA_TIME,
+            onVolume: events.JWPLAYER_MEDIA_VOLUME,
+            onBeforePlay: events.JWPLAYER_MEDIA_BEFOREPLAY,
+            onBeforeComplete: events.JWPLAYER_MEDIA_BEFORECOMPLETE,
+            onDisplayClick: events.JWPLAYER_DISPLAY_CLICK,
+            onControls: events.JWPLAYER_CONTROLS,
+            onQualityLevels: events.JWPLAYER_MEDIA_LEVELS,
+            onQualityChange: events.JWPLAYER_MEDIA_LEVEL_CHANGED,
+            onCaptionsList: events.JWPLAYER_CAPTIONS_LIST,
+            onCaptionsChange: events.JWPLAYER_CAPTIONS_CHANGED,
+            onAdError: events.JWPLAYER_AD_ERROR,
+            onAdClick: events.JWPLAYER_AD_CLICK,
+            onAdImpression: events.JWPLAYER_AD_IMPRESSION,
+            onAdTime: events.JWPLAYER_AD_TIME,
+            onAdComplete: events.JWPLAYER_AD_COMPLETE,
+            onAdCompanions: events.JWPLAYER_AD_COMPANIONS,
+            onAdSkipped: events.JWPLAYER_AD_SKIPPED,
+            onAdPlay: events.JWPLAYER_AD_PLAY,
+            onAdPause: events.JWPLAYER_AD_PAUSE,
+            onAdMeta: events.JWPLAYER_AD_META,
+            onCast: events.JWPLAYER_CAST_SESSION,
+            onAudioTrackChange: events.JWPLAYER_AUDIO_TRACK_CHANGED,
+            onAudioTracks: events.JWPLAYER_AUDIO_TRACKS
+        };
+
+        var _stateMapping = {
+            onBuffer: states.BUFFERING,
+            onPause: states.PAUSED,
+            onPlay: states.PLAYING,
+            onIdle: states.IDLE
+        };
+
+        // Add state callbacks
+        _.each(_stateMapping, function (value, name) {
+            _api[name] = _.partial(_api.on, value, _);
+        });
+
+        // Add event callbacks
+        _.each(_eventMapping, function (value, name) {
+            _api[name] = _.partial(_api.on, value, _);
+        });
+
+    };
+});

--- a/src/js/api/mutators.js
+++ b/src/js/api/mutators.js
@@ -1,0 +1,64 @@
+
+define([
+    'utils/underscore',
+], function(_) {
+
+    return function(_api) {
+        var _internalFuncsToGenerate = [
+            'getBuffer',
+            'getCaptionsList',
+            'getControls',
+            'getCurrentCaptions',
+            'getCurrentQuality',
+            'getCurrentAudioTrack',
+            'getDuration',
+            'getFullscreen',
+            'getHeight',
+            'getLockState',
+            'getMute',
+            'getPlaylistIndex',
+            'getSafeRegion',
+            'getPosition',
+            'getQualityLevels',
+            'getState',
+            'getVolume',
+            'getWidth',
+            'isBeforeComplete',
+            'isBeforePlay',
+            'releaseState'
+        ];
+
+        var _chainableInternalFuncs = [
+            'playlistNext',
+            'stop',
+
+            // The following pass an argument to function
+            'forceState',
+            'playlistPrev',
+            'seek',
+            'setCurrentCaptions',
+            'setControls',
+            'setCurrentQuality',
+            'setVolume',
+            'setCurrentAudioTrack'
+        ];
+
+
+        // given a name "getBuffer", it adds to jwplayer.api a function which internally triggers jwGetBuffer
+        function generateInternalFunction(name) {
+            var internalName = 'jw' + name.charAt(0).toUpperCase() + name.slice(1);
+
+            _api[name] = function () {
+                var value = _api.callInternal.apply(this,
+                    [internalName].concat(Array.prototype.slice.call(arguments, 0)));
+
+                if (_.has(_chainableInternalFuncs, name)) {
+                    return _api;
+                }
+                return value;
+            };
+        }
+
+        _.each(_internalFuncsToGenerate.concat(_chainableInternalFuncs), generateInternalFunction);
+    };
+});


### PR DESCRIPTION
The first thing we do is break out two logical sections of code into their own files.
1. callback method helper
2. mutator method helper

There are absolutely no logical changes to mutators, except location.

The callback system, was refactored such that any event triggered through the controller can be listened to via
```jwplayer().on(events.ANY_EVENT)`` and also ```jwplayer().on(states.ANY_STATE)```

The file 'callbacks-deprecate' allows us to also use the older jwplayer().onEvent and jwplayer.onState() until we are ready to remove this support.

[Delivers #90630030]