### PR TITLE
Adds Captions Menu and changes CC icon class [#91598950]

### DIFF
--- a/src/css/imports/icons.less
+++ b/src/css/imports/icons.less
@@ -77,7 +77,7 @@
         }
     }
 
-    .jw-icon-cc-on {
+    .jw-icon-cc {
         &:before {
             content: "\e605";
         }

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -223,6 +223,8 @@ define([
                     tracks: _model.get('captions'),
                     track: _model.get('captionsIndex')
                 });
+                // TODO: Fix for first item in a playlist not necessarily showing CC if it has it
+                _this._model.trigger('change:captionsList', _this._model, _this._model.get('captionsList'));
 
                 _load();
 

--- a/src/js/view/controlbar.js
+++ b/src/js/view/controlbar.js
@@ -84,8 +84,8 @@ define([
                 time: timeSlider,
                 duration: text('jw-duration'),
                 hd: menu('jw-icon-hd'),
-                cc: button('jw-icon-cc'),
-                mute: button('jw-icon-mute', this._api.setMute),
+                cc: menu('jw-icon-cc'),
+                mute: button('jw-icon-volume', this._api.setMute),
                 volume: volumeSlider,
                 cast: button('jw-icon-cast'),
                 fullscreen: button('jw-icon-fullscreen', this._api.setFullscreen)
@@ -155,6 +155,23 @@ define([
             }, this);
             this.elements.hd.on('toggle', function(){
                 this._model.getVideo().setCurrentQuality((this._model.getVideo().getCurrentQuality() === 0) ? 1 : 0);
+            }, this);
+
+            this.elements.cc.on('select', function(value){
+                this._api.setCurrentCaptions(value);
+            }, this);
+            this.elements.cc.on('toggle', function(){
+                this._api.setCurrentCaptions((this._api.getCurrentCaptions()=== 0)? 1 : 0);
+            }, this);
+            this._model.on('change:captionsList', function(model, tracks) {
+                this.elements.cc.setup(tracks, model.captionsIndex);
+            }, this);
+            this._model.on('change:captionsIndex', function(model) {
+                this.elements.cc.selectItem(model.captionsIndex);
+            }, this);
+
+            this.elements.volumetooltip.on('toggle', function(){
+                this._api.setMute();
             }, this);
         },
 

--- a/test/manual/index.html
+++ b/test/manual/index.html
@@ -105,8 +105,6 @@
 })(window.jwplayer);
 </script>
 
-<h2>Audio Single</h2>
-
 <h2>HD Menu Setup</h2>
 <div id="hd-container">before set up</div>
 <script type="text/javascript">
@@ -162,6 +160,19 @@
                         width: 1280
                     }
                 ],
+                tracks: [
+                    { file: "assets/thumbs.vtt", kind: "thumbnails" },
+                    {file: '//playertest.longtailvideo.com/chapters/sintel-chapters.vtt', kind: 'chapters'},
+                    {file: '//playertest.longtailvideo.com/captions/sintel-ch.srt', label: 'Chinese'},
+                    {file: '//playertest.longtailvideo.com/captions/sintel-fa.srt', label: 'Farsi'},
+                    {file: '//playertest.longtailvideo.com/captions/sintel-gr.srt', label: 'Greek'},
+                    {file: '//playertest.longtailvideo.com/captions/sintel-jp.srt', label: 'Japanese'},
+                    {file: '//playertest.longtailvideo.com/captions/sintel-ko.srt', label: 'Korean'},
+                    {file: '//playertest.longtailvideo.com/captions/sintel-pl.srt', label: 'Polish'},
+                    {file: '//playertest.longtailvideo.com/captions/sintel-ru.srt', label: 'Russian'},
+                    {file: '//playertest.longtailvideo.com/captions/sintel-sp.srt', label: 'Spanish'},
+                    {file: '//playertest.longtailvideo.com/captions/sintel-tr.srt', label: 'Turkish'}
+                ],
                 title: "4 quality levels"
             },
             {
@@ -176,6 +187,11 @@
                         width: 640
                     }
                 ],
+                tracks: [
+                    { file: "assets/thumbs.vtt", kind: "thumbnails" },
+                    {file: '//playertest.longtailvideo.com/chapters/sintel-chapters.vtt', kind: 'chapters'},
+                    {file: '//playertest.longtailvideo.com/captions/sintel-ch.srt', label: 'Chinese'}
+                ],
                 title: "2 quality toggle"
             },
             {
@@ -186,6 +202,7 @@
     });
 </script>
 
+<h2>Audio Single</h2>
 <div id="audio-container"></div>
 <script type="text/javascript">
     jwplayer('audio-container').setup({


### PR DESCRIPTION
Adds listeners to create the CC menu when necessary.  also changes the class for the cc icon so that it matches the .jw-off pattern.
This includes a slight hack to get the model to send out the captions list change for the first playlist item since the original event is sent out before the controller is  ready.  will have to discuss the best way to remove this.
Added caption files to the test page.

[#91598950]