### PR TITLE
RTMP Provider Ad Support

### DIFF
--- a/src/flash/com/longtailvideo/jwplayer/media/MediaProvider.as
+++ b/src/flash/com/longtailvideo/jwplayer/media/MediaProvider.as
@@ -364,6 +364,8 @@ package com.longtailvideo.jwplayer.media {
 			} else {
 				_media = null;
 			}
+			// update the model/view
+			sendMediaEvent(MediaEvent.JWPLAYER_MEDIA_LOADED);
 		}
 		
 		/**

--- a/src/flash/com/longtailvideo/jwplayer/media/VideoMediaProvider.as
+++ b/src/flash/com/longtailvideo/jwplayer/media/VideoMediaProvider.as
@@ -140,7 +140,6 @@ package com.longtailvideo.jwplayer.media {
 			sendQualityEvent(MediaEvent.JWPLAYER_MEDIA_LEVELS, _item.levels, _currentQuality);
 			// Do not set a stretchable media for AAC files.
 			_item.type == "aac" ? media = null: media = _video;
-			dispatchEvent(new MediaEvent(MediaEvent.JWPLAYER_MEDIA_LOADED));
 			// Initialize volume
 			streamVolume(config.mute ? 0 : config.volume);
 			// Get item start (should remove this someday)

--- a/src/flash/com/longtailvideo/jwplayer/media/YouTubeMediaProvider.as
+++ b/src/flash/com/longtailvideo/jwplayer/media/YouTubeMediaProvider.as
@@ -169,7 +169,6 @@
 			_ytAPI.cueVideoById(_videoId, _item.start, "default");
 			_currentQuality = 0;
 			media = _loader;
-			sendMediaEvent(MediaEvent.JWPLAYER_MEDIA_LOADED);
 			sendMediaEvent(MediaEvent.JWPLAYER_MEDIA_BUFFER_FULL);
 			setVolume(config.mute ? 0 : config.volume);
 			_statusTimer.start();


### PR DESCRIPTION
RTMP provider is prepared for ad playback control immediately when load(item) is called [Delivers #90936728]

This is done by setting media and sending a media loaded event followed by a buffering event (as other providers do).

Since all providers should send a media loaded event when the media property is set (updates the view and prevents controls from locking / buffering from being ignored), this is now enforced for all providers by building it into `MediaProvider.set media(DisplayItem)`. 