### PR TITLE
Enable usage of custom skins

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,7 +36,7 @@ module.exports = function(grunt) {
                 jshintrc: '.jshintrc'
             },
             player : [
-                'src/js/{,*/}*.js'
+                'src/js/**/*.js'
             ],
             tests : [
                 'test/{,*/}*.js'
@@ -373,7 +373,8 @@ module.exports = function(grunt) {
     ]);
 
     grunt.registerTask('build-js', [
-        'webpack',
+        'webpack:debug',
+        'webpack:release',
         'jshint:player',
         'recess'
     ]);

--- a/src/css/flags/bekle.css
+++ b/src/css/flags/bekle.css
@@ -1,0 +1,3 @@
+.jwplayer .jw-skin-bekle .jw-icon-display {
+    color : red;
+}

--- a/src/css/flags/skinloading.less
+++ b/src/css/flags/skinloading.less
@@ -1,0 +1,12 @@
+.jwplayer.jw-flag-skin-loading {
+    //.jw-media,
+    //.jw-preview,
+    .jw-captions,
+    .jw-controls,
+    .jw-title,
+    //.jw-rightclick
+    {
+        display : none;
+    }
+
+}

--- a/src/css/jwplayer.less
+++ b/src/css/jwplayer.less
@@ -22,6 +22,7 @@
 @import "states/buffering.less";
 @import "states/complete.less";
 
