### PR TITLE
Separate "complete" state from "idle" state

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -222,6 +222,8 @@ define([
             }
 
             function _stop(internal) {
+                var fromApi = !internal;
+
                 // Something has called stop() in an onComplete handler
                 if (_isIdle()) {
                     _stopPlaylist = true;
@@ -238,7 +240,7 @@ define([
                     return false;
                 }
 
-                if (!internal) {
+                if (fromApi) {
                     _stopPlaylist = true;
                 }
 
@@ -277,7 +279,8 @@ define([
             }
 
             function _isIdle() {
-                return (_model.get('state') === states.IDLE);
+                var state = _model.get('state');
+                return (state === states.IDLE || state === states.COMPLETE);
             }
 
             function _seek(pos) {
@@ -311,19 +314,24 @@ define([
                 }
 
                 _actionOnAttach = _completeHandler;
-                if (_model.get('repeat')) {
-                    _next();
-                } else {
-                    if (_model.get('item') === _model.get('playlist').length - 1) {
+
+                var idx = _model.get('item');
+                if (idx === _model.get('playlist').length - 1) {
+                    // If it's the last item in the playlist
+                    if (_model.get('repeat')) {
+                        _next();
+                    } else {
                         _loadOnPlay = 0;
-                        _stop(true);
                         setTimeout(function() {
                             _this.trigger(events.JWPLAYER_PLAYLIST_COMPLETE, {});
                         }, 0);
-                    } else {
-                        _next();
                     }
+                    return;
                 }
+
+                // It wasn't the last item in the playlist,
+                //  so go to the next one
+                _next();
             }
 
             function _setCurrentQuality(quality) {

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -322,9 +322,7 @@ define([
                         _next();
                     } else {
                         _loadOnPlay = 0;
-                        setTimeout(function() {
-                            _this.trigger(events.JWPLAYER_PLAYLIST_COMPLETE, {});
-                        }, 0);
+                        _this.trigger(events.JWPLAYER_PLAYLIST_COMPLETE, {});
                     }
                     return;
                 }

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -81,10 +81,11 @@ define([
                     break;
 
                 case events.JWPLAYER_PLAYER_STATE:
+                    var oldState = this.get('state');
                     var providerState = evt.newstate;
-                    var modelState = normalizeState(evt.newstate);
+                    var modelState = normalizeState(providerState);
 
-                    evt.oldstate = this.get('state');
+                    evt.oldstate = oldState;
                     evt.reason   = providerState;
                     evt.newstate = modelState;
                     evt.type     = modelState;

--- a/src/js/providers/flash.js
+++ b/src/js/providers/flash.js
@@ -97,7 +97,7 @@ define([
                 attachMedia: function() {
                     // This is after a postroll completes
                     if (_beforecompleted) {
-                        this.setState(states.IDLE);
+                        this.setState(states.COMPLETE);
                         this.sendEvent(events.JWPLAYER_MEDIA_COMPLETE);
                         _beforecompleted = false;
                     }
@@ -170,6 +170,7 @@ define([
 
                     }, this).on(events.JWPLAYER_PLAYER_STATE, function(e) {
                         var state = e.newstate;
+                        // TODO:: What is this for?
                         if (state === states.IDLE) {
                             return;
                         }
@@ -191,7 +192,7 @@ define([
                         this.sendEvent(e.type);
 
                     }, this).on(events.JWPLAYER_MEDIA_COMPLETE, function(e) {
-                        this.setState(states.IDLE);
+                        this.setState(states.COMPLETE);
                         this.sendEvent(e.type);
 
                     }, this).on(events.JWPLAYER_MEDIA_ERROR, function(e) {

--- a/src/js/providers/youtube.js
+++ b/src/js/providers/youtube.js
@@ -46,7 +46,7 @@ define([
 
         this.setState = function(state) {
             clearInterval(_playingInterval);
-            if (state !== states.IDLE) {
+            if (state !== states.IDLE && state !== states.COMPLETE) {
                 // always run this interval when not idle because we can't trust events from iFrame
                 _playingInterval = setInterval(_checkPlaybackHandler, 250);
                 if (state === states.PLAYING) {
@@ -158,10 +158,10 @@ define([
         }
 
         function _ended() {
-            if (_this.state !== states.IDLE) {
+            if (_this.state !== states.IDLE && _this.state !== states.COMPLETE) {
                 _beforecompleted = true;
                 _this.sendEvent(events.JWPLAYER_MEDIA_BEFORECOMPLETE);
-                _this.setState(states.IDLE);
+                _this.setState(states.COMPLETE);
                 _beforecompleted = false;
                 _this.sendEvent(events.JWPLAYER_MEDIA_COMPLETE);
             }
@@ -526,7 +526,7 @@ define([
 
         this.attachMedia = function() {
             if (_beforecompleted) {
-                this.setState(states.IDLE);
+                this.setState(states.COMPLETE);
                 this.sendEvent(events.JWPLAYER_MEDIA_COMPLETE);
                 _beforecompleted = false;
             }

--- a/src/js/view/captions.js
+++ b/src/js/view/captions.js
@@ -103,6 +103,7 @@ define([
         function _stateHandler(model, state) {
             switch (state) {
                 case states.IDLE:
+                case states.COMPLETE:
                     _idleHandler();
                     break;
                 case states.PLAYING:

--- a/src/js/view/controlbar.js
+++ b/src/js/view/controlbar.js
@@ -344,6 +344,7 @@ define([
                     }
                     break;
                 case states.IDLE:
+                case states.COMPLETE:
                     _toggleButton('play', false);
                     if (_elements.timeSliderThumb) {
                         cssUtils.style(_elements.timeSliderThumb, {
@@ -1099,7 +1100,7 @@ define([
 
         function _idle() {
             var currentState = _model.state;
-            return (currentState === states.IDLE);
+            return (currentState === states.IDLE || currentState === states.COMPLETE);
         }
 
         function _killSelect(evt) {

--- a/src/js/view/display.js
+++ b/src/js/view/display.js
@@ -189,6 +189,7 @@ define([
                 _previousState = state;
                 switch (state) {
                     case states.IDLE:
+                    case states.COMPLETE:
                         if (!_errorState && !_completedState) {
                             if (_image && !_imageHidden) {
                                 _setVisibility(D_PREVIEW_CLASS, true);

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -877,9 +877,12 @@ define([
         }
 
         function _showDisplay() {
+            var hasControls = _model.get('controls');
+            var state = _model.get('state');
+
             var model = _instreamMode ? _instreamModel : _model;
-            if (_display && _model.get('controls') && !_audioMode) {
-                if (!_isIPod || model.state === states.IDLE) {
+            if (_display && hasControls && !_audioMode) {
+                if (!_isIPod || state === states.IDLE || state === states.COMPLETE) {
                     _display.show();
                 }
             }
@@ -910,7 +913,7 @@ define([
                 _hideControlbar();
             }
 
-            if (state !== states.IDLE && state !== states.PAUSED) {
+            if (state !== states.COMPLETE && state !== states.IDLE && state !== states.PAUSED) {
                 _hideLogo();
             }
 
@@ -1034,6 +1037,7 @@ define([
                     }
                     break;
                 case states.IDLE:
+                case states.COMPLETE:
                     _showVideo(false);
                     if (!_audioMode) {
                         _display.hidePreview(false);


### PR DESCRIPTION
This change causes providers to set their state to COMPLETE as opposed to
IDLE after playback has concluded.

This distinction is important because the player behaves differently before playback
has began, versus after it has finished. Currently this difference is limited to the
View, however it could become important for plugins related to sharing as well.

[Delivers #92440878]