### PR TITLE
Remove '.xml' from skin names in the config

### DIFF
--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -50,6 +50,11 @@ define([
             }
         }
 
+        if (_.isString(config.skin) && config.skin.indexOf('.xml') > 0) {
+            console.log('JW Player does not support XML skins, please update your config');
+            config.skin = config.skin.replace('.xml', '');
+        }
+
         if (!config.aspectratio) {
             delete config.aspectratio;
         }

--- a/test/manual/index.html
+++ b/test/manual/index.html
@@ -26,6 +26,8 @@
             file:'css-skins/icons/smiley.png'
         },
 
+        skin : 'bekle.xml',
+
 
         listbar: {
             position: 'right'


### PR DESCRIPTION
This is to minimize users headaches when migrating from JW6 to JW7.
The player will output a warning into the console, alerting them to update.

[#93120080]