### PR TITLE
Add setCues to public API

### DIFF
--- a/src/js/api/api-mutators.js
+++ b/src/js/api/api-mutators.js
@@ -68,7 +68,8 @@ define([
             'setControls',
             'setFullscreen',
             'setVolume',
-            'setMute'
+            'setMute',
+            'setCues'
         ];
 
         // getters

--- a/src/js/view/components/slider.js
+++ b/src/js/view/components/slider.js
@@ -2,9 +2,8 @@ define([
     'view/components/extendable',
     'utils/ui',
     'handlebars-loader!templates/slider.html',
-    'utils/underscore',
     'utils/helpers'
-], function(Extendable, UI, SliderTemplate, _, utils) {
+], function(Extendable, UI, SliderTemplate, utils) {
 
     var Slider = Extendable.extend({
         constructor : function(className, orientation) {


### PR DESCRIPTION
This is used by the VAST plugin, which should not result in logging the "using deprecated jwSetCues method" message.