### PR TITLE
Fix for stretching preview images [Finishes #92873620]

### DIFF
--- a/src/css/imports/display.less
+++ b/src/css/imports/display.less
@@ -1,68 +1,82 @@
 @import "vars.less";
-.jw-display {
-    position: absolute;
-    width: 100%;
-    height: 100%;
-}
-
 
 // Preview Image
+.jwplayer {
+    .jw-display {
+        position: absolute;
+        width: 100%;
+        height: 100%;
+    }
 
-.jwplayer .jw-preview {
-    position: absolute;
-    display: none;
-    opacity: 1;
-    visibility: visible;
-    width: 100%;
-    height: 100%;
-    background: 50% 50% no-repeat rgb(0, 0, 0);
-    background-size: auto auto;
+    .jw-preview {
+        position: absolute;
+        display: none;
+        opacity: 1;
+        visibility: visible;
+        width: 100%;
+        height: 100%;
+        background: #000 no-repeat 50% 50%;
+    }
+
+    &.jw-stretch-none {
+        .jw-preview {
+            background-size: auto auto;
+        }
+    }
+
+    &, &.jw-stretch-uniform {
+        .jw-preview {
+            background-size: contain;
+        }
+    }
+
+    &.jw-stretch-fill {
+        .jw-preview {
+            background-size: cover;
+        }
+    }
+
+    &.jw-stretch-exactfit {
+        .jw-preview {
+            background-size: 100% 100%;
+        }
+    }
+
+    // DisplayIcon
+    .jw-display-icon-container {
+        position: relative;
+        top: 50%;
+        display: table;
+        float: none;
+        height: 3.5em;
+        padding: 0 1em;
+        margin-top: -1.75em;
+        margin-right: auto;
+        margin-left: auto;
+        cursor: pointer;
+
+        background-color: @def-background-color;
+        background: @def-transparent-background-style;
+        background-size: @def-background-size;
+        border-radius: @ui-corner-round;
+
+        .jw-icon-display {
+            position: relative;
+            display: table-cell;
+            padding: @ui-padding;
+            vertical-align: middle !important;
+            background-position: 50% 50%;
+            background-repeat: no-repeat;
+            font-size: 2em;
+        }
+    }
+
+    &:hover .jw-display-icon-container {
+        background-color: @def-background-color;
+        background: @def-background-style;
+        background-size: @def-background-size;
+    }
 }
-
-.jwplayer .jw-uniform {
-    background-size: contain;
-    opacity: 1;
-    visibility: visible;
-}
-
-// DisplayIcon
-.jwplayer .jw-display-icon-container {
-    position: relative;
-    top: 50%;
-    display: table;
-    float: none;
-    height: 3.5em;
-    padding: 0 1em;
-    margin-top: -1.75em;
-    margin-right: auto;
-    margin-left: auto;
-    cursor: pointer;
-
-    background-color: @def-background-color;
-    background: @def-transparent-background-style;
-    background-size: @def-background-size;
-    border-radius: @ui-corner-round;
-}
-
-.jwplayer:hover .jw-display-icon-container {
-    background-color: @def-background-color;
-    background: @def-background-style;
-    background-size: @def-background-size;
-}
-
-.jwplayer .jw-display-icon-container .jw-icon-display {
-    position: relative;
-    display: table-cell;
-    padding: @ui-padding;
-    vertical-align: middle !important;
-    background-position: 50% 50%;
-    background-repeat: no-repeat;
-}
-
-.jwplayer .jw-display-icon-container .jw-icon-display {
-    font-size: 2em;
-}
-
 
 // Hide the player when,
 .jwplayer.jw-flag-audio-player, // Audio only mode

--- a/src/css/imports/jwplayerelement.less
+++ b/src/css/imports/jwplayerelement.less
@@ -50,21 +50,6 @@
         background: transparent;
     }
 
-    /// Scale modes START
-    .jw-stretch-uniform {
-        background-size: contain !important;
-    }
-
-    .jw-stretch-fill {
-        background-position: 50% 50%;
-        background-size: cover !important;
-    }
-
-    .jw-stretch-exactfit {
-        background-size: 100% 100% !important;
-    }
-    /// Scale modes END
-
     // Aspect Ratio styles
     &.jw-aspect-mode {
         height: auto !important;

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -307,6 +307,13 @@ define([
                 utils.toggleClass(_controlsLayer, 'jw-cast-available', val);
             });
 
+            // set initial state
+            if(_model.get('stretching')){
+                _onStretchChange(_model, _model.get('stretching'));
+            }
+            // watch for changes
+            _model.on('change:stretching', _onStretchChange);
+
             _model.on('change:castState', function(evt) {
                 if (!_castDisplay) {
                     _castDisplay = new CastDisplay(_model.id);
@@ -360,6 +367,13 @@ define([
                 _resize(_model.width, _model.height);
             }, 0);
         };
+
+        function _onStretchChange (model, newVal, oldVal) {
+            if(oldVal){
+                utils.removeClass(_playerElement, 'jw-stretch-' + oldVal);
+            }
+            utils.addClass(_playerElement, 'jw-stretch-' + newVal);
+        }
 
         function _componentFadeListeners(comp) {
             if (comp) {
@@ -736,11 +750,6 @@ define([
                 return;
             }
             var transformScale = provider.resize(width, height, _model.stretching);
-            if(_model.stretching && !utils.hasClass(_playerElement, 'jw-stretch-' + _model.stretching)) {
-                utils.removeClass(_playerElement,
-                    'jw-stretch-none jw-stretch-uniform jw-stretch-fill jw-stretch-exactfit');
-                utils.addClass(_playerElement, 'jw-stretch-' + _model.stretching);
-            }
 
             // poll resizing if video is transformed
             if (transformScale) {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -736,6 +736,9 @@ define([
                 return;
             }
             var transformScale = provider.resize(width, height, _model.stretching);
+            utils.removeClass(_playerElement, 'jw-stretch-none jw-stretch-uniform jw-stretch-fill jw-stretch-exactfit');
+            utils.addClass(_playerElement, 'jw-stretch-' + _model.stretching);
+
             // poll resizing if video is transformed
             if (transformScale) {
                 clearTimeout(_resizeMediaTimeout);

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -736,8 +736,11 @@ define([
                 return;
             }
             var transformScale = provider.resize(width, height, _model.stretching);
-            utils.removeClass(_playerElement, 'jw-stretch-none jw-stretch-uniform jw-stretch-fill jw-stretch-exactfit');
-            utils.addClass(_playerElement, 'jw-stretch-' + _model.stretching);
+            if(_model.stretching && !utils.hasClass(_playerElement, 'jw-stretch-' + _model.stretching)) {
+                utils.removeClass(_playerElement,
+                    'jw-stretch-none jw-stretch-uniform jw-stretch-fill jw-stretch-exactfit');
+                utils.addClass(_playerElement, 'jw-stretch-' + _model.stretching);
+            }
 
             // poll resizing if video is transformed
             if (transformScale) {


### PR DESCRIPTION
This fixes an issue where the preview image wasn't receiving rules to style it when the scaling mode changed.  Stretching class applied to the jwplayer container where we call resize in view.js.  Scaling for the preview image defaults to uniform scaling.  Was checking whether we could apply all stretching via classes, but fill and exactfit would require inline styling.  Remains being done via JS for now, but may be  able to be done with less JS and more CSS if needed. [Finishes #92873620]