### PR TITLE
DFXP subtitle parser in HTML5-mode got begin time wrong if there is a duration attribute between begin and end.

### DIFF
--- a/src/js/html5/parsers/jwplayer.html5.parsers.dfxp.js
+++ b/src/js/html5/parsers/jwplayer.html5.parsers.dfxp.js
@@ -59,9 +59,10 @@
             try {
                 var idx = data.indexOf('begin=\"');
                 data = data.substr(idx + 7);
-                idx = data.indexOf('\" end=\"');
+                idx = data.indexOf('\"');
                 entry.begin = _seconds(data.substr(0, idx));
-                data = data.substr(idx + 7);
+                idx = data.indexOf('end=\"');
+                data = data.substr(idx + 5);
                 idx = data.indexOf('\"');
                 entry.end = _seconds(data.substr(0, idx));
                 idx = data.indexOf('\">');


### PR DESCRIPTION
This is a minimal fix to get "begin" time correct if there are other attribute between "begin" and "end" (such as "duration")
It is still pretty naive and breaks if "begin" and "end" attributes come in the other source order. This really should be done with a proper XML-parser.