### PR TITLE
Allows volume slider tip to slide [Finishes #96320438]

### DIFF
--- a/src/css/skins/seven.less
+++ b/src/css/skins/seven.less
@@ -131,8 +131,6 @@
         }
 
         .jw-thumb {
-            .vertically-centered-rail-element(.2em, .6em);
-
             &:after {
                 background-color: #fff;
                 box-shadow: 0px 0px 0px 1px rgba(0,0,0,1);
@@ -157,6 +155,7 @@
         }
 
         .jw-thumb {
+            .vertically-centered-rail-element(.2em, .6em);
             top: -15%;
         }
 
@@ -177,6 +176,10 @@
         .jw-buffer,
         .jw-progress {
             width: .2em;
+        }
+
+        .jw-thumb {
+            .horizontally-centered-thumb(.2em, .6em);
         }
     }
 


### PR DESCRIPTION
Removes a "top" style that was incorrectly being applied that conflicting with the "bottom" style that moves the slider thumb.

[Finishes #96320438]