### PR TITLE
Fixes to getSafeRegion

### DIFF
--- a/src/css/imports/dock.less
+++ b/src/css/imports/dock.less
@@ -7,12 +7,17 @@
 
     // This allows it to be positioned beneath the logo
     clear : right;
+
+    &:after {
+        content: '';
+        clear: both;
+        display: block;
+    }
     
     .jw-dock-button {
         cursor:pointer;
         float: right;
         position: relative;
-
 
         width: 2.5em;
         height: 2em;

--- a/src/js/view/controlbar.js
+++ b/src/js/view/controlbar.js
@@ -242,6 +242,7 @@ define([
         hideFullscreen : utils.noop,
         getVisibleBounds : function (){
             var el = this.el,
+                // getComputedStyle for modern browsers, currentStyle is for IE8
                 curStyle = (getComputedStyle) ? getComputedStyle(el) : el.currentStyle,
                 bounds;
 

--- a/src/js/view/controlbar.js
+++ b/src/js/view/controlbar.js
@@ -242,19 +242,18 @@ define([
         hideFullscreen : utils.noop,
         getVisibleBounds : function (){
             var el = this.el,
-                originalVisibility = el.style.visibility,
-                originalDisplay = el.style.display,
+                curStyle = (getComputedStyle) ? getComputedStyle(el) : el.currentStyle,
                 bounds;
 
-            el.style.visibility = 'visible';
-            el.style.display = 'table';
-
-            bounds = utils.bounds(el);
-
-            el.style.visibility = originalVisibility;
-            el.style.display = originalDisplay;
-
-            return bounds;
+            if(curStyle.display === 'table'){
+                return utils.bounds(el);
+            } else {
+                el.style.visibility = 'hidden';
+                el.style.display = 'table';
+                bounds = utils.bounds(el);
+                el.style.opacity = el.style.display = '';
+                return bounds;
+            }
         },
         setAltText : function(altText) {
             this.elements.alt.innerHTML = altText;

--- a/src/js/view/controlbar.js
+++ b/src/js/view/controlbar.js
@@ -240,6 +240,22 @@ define([
         show : utils.noop,
         audioMode : utils.noop,
         hideFullscreen : utils.noop,
+        getVisibleBounds : function (){
+            var el = this.el,
+                originalVisibility = el.style.visibility,
+                originalDisplay = el.style.display,
+                bounds;
+
+            el.style.visibility = 'visible';
+            el.style.display = 'table';
+
+            bounds = utils.bounds(el);
+
+            el.style.visibility = originalVisibility;
+            el.style.display = originalDisplay;
+
+            return bounds;
+        },
         setAltText : function(altText) {
             this.elements.alt.innerHTML = altText;
         },

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -1109,16 +1109,14 @@ define([
 
             includeCB = includeCB || !utils.exists(includeCB);
 
-
-            _controlbar.showTemp();
             var dispBounds = _bounds(_container),
                 dispOffset = dispBounds.top,
-                cbBounds = _bounds(_controlbar.element()),
-                dockButtons = _model.get('dock').length,
+                cbBounds = _controlbar.getVisibleBounds(),
+                dockButtons = _model.get('dock'),
                 logoTop = (_logo.position().indexOf('top') === 0),
                 dockBounds,
                 logoBounds = _bounds(_logo.element());
-            if (dockButtons && _model.get('controls')) {
+            if (dockButtons && dockButtons.length && _model.get('controls')) {
                 dockBounds = _bounds(_dock.element());
                 bounds.y = Math.max(0, dockBounds.bottom - dispOffset);
             }
@@ -1131,7 +1129,6 @@ define([
             } else {
                 bounds.height = dispBounds.height - bounds.y;
             }
-            _controlbar.hideTemp();
             return bounds;
         };
 


### PR DESCRIPTION
_controlbar.showTemp and _controlbar.hideTemp just made the controller visible so its dimensions could be found.  instead we're using one function that gets the dimensions of the controlbar without relying on toggling it on and then off.  Fixes an case where dock buttons could be undefined and adds a clearfix psuedoelement to the dock so that the floated dock buttons will push out the dock's size. previously was only returning 0 height.