### PR TITLE
Add multi-line caption support

### DIFF
--- a/src/js/view/captionsrenderer.js
+++ b/src/js/view/captionsrenderer.js
@@ -122,7 +122,8 @@ define([
                     fontWeight: _options.fontWeight,
                     textAlign: 'center',
                     textDecoration: _options.textDecoration,
-                    wordWrap: 'break-word'
+                    wordWrap: 'break-word',
+                    whiteSpace: 'pre-line'
                 };
 
             if (windowOpacity) {


### PR DESCRIPTION
Adding a "white-space" value of "pre-line" to support the proper display of multi-line captions.