### PR TITLE
Adds Volume Tooltip and Volume Toggling. Class for the mute icon changed [#91598950]

### DIFF
--- a/src/css/imports/icons.less
+++ b/src/css/imports/icons.less
@@ -162,13 +162,13 @@
         }
     }
 
-    .jw-icon-mute {
+    .jw-icon-volume {
         &:before {
-            content: "\e611";
+            content: "\e612";
         }
 
         &.jw-off:before {
-            content: "\e612";
+            content: "\e611";
         }
     }
 }

--- a/src/css/imports/slider.less
+++ b/src/css/imports/slider.less
@@ -75,7 +75,7 @@
 .jwplayer .jw-slider-horizontal {
     //top: @def-rail-width-padding;
     width: @volume-rail-length;
-    height: @volume-rail-width;
+    height: @def-rail-width-padding;
 
     .jw-rail,
     .jw-buffer,
@@ -92,6 +92,7 @@
 
     .jw-progress,
     .jw-buffer {
+        width: 0;   // Default width, overridden by player.
         border: @def-border;
         border-style: solid none solid;
     }
@@ -103,17 +104,19 @@
     }
 
     .jw-thumb {
+        left: 0;    // Default position, overridden by player.
         margin-left: @thumb-size/-2;
     }
 }
 
 .jwplayer .jw-slider-vertical {
-    width: @def-rail-width;
+    width: @def-rail-width-padding;
     height: @volume-rail-length;
     bottom: 0em;
     position: absolute;
 
-    .jw-rail, .jw-buffer,
+    .jw-rail,
+    .jw-buffer,
     .jw-progress {
         bottom: 0;
         height: 100%;
@@ -126,17 +129,27 @@
         border-top-left-radius: 0;
     }
 
-    .jw-progress, .jw-buffer {
+    .jw-progress,
+    .jw-buffer {
+        height: 0;   // Default height, overridden by player.
         border-style: none solid solid solid;
     }
 
-    .jw-rail-group, .jw-rail, .jw-progress {
+    .jw-rail-group,
+    .jw-rail,
+    .jw-progress {
         bottom: 0;
-        width: @volume-rail-width;
+        width: @def-rail-width-padding;
         height: 100%;
     }
 
+    .jw-rail-group {
+        height: 4em;
+        position: relative;
+    }
+
     .jw-thumb {
+        bottom: 0;  // Default position, overridden by player.
         margin-bottom: @thumb-size/-2;
     }
 }

--- a/src/css/imports/tooltip.less
+++ b/src/css/imports/tooltip.less
@@ -38,6 +38,7 @@
     }
 
     .jw-time-tip,
+    .jw-volume-tip,
     .jw-menu {
         position: relative;
         left: -50%;
@@ -48,6 +49,12 @@
         border: @def-border;
         border-radius: @ui-padding;
         margin: 0;
+    }
+
+    .jw-volume-tip {
+        height: 4em;
+        width: 0.7em;
+        display: block;
     }
 
     .jw-overlay .jw-contents {

--- a/src/js/view/components/slider.js
+++ b/src/js/view/components/slider.js
@@ -44,6 +44,7 @@ define([
         },
         dragStart : function(evt) {
             this.trigger('dragStart');
+            this.railBounds = utils.bounds(this.elementRail);
             window.addEventListener('mouseup', this.mouseuplistener, false);
             window.addEventListener('mousemove', this.mousemovelistener, false);
         },
@@ -54,17 +55,27 @@ define([
             this.trigger('dragEnd');
         },
         mouseMove : function(evt) {
-
+            console.log('dragin');
             var offset = this.getOffset(evt);
-            var bounds = utils.bounds(this.elementRail);
+            var bounds = this.railBounds;
             var percentage;
 
-            if (evt.x < bounds.left) {
-                percentage = 0;
-            } else if (evt.x > bounds.right) {
-                percentage = 100;
+            if (this.orientation === 'horizontal'){
+                if (evt.x < bounds.left) {
+                    percentage = 0;
+                } else if (evt.x > bounds.right) {
+                    percentage = 100;
+                } else {
+                    percentage = utils.between(offset.x/bounds.width, 0, 1) * 100;
+                }
             } else {
-                percentage = utils.between(offset.x/bounds.width, 0, 1) * 100;
+                if (offset > bounds.height) {
+                    percentage = 0;
+                } else if (offset < 0) {
+                    percentage = 100;
+                } else {
+                    percentage = utils.between((bounds.height-offset.y)/bounds.height, 0, 1) * 100;
+                }
             }
 
             this.render(percentage);
@@ -72,12 +83,18 @@ define([
 
             return false;
         },
+
         update : function(percentage) {
             this.trigger('update', { percentage : percentage });
         },
         render : function(percentage) {
-            this.elementThumb.style.left = percentage + '%';
-            this.elementProgress.style.width = percentage + '%';
+            if(this.orientation === 'horizontal'){
+                this.elementThumb.style.left = percentage + '%';
+                this.elementProgress.style.width = percentage + '%';
+            } else {
+                this.elementThumb.style.bottom = percentage + '%';
+                this.elementProgress.style.height = percentage + '%';
+            }
         },
         updateBuffer : function(percentage) {
             this.elementBuffer.style.width = percentage + '%';

--- a/src/js/view/components/tooltip.js
+++ b/src/js/view/components/tooltip.js
@@ -6,7 +6,7 @@ define([
     var Tooltip = Extendable.extend({
         'constructor' : function(name) {
             this.el = document.createElement('span');
-            this.el.className = name + ' jw-icon-tooltip jw-hidden';
+            this.el.className = 'jw-icon-tooltip ' + name + ' jw-hidden';
             this.container = document.createElement('div');
             this.container.className ='jw-overlay';
             this.el.appendChild(this.container);

--- a/src/js/view/components/volumetooltip.js
+++ b/src/js/view/components/volumetooltip.js
@@ -1,0 +1,35 @@
+define([
+    'view/components/tooltip',
+    'view/components/slider',
+    'utils/helpers'
+], function(Tooltip, Slider, utils) {
+    var VolumeTooltip = Tooltip.extend({
+        'constructor' : function(_model, _api, name) {
+            this._model = _model;
+            this._api = _api;
+
+            Tooltip.call(this, name);
+
+            this.volumeSlider = new Slider('jw-volume jw-volume-tip', 'vertical');
+            this.addContent(this.volumeSlider.element());
+
+            this.volumeSlider.on('update', function (evt) {
+                this.trigger('update', evt);
+            }.bind(this));
+
+            utils.toggleClass(this.el, 'jw-hidden', false);
+
+            this.el.addEventListener('click', this.toggle.bind(this));
+
+            this._model.on('change:volume', this.onVolume, this);
+        },
+        toggle : function(evt){
+            if(evt.target === this.el){
+                this.trigger('toggle');
+            }
+        }
+    });
+
+    return VolumeTooltip;
+});
+

--- a/src/templates/slider.html
+++ b/src/templates/slider.html
@@ -1,8 +1,8 @@
 <span class="{{className}} {{orientation}}">
     <span class="jw-rail-group">
         <span class="jw-rail"></span>
-        <span class="jw-buffer" style="width: 0;"></span>
-        <span class="jw-progress" style="width: 0"></span>
-        <span class="jw-thumb" style="left: 0;"></span>
+        <span class="jw-buffer"></span>
+        <span class="jw-progress"></span>
+        <span class="jw-thumb"></span>
     </span>
 </span>


### PR DESCRIPTION
Added a tooltip that contains a vertical volume slider.  Implements some code for vertical sliders and adds a toggle to the volume slider icon.  Styles moved out of the slider template file and into the css for the vertical and horizontal slider implementations.
Renamed NewMenu to Menu.
Adds some changed to the classes used for the volume icons.  .jw-icon-volume is the version with sound waves coming out of it.  .jw-icon-volume.jw-off is the icon without waves, indicating muted state.

[#91598950]