### PR TITLE
use model change:playlistItem instead of item index

### DIFF
--- a/src/js/view/controlbar.js
+++ b/src/js/view/controlbar.js
@@ -224,13 +224,13 @@ define([
         _buildControlbar();
         cssUtils.unblock(_id + 'build');
         _addEventListeners();
-        _playlistHandler();
-        _castAvailable();
-
         _this.visible = false;
 
         _.defer(function() {
             _volumeHandler(_model);
+            _playlistHandler();
+            _itemHandler(_model, _model.get('playlistItem'));
+            _castAvailable();
         });
 
         function _layoutElement(name, type, className) {
@@ -248,7 +248,7 @@ define([
             _api.onCaptionsChange(_captionChanged);
 
             _model.on('change:state', _stateHandler);
-            _model.on('change:item', _itemHandler);
+            _model.on('change:playlistItem', _itemHandler);
             _model.on('change:buffer', _bufferHandler);
             _model.on('change:position', _timeUpdated); // pos and dur come together from time event
             _model.on('change:duration', _timeUpdated);
@@ -360,9 +360,9 @@ define([
             }
         }
 
-        function _itemHandler(model, index) {
+        function _itemHandler(model, playlistItem) {
             if (!_instreamMode) {
-                var tracks = _model.playlist[index].tracks,
+                var tracks = playlistItem.tracks,
                     tracksloaded = false,
                     cuesloaded = false;
                 _removeCues();

--- a/src/js/view/title.js
+++ b/src/js/view/title.js
@@ -14,7 +14,7 @@ define([
         this.title = arr[0];
         this.description = arr[1];
 
-        this.model.on('change:item', this.updateText, this);
+        this.model.on('change:playlistItem', this.updateText, this);
         this.updateText(this.model, 0);
     };
 
@@ -28,11 +28,10 @@ define([
             this.el.style.display = '';
         },
 
-        updateText: function(model, index) {
-            var item = model.get('playlist')[index];
+        updateText: function(model, playlistItem) {
 
-            var title = item.title;
-            var description = item.description || '';
+            var title = playlistItem.title;
+            var description = playlistItem.description || '';
 
             if (title) {
                 this.show();


### PR DESCRIPTION
and defer controlbar updates for state set before view is setup (we were not seeing cue-points on the first item until the first item in a list is replayed)