### PR TITLE
When adding a button remove any with same ID

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -543,23 +543,17 @@ define([
             this.setCues = _view.addCues;
             this.setFullscreen = _view.fullscreen;
             this.addButton = function(img, tooltip, callback, id) {
-                var btn;
-                if (_.isObject(img)) {
-                    // Handle passing in an object
-                    btn = img;
-                    btn.id = _.uniqueId();
-                } else {
-                    // Handle legacy setup
-                    btn = {
-                        img : img,
-                        tooltip : tooltip,
-                        callback : callback,
-                        id : id
-                    };
-                }
+                var btn = {
+                    img : img,
+                    tooltip : tooltip,
+                    callback : callback,
+                    id : id
+                };
 
                 var dock = _model.get('dock');
                 dock = (dock) ? dock.slice(0) : [];
+                dock = _.reject(dock, _.matches({id : btn.id}));
+
                 dock.push(btn);
                 _model.set('dock', dock);
             };


### PR DESCRIPTION
This is a bugfix so that the related plugin does not add itself multiple times.
Currently, it attempts to add the button after each playlist item change.

[Fixes #96015008]