### PR TITLE
Give all button icons a min-width

### DIFF
--- a/src/css/imports/controlbar.less
+++ b/src/css/imports/controlbar.less
@@ -50,18 +50,27 @@
 }
 
 // control bar content (icons/text)
-.jw-controlbar .jw-icon-inline,
-.jw-controlbar .jw-icon-tooltip,
-.jw-controlbar .jw-slider-horizontal,
-.jw-controlbar .jw-elapsed,
-.jw-controlbar .jw-duration {
-    display: inline-block;
-    height: @controlbar-height;
-    position: relative;
-    padding: 0 @control-padding;
-    line-height: @controlbar-height;
-    vertical-align: middle;
-    cursor: pointer;
+.jw-controlbar {
+    .jw-icon-inline,
+    .jw-icon-tooltip,
+    .jw-slider-horizontal,
+    .jw-elapsed,
+    .jw-duration {
+        display: inline-block;
+        height: @controlbar-height;
+        position: relative;
+        padding: 0 @control-padding;
+        line-height: @controlbar-height;
+        vertical-align: middle;
+        cursor: pointer;
+    }
+}
+.jw-controlbar {
+    .jw-icon-inline,
+    .jw-icon-tooltip {
+        min-width: @controlbar-height * 5/8;
+        text-align: center;
+    }
 }
 
 .jw-time-tip {


### PR DESCRIPTION
Make sure that buttons on the controlbar have a base width. This keeps toggle buttons aligned, preventing jittering while using controls. Users should not have to set sizes on their svg assets for this purpose. SVG dimensions are for more precise control over scaling and alignment.