### PR TITLE
Dispatch model state change events from API [Delivers #90930900]

### DIFF
--- a/src/flash/com/longtailvideo/jwplayer/events/MediaEvent.as
+++ b/src/flash/com/longtailvideo/jwplayer/events/MediaEvent.as
@@ -14,7 +14,7 @@ public class MediaEvent extends PlayerEvent {
     public static const JWPLAYER_MEDIA_BEFOREPLAY:String = "beforePlay";
     public static const JWPLAYER_MEDIA_BEFORECOMPLETE:String = "beforeComplete";
 
-    public static const JWPLAYER_MEDIA_BUFFER:String = "buffer";
+    public static const JWPLAYER_MEDIA_BUFFER:String = "bufferChange";
     public static const JWPLAYER_MEDIA_BUFFER_FULL:String = "bufferFull";
     public static const JWPLAYER_MEDIA_SEEK:String = "seek";
     public static const JWPLAYER_MEDIA_TIME:String = "time";

--- a/src/js/api/callbacks-deprecate.js
+++ b/src/js/api/callbacks-deprecate.js
@@ -1,8 +1,7 @@
 define([
     'utils/underscore',
-    'events/states',
     'events/events'
-], function(_, states, events) {
+], function(_, events) {
 
     return function init(_api) {
 
@@ -47,10 +46,10 @@ define([
         };
 
         var _stateMapping = {
-            onBuffer: states.BUFFERING,
-            onPause: states.PAUSED,
-            onPlay: states.PLAYING,
-            onIdle: states.IDLE
+            onBuffer: 'buffer',
+            onPause: 'pause',
+            onPlay: 'play',
+            onIdle: 'idle'
         };
 
         // Add state callbacks

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -96,15 +96,19 @@ define([
                 _model.mediaModel.on('change:state', function(mediaModel, state){
                     var modelState = normalizeState(state);
 
+                    // buffering, playing and paused states become:
+                    // buffer, play and pause events
+                    var apiEventType = modelState.replace(/(?:ing|d)$/, '');
+
                     var evt = {
-                        oldstate: this.get('state'),
-                        reason: state,
+                        type: apiEventType,
                         newstate: modelState,
-                        type: modelState
+                        oldstate: _model.get('state'),
+                        reason: state
                     };
 
                     _model.set('state', modelState);
-                    _model.trigger(evt.type, evt);
+                    _this.trigger(apiEventType, evt);
                 });
             }
             initMediaModel();

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -29,6 +29,15 @@ define([
         return newstate;
     }
 
+    // The api should dispatch an idle event when the model's state changes to complete
+    // This is to avoid conflicts with the complete event and to maintain legacy event flow
+    function normalizeApiState(newstate) {
+        if (newstate === states.COMPLETE) {
+            return states.IDLE;
+        }
+        return newstate;
+    }
+
     var Controller = function() {
         this.eventsQueue = [];
         _.extend(this, Events);
@@ -83,7 +92,7 @@ define([
 
             _model.mediaController.on(events.JWPLAYER_MEDIA_COMPLETE, function() {
                 // Insert a small delay here so that other complete handlers can execute
-                setTimeout(_completeHandler, 25);
+                _.defer(_completeHandler);
             });
             _model.mediaController.on(events.JWPLAYER_MEDIA_ERROR, function(evt) {
                 // Re-dispatch media errors as general error
@@ -93,22 +102,9 @@ define([
             }, this);
 
             function initMediaModel() {
-                _model.mediaModel.on('change:state', function(mediaModel, state){
+                _model.mediaModel.on('change:state', function(mediaModel, state) {
                     var modelState = normalizeState(state);
-
-                    // buffering, playing and paused states become:
-                    // buffer, play and pause events
-                    var apiEventType = modelState.replace(/(?:ing|d)$/, '');
-
-                    var evt = {
-                        type: apiEventType,
-                        newstate: modelState,
-                        oldstate: _model.get('state'),
-                        reason: state
-                    };
-
                     _model.set('state', modelState);
-                    _this.trigger(apiEventType, evt);
                 });
             }
             initMediaModel();
@@ -119,6 +115,24 @@ define([
                 _setup = null;
 
                 _view.completeSetup();
+
+                _model.on('change:state', function(model, newstate, oldstate) {
+                    newstate = normalizeApiState(newstate);
+                    oldstate = normalizeApiState(oldstate);
+                    // do not dispatch idle a second time after complete
+                    if (newstate !== oldstate) {
+                        // buffering, playing and paused states become:
+                        // buffer, play and pause events
+                        var eventType = newstate.replace(/(?:ing|d)$/, '');
+                        var evt = {
+                            type: eventType,
+                            newstate: newstate,
+                            oldstate: oldstate,
+                            reason: model.mediaModel.get('state')
+                        };
+                        _this.trigger(eventType, evt);
+                    }
+                });
 
                 // For 'onCast' callback
                 _model.on('change:castState', function(model, evt) {

--- a/src/js/events/events.js
+++ b/src/js/events/events.js
@@ -50,7 +50,7 @@ define([], function() {
         JWPLAYER_CAST_AVAILABLE: 'castAvailable',
 
         // Model Changes
-        JWPLAYER_MEDIA_BUFFER: 'buffer',
+        JWPLAYER_MEDIA_BUFFER: 'bufferChange',
         JWPLAYER_MEDIA_TIME: 'time',
         JWPLAYER_MEDIA_VOLUME: 'volume',
         JWPLAYER_MEDIA_MUTE: 'mute',


### PR DESCRIPTION
(b6f0e75) Fixes a regression where state events are no longer sent by the api. :eyes: 

The buffering, playing and paused states become: buffer, play and pause events. The newstate and oldstate event properties are unchanged, representing the current and previous states.

So now:
onPlay becomes on('play') (instead of on('playing'))
onPause becomes on('pause')
onBuffer becomes on('buffer')
and
onBufferChange becomes on('bufferChange')

(4730a61) The api should continue to dispatch "idle" when the model is in a complete state, since the api already dispatched a "complete" event of it's own.
