### PR TITLE
Fix instream waterfall edgecases

### DIFF
--- a/src/js/api/instreamPlayer.js
+++ b/src/js/api/instreamPlayer.js
@@ -44,8 +44,6 @@ define([
             if (_instream) {
                 _instream.instreamDestroy();
                 _instream = null;
-            } else if (__DEBUG__ === true) {
-                console.log('Instream being destroyed a second time');
             }
         };
 

--- a/src/js/controller/instream.js
+++ b/src/js/controller/instream.js
@@ -150,6 +150,7 @@ define([
             }
 
             // Match the main player's controls state
+            _adModel.off(events.JWPLAYER_ERROR);
             _adModel.on(events.JWPLAYER_ERROR, errorHandler);
 
             // start listening for ad click
@@ -182,10 +183,6 @@ define([
 
         function errorHandler(evt) {
             _sendEvent(evt.type, evt);
-
-            if (_adModel) {
-                _this.instreamDestroy();
-            }
         }
 
         /** Stop the instream playback and revert the main player back to its original state **/


### PR DESCRIPTION
- __DEBUG__ is not a build constant, and calling destroy more than once has no negative effect
- clear error event handler in the case that instream loads an item more than once (waterfall or adpod)
- do not destroy instream internally because of a media error. instream may be used to load another item (waterfall) and will be destroyed by vast after the error is dispatched if waterfall is not taking place.