### PR TITLE
Aspect ratio fix and previous content replacement moved to controller [Delivers #90152754]

### DIFF
--- a/src/css/imports/jwplayerelement.less
+++ b/src/css/imports/jwplayerelement.less
@@ -13,10 +13,6 @@
         box-sizing: inherit;
     }
 
-    &.jw-setup-hide {
-        opacity: 0;
-    }
-
     .jw-main {
         position:  absolute;
         top: 0;
@@ -69,15 +65,17 @@
     }
     /// Scale modes END
 
-
     // Aspect Ratio styles
-    &.jw-aspect-mode:before{
-        content: "";
-        display: block;
-    }
-
     &.jw-aspect-mode {
         height: auto !important;
+
+        & .jw-aspect{
+            display: block;
+        }
+    }
+
+    .jw-aspect{
+        display: none;
     }
 
     &:focus, .jw-swf {

--- a/src/js/controller/Setup.js
+++ b/src/js/controller/Setup.js
@@ -72,7 +72,7 @@ define([
         };
 
         function _setupTimeoutHandler(){
-            _error('Setup Timeout Error: Setup took longer than '+(_errorTimeoutSeconds)+' seconds to complete.');
+            _error('Setup Timeout Error',  'Setup took longer than '+(_errorTimeoutSeconds)+' seconds to complete.');
         }
 
         function _nextTask() {
@@ -98,7 +98,7 @@ define([
 
         function _parseConfig() {
             if (_model.edition && _model.edition() === 'invalid') {
-                _error('Error setting up player: Invalid license key');
+                _error('Error setting up player', 'Invalid license key');
             } else {
                 _taskComplete(PARSE_CONFIG);
             }
@@ -114,7 +114,7 @@ define([
         }
 
         function _skinError(message) {
-            _error('Error loading skin: ' + message);
+            _error('Error loading skin', message);
         }
 
         function _loadPlaylist() {
@@ -122,14 +122,14 @@ define([
             if (type === 'array') {
                 _completePlaylist(Playlist(_model.config.playlist));
             } else {
-                _error('Playlist type not supported: ' + type);
+                _error('Playlist type not supported', type);
             }
         }
 
         function _completePlaylist(playlist) {
             _model.setPlaylist(playlist);
             if (_model.playlist.length === 0 || _model.playlist[0].sources.length === 0) {
-                _error('Error loading playlist: No playable sources found');
+                _error('Error loading playlist', 'No playable sources found');
             } else {
                 _taskComplete(LOAD_PLAYLIST);
             }
@@ -145,14 +145,19 @@ define([
             _this.destroy();
         }
 
-        function _error(message) {
-            _view.setupError(message);
+        function _error(message, body) {
+            var width = _model.get('width'),
+                height = _model.get('height');
+
             _this.trigger(events.JWPLAYER_SETUP_ERROR, {
-                message: message
+                message: message,
+                body: body,
+                width: width.toString().indexOf('%') > 0 ? width : (width + 'px'),
+                height: height.toString().indexOf('%') > 0 ? height : (height + 'px')
             });
+            clearTimeout(_setupFailureTimeout);
             _this.destroy();
         }
-
     };
 
     Setup.prototype = Events;

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -10,9 +10,10 @@ define([
     'view/view',
     'utils/backbone.events',
     'events/states',
-    'events/events'
+    'events/events',
+    'view/errorscreen'
 ], function(setupInstreamMethods, deprecateInit, _, Setup,
-            Model, Playlist, PlaylistLoader, utils, View, Events, states, events) {
+            Model, Playlist, PlaylistLoader, utils, View, Events, states, events, errorScreen) {
 
     function _queue(command) {
         return function() {
@@ -38,7 +39,8 @@ define([
         return newstate;
     }
 
-    var Controller = function() {
+    var Controller = function(originalContainer) {
+        this.originalContainer = this.currentContainer = originalContainer;
         this.eventsQueue = [];
         _.extend(this, Events);
 
@@ -84,7 +86,12 @@ define([
             this.skin = _view._skin;
 
             _setup.on(events.JWPLAYER_READY, _playerReady, this);
-            _setup.on(events.JWPLAYER_SETUP_ERROR, this.trigger);
+            _setup.on(events.JWPLAYER_SETUP_ERROR, function(evt) {
+                if (_view) {
+                    _view.completeSetup();
+                }
+                _this.setupError(evt.message, evt.body, evt.width, evt.height);
+            });
             _setup.start();
 
             // Helper function
@@ -114,6 +121,7 @@ define([
                 _setup.destroy();
                 _setup = null;
 
+                this.showView(_view.element());
                 _view.completeSetup();
 
                 _model.on('change:state', function(model, newstate, oldstate) {
@@ -519,6 +527,7 @@ define([
             this.getProvider = function(){ return _model.get('provider'); };
 
             // View passthroughs
+            this.getContainer = function(){ return this.currentContainer; };
             this.resize = _view.resize;
             this.getSafeRegion = _view.getSafeRegion;
             this.forceState = _view.forceState;
@@ -593,6 +602,25 @@ define([
 
             // This is here because it binds to the methods declared above
             deprecateInit(_api, this);
+        },
+
+        showView: function(viewElement){
+            if(this.currentContainer.parentElement) {
+                this.currentContainer.parentElement.replaceChild(viewElement, this.currentContainer);
+            }
+            this.currentContainer = viewElement;
+        },
+
+        setupError: function(message, body, width, height){
+            var errorScreenElement = utils.createElement(errorScreen(message, body));
+
+            utils.style(errorScreenElement, { 'width': width, 'height': height } );
+
+            this.showView(errorScreenElement);
+        },
+
+        reset: function() {
+            this.showView(this.originalContainer);
         }
     };
 

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -138,9 +138,9 @@ define([
         };
 
 
-        // Find video tag, or create it if it doesn't exist
+        // Find video tag, or create it if it doesn't exist.  View may not be built yet.
         var element = document.getElementById(_playerId);
-        var _videotag = element.querySelector('video');
+        var _videotag = (element) ? element.querySelector('video') : undefined;
         _videotag = _videotag || document.createElement('video');
 
         _setupListeners(_mediaEvents, _videotag);

--- a/src/js/view/errorscreen.js
+++ b/src/js/view/errorscreen.js
@@ -3,14 +3,11 @@ define([
     'handlebars-loader!templates/errorscreen.html'
 ], function(utils, errorscreen) {
 
-    function make(container, title, body) {
-        var html = errorscreen({
+    function make(title, body) {
+        return errorscreen({
             title: title,
             body: body
         });
-
-        utils.removeClass(container, 'jw-setup-hide');
-        container.appendChild(utils.createElement(html));
     }
 
     return make;

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -373,7 +373,9 @@ define([
 
         function _setAspectRatio(){
             var styleTarget = '#'+_playerElement.id+'.jw-aspect-mode:before';
-            document.styleSheets[0].addRule(styleTarget, 'padding-top: ' + _model.aspectratio + '%');
+            var targetStylesheet = document.styleSheets[0];
+            targetStylesheet.insertRule(styleTarget + ' { padding-top: ' + _model.aspectratio + '; }',
+                targetStylesheet.cssRules.length);
         }
 
         function _componentFadeListeners(comp) {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -8,17 +8,16 @@ define([
     'view/display',
     'view/displayicon',
     'view/dock',
-    'view/errorscreen',
     'view/logo',
     'view/controlbar',
     'view/rightclick',
     'view/title',
     'utils/css',
     'utils/underscore',
-    'handlebars-loader!templates/view.html'
+    'handlebars-loader!templates/player.html'
 ], function(utils, events, Events, states, CastDisplay,
-            Captions, Display, DisplayIcon, Dock, errorScreen, Logo,
-            Controlbar, RightClick, Title, cssUtils, _, viewTemplate) {
+            Captions, Display, DisplayIcon, Dock, Logo,
+            Controlbar, RightClick, Title, cssUtils, _, playerTemplate) {
 
     var _styles = utils.style,
         _bounds = utils.bounds,
@@ -46,6 +45,7 @@ define([
             _controlsTimeout = -1,
             _timeoutDuration = _isMobile ? 4000 : 2000,
             _videoLayer,
+            _aspectRatioContainer,
             _lastWidth,
             _lastHeight,
             _instreamModel,
@@ -66,6 +66,7 @@ define([
             _resizeMediaTimeout = -1,
             _inCB = false, // in control bar
             _currentState,
+            _originalContainer,
 
             // view fullscreen methods and ability
             _requestFullscreen,
@@ -78,9 +79,15 @@ define([
 
             _this = _.extend(this, Events);
 
-        _playerElement = _api.getContainer();
-        _playerElement.id = _model.id;
-        _playerElement.tabIndex = 0;
+        _playerElement = utils.createElement(playerTemplate({id: _model.id}));
+
+        var width = _model.get('width'),
+            height = _model.get('height');
+
+        _styles(_playerElement, {
+            width: width.toString().indexOf('%') > 0 ? width : (width+ 'px'),
+            height: height.toString().indexOf('%') > 0 ? height : (height + 'px')
+        });
 
         _requestFullscreen =
             _playerElement.requestFullscreen ||
@@ -95,9 +102,6 @@ define([
             document.mozCancelFullScreen ||
             document.msExitFullscreen;
         _elementSupportsFullscreen = _requestFullscreen && _exitFullscreen;
-
-        var replace = document.getElementById(_model.id);
-        replace.parentNode.replaceChild(_playerElement, replace);
 
         function adjustSeek(amount) {
             var newSeek = utils.between(_model.position + amount, 0, this.getDuration());
@@ -262,12 +266,11 @@ define([
             // TODO: remove when adding in templates. exposed for controller/instream
             this._skin = _skin = skin;
 
-            _playerElement.appendChild(utils.createElement(viewTemplate({})));
-
             _container = _playerElement.getElementsByClassName('jw-main')[0];
             _videoLayer = _playerElement.getElementsByClassName('jw-video')[0];
 
             _controlsLayer = _playerElement.getElementsByClassName('jw-controls')[0];
+            _aspectRatioContainer = _playerElement.getElementsByClassName('jw-aspect')[0];
 
             _setupControls();
 
@@ -363,20 +366,13 @@ define([
 
             if (_model.get('aspectratio')) {
                 utils.addClass(_playerElement, 'jw-aspect-mode');
-                _setAspectRatio();
+                utils.style(_aspectRatioContainer, { 'padding-top': _model.aspectratio });
             }
 
             setTimeout(function() {
                 _resize(_model.width, _model.height);
             }, 0);
         };
-
-        function _setAspectRatio(){
-            var styleTarget = '#'+_playerElement.id+'.jw-aspect-mode:before';
-            var targetStylesheet = document.styleSheets[0];
-            targetStylesheet.insertRule(styleTarget + ' { padding-top: ' + _model.aspectratio + '; }',
-                targetStylesheet.cssRules.length);
-        }
 
         function _componentFadeListeners(comp) {
             if (comp) {
@@ -771,9 +767,14 @@ define([
         };
         this.resizeMedia = _resizeMedia;
 
-        var _completeSetup = this.completeSetup = function() {
-            utils.removeClass(_playerElement, 'jw-setup-hide');
+        this.reset = function(){
+            if (document.contains(_playerElement)) {
+                _playerElement.parentNode.replaceChild(_originalContainer, _playerElement);
+            }
+            utils.emptyElement(_playerElement);
+        };
 
+        this.completeSetup = function() {
             window.addEventListener('beforeunload', function() {
                 if (!_isCasting()) { // don't call stop while casting
                     // prevent video error in display on window close
@@ -997,7 +998,7 @@ define([
                     _display.hidePreview(false);
                 }
 
-                // TODO: needs to be done in the provider
+                // TODO: needs to be done in the provider.setVisibility
                 utils.addClass(_videoLayer, 'jw-video-show');
 
                 // force control bar without audio check
@@ -1088,13 +1089,6 @@ define([
             provider.setVisibility(true);
         };
 
-        this.setupError = function(message) {
-            _errorState = true;
-            message = message.split(':');
-            errorScreen(_playerElement, message[0], message[1]);
-            _completeSetup();
-        };
-
         this.addCues = function(cues) {
             if (_controlbar) {
                 _controlbar.addCues(cues);
@@ -1116,6 +1110,10 @@ define([
 
         this.controlsContainer = function() {
             return _controlsLayer;
+        };
+
+        this.getContainer = this.element = function() {
+            return _playerElement;
         };
 
         this.getSafeRegion = function(includeCB) {
@@ -1160,8 +1158,8 @@ define([
             for (var i = DOCUMENT_FULLSCREEN_EVENTS.length; i--;) {
                 document.removeEventListener(DOCUMENT_FULLSCREEN_EVENTS[i], _fullscreenChangeHandler, false);
             }
-            if (_model.mediacontroller) {
-                _model.mediacontroller.off('fullscreenchange', _fullscreenChangeHandler);
+            if (_model.mediaController) {
+                _model.mediaController.off('fullscreenchange', _fullscreenChangeHandler);
             }
             _playerElement.removeEventListener('keydown', handleKeydown, false);
             if (_rightClickMenu) {

--- a/src/templates/player.html
+++ b/src/templates/player.html
@@ -1,1 +1,9 @@
-<div class="jwplayer jw-setup-hide"></div>
+<div id="{{id}}" class="jwplayer" tabindex="0">
+    <div class="jw-main">
+        <div class="jw-video">
+            <video x-webkit-airplay="allow" webkit-playsinline=""></video>
+        </div>
+        <div class="jw-controls"></div>
+    </div>
+    <div class="jw-aspect"></div>
+</div>

--- a/test/unit/api.js
+++ b/test/unit/api.js
@@ -77,20 +77,36 @@ define([
         }).remove();
     });
 
-    test('replaces and restores container', function() {
+    test('replaces and restores container', function(assert) {
         var originalContainer = createContainer('player');
+        var done = assert.async();
         var api = new Api(originalContainer, noop);
+
+        //This is to fix an issue in helpers.js where canCast is called and breaks due to no window.jwplayer.cast value
+        window.jwplayer = {
+            cast: true
+        };
 
         var elementInDom = document.getElementById('player');
         strictEqual(elementInDom, originalContainer, 'container is not replaced before setup');
 
-        api.setup({});
-        elementInDom = document.getElementById('player');
-        ok(elementInDom !== originalContainer, 'container is replaced after setup');
+        api.setup({
+            sources: [
+                {file: '//content.bitsontherun.com/videos/bkaovAYt-52qL9xLP.mp4'},
+            ],
+            title: 'Big Buck Bunny'
+        });
 
-        api.remove();
-        elementInDom = document.getElementById('player');
-        strictEqual(elementInDom, originalContainer, 'container is restored after remove');
+        api.on('ready', function(){
+            elementInDom = document.getElementById('player');
+            ok(elementInDom !== originalContainer, 'container is replaced after ready is called');
+            api.remove();
+
+            elementInDom = document.getElementById('player');
+            strictEqual(elementInDom, originalContainer, 'container is restored after remove');
+
+            done();
+        });
     });
 
     test('event dispatching', function(assert) {

--- a/test/unit/setup.js
+++ b/test/unit/setup.js
@@ -146,6 +146,16 @@ define([
     function getModel(config) {
         return {
             config: config,
+            get: function(type) {
+                switch(type) {
+                    case 'width':
+                        return 480;
+                    case 'height':
+                        return 270;
+                    default:
+                        return 270;
+                }
+            },
             setPlaylist: function(p) {
                 this.playlist = p;
             }


### PR DESCRIPTION
Fixes aspect ratio via adding the jw-aspect container back in. Moves the responsibility of replacing view content with the previous container from the API to the controller. Controller also has responsibility for listening for errors and creating the error screen. All basic view setup done in a single template file [Delivers #90152754]