### PR TITLE
Do not call redraw on controlbar anymore

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -691,12 +691,6 @@ define([
         };
 
 
-        function _redrawComponent(comp) {
-            if (comp) {
-                comp.redraw();
-            }
-        }
-
         /**
          * Resize the player
          */
@@ -864,7 +858,6 @@ define([
                 });
             }
 
-            _redrawComponent(_controlbar);
             _resizeMedia();
 
             _toggleFullscreen(fullscreenState);


### PR DESCRIPTION
This method was deprecated and throwing an error when we toggle fullscreen mode

[Delivers #96483856]