### PR TITLE
Allow player to load item of same playlist index

### DIFF
--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -176,21 +176,10 @@ define([
         };
 
         this.setItem = function(index) {
-            var newItem;
-            var repeat = false;
             var playlist = _this.get('playlist');
-            if (index === playlist.length || index < -1) {
-                newItem = 0;
-                repeat = true;
-            } else if (index === -1 || index > playlist.length) {
-                newItem = playlist.length - 1;
-            } else {
-                newItem = index;
-            }
 
-            if (newItem === this.get('item') && !repeat) {
-                return;
-            }
+            // If looping past the end, or before the beginning
+            var newItem = (index + playlist.length) % playlist.length;
 
             // Item is actually changing
             this.mediaModel.off();


### PR DESCRIPTION
Here I simplify the logic for setting a new playlist item in two ways.
1. Rewrite the formula to use modulo instead of 3 conditional blocks
2. Remove the early return on same playlist index

The second change is important because of a situation where you load a new playlist
while on the first playlist item of a previous playlist. We want to execute this as a
real change, so we will no longer do this check. It is safe to do so, because "repeat"
functionality is handled by the controller now instead of the player.

[Fixes #92550212]