+@import "flags/skinloading.less";
 @import "flags/audioplayer.less";
 @import "flags/fullscreen.less";
 @import "flags/live.less";

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -22,6 +22,12 @@ define([
         config.base = config.base || utils.getScriptPath('jwplayer.js');
         config.flashplayer = config.flashplayer || config.base + 'jwplayer.flash.swf';
         config.aspectratio = _evaluateAspectRatio(config.aspectratio, config.width);
+
+        if (_.isObject(config.skin)) {
+            config.skinUrl = config.skin.url;
+            config.skin = config.skin.name;
+        }
+
         if (!config.aspectratio) {
             delete config.aspectratio;
         }

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -112,7 +112,6 @@ define([
             _model.on('change:mediaModel', initMediaModel);
 
             function _playerReady() {
-                _setup.destroy();
                 _setup = null;
 
                 _model.on('change:state', function(model, newstate, oldstate) {

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -24,7 +24,7 @@ define([
         mute: false,
         playlist: [],
         repeat: false,
-        // skin: undefined,
+        skin: 'seven',
         stretching: stretchUtils.UNIFORM,
         width: 480,
         volume: 90

--- a/src/js/utils/constants.js
+++ b/src/js/utils/constants.js
@@ -1,0 +1,7 @@
+define([], function() {
+    return {
+        repo : '//p.jwpcdn.com/7/',
+        skinsVersion : '0.1.0',
+        Skins : ['bekle', 'stormtrooper', 'six']
+    };
+});

--- a/src/js/utils/helpers.js
+++ b/src/js/utils/helpers.js
@@ -1,8 +1,9 @@
 define([
+    'utils/constants',
     'utils/strings',
     'utils/underscore',
     'utils/jqueryfuncs'
-], function(strings, _, jqfns) {
+], function(Constants, strings, _, jqfns) {
 
     // TODO:: the next lines are a holdover until we update our CDN w/ plugins for 7.0
     // This is replaced by compiler
@@ -323,6 +324,17 @@ define([
         });
 
         return repo;
+    };
+
+    utils.getSkinUrl = function(skin) {
+        return Constants.repo + 'skins/' + Constants.skinsVersion + '/' + skin + '.css';
+    };
+
+    utils.addStyleSheet = function(url) {
+        var link = document.createElement('link');
+        link.rel = 'stylesheet';
+        link.href = url;
+        document.getElementsByTagName('head')[0].appendChild(link);
     };
 
     // Return true:Boolean if major and minor version of target is less than current version

--- a/src/js/utils/scriptloader.js
+++ b/src/js/utils/scriptloader.js
@@ -6,13 +6,29 @@ define([
 
     var _loaders = {};
 
-    var scriptloader = function (url) {
+    var scriptloader = function (url, isStyle) {
         var _this = _.extend(this, Events),
             _status = _loaderstatus.NEW;
 
         // legacy support
         this.addEventListener = this.on;
         this.removeEventListener = this.off;
+
+
+        this.makeStyleLink = function(url) {
+            var link = document.createElement('link');
+            link.type = 'text/css';
+            link.rel = 'stylesheet';
+            link.href = url;
+            return link;
+        };
+        this.makeScriptTag = function(url) {
+            var scriptTag = document.createElement('script');
+            scriptTag.src = url;
+            return scriptTag;
+        };
+
+        this.makeTag = (isStyle ? this.makeStyleLink : this.makeScriptTag);
 
         this.load = function () {
             // Only execute on the first run
@@ -34,7 +50,7 @@ define([
             }
 
             var head = document.getElementsByTagName('head')[0] || document.documentElement;
-            var scriptTag = document.createElement('script');
+            var scriptTag = this.makeTag(url);
 
             var done = false;
             scriptTag.onload = scriptTag.onreadystatechange = function (evt) {
@@ -45,14 +61,13 @@ define([
 
                     // Handle memory leak in IE
                     scriptTag.onload = scriptTag.onreadystatechange = null;
-                    if (head && scriptTag.parentNode) {
+                    if (head && scriptTag.parentNode && !isStyle) {
                         head.removeChild(scriptTag);
                     }
                 }
             };
             scriptTag.onerror = _sendError;
 
-            scriptTag.src = url;
             head.insertBefore(scriptTag, head.firstChild);
 
             _status = _loaderstatus.LOADING;

--- a/src/js/view/components/extendable.js
+++ b/src/js/view/components/extendable.js
@@ -30,11 +30,11 @@ define([
             this.constructor = child;
         };
         Surrogate.prototype = parent.prototype;
-        child.prototype = new Surrogate;
+        child.prototype = new Surrogate();
 
         // Add prototype properties (instance properties) to the subclass,
         // if supplied.
-        if (protoProps) _.extend(child.prototype, protoProps);
+        if (protoProps)  { _.extend(child.prototype, protoProps); }
 
         // Set a convenience property in case the parent's prototype is needed
         // later.

--- a/src/js/view/components/tooltip.js
+++ b/src/js/view/components/tooltip.js
@@ -1,7 +1,6 @@
 define([
-    'view/components/extendable',
-    'utils/underscore'
-], function(Extendable, _) {
+    'view/components/extendable'
+], function(Extendable) {
 
     var Tooltip = Extendable.extend({
         'constructor' : function(name) {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -243,10 +243,26 @@ define([
         }
 
 
+        this.onChangeSkin = function(model, newSkin, oldSkin) {
+            utils.removeClass(_playerElement, 'jw-skin-'+oldSkin);
+            utils.addClass(_playerElement, 'jw-skin-'+newSkin);
+        };
+
         this.setup = function() {
             if (_errorState) {
                 return;
             }
+
+            // Hide control elements until skin is loaded
+            if (_model.get('skin-loading') === true) {
+                utils.addClass(_playerElement, 'jw-flag-skin-loading');
+                _model.once('change:skin-loading', function() {
+                    utils.removeClass(_playerElement, 'jw-flag-skin-loading');
+                });
+            }
+
+            this.onChangeSkin(_model, _model.get('skin'), '');
+            _model.on('change:skin', this.onChangeSkin, this);
 
             _container = _playerElement;
             _videoLayer = _playerElement.getElementsByClassName('jw-media')[0];

--- a/test/manual/index.html
+++ b/test/manual/index.html
@@ -27,6 +27,8 @@
             position: 'right'
         },
 
+        skin : 'bekle',
+
         playlist: [
             {
                 image:'http://content.bitsontherun.com/thumbs/3XnJSIm4-480.jpg',
@@ -105,7 +107,6 @@
 
 })(window.jwplayer);
 </script>
-
 <h2>HD Menu Setup</h2>
 <div id="hd-container">before set up</div>
 <script type="text/javascript">

--- a/test/unit/setup.js
+++ b/test/unit/setup.js
@@ -156,6 +156,9 @@ define([
     function getModel(config) {
         return {
             config: config,
+            'get' : function(a) {
+                return this[a];
+            },
             setPlaylist: function(p) {
                 this.playlist = p;
             }


### PR DESCRIPTION
This comes in two parts. Enabling premium skins to be loaded from over a CDN
using a shorthand name (for example "bekle") and also accepting css files
from external sources when a path is given in the config.

The use cases within the config are
1)
    skin : 'premium-skin'
2)
    
    skin : {
        name : 'myskin',
        url : '//mysite/myskin.css'
    }

[Delivers #93441634]
[#92046794]