### PR TITLE
Hide elapsed time and duration for livestreams

### DIFF
--- a/src/css/flags/live.less
+++ b/src/css/flags/live.less
@@ -1,5 +1,7 @@
 .jwplayer.jw-flag-live {
     .jw-controlbar {
+        .jw-text-elapsed,
+        .jw-text-duration,
         .jw-slider-time {
             display: none;
         }

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -99,7 +99,7 @@ define([
                     break;
 
                 case events.JWPLAYER_MEDIA_TIME:
-                    var isLive = (evt.duration === -1);
+                    var isLive = (evt.duration === -1 || evt.duration === Infinity);
 
                     this.mediaModel.set('isLive', isLive);
                     this.mediaModel.set('position', evt.position);


### PR DESCRIPTION
This also has the player detect live streams when item duration === Infinity

[Fixes #92363070]