### PR TITLE
View template Aspect Ratio Fix for Firefox [Finishes #90152754]

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -379,7 +379,9 @@ define([
 
         function _setAspectRatio(){
             var styleTarget = '#'+_playerElement.id+'.jw-aspect-mode:before';
-            document.styleSheets[0].addRule(styleTarget, 'padding-top: ' + _model.aspectratio + '%');
+            var targetStylesheet = document.styleSheets[0];
+            targetStylesheet.insertRule(styleTarget + ' { padding-top: ' + _model.aspectratio + '; }',
+                targetStylesheet.cssRules.length);
         }
 
         function _componentFadeListeners(comp) {


### PR DESCRIPTION
Fix by using insertRule which is more compatible cross-browser (was working in webkit but not Firefox).  There was also an issue where there were 2 '%' signs, which chrome counted as 1

[Finishes #90152754]