### PR TITLE
DFXP subtitle parser got begin time wrong if there is a duration attribute between begin and end.

### DIFF
--- a/src/js/parsers/captions/parsers.dfxp.js
+++ b/src/js/parsers/captions/parsers.dfxp.js
@@ -56,9 +56,10 @@ define([
             utils.tryCatch(function() {
                 var idx = data.indexOf('begin=\"');
                 data = data.substr(idx + 7);
-                idx = data.indexOf('\" end=\"');
+                idx = data.indexOf('\"');
                 entry.begin = _seconds(data.substr(0, idx));
-                data = data.substr(idx + 7);
+                idx = data.indexOf('end=\"');
+                data = data.substr(idx + 5);
                 idx = data.indexOf('\"');
                 entry.end = _seconds(data.substr(0, idx));
                 idx = data.indexOf('\">');


### PR DESCRIPTION
This is a minimal fix to get "begin" time correct if there are other attribute between "begin" and "end" (such as "duration")
It is still pretty naive and breaks if "begin" and "end" attributes come in the other source order. This really should be done with a proper XML-parser.