### PR TITLE
Handle display icon flickering after seek

### DIFF
--- a/src/js/view/components/timeslider.js
+++ b/src/js/view/components/timeslider.js
@@ -78,9 +78,10 @@ define([
             Slider.prototype.dragStart.apply(this, arguments);
         },
         dragEnd : function() {
-            this._model.set('scrubbing', false);
             Slider.prototype.dragEnd.apply(this, arguments);
+            this._model.set('scrubbing', false);
         },
+
 
         // Event Listeners
         onSeeked : function () {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -540,11 +540,25 @@ define([
             }
         }
 
+        function stopDragging(model) {
+            if (model.get('state') === states.PAUSED) {
+                model.once('change:state', stopDragging);
+                return;
+            }
+
+            // Handle the case where they begin seeking again before the last seek completes
+            if (model.get('scrubbing') === false) {
+                utils.removeClass(_playerElement, 'jw-flag-dragging');
+            }
+        }
+
         function _dragging(model, val) {
+            model.off('change:state', stopDragging);
+
             if (val) {
                 utils.addClass(_playerElement, 'jw-flag-dragging');
             } else {
-                utils.removeClass(_playerElement, 'jw-flag-dragging');
+                stopDragging(model);
             }
         }
 
@@ -918,17 +932,9 @@ define([
             }, this);
         }
 
-        /**
-         * Player state handler
-         */
-        var _stateTimeout;
-
         function _stateHandler(model, state) {
             _replayState = false;
-            clearTimeout(_stateTimeout);
-            _stateTimeout = setTimeout(function() {
-                _updateState(state);
-            }, 100);
+            _updateState(state);
         }
 
         function _errorHandler() {


### PR DESCRIPTION
This change involved how the seekbar interacts with the player.
When the user clicks down on the time slider, a flag is added to the player
"jw-flag-scrubbing", then the player is paused, and seeks occur until the mouse button
is lifted.
At this point the flag was removed and the player is told to begin playing again.

The bug occurred because the flag was being removed before the player reached a play state.
The solution is to wait until we leave the "pause" state (it will go to either playing or loading)
and then remove the flag.

After testing it, I noticed you could get it to flicker by clicking repeatedly, which is resolved by
not removing the flag in the case that the player has re-entered scrubbing state before the previous
scrubbing event stack had cleared.

[Delivers #93654250]