### PR TITLE
qoe unit tests [Delivers #88512386] [#90699216]

### DIFF
--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -222,18 +222,28 @@ define([
             var instreamState = _instream && _instream.getState();
 
             if (instreamState) {
-                if (instreamState === states.IDLE || instreamState === states.PLAYING ||
-                    instreamState === states.BUFFERING) {
-                    _controller.instreamPause();
-                } else {
-                    _controller.instreamPlay();
+                switch (instreamState) {
+                    case states.IDLE:
+                    case states.PLAYING:
+                    case states.LOADING:
+                    case states.STALLED:
+                    case states.BUFFERING:
+                        _controller.instreamPause();
+                        break;
+                    default:
+                        _controller.instreamPlay();
                 }
             }
 
-            if (state === states.PLAYING || state === states.BUFFERING) {
-                _controller.pause();
-            } else {
-                _controller.play();
+            switch (state) {
+                case states.PLAYING:
+                case states.LOADING:
+                case states.STALLED:
+                case states.BUFFERING:
+                    _controller.pause();
+                    break;
+                default:
+                    _controller.play();
             }
 
             return _this;
@@ -242,10 +252,15 @@ define([
         this.pause = function (state) {
             if (state === undefined) {
                 state = _this.getState();
-                if (state === states.PLAYING || state === states.BUFFERING) {
-                    _controller.pause();
-                } else {
-                    _controller.play();
+                switch (state) {
+                    case states.PLAYING:
+                    case states.LOADING:
+                    case states.STALLED:
+                    case states.BUFFERING:
+                        _controller.pause();
+                        break;
+                    default:
+                        _controller.play();
                 }
             } else {
                 _controller.pause(state);

--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -225,8 +225,6 @@ define([
                 switch (instreamState) {
                     case states.IDLE:
                     case states.PLAYING:
-                    case states.LOADING:
-                    case states.STALLED:
                     case states.BUFFERING:
                         _controller.instreamPause();
                         break;
@@ -237,8 +235,6 @@ define([
 
             switch (state) {
                 case states.PLAYING:
-                case states.LOADING:
-                case states.STALLED:
                 case states.BUFFERING:
                     _controller.pause();
                     break;
@@ -254,8 +250,6 @@ define([
                 state = _this.getState();
                 switch (state) {
                     case states.PLAYING:
-                    case states.LOADING:
-                    case states.STALLED:
                     case states.BUFFERING:
                         _controller.pause();
                         break;

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -96,9 +96,10 @@ define([
                     });
                 });
                 // For onItem callback
-                _model.on('change:item', function(model, idx) {
+                _model.on('change:playlistItem', function(model, playlistItem) {
                     _this.trigger(events.JWPLAYER_PLAYLIST_ITEM, {
-                        index: idx
+                        index: model.get('item'),
+                        item: playlistItem
                     });
                 });
                 // For onPlaylist callback
@@ -257,6 +258,8 @@ define([
                 }
                 switch (_model.get('state')) {
                     case states.PLAYING:
+                    case states.LOADING:
+                    case states.STALLED:
                     case states.BUFFERING:
                         var status = utils.tryCatch(function(){
                             _video().pause();

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -258,8 +258,6 @@ define([
                 }
                 switch (_model.get('state')) {
                     case states.PLAYING:
-                    case states.LOADING:
-                    case states.STALLED:
                     case states.BUFFERING:
                         var status = utils.tryCatch(function(){
                             _video().pause();

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -28,6 +28,18 @@ define([
         volume: 90
     };
 
+    // The model stores a different state than the provider
+    function normalizeState(newstate) {
+        if (newstate === states.LOADING || newstate === states.STALLED) {
+            return states.BUFFERING;
+        }
+        return newstate;
+    }
+
+    // Represents the state of the provider/media element
+    var MediaModel = function() {};
+
+    // Represents the state of the player
     var Model = function(config) {
         var _this = this,
             // Video provider
@@ -49,10 +61,11 @@ define([
             duration: -1,
             position: 0,
             buffer: 0
-        }, Events);
+        });
 
         this.mediaController = _.extend({}, Events);
-        this.mediaModel = {};
+        this.mediaModel = new MediaModel();
+        this.mediaModel.set('state', states.IDLE);
 
         QOE.model(this);
 
@@ -66,20 +79,20 @@ define([
                 case events.JWPLAYER_MEDIA_VOLUME:
                     this.set('volume', evt.volume);
                     break;
+
                 case events.JWPLAYER_PLAYER_STATE:
-                    // model uses all states
-                    this.set('state', evt.newstate);
-                    // These two states exist at a provider>model level, but the player itself expects BUFFERING
-                    evt = _.extend({}, evt);
-                    if (evt.newstate === states.LOADING || evt.newstate === states.STALLED) {
-                        evt.reason = evt.newstate;
-                        evt.newstate = states.BUFFERING;
-                    }
-                    if (evt.oldstate === states.LOADING || evt.oldstate === states.STALLED) {
-                        evt.oldstate = states.BUFFERING;
-                    }
-                    evt.type = evt.newstate;
+                    var providerState = evt.newstate;
+                    var modelState = normalizeState(evt.newstate);
+
+                    evt.oldstate = this.get('state');
+                    evt.reason   = providerState;
+                    evt.newstate = modelState;
+                    evt.type     = modelState;
+
+                    this.mediaModel.set('state', providerState);
+                    this.set('state', modelState);
                     break;
+
                 case events.JWPLAYER_MEDIA_BUFFER:
                     this.set('buffer', evt.bufferPercent); // note value change
                     break;
@@ -99,7 +112,7 @@ define([
                 case 'visualQuality':
                     var visualQuality = _.extend({}, evt);
                     delete visualQuality.type;
-                    this.mediaModel.visualQuality =  visualQuality;
+                    this.mediaModel.set('visualQuality', visualQuality);
                     break;
             }
 
@@ -187,7 +200,7 @@ define([
             }
 
             // Item is actually changing
-            this.mediaModel = {};
+            this.mediaModel = new MediaModel();
             this.set('item', newItem);
             // select provider based on item source (video, youtube...)
             var item = this.get('playlist')[newItem];
@@ -267,11 +280,11 @@ define([
         };
     };
 
-    _.extend(Model.prototype, {
-        'get' : function(attr) {
+    var SimpleModel = _.extend({
+        'get' : function (attr) {
             return this[attr];
         },
-        'set' : function(attr, val) {
+        'set' : function (attr, val) {
             if (this[attr] === val) {
                 return;
             }
@@ -279,8 +292,10 @@ define([
             this[attr] = val;
             this.trigger('change:' + attr, this, val, oldVal);
         }
-    });
+    }, Events);
+
+    _.extend(Model.prototype, SimpleModel);
+    _.extend(MediaModel.prototype, SimpleModel);
 
     return Model;
-
 });

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -67,18 +67,18 @@ define([
                     this.set('volume', evt.volume);
                     break;
                 case events.JWPLAYER_PLAYER_STATE:
-                    // These two states exist at a provider level, but the player itself expects BUFFERING
+                    // model uses all states
+                    this.set('state', evt.newstate);
+                    // These two states exist at a provider>model level, but the player itself expects BUFFERING
                     evt = _.extend({}, evt);
-                    if (evt.newstate === states.LOADING) {
-                        this.mediaController.trigger(events.JWPLAYER_PROVIDER_LOADING);
-                        evt.newstate = states.BUFFERING;
-                    } else if (evt.newstate === states.STALLED) {
-                        this.mediaController.trigger(events.JWPLAYER_PROVIDER_STALLED);
+                    if (evt.newstate === states.LOADING || evt.newstate === states.STALLED) {
+                        evt.reason = evt.newstate;
                         evt.newstate = states.BUFFERING;
                     }
+                    if (evt.oldstate === states.LOADING || evt.oldstate === states.STALLED) {
+                        evt.oldstate = states.BUFFERING;
+                    }
                     evt.type = evt.newstate;
-
-                    this.set('state', evt.newstate);
                     break;
                 case events.JWPLAYER_MEDIA_BUFFER:
                     this.set('buffer', evt.bufferPercent); // note value change

--- a/src/js/controller/qoe.js
+++ b/src/js/controller/qoe.js
@@ -51,8 +51,7 @@ define([
     function initModel(model) {
 
         model.on('change:playlistItem', function(model /*, playlistItem */) {
-            //var state = model.mediaModel.get('state');
-            var state = model.mediaModel.state;
+            var state = model.mediaModel.get('state');
             // finish previous item
             if (model._qoeItem) {
                 model._qoeItem.end(state);

--- a/src/js/controller/qoe.js
+++ b/src/js/controller/qoe.js
@@ -1,9 +1,8 @@
 define([
     'utils/timer',
     'events/events',
-    'events/states',
     'utils/underscore'
-], function(Timer, events, states, _) {
+], function(Timer, events, _) {
 
     // This is to provide a first frame event even when
     //  a provider does not give us one.
@@ -20,6 +19,7 @@ define([
     });
 
     function unbindFirstFrameEvents(model) {
+        model.mediaController.off(events.JWPLAYER_MEDIA_PLAY_ATTEMPT, model._onPlayAttempt);
         model.mediaController.off(events.JWPLAYER_PROVIDER_FIRST_FRAME, model._triggerFirstFrame);
         model.mediaController.off(events.JWPLAYER_MEDIA_TIME, model._onTime);
     }
@@ -39,37 +39,34 @@ define([
 
         model._onTime = onTimeIncreasesGenerator(model._triggerFirstFrame);
 
+        model._onPlayAttempt = function() {
+            model._qoeItem.tick(events.JWPLAYER_MEDIA_PLAY_ATTEMPT);
+        };
+
+        model.mediaController.once(events.JWPLAYER_MEDIA_PLAY_ATTEMPT, model._onPlayAttempt);
         model.mediaController.once(events.JWPLAYER_PROVIDER_FIRST_FRAME, model._triggerFirstFrame);
         model.mediaController.on(events.JWPLAYER_MEDIA_TIME, model._onTime);
     }
 
-
-    function trackStalledTime(model) {
-        model.mediaController.on(events.JWPLAYER_PROVIDER_LOADING, function() {
-            model._qoeItem.start(states.LOADING);
-        });
-        model.mediaController.on(events.JWPLAYER_PROVIDER_STALLED, function() {
-            model._qoeItem.start(states.STALLED);
-        });
-        model.on('change:state', function(mod, newstate, oldstate) {
-            if (newstate !== states.BUFFERING) {
-                model._qoeItem.end(oldstate);
-            }
-        });
-    }
-
     function initModel(model) {
-        model.on('change:playlistItem', function() {
+
+        model.on('change:playlistItem', function(model /*, playlistItem */) {
+            var state = model.get('state');
+            // finish previous item
+            if (model._qoeItem) {
+                model._qoeItem.end(state);
+            }
             // reset item level qoe
             model._qoeItem = new Timer();
             model._qoeItem.tick(events.JWPLAYER_PLAYLIST_ITEM);
-
-            model.mediaController.once(events.JWPLAYER_MEDIA_PLAY_ATTEMPT, function() {
-                model._qoeItem.tick(events.JWPLAYER_MEDIA_PLAY_ATTEMPT);
-            });
+            model._qoeItem.start(state);
 
             trackFirstFrame(model);
-            trackStalledTime(model);
+        });
+
+        model.on('change:state', function(model, newstate, oldstate) {
+            model._qoeItem.end(oldstate);
+            model._qoeItem.start(newstate);
         });
     }
 

--- a/src/js/controller/qoe.js
+++ b/src/js/controller/qoe.js
@@ -51,7 +51,8 @@ define([
     function initModel(model) {
 
         model.on('change:playlistItem', function(model /*, playlistItem */) {
-            var state = model.get('state');
+            //var state = model.mediaModel.get('state');
+            var state = model.mediaModel.state;
             // finish previous item
             if (model._qoeItem) {
                 model._qoeItem.end(state);
@@ -64,7 +65,7 @@ define([
             trackFirstFrame(model);
         });
 
-        model.on('change:state', function(model, newstate, oldstate) {
+        model.mediaModel.on('change:state', function(mediaModel, newstate, oldstate) {
             model._qoeItem.end(oldstate);
             model._qoeItem.start(newstate);
         });

--- a/src/js/events/events.js
+++ b/src/js/events/events.js
@@ -75,8 +75,6 @@ define([], function() {
 
         // Provider Communication
         JWPLAYER_PROVIDER_CHANGED: 'providerChanged',
-        JWPLAYER_PROVIDER_LOADING: 'providerLoading',
-        JWPLAYER_PROVIDER_STALLED: 'providerStalled',
         JWPLAYER_PROVIDER_FIRST_FRAME: 'providerFirstFrame',
 
         // UI Events

--- a/src/js/providers/default.js
+++ b/src/js/providers/default.js
@@ -61,7 +61,6 @@ define([
             }
 
             this.sendEvent(events.JWPLAYER_PLAYER_STATE, {
-                oldstate: oldState,
                 newstate: state
             });
         }

--- a/test/tests.js
+++ b/test/tests.js
@@ -2,6 +2,7 @@ define([
     // List all files to run tests from here
     'unit/jwplayer-selectplayer',
     'unit/api',
+    'unit/model-qoe',
     'unit/provider',
     'unit/embed',
     'unit/embed-config',

--- a/test/unit/model-qoe.js
+++ b/test/unit/model-qoe.js
@@ -15,8 +15,8 @@ define([
         model.set('playlistItem', {});
 
         model.mediaController.trigger(events.JWPLAYER_MEDIA_PLAY_ATTEMPT);
-        model.set('state', states.LOADING);
-        model.set('state', states.PLAYING);
+        model.mediaModel.set('state', states.LOADING);
+        model.mediaModel.set('state', states.PLAYING);
 
         // FIXME: JWPLAYER_PROVIDER_FIRST_FRAME triggers JWPLAYER_MEDIA_FIRST_FRAME : we only need one event
         model.mediaController.trigger(events.JWPLAYER_PROVIDER_FIRST_FRAME);
@@ -31,8 +31,8 @@ define([
         model.set('playlistItem', {});
 
         model.mediaController.trigger(events.JWPLAYER_MEDIA_PLAY_ATTEMPT);
-        model.set('state', states.LOADING);
-        model.set('state', states.PLAYING);
+        model.mediaModel.set('state', states.LOADING);
+        model.mediaModel.set('state', states.PLAYING);
         model.mediaController.trigger(events.JWPLAYER_MEDIA_TIME, {
             position: 0
         });
@@ -75,10 +75,10 @@ define([
 
         model.set('playlistItem', {});
 
-        model.set('state', states.LOADING);
-        model.set('state', states.PLAYING);
-        model.set('state', states.STALLED);
-        model.set('state', states.PLAYING);
+        model.mediaModel.set('state', states.LOADING);
+        model.mediaModel.set('state', states.PLAYING);
+        model.mediaModel.set('state', states.STALLED);
+        model.mediaModel.set('state', states.PLAYING);
 
         var qoeDump = model._qoeItem.dump();
         ok(validateMeasurement(qoeDump.sums.stalled), 'stalled sum is a valid number');
@@ -97,7 +97,7 @@ define([
         var secondQoeItem = model._qoeItem;
 
         model.mediaController.trigger(events.JWPLAYER_MEDIA_PLAY_ATTEMPT);
-        model.set('state', states.LOADING);
+        model.mediaModel.set('state', states.LOADING);
 
         ok(firstQoeItem !== secondQoeItem, 'qoe items are unique between playlistItem changes');
 

--- a/test/unit/model-qoe.js
+++ b/test/unit/model-qoe.js
@@ -1,0 +1,139 @@
+define([
+    'test/underscore',
+    'controller/model',
+    'events/events',
+    'events/states'
+], function (_, Model, events, states) {
+    /* jshint qunit: true */
+
+    module('Model QoE');
+
+    test('tracks first frame with provider first frame event', function() {
+        var startTime = _.now();
+        var model = new Model({});
+
+        model.set('playlistItem', {});
+
+        model.mediaController.trigger(events.JWPLAYER_MEDIA_PLAY_ATTEMPT);
+        model.set('state', states.LOADING);
+        model.set('state', states.PLAYING);
+
+        // FIXME: JWPLAYER_PROVIDER_FIRST_FRAME triggers JWPLAYER_MEDIA_FIRST_FRAME : we only need one event
+        model.mediaController.trigger(events.JWPLAYER_PROVIDER_FIRST_FRAME);
+
+        validateQoeFirstFrame(model._qoeItem, startTime);
+    });
+
+    test('tracks first frame with first increasing time event', function() {
+        var startTime = _.now();
+        var model = new Model({});
+
+        model.set('playlistItem', {});
+
+        model.mediaController.trigger(events.JWPLAYER_MEDIA_PLAY_ATTEMPT);
+        model.set('state', states.LOADING);
+        model.set('state', states.PLAYING);
+        model.mediaController.trigger(events.JWPLAYER_MEDIA_TIME, {
+            position: 0
+        });
+        model.mediaController.trigger(events.JWPLAYER_MEDIA_TIME, {
+            position: 1
+        });
+
+        validateQoeFirstFrame(model._qoeItem, startTime);
+    });
+
+    test('removes media controller event listeners', function() {
+        var startTime = _.now();
+        var model = new Model({});
+
+        model.set('playlistItem', {});
+        model.mediaController.trigger(events.JWPLAYER_MEDIA_PLAY_ATTEMPT);
+        model.mediaController.trigger(events.JWPLAYER_PROVIDER_FIRST_FRAME);
+        var qoeItem = model._qoeItem;
+
+        var qoeDump = qoeItem.dump();
+        ok(validateMeasurement(qoeDump.events.playAttempt, startTime), 'play attempt event was fired');
+        ok(validateMeasurement(qoeDump.events.firstFrame, startTime), 'first frame event was fired');
+
+        // test that listeners are removed by testing that tick events are no longer changed
+        qoeItem.tick('playAttempt', -1);
+        qoeItem.tick('firstFrame', -1);
+        model.mediaController.trigger(events.JWPLAYER_MEDIA_PLAY_ATTEMPT);
+        model.mediaController.trigger(events.JWPLAYER_MEDIA_TIME, {
+            position: 2
+        });
+        model.mediaController.trigger(events.JWPLAYER_PROVIDER_FIRST_FRAME);
+
+        qoeDump = qoeItem.dump();
+        equal(qoeDump.events.playAttempt, -1, 'play attempt is unchanged after further media events');
+        equal(qoeDump.events.firstFrame,  -1, 'first frame is unchanged after further media events');
+    });
+
+    test('tracks stalled time', function() {
+        var model = new Model({});
+
+        model.set('playlistItem', {});
+
+        model.set('state', states.LOADING);
+        model.set('state', states.PLAYING);
+        model.set('state', states.STALLED);
+        model.set('state', states.PLAYING);
+
+        var qoeDump = model._qoeItem.dump();
+        ok(validateMeasurement(qoeDump.sums.stalled), 'stalled sum is a valid number');
+    });
+
+    test('uses one qoe item per playlist item', function() {
+        // Test qoe model observation
+        var model = new Model({});
+
+        model.set('playlistItem', {});
+        var firstQoeItem = model._qoeItem;
+
+        // no state changes, play attempt or first frame events
+
+        model.set('playlistItem', {});
+        var secondQoeItem = model._qoeItem;
+
+        model.mediaController.trigger(events.JWPLAYER_MEDIA_PLAY_ATTEMPT);
+        model.set('state', states.LOADING);
+
+        ok(firstQoeItem !== secondQoeItem, 'qoe items are unique between playlistItem changes');
+
+        console.log('firstQoeItem', firstQoeItem.dump());
+        console.log('secondQoeItem', secondQoeItem.dump());
+
+        var firstQoeDump = firstQoeItem.dump();
+        var secondQoeDump = secondQoeItem.dump();
+
+        ok(firstQoeDump.events.playAttempt === undefined, 'play attempt is was not tracked for first unplayed item');
+        ok(secondQoeDump.events.playAttempt !== undefined, 'play attempt is was tracked for second item');
+
+        ok(firstQoeDump.counts.loading === undefined, 'loading was not tracked for first unplayed item');
+        ok(secondQoeDump.counts.loading === 1, 'loading was tracked for second item');
+
+    });
+
+    function validateQoeFirstFrame(qoeItem, startTime) {
+        ok(!!qoeItem, 'qoeItem is defined');
+
+        var loadtime = qoeItem.between(events.JWPLAYER_MEDIA_PLAY_ATTEMPT, events.JWPLAYER_MEDIA_FIRST_FRAME);
+        ok(validateMeasurement(loadtime), 'time to first frame is a valid number');
+
+        var qoeDump = qoeItem.dump();
+        equal(qoeDump.counts.idle, 1,       'one idle event');
+        equal(qoeDump.counts.loading, 1, 'one loading event');
+        equal(qoeDump.counts.playing, 1, 'one playing event');
+        ok(validateMeasurement(qoeDump.sums.idle),       'idle sum is a valid number');
+        ok(validateMeasurement(qoeDump.sums.loading), 'loading sum is a valid number');
+        ok(validateMeasurement(qoeDump.events.playlistItem, startTime), 'playlistItem epoch time is ok');
+        ok(validateMeasurement(qoeDump.events.playAttempt, startTime),   'playAttempt epoch time is ok');
+        ok(validateMeasurement(qoeDump.events.firstFrame, startTime),     'firstFrame epoch time is ok');
+    }
+
+    function validateMeasurement(value, min) {
+        return typeof value === 'number' && !isNaN(value) && value >= (min||0);
+    }
+
+});


### PR DESCRIPTION
- loading and stalled states are used in model.state, but not triggered as events through mediacontroller
- model state changes are tracked as qoe time spans (idle->loading|buffering|stalled->playing|paused->idle)
- qoe item play attempt and first frame event registration cleanup
