### PR TITLE
Make setup extendable by commercial project

### DIFF
--- a/src/js/controller/Setup.js
+++ b/src/js/controller/Setup.js
@@ -42,11 +42,12 @@ define([
         function _nextTask() {
             _.each(_queue, function(c) {
                 // If task completed, or destroy was called
-                if (c.complete === true || _api === null) {
+                if (c.complete === true || c.running === true || _api === null) {
                     return;
                 }
 
                 if (_allComplete(c.depends)) {
+                    c.running = true;
                     callTask(c);
                 }
             });

--- a/src/js/controller/Setup.js
+++ b/src/js/controller/Setup.js
@@ -1,4 +1,5 @@
 define([
+    'controller/setup-steps',
     'plugins/plugins',
     'playlist/loader',
     'playlist/playlist',
@@ -8,56 +9,17 @@ define([
     'utils/constants',
     'utils/underscore',
     'events/events'
-], function(plugins, PlaylistLoader, Playlist, ScriptLoader, utils, Events, Constants, _, events) {
+], function(SetupSteps, plugins, PlaylistLoader, Playlist, ScriptLoader, utils, Events, Constants, _, events) {
+
 
     var Setup = function(_api, _model, _view, _errorTimeoutSeconds) {
         var _this = this,
-            _pluginLoader,
-            _playlistLoader,
             _setupFailureTimeout;
+
+        var _queue = SetupSteps.getQueue();
 
         _errorTimeoutSeconds = _errorTimeoutSeconds || 10;
 
-        var LOAD_PLUGINS = {
-                method: _loadPlugins,
-                depends: []
-            },
-            LOAD_PROVIDERS = {
-                method: _loadProviders,
-                depends : []
-            },
-            LOAD_SKIN = {
-                method: _loadSkin,
-                depends: []
-            },
-            LOAD_PLAYLIST = {
-                method: _loadPlaylist,
-                depends: [LOAD_PROVIDERS]
-            },
-            SETUP_COMPONENTS = {
-                method: _setupComponents,
-                depends: [
-                    // view controls require that a playlist item be set
-                    LOAD_PLAYLIST,
-                    LOAD_SKIN
-                ]
-            },
-            SEND_READY = {
-                method: _sendReady,
-                depends: [
-                    LOAD_PLUGINS,
-                    SETUP_COMPONENTS
-                ]
-            };
-
-        var _queue = [
-            LOAD_PLUGINS,
-            LOAD_PROVIDERS,
-            LOAD_PLAYLIST,
-            LOAD_SKIN,
-            SETUP_COMPONENTS,
-            SEND_READY
-        ];
 
         this.start = function () {
             _setupFailureTimeout = setTimeout(_setupTimeoutHandler, _errorTimeoutSeconds * 1000);
@@ -66,203 +28,56 @@ define([
 
         this.destroy = function() {
             this.off();
-            _queue.length = 0;
             clearTimeout(_setupFailureTimeout);
-            if (_pluginLoader) {
-                _pluginLoader.destroy();
-                _pluginLoader = null;
-            }
-            if (_playlistLoader) {
-                _playlistLoader.destroy();
-                _playlistLoader = null;
-            }
+            _queue = 0;
             _api = null;
             _model = null;
             _view = null;
         };
 
-        function _setupTimeoutHandler(){
+        function _setupTimeoutHandler() {
             _error('Setup Timeout Error', 'Setup took longer than ' + _errorTimeoutSeconds + ' seconds to complete.');
         }
 
         function _nextTask() {
-            for (var i = 0; i < _queue.length; i++) {
-                var task = _queue[i];
-                if (_allComplete(task.depends)) {
-                    _queue.splice(i--, 1);
-                    task.method();
+            _.each(_queue, function(c) {
+                // If task completed, or destroy was called
+                if (c.complete === true || _api === null) {
+                    return;
                 }
-            }
+
+                if (_allComplete(c.depends)) {
+                    callTask(c);
+                }
+            });
+        }
+
+        function callTask(task) {
+            var resolve = function(resolveState) {
+                resolveState = resolveState || {};
+                _taskComplete(task, resolveState);
+            };
+            task.method(resolve, _model, _api, _view);
         }
 
         function _allComplete(dependencies) {
             // return true if empty array,
             //  or if each object has an attribute 'complete' which is true
-            return _.all(_.map(dependencies, _.property('complete')));
-        }
-
-        function _taskComplete(task) {
-            task.complete = true;
-            _nextTask();
-        }
-
-        function _loadPlugins() {
-            _pluginLoader = plugins.loadPlugins(_model.config.id, _model.config.plugins);
-            _pluginLoader.on(events.COMPLETE, _completePlugins);
-            _pluginLoader.on(events.ERROR, _pluginsError);
-            _pluginLoader.load();
-        }
-
-        function _loadProviders() {
-            var config = _model.get('config');
-
-            if (config.dash === 'dashjs') {
-                require.ensure(['providers/dashjs'], function (require) {
-                    var dashjs = require('providers/dashjs');
-                    dashjs.register(window.jwplayer);
-                    _model.updateProviders();
-                    _taskComplete(LOAD_PROVIDERS);
-                }, 'provider.dashjs');
-            } else if (config.dash) {
-                require.ensure(['providers/shaka'], function(require) {
-                    var shaka = require('providers/shaka');
-                    shaka.register(window.jwplayer);
-                    _model.updateProviders();
-                    _taskComplete(LOAD_PROVIDERS);
-                }, 'provider.shaka');
-            } else {
-                _taskComplete(LOAD_PROVIDERS);
-            }
-        }
-
-        function _completePlugins() {
-            // TODO: flatten flashPlugins and pass to flash provider
-            _model.config.flashPlugins = _pluginLoader.setupPlugins(_api, _model.config, _resizePlugin);
-
-            // Volume option is tricky to remove, since it needs to be in the HTML5 player model.
-            delete _model.config.volume;
-
-            _taskComplete(LOAD_PLUGINS);
-        }
-
-        function _resizePlugin(plugin, div, onready) {
-            var id = _api.id;
-            return function() {
-                var displayarea = document.querySelector('#' + id + ' .jw-overlays');
-                if (displayarea && onready) {
-                    displayarea.appendChild(div);
-                }
-                if (typeof plugin.resize === 'function') {
-                    plugin.resize(displayarea.clientWidth, displayarea.clientHeight);
-                    setTimeout(function() {
-                        plugin.resize(displayarea.clientWidth, displayarea.clientHeight);
-                    }, 400);
-                }
-                div.left = displayarea.style.left;
-                div.top = displayarea.style.top;
-            };
-        }
-
-        function _pluginsError(evt) {
-            _error('Could not load plugin', evt.message);
-        }
-
-        function _loadPlaylist() {
-            var playlist = _model.config.playlist;
-            if (_.isString(playlist)) {
-                _playlistLoader = new PlaylistLoader();
-                _playlistLoader.on(events.JWPLAYER_PLAYLIST_LOADED, _completePlaylist);
-                _playlistLoader.on(events.JWPLAYER_ERROR, _playlistError);
-                _playlistLoader.load(playlist);
-            } else {
-                _completePlaylist(_model.config);
-            }
-        }
-
-        function _completePlaylist(data) {
-            var playlist = data.playlist;
-            if (_.isArray(playlist)) {
-                playlist = Playlist(playlist);
-                _model.setPlaylist(playlist);
-                if (_model.playlist.length === 0) {
-                    _playlistError();
-                    return;
-                }
-                _taskComplete(LOAD_PLAYLIST);
-            } else {
-                _error('Playlist type not supported', typeof playlist);
-            }
-        }
-
-        function _playlistError(evt) {
-            if (evt && evt.message) {
-                _error('Error loading playlist', evt.message);
-            } else {
-                _error('Error loading player', 'No playable sources found');
-            }
-        }
-
-        function skinToLoad(skin) {
-            if(_.contains(Constants.Skins, skin)) {
-                return utils.getSkinUrl(skin);
-            } else {
-                console.log('The skin parameter does not match any of our skins : ' + skin);
-            }
-        }
-
-        function isSkinLoaded(skinPath) {
-            var ss = document.styleSheets;
-            for (var i = 0, max = ss.length; i < max; i++) {
-                if (ss[i].href === skinPath) {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        function _loadSkin() {
-            var skinName = _model.get('skin');
-            var skinUrl = _model.get('skinUrl');
-
-
-            if (skinName && !skinUrl) {
-                // if a skin name is defined, but there is no URL, load from CDN
-                skinUrl = skinToLoad(skinName);
-            }
-
-            // seven is built into the player
-            if (skinName !== 'seven' && _.isString(skinUrl) && !isSkinLoaded(skinUrl)) {
-                _model.set('skin-loading', true);
-
-                var isStylesheet = true;
-                var loader = new ScriptLoader(skinUrl, isStylesheet);
-
-                loader.addEventListener(events.COMPLETE, function() {
-                        _model.set('skin-loading', false);
-                    })
-                    .addEventListener(events.ERROR, function() {
-                        console.log('The given skin failed to load : ', skinUrl);
-                        _model.set('skin', null);
-                        _model.set('skin-loading', false);
-                    });
-
-                loader.load();
-            }
-
-            // Control elements are hidden by the loading flag until it is ready
-            _.defer(function() {
-                _taskComplete(LOAD_SKIN);
+            return _.all(dependencies, function(name) {
+                return _queue[name].complete;
             });
         }
 
-        function _setupComponents() {
-            _view.setup();
-            _taskComplete(SETUP_COMPONENTS);
-        }
-
-        function _sendReady() {
-            _this.trigger(events.JWPLAYER_READY);
-            clearTimeout(_setupFailureTimeout);
+        function _taskComplete(task, resolveState) {
+            if (resolveState.type === 'error') {
+                _error(resolveState.msg, resolveState.reason);
+            } else if (resolveState.type === 'complete') {
+                _this.trigger(events.JWPLAYER_READY);
+                clearTimeout(_setupFailureTimeout);
+            } else {
+                task.complete = true;
+                _nextTask();
+            }
         }
 
         function _error(message, reason) {

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -77,6 +77,7 @@ define([
 
             var _video = function() { return _model.getVideo(); };
 
+
             _model = this._model.setup(config);
             _view  = this._view  = new View(_api, _model);
             _captions = new Captions(_api, _model);

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -65,9 +65,13 @@ define([
                 buffer: 0
             });
 
-            _providers = new Providers(_this.config);
+            this.updateProviders();
 
             return this;
+        };
+
+        this.updateProviders = function() {
+            _providers = new Providers(_this.config);
         };
 
         function _videoEventHandler(evt) {

--- a/src/js/controller/setup-steps.js
+++ b/src/js/controller/setup-steps.js
@@ -1,0 +1,203 @@
+define([
+    'plugins/plugins',
+    'playlist/loader',
+    'playlist/playlist',
+    'utils/scriptloader',
+    'utils/helpers',
+    'utils/backbone.events',
+    'utils/constants',
+    'utils/underscore',
+    'events/events'
+], function(plugins, PlaylistLoader, Playlist, ScriptLoader, utils, Events, Constants, _, events) {
+
+    var _pluginLoader,
+        _playlistLoader;
+
+
+    function getQueue() {
+
+        var Components = {
+            LOAD_PLUGINS : {
+                method: _loadPlugins,
+                depends: []
+            },
+            LOAD_SKIN : {
+                method: _loadSkin,
+                depends: []
+            },
+            LOAD_PLAYLIST : {
+                method: _loadPlaylist,
+                depends: []
+            },
+            SETUP_COMPONENTS : {
+                method: _setupComponents,
+                depends: [
+                    // view controls require that a playlist item be set
+                    'LOAD_PLAYLIST',
+                    'LOAD_SKIN'
+                ]
+            },
+            SEND_READY : {
+                method: _sendReady,
+                depends: [
+                    'LOAD_PLUGINS',
+                    'SETUP_COMPONENTS'
+                ]
+            }
+        };
+
+        return Components;
+    }
+
+
+    function _loadPlugins(resolve, _model, _api) {
+        _pluginLoader = plugins.loadPlugins(_model.config.id, _model.config.plugins);
+        _pluginLoader.on(events.COMPLETE, _.partial(_completePlugins, resolve, _model, _api));
+        _pluginLoader.on(events.ERROR, _.partial(_pluginsError, resolve));
+        _pluginLoader.load();
+    }
+
+    function _completePlugins(resolve, _model, _api) {
+        // TODO: flatten flashPlugins and pass to flash provider
+        _model.config.flashPlugins = _pluginLoader.setupPlugins(_api, _model.config, _.partial(_resizePlugin, _api));
+
+        // Volume option is tricky to remove, since it needs to be in the HTML5 player model.
+        delete _model.config.volume;
+
+        resolve();
+    }
+
+    function _resizePlugin(_api, plugin, div, onready) {
+        var id = _api.id;
+        return function() {
+            var displayarea = document.querySelector('#' + id + ' .jw-overlays');
+            if (displayarea && onready) {
+                displayarea.appendChild(div);
+            }
+            if (typeof plugin.resize === 'function') {
+                plugin.resize(displayarea.clientWidth, displayarea.clientHeight);
+                setTimeout(function() {
+                    plugin.resize(displayarea.clientWidth, displayarea.clientHeight);
+                }, 400);
+            }
+            div.left = displayarea.style.left;
+            div.top = displayarea.style.top;
+        };
+    }
+
+    function _pluginsError(resolve, evt) {
+        _error(resolve, 'Could not load plugin', evt.message);
+    }
+
+    function _loadPlaylist(resolve, _model) {
+        var playlist = _model.config.playlist;
+        if (_.isString(playlist)) {
+            _playlistLoader = new PlaylistLoader();
+            _playlistLoader.on(events.JWPLAYER_PLAYLIST_LOADED, _.partial(_completePlaylist, resolve));
+            _playlistLoader.on(events.JWPLAYER_ERROR, _.partial(_playlistError, resolve));
+            _playlistLoader.load(playlist);
+        } else {
+            _completePlaylist(resolve, _model);
+        }
+    }
+
+    function _completePlaylist(resolve, _model) {
+        var data = _model.config;
+        var playlist = data.playlist;
+        if (_.isArray(playlist)) {
+            playlist = Playlist(playlist);
+            _model.setPlaylist(playlist);
+            if (_model.playlist.length === 0) {
+                _playlistError(resolve);
+                return;
+            }
+            resolve();
+        } else {
+            _error(resolve, 'Playlist type not supported', typeof playlist);
+        }
+    }
+
+    function _playlistError(resolve, evt) {
+        if (evt && evt.message) {
+            _error(resolve, 'Error loading playlist', evt.message);
+        } else {
+            _error(resolve, 'Error loading player', 'No playable sources found');
+        }
+    }
+
+    function skinToLoad(skin) {
+        if(_.contains(Constants.Skins, skin)) {
+            return utils.getSkinUrl(skin);
+        } else {
+            console.log('The skin parameter does not match any of our skins : ' + skin);
+        }
+    }
+
+    function isSkinLoaded(skinPath) {
+        var ss = document.styleSheets;
+        for (var i = 0, max = ss.length; i < max; i++) {
+            if (ss[i].href === skinPath) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    function _loadSkin(resolve, _model) {
+        var skinName = _model.get('skin');
+        var skinUrl = _model.get('skinUrl');
+
+
+        if (skinName && !skinUrl) {
+            // if a skin name is defined, but there is no URL, load from CDN
+            skinUrl = skinToLoad(skinName);
+        }
+
+        // seven is built into the player
+        if (skinName !== 'seven' && _.isString(skinUrl) && !isSkinLoaded(skinUrl)) {
+            _model.set('skin-loading', true);
+
+            var isStylesheet = true;
+            var loader = new ScriptLoader(skinUrl, isStylesheet);
+
+            loader.addEventListener(events.COMPLETE, function() {
+                _model.set('skin-loading', false);
+            })
+                .addEventListener(events.ERROR, function() {
+                    console.log('The given skin failed to load : ', skinUrl);
+                    _model.set('skin', null);
+                    _model.set('skin-loading', false);
+                });
+
+            loader.load();
+        }
+
+        // Control elements are hidden by the loading flag until it is ready
+        _.defer(function() {
+            resolve();
+        });
+    }
+
+    function _setupComponents(resolve, _model, _api, _view) {
+        _view.setup();
+        resolve();
+    }
+
+    function _sendReady(resolve) {
+        resolve({
+            type : 'complete'
+        });
+    }
+
+    function _error(resolve, msg, reason) {
+        resolve({
+            type : 'error',
+            msg : msg,
+            reason : reason
+        });
+    }
+
+    return {
+        getQueue : getQueue
+    };
+});

--- a/src/js/utils/underscore.js
+++ b/src/js/utils/underscore.js
@@ -415,6 +415,11 @@ define([], function() {
         return copy;
     };
 
+    // Create a (shallow-cloned) duplicate of an object.
+    _.clone = function(obj) {
+        if (!_.isObject(obj)) return obj;
+        return _.isArray(obj) ? obj.slice() : _.extend({}, obj);
+    };
 
     // Is a given value an array?
     // Delegates to ECMA5's native Array.isArray

--- a/src/js/view/components/menu.js
+++ b/src/js/view/components/menu.js
@@ -39,7 +39,10 @@ define([
         },
         select: function (evt) {
             if(evt.target.parentElement === this.content) {
-                this.trigger('select', parseInt(evt.target.classList[1].split('-')[1]));
+                var classes = evt.target.classList;
+                // find the class with a name of the form 'item-1'
+                var item = _.find(classes, function(c) { return c.indexOf('item') === 0;});
+                this.trigger('select', parseInt(item.split('-')[1]));
             }
         },
         selectItem : function(selectedIndex) {


### PR DESCRIPTION
Most of this change is moving pieces of setup into a file called "setup-steps."

The important part here is decoupling _model, _api and other variables which were bound into the closure so that they are parameters passed into the setup functions.

This will make it possible for the commercial player to fetch the queue and insert new things into it.
[Delivers #91404968 #93714018]