### PR TITLE
Visual Quality Events listener [Finishes #88511936]

### DIFF
--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -97,6 +97,9 @@ define([
                 case events.JWPLAYER_PROVIDER_CHANGED:
                     this.set('provider', _provider.getName());
                     break;
+                case events.JWPLAYER_VISUAL_QUALITY:
+                    this.set('visualQuality', evt.level);
+                    break;
             }
 
             this.mediaController.trigger(evt.type, evt);

--- a/src/js/controller/qoe.js
+++ b/src/js/controller/qoe.js
@@ -71,9 +71,6 @@ define([
             trackFirstFrame(model);
             trackStalledTime(model);
         });
-        model.mediaController.on(events.JWPLAYER_VISUAL_QUALITY, function(evt){
-            model.set('visualQuality', evt.level);
-        });
     }
 
     return {

--- a/src/js/controller/qoe.js
+++ b/src/js/controller/qoe.js
@@ -71,6 +71,9 @@ define([
             trackFirstFrame(model);
             trackStalledTime(model);
         });
+        model.mediaController.on(events.JWPLAYER_VISUAL_QUALITY, function(evt){
+            model.set('visualQuality', evt.level);
+        });
     }
 
     return {

--- a/src/js/events/events.js
+++ b/src/js/events/events.js
@@ -40,6 +40,7 @@ define([], function() {
         JWPLAYER_MEDIA_PLAY_ATTEMPT: 'playAttempt',
         JWPLAYER_MEDIA_LOADED: 'loaded',
         JWPLAYER_MEDIA_SEEKED: 'seeked',
+        JWPLAYER_VISUAL_QUALITY: 'visualQuality',
 
         // Setup Events
         API_SETUP: 'apiSetup',

--- a/src/js/providers/flash.js
+++ b/src/js/providers/flash.js
@@ -228,6 +228,10 @@ define([
                         this.sendEvent(events.JWPLAYER_PROVIDER_CHANGED, data);
                     }, this);
 
+                    _swf.on(events.JWPLAYER_VISUAL_QUALITY, function(data) {
+                        this.sendEvent(events.JWPLAYER_VISUAL_QUALITY, data);
+                    }, this);
+
                     // ignoring:
                     // jwplayerMediaLoaded, jwplayerMediaBeforePlay, ...
 


### PR DESCRIPTION
Handles visualQuality events coming from the Flash player and the QOE module will set the current visual quality value on the model.  [Finishes #88511936]  This is paired with the jwplayer-commercial PR https://github.com/jwplayer/jwplayer-commercial/pull/542