### PR TITLE
Fix bottom list bar setup [Delivers #90702642]

### DIFF
--- a/src/js/html5/jwplayer.html5.view.js
+++ b/src/js/html5/jwplayer.html5.view.js
@@ -785,14 +785,15 @@
                 return false;
             }
             var bounds = _bounds(_playerElement);
+            if (_model.playlistposition === 'bottom') {
+                bounds.height -= _model.playlistsize;
+            }
             return _isControlBarOnly(bounds.height);
         }
 
         function _isControlBarOnly(verticalPixels) {
             if (!verticalPixels) {
                 return false;
-            } else if (_model.playlistposition === 'bottom') {
-                verticalPixels -= _model.playlistsize;
             }
             return verticalPixels <= 40;
         }


### PR DESCRIPTION
`playlistsize` should only be subtracted from the full player bounds, not the model height.