### PR TITLE
Track video start time

### DIFF
--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -100,7 +100,7 @@ define([
         this.qoe = function() {
             var item = _controller.getItemQoe();
 
-            var firstFrame = item.between(events.JWPLAYER_PLAYLIST_ITEM, events.JWPLAYER_MEDIA_FIRST_FRAME);
+            var firstFrame = item.between(events.JWPLAYER_MEDIA_PLAY_ATTEMPT, events.JWPLAYER_MEDIA_FIRST_FRAME);
 
             return {
                 firstFrame : firstFrame,

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -73,8 +73,8 @@ define([
             _view.addGlobalListener(_forward);
 
             // TODO: send copies of these objects to public listeners
-            var playlist = _model.playlist;
-            var item = _model.item;
+            var playlist = _model.get('playlist');
+            var item = _model.get('item');
 
             _this.trigger(events.JWPLAYER_PLAYLIST_LOADED, {
                 playlist: playlist
@@ -85,7 +85,7 @@ define([
 
             _load();
 
-            if (_model.autostart && !utils.isMobile()) {
+            if (_model.get('autostart') && !utils.isMobile()) {
                 _play();
             }
 
@@ -102,7 +102,7 @@ define([
         }
 
         function _bufferFullHandler() {
-            _video().play();
+            _model.playVideo();
         }
 
         function _load(item) {
@@ -158,16 +158,16 @@ define([
             }
 
             if (_isIdle()) {
-                if (_model.playlist.length === 0) {
+                if (_model.get('playlist').length === 0) {
                     return false;
                 }
 
                 status = utils.tryCatch(function() {
-                    _video().load(_model.playlist[_model.item]);
+                    _model.loadVideo();
                 });
-            } else if (_model.state === states.PAUSED) {
+            } else if (_model.get('state') === states.PAUSED) {
                 status = utils.tryCatch(function() {
-                    _video().play();
+                    _model.playVideo();
                 });
             }
 
@@ -209,7 +209,7 @@ define([
             } else if (!state) {
                 return _play();
             }
-            switch (_model.state) {
+            switch (_model.get('state')) {
                 case states.PLAYING:
                 case states.BUFFERING:
                     var status = utils.tryCatch(function(){
@@ -230,11 +230,11 @@ define([
         }
 
         function _isIdle() {
-            return (_model.state === states.IDLE);
+            return (_model.get('state') === states.IDLE);
         }
 
         function _seek(pos) {
-            if (!_model.dragging && _model.state !== states.PLAYING) {
+            if (!_model.get('dragging') && _model.get('state') !== states.PLAYING) {
                 _play(true);
             }
             _video().seek(pos);
@@ -250,11 +250,11 @@ define([
         }
 
         function _prev() {
-            _item(_model.item - 1);
+            _item(_model.get('item') - 1);
         }
 
         function _next() {
-            _item(_model.item + 1);
+            _item(_model.get('item') + 1);
         }
 
         function _completeHandler() {
@@ -268,10 +268,10 @@ define([
             }
 
             _actionOnAttach = _completeHandler;
-            if (_model.repeat) {
+            if (_model.get('repeat')) {
                 _next();
             } else {
-                if (_model.item === _model.playlist.length - 1) {
+                if (_model.get('item') === _model.get('playlist').length - 1) {
                     _loadOnPlay = 0;
                     _stop(true);
                     setTimeout(function() {

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -253,6 +253,16 @@ define([
         this.componentConfig = function(name) {
             return _componentConfigs[name];
         };
+
+        // The model is also the mediaController for now
+        this.playVideo = function() {
+            this.getVideo().play();
+        };
+        this.loadVideo = function() {
+            this.trigger(events.JWPLAYER_MEDIA_PLAY_ATTEMPT);
+            var idx = this.get('item');
+            this.getVideo().load(this.get('playlist')[idx]);
+        };
     };
 
     _.extend(Model.prototype, {

--- a/src/js/controller/qoe.js
+++ b/src/js/controller/qoe.js
@@ -29,9 +29,11 @@ define([
 
         // When it occurs, send the event, and unbind all listeners
         model._triggerFirstFrame = _.once(function() {
-            model._qoeItem.tick(events.JWPLAYER_MEDIA_FIRST_FRAME);
+            var qoeItem = model._qoeItem;
+            qoeItem.tick(events.JWPLAYER_MEDIA_FIRST_FRAME);
 
-            model.trigger(events.JWPLAYER_MEDIA_FIRST_FRAME);
+            var time = qoeItem.between(events.JWPLAYER_MEDIA_PLAY_ATTEMPT, events.JWPLAYER_MEDIA_FIRST_FRAME);
+            model.trigger(events.JWPLAYER_MEDIA_FIRST_FRAME, {loadtime : time});
             unbindFirstFrameEvents(model);
         });
 
@@ -68,7 +70,6 @@ define([
 
             trackFirstFrame(model);
             trackStalledTime(model);
-
         });
     }
 

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -77,7 +77,7 @@ define([
                 ended: _endedHandler,
                 error: _errorHandler,
 
-                play: _onPlayHandler, // play is attempted, but hasn't necessarily started
+                //play: _onPlayHandler, // play is attempted, but hasn't necessarily started
                 //loadstart: _generalHandler,
                 //loadeddata: _onLoadedData, // we have duration
                 loadedmetadata: _onLoadedMetaData, // we have video dimensions
@@ -212,10 +212,6 @@ define([
             });
         }
 
-        function _onPlayHandler() {
-            _this.sendEvent(events.JWPLAYER_MEDIA_PLAY_ATTEMPT);
-        }
-
         function _canPlayHandler() {
             if (!_attached) {
                 return;
@@ -271,7 +267,7 @@ define([
             }
 
             _this.setState(states.PLAYING);
-            _this.sendEvent(events.JWPLAYER_PROVIDER_FIRST_FRAME, { time : _.now() });
+            _this.sendEvent(events.JWPLAYER_PROVIDER_FIRST_FRAME, {});
         }
 
         function _stalledHandler() {


### PR DESCRIPTION
Here we track the time from when we attempt to load a new video (labeled with ```events.JWPLAYER_MEDIA_PLAY_ATTEMPT```). We compare this against the first frame time, and report it in jwplayer().qoe()

[Delivers #88512034]