### PR TITLE
State Specific Styles Isolated to Separate Files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -111,7 +111,8 @@ module.exports = function(grunt) {
             css: {
                 files: [
                     'src/css/*.less',
-                    'src/css/imports/*.less'],
+                    'src/css/imports/*.less',
+                    'src/css/states/*.less'],
                 tasks: ['webpack']
             },
             grunt: {

--- a/src/css/imports/display.less
+++ b/src/css/imports/display.less
@@ -2,6 +2,7 @@
 
 .jw-display {
     position: absolute;
+    display: none;
     width: 100%;
     height: 100%;
 }

--- a/src/css/imports/icons.less
+++ b/src/css/imports/icons.less
@@ -54,77 +54,120 @@
 }
 
 /*** ICONS ***/
-.jwplayer .icon-audio-tracks:after {
-    content: "\e600";
-}
+.jwplayer {
+    .icon-audio-tracks {
+        &:after {
+            content: "\e600";
+        }
+    }
 
-.jwplayer .jw-icon-buffer:after {
-    content: "\e601";
-}
+    .jw-icon-buffer{
+        &:after {
+            content: "\e601";
+        }
+    }
 
-.jwplayer .jw-icon-cast-off:after {
-    content: "\e602";
-}
+    .jw-icon-cast-off {
+        &:after {
+            content: "\e602";
+        }
+    }
 
-.jwplayer .jw-icon-cast-on:after {
-    content: "\e603";
-}
+    .jw-icon-cast-on {
+        &:after {
+            content: "\e603";
+        }
+    }
 
-.jwplayer .jw-icon-cc-off:after {
-    content: "\e604";
-}
+    .jw-icon-cc-off{
+        &:after {
+            content: "\e604";
+        }
+    }
 
-.jwplayer .jw-icon-cc-on:after {
-    content: "\e605";
-}
+    .jw-icon-cc-on {
+        &:after {
+            content: "\e605";
+        }
+    }
 
-.jwplayer .jw-icon-cue:after,
-.jwplayer .jw-menu .jw-option:before {
-    content: "\e606";
-}
+    .jw-icon-cue {
+        &:after {
+            content: "\e606";
+        }
+    }
 
-.jwplayer .jw-icon-error:after {
-    content: "\e607";
-}
+    .jw-icon-menu-bullet {
+        &:before {
+            content: "\e606";
+        }
+    }
 
-.jwplayer .jw-icon-fullscreen:after {
-    content: "\e608";
-}
+    .jw-icon-error {
+        &:after {
+            content: "\e607";
+        }
+    }
 
-.jwplayer .jw-icon-hd-off:after {
-    content: "\e609";
-}
+    .jw-icon-fullscreen{
+        &:after {
+            content: "\e608";
+        }
+    }
 
-.jwplayer .jw-icon-hd-on:after {
-    content: "\e60a";
-}
+    .jw-icon-hd-off {
+        &:after {
+            content: "\e609";
+        }
+    }
 
-.jwplayer .jw-icon-next:after,
-.jwplayer .jw-icon-prev:after {
-    content: "\e60b";
-}
+    .jw-icon-hd-on {
+        &:after {
+            content: "\e60a";
+        }
+    }
 
-.jwplayer .jw-icon-pause:after {
-    content: "\e60c";
-}
+    .jw-icon-next,
+    .jw-icon-prev {
+        &:after {
+            content: "\e60b";
+        }
+    }
 
-.jwplayer .jw-icon-play:after {
-    content: "\e60d";
-}
+    .jw-icon-pause {
+        &:after {
+            content: "\e60c";
+        }
+    }
 
-.jwplayer .jw-icon-replay:after {
-    content: "\e60e";
-}
+    .jw-icon-play {
+        &:after {
+            content: "\e60d";
+        }
+    }
 
-.jwplayer .jw-slider-horizontal .jw-thumb:after,
-.jwplayer .jw-slider-vertical .jw-thumb:after {
-    content: "\e60f";
-}
+    .jw-icon-replay {
+        &:after {
+            content: "\e60e";
+        }
+    }
 
-.jwplayer .jw-icon-volume-mute:after {
-    content: "\e611";
-}
+    .jw-slider-horizontal .jw-thumb,
+    .jw-slider-vertical .jw-thumb {
+        &:after {
+            content: "\e60f";
+        }
+    }
 
-.jwplayer .jw-icon-volume-unmute:after {
-    content: "\e612";
+    .jw-icon-volume-mute {
+        &:after {
+            content: "\e611";
+        }
+    }
+
+    .jw-icon-volume-unmute{
+        &:after {
+            content: "\e612";
+        }
+    }
 }

--- a/src/css/imports/tooltip.less
+++ b/src/css/imports/tooltip.less
@@ -21,6 +21,8 @@
         position: relative;
         white-space: nowrap;
         cursor: pointer;
+
+        .jwplayer .jw-icon-menu-bullet;
     }
 
     .jw-overlay {

--- a/src/css/jwplayer.less
+++ b/src/css/jwplayer.less
@@ -12,6 +12,12 @@
 @import "imports/captions.less";
 @import "imports/rightclick.less";
 
+@import "states/idle.less";
+@import "states/play.less";
+@import "states/pause.less";
+@import "states/buffer.less";
+@import "states/replay.less";
+
 .jwplayer {
     width: 100%;
     font-size: @default-em-size;
@@ -21,6 +27,7 @@
     overflow: hidden;
     box-sizing: border-box;
     font-family: Arial, Helvetica, sans-serif;
+    background-color: #000;
 
     * {
         box-sizing: inherit;

--- a/src/css/states/buffer.less
+++ b/src/css/states/buffer.less
@@ -1,0 +1,21 @@
+.jwplayer.jw-state-buffer {
+    .jw-display {
+        display: block;
+    }
+
+    .jw-display-icon-cont {
+        .jw-icon-display:after {
+            // EXTEND .jw-icon-buffer:after {
+            content: "\e601";
+        }
+
+        .jw-text {
+            display: none;
+        }
+    }
+
+    .jw-controlbar--left-group .jw-play-state-icon:after {
+        // EXTEND .jw-icon-play:after
+        content: "\e60d";
+    }
+}

--- a/src/css/states/buffer.less
+++ b/src/css/states/buffer.less
@@ -4,9 +4,8 @@
     }
 
     .jw-display-icon-cont {
-        .jw-icon-display:after {
-            // EXTEND .jw-icon-buffer:after {
-            content: "\e601";
+        .jw-icon-display {
+            .jwplayer .jw-icon-buffer;
         }
 
         .jw-text {
@@ -14,8 +13,7 @@
         }
     }
 
-    .jw-controlbar--left-group .jw-play-state-icon:after {
-        // EXTEND .jw-icon-play:after
-        content: "\e60d";
+    .jw-controlbar--left-group .jw-play-state-icon {
+        .jwplayer .jw-icon-play;
     }
 }

--- a/src/css/states/idle.less
+++ b/src/css/states/idle.less
@@ -2,14 +2,16 @@
     .jw-display {
         display: block;
 
-        .jw-icon-display:after {
-            // EXTEND .jw-icon-play:after
-            content: "\e60d";
+        .jw-icon-display {
+            .jwplayer .jw-icon-replay;
         }
     }
 
     .jw-controlbar--left-group .jw-play-state-icon:after {
-        // EXTEND .jw-icon-play:after
-        content: "\e60d";
+        .jwplayer .jw-icon-play;
+    }
+
+    .jw-captions {
+        display: none;
     }
 }

--- a/src/css/states/idle.less
+++ b/src/css/states/idle.less
@@ -1,0 +1,15 @@
+.jwplayer.jw-state-idle {
+    .jw-display {
+        display: block;
+
+        .jw-icon-display:after {
+            // EXTEND .jw-icon-play:after
+            content: "\e60d";
+        }
+    }
+
+    .jw-controlbar--left-group .jw-play-state-icon:after {
+        // EXTEND .jw-icon-play:after
+        content: "\e60d";
+    }
+}

--- a/src/css/states/pause.less
+++ b/src/css/states/pause.less
@@ -4,9 +4,8 @@
     }
 
     .jw-display-icon-cont {
-        .jw-icon-display:after {
-            // EXTEND .jw-icon-play:after
-            content: "\e60d";
+        .jw-icon-display {
+            .jwplayer .jw-icon-play;
         }
 
         .jw-text {
@@ -14,8 +13,7 @@
         }
     }
 
-    .jw-controlbar--left-group .jw-play-state-icon:after {
-        // EXTEND .jw-icon-play:after
-        content: "\e60d";
+    .jw-controlbar--left-group .jw-play-state-icon {
+        .jwplayer .jw-icon-play;
     }
 }

--- a/src/css/states/pause.less
+++ b/src/css/states/pause.less
@@ -1,0 +1,21 @@
+.jwplayer.jw-state-pause {
+    .jw-display {
+        display: block;
+    }
+
+    .jw-display-icon-cont {
+        .jw-icon-display:after {
+            // EXTEND .jw-icon-play:after
+            content: "\e60d";
+        }
+
+        .jw-text {
+            display: none;
+        }
+    }
+
+    .jw-controlbar--left-group .jw-play-state-icon:after {
+        // EXTEND .jw-icon-play:after
+        content: "\e60d";
+    }
+}

--- a/src/css/states/play.less
+++ b/src/css/states/play.less
@@ -1,6 +1,5 @@
 .jwplayer.jw-state-play {
-    .jw-controlbar .jw-controlbar--left-group .jw-play-state-icon:after {
-        // EXTEND .jw-icon-pause:after
-        content: "\e60c";
+    .jw-controlbar .jw-controlbar--left-group .jw-play-state-icon {
+        .jwplayer .jw-icon-pause;
     }
 }

--- a/src/css/states/play.less
+++ b/src/css/states/play.less
@@ -1,0 +1,6 @@
+.jwplayer.jw-state-play {
+    .jw-controlbar .jw-controlbar--left-group .jw-play-state-icon:after {
+        // EXTEND .jw-icon-pause:after
+        content: "\e60c";
+    }
+}

--- a/src/css/states/replay.less
+++ b/src/css/states/replay.less
@@ -4,9 +4,8 @@
     }
 
     .jw-display-icon-cont {
-        .jw-icon-display:after {
-            // EXTEND .jw-icon-replay:after {
-            content: "\e60e";
+        .jw-icon-display {
+            .jwplayer .jw-icon-replay;
         }
 
         .jw-text {
@@ -15,7 +14,10 @@
     }
 
     .jw-controlbar--left-group .jw-play-state-icon:after {
-        // EXTEND .jw-icon-play:after
-        content: "\e60d";
+        .jwplayer .jw-icon-play;
+    }
+
+    .jw-captions {
+        display: none;
     }
 }

--- a/src/css/states/replay.less
+++ b/src/css/states/replay.less
@@ -1,0 +1,21 @@
+.jwplayer.jw-state-replay {
+    .jw-display {
+        display: block;
+    }
+
+    .jw-display-icon-cont {
+        .jw-icon-display:after {
+            // EXTEND .jw-icon-replay:after {
+            content: "\e60e";
+        }
+
+        .jw-text {
+            display: none;
+        }
+    }
+
+    .jw-controlbar--left-group .jw-play-state-icon:after {
+        // EXTEND .jw-icon-play:after
+        content: "\e60d";
+    }
+}

--- a/test/manual/css-skins/index.html
+++ b/test/manual/css-skins/index.html
@@ -34,20 +34,6 @@
             margin: 0;
         }
 
-        /*
-        .play-state .jw-display-icon-cont {
-            display: none;
-        }
-
-        .pause-state .jw-display-icon-cont .jw-text {
-            display: none;
-        }
-
-        .buffering-state .jw-display-icon-cont .jw-text {
-            display: none;
-        }
-        */
-
         @media all and (min-width: 1024px) {
             .vid-cont {
                 margin: 100px 20% 100px 20%;

--- a/test/manual/css-skins/index.html
+++ b/test/manual/css-skins/index.html
@@ -34,6 +34,7 @@
             margin: 0;
         }
 
+        /*
         .play-state .jw-display-icon-cont {
             display: none;
         }
@@ -45,6 +46,7 @@
         .buffering-state .jw-display-icon-cont .jw-text {
             display: none;
         }
+        */
 
         @media all and (min-width: 1024px) {
             .vid-cont {
@@ -152,7 +154,7 @@
                         <div class="jw-preview" style="background-image:url(http://content.bitsontherun.com/thumbs/3XnJSIm4-480.jpg)"></div>
                         <div class="jw-display-icon-cont">
                             <div class="jw-text">TEST TEXT</div>
-                            <div class="jw-icon-display jw-icon-play"></div>
+                            <div class="jw-icon-display"></div>
                         </div>
                     </div>
                     <img class="jw-logo">
@@ -177,7 +179,7 @@
                     </div>
                     <div class="jw-controlbar">
                         <div class="jw-controlbar--left-group">
-                            <span class="jw-icon-inline jw-icon-play"></span>
+                            <span class="jw-icon-inline jw-play-state-icon"></span>
                             <span class="jw-icon-inline jw-icon-prev"></span>
                             <span class="jw-icon-inline jw-icon-next"></span>
                             <span class="jw-elapsed">
@@ -258,6 +260,7 @@
         <button id='play-state'>Play</button>
         <button id='pause-state'>Pause</button>
         <button id='buffering-state'>Buffering</button>
+        <button id='replay-state'>Replay</button>
     </div>
 </body>
 </html>

--- a/test/manual/css-skins/scripts.js
+++ b/test/manual/css-skins/scripts.js
@@ -82,7 +82,6 @@ $(document).ready(function(){
         document.styleSheets[0].addRule('.jwplayer:before','padding-top: ' + Math.round(9/16 * 100) + '%');
         if(document.attachEvent)document.styleSheets[0].addRule('.jwplayer:before','content: ' + Math.round(Math.random()*1000));
         if(!document.attachEvent) document.styleSheets[0].insertRule('.jwplayer:before { padding-top: ' + Math.round(9/16 * 100) + '%; }', 0);
-        //$('.jwplayer:before').css('padding-top', Math.round(9/16 * 100) + '%');
     };
 
     $('#aspect-ratio-16-9').on('click', aspect169);
@@ -100,7 +99,6 @@ $(document).ready(function(){
         document.styleSheets[0].addRule('.jwplayer:before','padding-top: ' + Math.round(3/4 * 100) + '%');
         if(document.attachEvent)document.styleSheets[0].addRule('.jwplayer:before','content: ' + Math.round(Math.random()*1000));
         if(!document.attachEvent) document.styleSheets[0].insertRule('.jwplayer:before { padding-top: ' + Math.round(3/4 * 100) + '%; }', 0);
-        //$('.jwplayer:before').css('padding-top', Math.round(3/4 * 100) + '%');
     };
 
     $('#aspect-ratio-4-3').on('click', aspect43);
@@ -110,14 +108,6 @@ $(document).ready(function(){
     var idlestate = function(e) {
         $('.jwplayer').addClass('jw-state-idle');
         $('.jwplayer').removeClass('jw-state-play jw-state-pause jw-state-buffer jw-state-replay');
-
-        //$('.jwplayer').removeClass('pause-state');
-        //$('.jwplayer').removeClass('buffering-state');
-        //$('.jwplayer .jw-display-icon-cont .jw-icon-display').addClass('jw-icon-play');
-        //$('.jwplayer .jw-display-icon-cont .jw-icon-display').removeClass('jw-icon-buffer');
-        //
-        //$($('.jwplayer .jw-left .jw-icon')[0]).addClass('jw-icon-play');
-        //$($('.jwplayer .jw-left .jw-icon')[0]).removeClass('jw-icon-pause');
     };
 
     $('#idle-state').on('click', idlestate);

--- a/test/manual/css-skins/scripts.js
+++ b/test/manual/css-skins/scripts.js
@@ -108,14 +108,16 @@ $(document).ready(function(){
 
 
     var idlestate = function(e) {
-        $('.jwplayer').removeClass('play-state');
-        $('.jwplayer').removeClass('pause-state');
-        $('.jwplayer').removeClass('buffering-state');
-        $('.jwplayer .jw-display-icon-cont .jw-icon-display').addClass('jw-icon-play');
-        $('.jwplayer .jw-display-icon-cont .jw-icon-display').removeClass('jw-icon-buffer');
+        $('.jwplayer').addClass('jw-state-idle');
+        $('.jwplayer').removeClass('jw-state-play jw-state-pause jw-state-buffer jw-state-replay');
 
-        $($('.jwplayer .jw-left .jw-icon')[0]).addClass('jw-icon-play');
-        $($('.jwplayer .jw-left .jw-icon')[0]).removeClass('jw-icon-pause');
+        //$('.jwplayer').removeClass('pause-state');
+        //$('.jwplayer').removeClass('buffering-state');
+        //$('.jwplayer .jw-display-icon-cont .jw-icon-display').addClass('jw-icon-play');
+        //$('.jwplayer .jw-display-icon-cont .jw-icon-display').removeClass('jw-icon-buffer');
+        //
+        //$($('.jwplayer .jw-left .jw-icon')[0]).addClass('jw-icon-play');
+        //$($('.jwplayer .jw-left .jw-icon')[0]).removeClass('jw-icon-pause');
     };
 
     $('#idle-state').on('click', idlestate);
@@ -123,14 +125,8 @@ $(document).ready(function(){
 
 
     var playstate = function(e){
-        $('.jwplayer').addClass('play-state');
-        $('.jwplayer').removeClass('pause-state');
-        $('.jwplayer').removeClass('buffering-state');
-        $('.jwplayer .jw-display-icon-cont .jw-icon-display').addClass('jw-icon-play');
-        $('.jwplayer .jw-display-icon-cont .jw-icon-display').removeClass('jw-icon-buffer');
-
-        $($('.jwplayer .jw-controlbar--center-group .jw-icon-inline')[0]).removeClass('jw-icon-play');
-        $($('.jwplayer .jw-controlbar--center-group .jw-icon-inline')[0]).addClass('jw-icon-pause');
+        $('.jwplayer').addClass('jw-state-play');
+        $('.jwplayer').removeClass('jw-state-idle jw-state-pause jw-state-buffer jw-state-replay');
     };
 
     $('#play-state').on('click', playstate);
@@ -138,30 +134,26 @@ $(document).ready(function(){
 
 
     var pausestate = function(e){
-        $('.jwplayer').removeClass('play-state');
-        $('.jwplayer').addClass('pause-state');
-        $('.jwplayer').removeClass('buffering-state');
-        $('.jwplayer .jw-display-icon-cont .jw-icon-display').addClass('jw-icon-play');
-        $('.jwplayer .jw-display-icon-cont .jw-icon-display').removeClass('jw-icon-buffer');
-
-        $($('.jwplayer .jw-controlbar--center-group .jw-icon-inline')[0]).addClass('jw-icon-play');
-        $($('.jwplayer .jw-controlbar--center-group .jw-icon-inline')[0]).removeClass('jw-icon-pause');
+        $('.jwplayer').addClass('jw-state-pause');
+        $('.jwplayer').removeClass('jw-state-play jw-state-idle jw-state-buffer jw-state-replay');
     };
 
     $('#pause-state').on('click', pausestate);
     if(document.attachEvent) document.getElementById('pause-state').attachEvent('onclick', pausestate);
 
     var bufferingstate = function(e){
-        $('.jwplayer').removeClass('play-state');
-        $('.jwplayer').removeClass('pause-state');
-        $('.jwplayer').addClass('buffering-state');
-        $('.jwplayer .jw-display-icon-cont .jw-icon-display').removeClass('jw-icon-play');
-        $('.jwplayer .jw-display-icon-cont .jw-icon-display').addClass('jw-icon-buffer');
-
-        $($('.jwplayer .jw-controlbar--center-group .jw-icon-inline')[0]).addClass('jw-icon-play');
-        $($('.jwplayer .jw-controlbar--center-group .jw-icon-inline')[0]).removeClass('jw-icon-pause');
+        $('.jwplayer').addClass('jw-state-buffer');
+        $('.jwplayer').removeClass('jw-state-play jw-state-pause jw-state-idle jw-state-replay');
     };
 
     $('#buffering-state').on('click', bufferingstate);
     if(document.attachEvent) document.getElementById('buffering-state').attachEvent('onclick', bufferingstate);
+
+    var replaystate = function(e){
+        $('.jwplayer').addClass('jw-state-replay');
+        $('.jwplayer').removeClass('jw-state-play jw-state-pause jw-state-buffer jw-state-idle');
+    };
+
+    $('#replay-state').on('click', replaystate);
+    if(document.attachEvent) document.getElementById('replay-state').attachEvent('onclick', replaystate);
 });


### PR DESCRIPTION
Isolates state specific styling to separate files.  This makes it easier to find and modify the styles that exist in specific states, as well as apply states consistently by applying a single class to the root of the player.  also changed how we're setting up icon styles so that they can be used as mixins so that its easier to apply an icon's style information to an element.