### PR TITLE
skin css examples

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -67,9 +67,13 @@ module.exports = function(grunt) {
                     zeroUnits: false,
                     includePaths: ['src/css', 'src/css/*']
                 },
-                files: {
-                    'bin-debug/jwplayer.css': 'src/css/jwplayer.less'
-                }
+                files: [{
+                    expand: true,
+                    ext: '.css',
+                    dest: 'bin-debug/skins/',
+                    cwd: 'src/css/',
+                    src: '{,*/}*.less'
+                }]
             },
             'generate-test-css': {
                 options: {
@@ -87,6 +91,27 @@ module.exports = function(grunt) {
                 files: {
                     'bin-debug/jwplayer.css': 'src/css/jwplayer.less'
                 }
+            },
+            skins: {
+                options: {
+                    compile: true,
+                    compress: false,
+                    noIDs: true,
+                    noJSPrefix: true,
+                    noOverqualifying: false,
+                    noUnderscores: true,
+                    noUniversalSelectors: false,// true,
+                    strictPropertyOrder: false, // true,
+                    zeroUnits: false,
+                    includePaths: ['src/css', 'src/css/*']
+                },
+                files: [{
+                    expand: true,
+                    ext: '.css',
+                    dest: 'bin-debug/skins/',
+                    cwd: 'src/css/skins/',
+                    src: '*.less'
+                }]
             }
         },
 
@@ -110,7 +135,7 @@ module.exports = function(grunt) {
             },
             css: {
                 files: ['src/css/{,*/}*.less'],
-                tasks: ['webpack:debug', 'recess'],
+                tasks: ['webpack:debug', 'recess:lint'],
                 options: {
                     spawn: false
                 }

--- a/src/css/flags/audioplayer.less
+++ b/src/css/flags/audioplayer.less
@@ -1,3 +1,5 @@
+@import "../imports/icons";
+
 .jwplayer.jw-flag-audio-player {
     background-color: transparent;
 

--- a/src/css/imports/dock.less
+++ b/src/css/imports/dock.less
@@ -1,4 +1,4 @@
-@dock-corner-radius: 0.25em;
+@import "vars";
 
 .jw-dock {
     margin: @ui-margin/2;

--- a/src/css/imports/jwplayerelement.less
+++ b/src/css/imports/jwplayerelement.less
@@ -1,3 +1,6 @@
+@import "../imports/vars";
+@import "../imports/icons";
+
 .jwplayer {
     width: 100%;
     font-size: @default-em-size;

--- a/src/css/imports/logo.less
+++ b/src/css/imports/logo.less
@@ -1,3 +1,5 @@
+@import "../imports/vars";
+
 .jwplayer .jw-logo {
 
     float : right;

--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -1,3 +1,5 @@
+@import "vars";
+
 .inset-controlbar() {
 	margin: 0 auto;
     max-width: @controlbar-max-width;

--- a/src/css/imports/skipad.less
+++ b/src/css/imports/skipad.less
@@ -1,3 +1,6 @@
+@import "../imports/vars";
+@import "../imports/icons";
+
 .jwplayer {
     .jw-skip {
         cursor: default;

--- a/src/css/imports/slider.less
+++ b/src/css/imports/slider.less
@@ -1,6 +1,4 @@
-@import "vars.less";
-
-@thumb-size: .65em;
+@import "vars";
 
 .jwplayer .jw-slider-horizontal,
 .jwplayer .jw-slider-vertical {

--- a/src/css/imports/title.less
+++ b/src/css/imports/title.less
@@ -1,3 +1,5 @@
+@import "../imports/vars";
+
 .jwplayer {
     .jw-title {
         display: none;

--- a/src/css/imports/vars.less
+++ b/src/css/imports/vars.less
@@ -43,6 +43,11 @@
 @volume-rail-width: @def-rail-width;
 @volume-rail-length: 6em;
 
+/* icons */
+@thumb-size: .65em;
+/* doc */
+@dock-corner-radius: 0.25em;
+
 /* IE9 SVG, needs conditional override of 'filter' to 'none' */
 //background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgdmlld0JveD0iMCAwIDEgMSIgcHJlc2VydmVBc3BlY3RSYXRpbz0ibm9uZSI+CiAgPGxpbmVhckdyYWRpZW50IGlkPSJncmFkLXVjZ2ctZ2VuZXJhdGVkIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgeDE9IjAlIiB5MT0iMCUiIHgyPSIwJSIgeTI9IjEwMCUiPgogICAgPHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iIzQ5NDk0YiIgc3RvcC1vcGFjaXR5PSIwLjg3Ii8+CiAgICA8c3RvcCBvZmZzZXQ9IjMlIiBzdG9wLWNvbG9yPSIjNDU0NTQ3IiBzdG9wLW9wYWNpdHk9IjEiLz4KICAgIDxzdG9wIG9mZnNldD0iNyUiIHN0b3AtY29sb3I9IiMzZjNmNDEiIHN0b3Atb3BhY2l0eT0iMSIvPgogICAgPHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiMzZTNlNDAiIHN0b3Atb3BhY2l0eT0iMSIvPgogICAgPHN0b3Agb2Zmc2V0PSI1OSUiIHN0b3AtY29sb3I9IiMzYTNhM2QiIHN0b3Atb3BhY2l0eT0iMSIvPgogICAgPHN0b3Agb2Zmc2V0PSI5NyUiIHN0b3AtY29sb3I9IiMzNDM0MzciIHN0b3Atb3BhY2l0eT0iMSIvPgogICAgPHN0b3Agb2Zmc2V0PSIxMDAlIiBzdG9wLWNvbG9yPSIjMzQzNDM3IiBzdG9wLW9wYWNpdHk9IjAuODciLz4KICA8L2xpbmVhckdyYWRpZW50PgogIDxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxIiBoZWlnaHQ9IjEiIGZpbGw9InVybCgjZ3JhZC11Y2dnLWdlbmVyYXRlZCkiIC8+Cjwvc3ZnPg==);
 //background: -moz-linear-gradient(top, rgba(73,73,75,0.87) 0%, rgba(69,69,71,1) 3%, rgba(63,63,65,1) 7%, rgba(62,62,64,1) 10%, rgba(58,58,61,1) 59%, rgba(52,52,55,1) 97%, rgba(52,52,55,0.87) 100%); /* FF3.6+ */

--- a/src/css/skins/beelden.less
+++ b/src/css/skins/beelden.less
@@ -1,3 +1,5 @@
+@import "../imports/vars";
+
 .jw-skin-beelden {
 
 	.jw-controlbar {

--- a/src/css/skins/bekle.less
+++ b/src/css/skins/bekle.less
@@ -1,3 +1,5 @@
+@import "../imports/vars";
+
 .jw-skin-bekle {
 	.jw-controlbar {
 		background-color: #182335;

--- a/src/css/skins/roundster.less
+++ b/src/css/skins/roundster.less
@@ -1,3 +1,5 @@
+@import "../imports/vars";
+
 .jw-skin-roundster {
 	.jw-controlbar {
 		background: #dfe2e9;

--- a/src/css/skins/seven.less
+++ b/src/css/skins/seven.less
@@ -1,3 +1,5 @@
+@import "../imports/mixins";
+
 @active-color: #FF0046;
 
 .jw-skin-seven {
@@ -158,13 +160,13 @@
         min-width: 2.25em;
     }
 
-    .jw-icon-hd:before,
-    .jw-icon-cc:before {
+    .jw-icon-hd,
+    .jw-icon-cc {
         color: @active-color;
     }
 
-    .jw-icon-hd.jw-off:before,
-    .jw-icon-cc.jw-off:before {
+    .jw-icon-hd.jw-off,
+    .jw-icon-cc.jw-off {
         color: white;
     }
 

--- a/src/css/skins/six.less
+++ b/src/css/skins/six.less
@@ -1,3 +1,8 @@
+@import "../imports/vars";
+@import "../imports/mixins";
+@import "../imports/icons";
+@import "../imports/dock";
+
 @active-color: #eee;
 @inactive-color: #aaa;
 @buffer-color: #202020;

--- a/src/css/states/buffering.less
+++ b/src/css/states/buffering.less
@@ -1,3 +1,5 @@
+@import "../imports/icons";
+
 .jwplayer.jw-state-buffering {
     .jw-display-icon-container {
         .jw-icon-display {

--- a/src/css/states/complete.less
+++ b/src/css/states/complete.less
@@ -1,3 +1,5 @@
+@import "../imports/icons";
+
 .jwplayer.jw-state-complete {
     .jw-preview {
         display: block;

--- a/src/css/states/idle.less
+++ b/src/css/states/idle.less
@@ -1,3 +1,5 @@
+@import "../imports/icons";
+
 .jwplayer.jw-state-idle {
     .jw-preview {
         display: block;

--- a/src/css/states/paused.less
+++ b/src/css/states/paused.less
@@ -1,3 +1,5 @@
+@import "../imports/icons";
+
 .jwplayer.jw-state-paused {
     .jw-display-icon-container {
         display: none;

--- a/src/css/states/playing.less
+++ b/src/css/states/playing.less
@@ -1,3 +1,5 @@
+@import "../imports/icons";
+
 .jwplayer.jw-state-playing {
   .jw-display-icon-container {
       display: none;


### PR DESCRIPTION
Output css with recess for each skin so there are examples customers can base their skins off of, and fix seven skin cc/hd color: remove :before pseudo class from selector that applies color to cc/hd icons