### PR TITLE
optimize jwplayer() by storing all instances in global-api before setup

### DIFF
--- a/src/js/api/global-api.js
+++ b/src/js/api/global-api.js
@@ -1,38 +1,38 @@
 define([
-    'utils/helpers',
     'api/api'
-], function(utils, Api) {
+], function(Api) {
 
     var _instances = [],
         _uniqueIndex = 0;
 
 
-    var selectPlayer = function (identifier) {
-        var _container;
+    var selectPlayer = function (query) {
+        var player;
+        var domElement;
 
-        if (!utils.exists(identifier)) {
-            identifier = 0;
-        }
-
-        if (identifier.nodeType) {
-            // Handle DOM Element
-            _container = identifier;
-        } else if (typeof identifier === 'string') {
-            // Find container by ID
-            _container = document.getElementById(identifier);
-        }
-
-        if (_container) {
-            var foundPlayer = playerById(_container.id);
-            if (foundPlayer) {
-                return foundPlayer;
-            } else {
-                return (new Api(_container));
+        // prioritize getting a player over querying an element
+        if (!query) {
+            player = _instances[0];
+        } else if (typeof query === 'string') {
+            player = playerById(query);
+            if (!player) {
+                domElement = document.getElementById(query);
             }
-        } else if (typeof identifier === 'number') {
-            return _instances[identifier];
+        } else if (typeof query === 'number') {
+            player = _instances[query];
+        } else if (query.nodeType) {
+            domElement = query;
+            player = playerById(domElement.id);
         }
-
+        // found player
+        if (player) {
+            return player;
+        }
+        // create player
+        if (domElement) {
+            return _addPlayer(new Api(domElement, _removePlayer));
+        }
+        // invalid query
         return null;
     };
 
@@ -47,23 +47,26 @@ define([
         return null;
     };
 
-     var addPlayer = function (api) {
-        for (var p = 0; p < _instances.length; p++) {
-            if (_instances[p] === api) {
-                return api; // Player is already in the list;
-            }
-        }
-
+    var _addPlayer = function (api) {
         _uniqueIndex++;
         api.uniqueId = _uniqueIndex;
         _instances.push(api);
         return api;
     };
 
+    var _removePlayer = function (api) {
+        for (var i=_instances.length; i--;) {
+            if (_instances[i].uniqueId === api.uniqueId) {
+                _instances.splice(i, 1);
+                api.destroyPlayer();
+                break;
+            }
+        }
+    };
+
     return {
         _instances : _instances,
         selectPlayer : selectPlayer,
-        playerById : playerById,
-        addPlayer : addPlayer
+        playerById : playerById
     };
 });

--- a/src/js/embed/embed.js
+++ b/src/js/embed/embed.js
@@ -6,10 +6,9 @@ define([
     'playlist/loader',
     'embed/config',
     'plugins/plugins',
-    'controller/controller',
     'view/errorscreen',
     'underscore'
-], function(utils, cssUtils, events, scriptloader, PlaylistLoader, EmbedConfig, plugins, Controller, errorScreen, _) {
+], function(utils, cssUtils, events, scriptloader, PlaylistLoader, EmbedConfig, plugins, errorScreen, _) {
 
     var _css = cssUtils.css;
 
@@ -19,7 +18,6 @@ define([
             _config = new EmbedConfig(api.config),
             _width = _config.width,
             _height = _config.height,
-            _oldContainer = document.getElementById(api.id),
             _pluginloader = plugins.loadPlugins(api.id, _config.plugins),
             _loader,
             _playlistLoading = false,
@@ -109,8 +107,6 @@ define([
                 var pluginConfigCopy = _.extend({}, _config);
                 _pluginloader.setupPlugins(api, pluginConfigCopy, _resizePlugin);
 
-                utils.emptyElement(_container);
-
                 // Volume option is tricky to remove, since it needs to be in the HTML5 player model.
                 var playerConfigCopy = _.extend({}, pluginConfigCopy);
                 delete playerConfigCopy.volume;
@@ -170,7 +166,10 @@ define([
             }
 
             // Put new container in page
-            _oldContainer.parentNode.replaceChild(_container, _oldContainer);
+            var container = document.getElementById(_container.id);
+            if (container !== _container) {
+                container.parentNode.replaceChild(_container, container);
+            }
 
             _errorOccurred = true;
             errorScreen(_container, message, body);

--- a/src/js/jwplayer.js
+++ b/src/js/jwplayer.js
@@ -1,19 +1,16 @@
 define([
     'api/global-api',
-    'events/events',
     'polyfill/bind',
     'polyfill/eventlisteners',
     '../css/styles.less',
     '../css/imports/errorscreen.less'
-], function (Api, events) {
+], function (GlobalApi) {
     var jwplayer = function () {
-        return Api.selectPlayer.apply(this, arguments);
+        return GlobalApi.selectPlayer.apply(GlobalApi, arguments);
     };
 
     // This is replaced by compiler
     jwplayer.version = __BUILD_VERSION__;
-    jwplayer.api = Api;
-    jwplayer.events = events;
     jwplayer.vid = document.createElement('video');
 
     if (!window.jwplayer) {


### PR DESCRIPTION
- removes global-api from jwplayer.api (will move to commercial legacy.js)
- global-api creates and adds instances on first query
- jwplayer().remove() removes itself from the global list then is destroyed
- api is cleaned up and global-api addPlayer and new removePlayer methods are private