### PR TITLE
model change:playlistItem [Delivers #88512034]

### DIFF
--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -63,9 +63,6 @@ define([
 
         QOE.model(this);
 
-        // This gets added later
-        this.set('playlist', []);
-
         _providers = new Providers(_this.config.primary);
 
         function _videoEventHandler(evt) {
@@ -176,7 +173,6 @@ define([
                 return;
             }
 
-            this.set('item', -1);
             this.setItem(0);
         };
 
@@ -202,6 +198,7 @@ define([
             this.set('item', newItem);
             // select provider based on item source (video, youtube...)
             var item = this.get('playlist')[newItem];
+            this.set('playlistItem', item);
             var source = item && item.sources && item.sources[0];
             if (source === undefined) {
                 // source is undefined when resetting index with empty playlist

--- a/src/js/controller/qoe.js
+++ b/src/js/controller/qoe.js
@@ -59,7 +59,7 @@ define([
     }
 
     function initModel(model) {
-        model.on(events.JWPLAYER_PLAYLIST_ITEM, function() {
+        model.on('change:playlistItem', function() {
             // reset item level qoe
             model._qoeItem = new Timer();
             model._qoeItem.tick(events.JWPLAYER_PLAYLIST_ITEM);


### PR DESCRIPTION
fixes an issue with qoe video start time by listening for playlist item changes on the model (JWPLAYER_PLAYLIST_ITEM is now only dispatched by the controller)

As a follow up we can use 'change:playlistItem' internally instead of the unreliable 'change:item'.