### PR TITLE
Reduce surface points of Playlist filtering

### DIFF
--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -48,11 +48,9 @@ define([
             delete config.aspectratio;
         }
 
-        if (_.isString(config.playlist)) {
-            // If playlist is a string, then it's an RSS feed, let it be
-        } else {
-            // Else use the playlist obj/array or generate it from config
-            config.playlist = Playlist(config.playlist || config);
+        if (!config.playlist) {
+            // This is a legacy fallback, assuming a playlist item has been flattened into the config
+            config.playlist = config;
         }
 
         return config;

--- a/src/js/controller/Setup.js
+++ b/src/js/controller/Setup.js
@@ -1,15 +1,10 @@
 define([
     'controller/setup-steps',
-    'plugins/plugins',
-    'playlist/loader',
-    'playlist/playlist',
-    'utils/scriptloader',
     'utils/helpers',
     'utils/backbone.events',
-    'utils/constants',
     'utils/underscore',
     'events/events'
-], function(SetupSteps, plugins, PlaylistLoader, Playlist, ScriptLoader, utils, Events, Constants, _, events) {
+], function(SetupSteps, utils, Events, _, events) {
 
 
     var Setup = function(_api, _model, _view, _errorTimeoutSeconds) {

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -5,7 +5,6 @@ define([
     'controller/Setup',
     'controller/captions',
     'controller/model',
-    'playlist/playlist',
     'playlist/loader',
     'utils/helpers',
     'view/view',
@@ -14,7 +13,7 @@ define([
     'events/events',
     'view/errorscreen'
 ], function(setupInstreamMethods, deprecateInit, _, Setup, Captions,
-            Model, Playlist, PlaylistLoader, utils, View, Events, states, events, errorScreen) {
+            Model, PlaylistLoader, utils, View, Events, states, events, errorScreen) {
 
     function _queue(command) {
         return function() {
@@ -215,8 +214,6 @@ define([
                     track: _model.get('captionsIndex')
                 });
 
-                _load();
-
                 if (_model.get('autostart') && !utils.isMobile()) {
                     _play();
                 }
@@ -237,7 +234,7 @@ define([
                         _loadPlaylist(item);
                         break;
                     case 'object':
-                        _model.setPlaylist(Playlist(item));
+                        _model.setPlaylist(item);
                         break;
                     case 'number':
                         _model.setItem(item);

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -175,8 +175,9 @@ define([
 
         // TODO: make this a synchronous action; throw error if playlist is empty
         this.setPlaylist = function(p) {
+            var playlist = Playlist(p);
 
-            var playlist = Playlist.filterPlaylist(p, _providers, _this.androidhls);
+            playlist = Playlist.filterPlaylist(playlist, _providers, _this.androidhls);
 
             if (playlist.length === 0) {
                 this.playlist = [];

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -177,7 +177,7 @@ define([
         this.setPlaylist = function(p) {
             var playlist = Playlist(p);
 
-            playlist = Playlist.filterPlaylist(playlist, _providers, _this.androidhls);
+            playlist = Playlist.filterPlaylist(playlist, _providers, _this.get('androidhls'), this.get('protection'));
 
             if (playlist.length === 0) {
                 this.playlist = [];

--- a/src/js/controller/setup-steps.js
+++ b/src/js/controller/setup-steps.js
@@ -102,7 +102,8 @@ define([
 
     function _completePlaylist(resolve, _model, playlist) {
         _model.setPlaylist(playlist);
-        if (_model.get('playlist').length === 0) {
+        var p = _model.get('playlist');
+        if (!_.isArray(p) || p.length === 0) {
             _playlistError(resolve, 'Playlist type not supported');
             return;
         }

--- a/src/js/controller/setup-steps.js
+++ b/src/js/controller/setup-steps.js
@@ -90,28 +90,23 @@ define([
         var playlist = _model.config.playlist;
         if (_.isString(playlist)) {
             _playlistLoader = new PlaylistLoader();
-            _playlistLoader.on(events.JWPLAYER_PLAYLIST_LOADED, _.partial(_completePlaylist, resolve));
+            _playlistLoader.on(events.JWPLAYER_PLAYLIST_LOADED, function(data) {
+                _completePlaylist(resolve, _model, data.playlist);
+            });
             _playlistLoader.on(events.JWPLAYER_ERROR, _.partial(_playlistError, resolve));
             _playlistLoader.load(playlist);
         } else {
-            _completePlaylist(resolve, _model);
+            _completePlaylist(resolve, _model, playlist);
         }
     }
 
-    function _completePlaylist(resolve, _model) {
-        var data = _model.config;
-        var playlist = data.playlist;
-        if (_.isArray(playlist)) {
-            playlist = Playlist(playlist);
-            _model.setPlaylist(playlist);
-            if (_model.playlist.length === 0) {
-                _playlistError(resolve);
-                return;
-            }
-            resolve();
-        } else {
-            _error(resolve, 'Playlist type not supported', typeof playlist);
+    function _completePlaylist(resolve, _model, playlist) {
+        _model.setPlaylist(playlist);
+        if (_model.get('playlist').length === 0) {
+            _playlistError(resolve, 'Playlist type not supported');
+            return;
         }
+        resolve();
     }
 
     function _playlistError(resolve, evt) {

--- a/src/js/playlist/loader.js
+++ b/src/js/playlist/loader.js
@@ -41,7 +41,7 @@ define([
                     return;
                 }
 
-                var pl = new Playlist(rssParser.parse(rss));
+                var pl = rssParser.parse(rss);
                 _this.trigger(events.JWPLAYER_PLAYLIST_LOADED, {
                     playlist: pl
                 });

--- a/src/js/playlist/playlist.js
+++ b/src/js/playlist/playlist.js
@@ -13,12 +13,12 @@ define([
     };
 
     /** Go through the playlist and choose a single playable type to play; remove sources of a different type **/
-    Playlist.filterPlaylist = function(playlist, providers, androidhls) {
+    Playlist.filterPlaylist = function(playlist, providers, androidhls, configProtection) {
         var list = [];
 
         _.each(playlist, function(item) {
             item = _.extend({}, item);
-            item.sources = _filterSources(item.sources, providers, androidhls);
+            item.sources = _filterSources(item.sources, providers, androidhls, item.protection || configProtection);
 
             if (!item.sources.length) {
                 return;
@@ -34,7 +34,7 @@ define([
     };
 
     // A playlist item may have multiple different sources, but we want to stick with one.
-    var _filterSources = Playlist.filterSources = function(sources, providers, androidhls) {
+    var _filterSources = Playlist.filterSources = function(sources, providers, androidhls, itemProtection) {
 
         // legacy plugin support
         if (!providers || !providers.choose) {
@@ -48,6 +48,11 @@ define([
             if (androidhls) {
                 originalSource.androidhls =  androidhls;
             }
+
+            if (originalSource.protection || itemProtection) {
+                originalSource.protection = originalSource.protection || itemProtection;
+            }
+
             return Source(originalSource);
         }));
 

--- a/test/unit/api-config.js
+++ b/test/unit/api-config.js
@@ -73,7 +73,7 @@ define([
         x = testConfig({
             file:'abc.mp4'
         });
-        equal(x.playlist[0].sources[0].file, 'abc.mp4', 'Passing a file attr works');
+        equal(x.playlist.file, 'abc.mp4', 'Passing a file attr works');
     });
 
     test('Testing aspect ratio', function() {


### PR DESCRIPTION
There is now only one place where Playlists are officially parsed and filtered, when we call
model.setPlaylist(..).

This makes it easier to add the new config block for "protection" all the way from the player config level down to the individual source level.