### PR TITLE
Dock Buttons: Creating duplicate array so model updates

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -575,7 +575,8 @@ define([
                     };
                 }
 
-                var dock = _model.get('dock') || [];
+                var dock = _model.get('dock');
+                dock = (dock) ? dock.slice(0) : [];
                 dock.push(btn);
                 _model.set('dock', dock);
             };


### PR DESCRIPTION
Creating duplicate array so model updates.   This causes the change to happen because previously we were using the reference inside the model so the model was not actually changing.  [Fixes #93062388] [Fixes #93132818]