### PR TITLE
CSS cleanup [Delivers #96453472]

### DIFF
--- a/src/css/imports/controlbar.less
+++ b/src/css/imports/controlbar.less
@@ -8,11 +8,14 @@
     bottom: 0;
     height: @controlbar-height;
     padding: 0 @ui-padding;
-    background-color: rgb(65, 64, 64);
 
     .jw-hidden {
         display: none;
     }
+}
+
+.jw-background-color {
+    background-color: rgb(65, 64, 64);
 }
 
 .jw-group {

--- a/src/css/imports/controlbar.less
+++ b/src/css/imports/controlbar.less
@@ -39,7 +39,7 @@
 
 // control bar content (icons/text)
 
-.jw-thumb,
+.jw-knob,
 .jw-icon-inline,
 .jw-icon-tooltip,
 .jw-icon-display,

--- a/src/css/imports/display.less
+++ b/src/css/imports/display.less
@@ -66,15 +66,6 @@
     }
 }
 
-
-.jwplayer {
-    &:hover .jw-display-icon-container {
-        background-color: @display-bkgd-color;
-        background: @display-bkgd-color;
-        background-size: @display-bkgd-color
-    }
-}
-
 // Hide the player when,
 .jw-flag-audio-player, // Audio only mode
 .jw-flag-dragging {     // Scrubbing

--- a/src/css/imports/effects.less
+++ b/src/css/imports/effects.less
@@ -12,7 +12,7 @@
     transition: opacity .25s, background .25s, visibility .25s;
 }
 
-.jw-controlbar button {
+.jw-button-color {
     transition: opacity .25s, background .25s, visibility .25s;
 }
 
@@ -20,7 +20,7 @@
     transition: background .25s, opacity .25s;
 }
 
-.jw-dock .jw-button .jw-overlay {
+.jw-dock .jw-overlay {
     transition: opacity .25s;
 }
 

--- a/src/css/imports/icons.less
+++ b/src/css/imports/icons.less
@@ -20,12 +20,11 @@
 }
 
 
-.jw-thumb,
+.jw-knob,
 .jw-icon-inline,
 .jw-icon-tooltip,
 .jw-icon-display,
 .jw-controlbar .jw-menu .jw-option:before {
-
     .jw-icon;
 }
 
@@ -72,8 +71,8 @@
     }
 }
 
-.jw-slider-horizontal .jw-thumb,
-.jw-slider-vertical .jw-thumb {
+.jw-slider-horizontal .jw-knob,
+.jw-slider-vertical .jw-knob {
     &:before {
     }
 }
@@ -102,7 +101,7 @@
     }
 }
 
-.jw-icon-jw-logo {
+.jw-rightlick-logo {
     &:before {
         content: "\e60b";
     }

--- a/src/css/imports/icons.less
+++ b/src/css/imports/icons.less
@@ -54,9 +54,6 @@
     &:before {
         content: "\e605";
     }
-    &.jw-off:before {
-        content: "\e604";
-    }
 }
 
 .jw-icon-cue {
@@ -95,9 +92,6 @@
 .jw-icon-hd {
     &:before {
         content: "\e60a";
-    }
-    &.jw-off:before {
-        content: "\e609";
     }
 }
 

--- a/src/css/imports/jwplayerelement.less
+++ b/src/css/imports/jwplayerelement.less
@@ -75,7 +75,6 @@
     background: transparent;
 }
 
-
 .jw-controls {
 
     &.jw-controls-disabled {
@@ -102,6 +101,11 @@
     font-stretch: normal;
 }
 
+.jw-plugin {
+    position: absolute;
+    top: 0;
+}
+
 .jw-cast-screen {
     width: 100%;
     height: 100%;
@@ -119,7 +123,6 @@
 .jw-icon-playback {
     .jw-icon-play;
 }
-
 
 .jw-tab-focus:focus {
     outline: solid 2px #0b7ef4;

--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -29,20 +29,6 @@
     bottom: .7em;
 }
 
-.jw-thumbs(@size:@thumb-size, @color:@thumb-color) {
-    width: 1em;
-    height: 1em;
-    font-size: @size;
-    color: @color;
-
-    &:after {
-        width: 1em;
-        height: 1em;
-        border-radius: 50%;
-        background-color: @thumb-color;
-    }
-}
-
 .vertically-centered-rail-element(@rail-height, @element-height) {
     top: (@rail-height - @element-height)/2;
 }
@@ -81,7 +67,7 @@
             color: @inactive-color;
         }
 
-        .jw-thumb,
+        .jw-knob,
         .jw-icon-inline,
         .jw-icon-tooltip,
         .jw-icon-display,
@@ -121,14 +107,14 @@
 
         .jw-slider-horizontal {
 
-            .jw-thumb {
+            .jw-knob {
                 margin-left: @thumb-size/-2;
             }
         }
 
         .jw-slider-vertical {
 
-            .jw-thumb {
+            .jw-knob {
                 margin-bottom: @thumb-size/-2;
             }
         }

--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -56,23 +56,40 @@
 #namespace() {
     .basic-skin-styles() {
 
-        .jw-controlbar,
-        .jw-volume-tip {
-            background: @controlbar-background;
+        .jw-background-color {
+            //background: @controlbar-background;
+            background: @display-bkgd-color;
         }
 
-        .jw-icon,
-        .jw-text,
-        .jw-icon-inline {
+        .jw-text {
             color: @inactive-color;
         }
 
-        .jw-knob,
-        .jw-icon-inline,
-        .jw-icon-tooltip,
-        .jw-icon-display,
-        .jw-option:before {
+        .jw-tooltip-title {
+            color: @inactive-color;
+        }
+
+        .jw-knob {
+            color: @inactive-color;
+        }
+
+        .jw-button-color {
+            color: @inactive-color;
             .hover(@hover-color);
+        }
+
+        .jw-toggle {
+            color: @hover-color;
+            &.jw-off {
+                color: @inactive-color;
+            }
+        }
+
+        .jw-option {
+            color: @inactive-color;
+            &.jw-active-option {
+                color: @hover-color;
+            }
         }
 
         .jw-icon-display {
@@ -80,7 +97,6 @@
         }
 
         .jw-display-icon-container {
-            background: @display-bkgd-color;
             border-radius: @ui-corner-round;
             padding: 0.5em .75em;
 
@@ -142,10 +158,6 @@
             &:hover {
                 background: @display-bkgd-hover-color;
             }
-        }
-
-        .jw-playlist-container {
-            padding: 0;
         }
     }
 }

--- a/src/css/imports/playlist.less
+++ b/src/css/imports/playlist.less
@@ -47,7 +47,6 @@
         font-size: .8em;
     }
 
-
     .jw-label, .jw-name {
         display: inline-block;
         line-height: 3em;

--- a/src/css/imports/playlist.less
+++ b/src/css/imports/playlist.less
@@ -27,7 +27,6 @@
 }
 
 .jw-tooltip-title {
-    background-color : black;
     border-bottom: 1px solid #444;
     text-align: left;
     padding-left: .7em;

--- a/src/css/imports/reset.less
+++ b/src/css/imports/reset.less
@@ -1,33 +1,22 @@
-.jwplayer, .jw-error {
-    button {
-        padding: 0;
-        border: 0;
-    }
 
-    //div,
-    //span,
-    //a,
-    //img,
-    //video,
-    &,
-    ul, 
-    li
-    {
-        font-family: Arial, Helvetica, sans-serif;
-        font-size: 1em;
-        padding: 0;
-        margin: 0;
-        line-height: 1em;
-        text-align: left;
-        vertical-align: baseline;
-        border: 0;
-        direction: ltr;
-        font-variant: inherit;
-        font-stretch: inherit;
-        -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
-    }
+.jw-reset {
+    padding: 0;
+    margin: 0;
+    font-family: Arial, Helvetica, sans-serif;
+    font-size: 1em;
+    line-height: 1em;
+    text-align: left;
+    vertical-align: baseline;
+    border: 0;
+    direction: ltr;
+    font-variant: inherit;
+    font-stretch: inherit;
+    -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+}
 
-    ul {
-        list-style: none;
-    }
+.jw-reset-ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    border: 0;
 }

--- a/src/css/imports/rightclick.less
+++ b/src/css/imports/rightclick.less
@@ -8,7 +8,6 @@
 .jw-rightclick {
     position: absolute;
     white-space: nowrap;
-    z-index:10;
 
     ul {
         list-style: none;
@@ -19,7 +18,7 @@
         padding-left:0;
     }
 
-    .jw-icon {
+    .jw-rightlick-logo {
         font-size: 2em;
         color : #ff0147;
         vertical-align: middle;

--- a/src/css/imports/slider.less
+++ b/src/css/imports/slider.less
@@ -1,7 +1,7 @@
 @import "vars";
 
 
-.jw-rail-group {
+.jw-slider-container {
     display : inline-block;
     height: 1em;
     position: relative;
@@ -26,9 +26,8 @@
 }
 
 .jw-cue,
-.jw-thumb {
+.jw-knob {
     position: absolute;
-    z-index: 1;
     cursor: pointer;
 
     &:after {
@@ -38,7 +37,19 @@
 }
 
 .jw-cue {
-    z-index: 0;
+    &:after {
+        background-color: #fff;
+        width: .1em;
+        height: .4em;
+    }
+}
+
+.jw-knob {
+    &:after {
+        background-color: #aaa;
+        width: .4em;
+        height: .4em;
+    }
 }
 
 .jw-slider-horizontal {
@@ -63,26 +74,13 @@
 
     .jw-rail,
     .jw-progress,
-    .jw-rail-group {
+    .jw-slider-container {
         width: 100%;
     }
 
-    .jw-thumb {
+    .jw-knob {
         left: 0;    // Default position, overridden by player.
         margin-left: @thumb-size/-2;
-        &:after {
-            background: #aaa;
-            width: .4em;
-            height: .4em;
-        }
-    }
-
-    .jw-cue {
-        &:after {
-            background-color: #fff;
-            width: .1em;
-            height: .4em;
-        }
     }
 }
 
@@ -105,7 +103,7 @@
         height: 0;   // Default height, overridden by player.
     }
 
-    .jw-rail-group,
+    .jw-slider-container,
     .jw-rail,
     .jw-progress {
         bottom: 0;
@@ -116,17 +114,16 @@
         margin: 0 auto;
     }
 
-    .jw-rail-group {
+    .jw-slider-container {
         height: 4em;
         position: relative;
     }
 
-    .jw-thumb {
+    .jw-knob {
         bottom: 0;  // Default position, overridden by player.
         left: 0;
         right: 0;
         margin: 0 auto;
-        
     }
 }
 

--- a/src/css/imports/tooltip.less
+++ b/src/css/imports/tooltip.less
@@ -24,7 +24,6 @@
 .jw-menu {
     position: relative;
     left: -50%;
-    background-color: #000;
     border: solid 1px #000;
     margin: 0;
 }

--- a/src/css/imports/tooltip.less
+++ b/src/css/imports/tooltip.less
@@ -49,6 +49,7 @@
 
 .jw-controlbar {
     .jw-overlay {
+        margin: 0;
         position: absolute;
         bottom: 2em;
         left: 50%;
@@ -57,7 +58,6 @@
 
         .jw-contents {
             position: relative;
-            z-index: 1;
         }
     }
 

--- a/src/css/skins/beelden.less
+++ b/src/css/skins/beelden.less
@@ -37,9 +37,11 @@
     #namespace > .basic-skin-styles(); // Using the above local variables
     .skin-element-padding();
 
+    .jw-background-color {
+        background-color: @controlbar-background-color; /* Old browsers */
+    }
     .jw-controlbar {
         .inset-controlbar();
-        background-color: @controlbar-background-color; /* Old browsers */
         box-shadow: inset 0px 7px 1px -5px rgba(128,128,128,1);
         border-radius: .3em;
     }
@@ -227,16 +229,13 @@
         border-radius: @ui-padding;
     }
 
-    .jw-icon-cc {
+    .jw-toggle {
         color: @cc-active;
 
         &.jw-off {
-            color: @cc-inactive;   
-
-            &:before {
-                content: "\e605";
-            }        
+            color: @cc-inactive;
         }
     }
+
 }
 

--- a/src/css/skins/beelden.less
+++ b/src/css/skins/beelden.less
@@ -143,7 +143,7 @@
 
     .jw-slider-horizontal,
     .jw-slider-vertical {
-        .jw-thumb {
+        .jw-knob {
 
             &:after {
                 background-color: #bbb5b7;
@@ -155,7 +155,7 @@
     }
 
     .jw-slider-horizontal {
-        .jw-rail-group {
+        .jw-slider-container {
             .vertically-centered-rail-element(@rail-height, 2em);
             height: .4em;
         }
@@ -177,7 +177,7 @@
             }
         }
 
-        .jw-thumb {
+        .jw-knob {
             .vertically-centered-rail-element(@rail-height, .8em);
 
             &:after {
@@ -204,7 +204,7 @@
             background: @progress-vert-gradient;
         }
 
-        .jw-thumb {
+        .jw-knob {
             .horizontally-centered-thumb(.75em, .7em);
 
             &:after {

--- a/src/css/skins/bekle.less
+++ b/src/css/skins/bekle.less
@@ -95,7 +95,7 @@
             border-radius: @ui-corner-round;
         }
 
-        .jw-thumb {
+        .jw-knob {
 
             &:after {
                 background-color: #fff;
@@ -125,7 +125,7 @@
             }
         }
 
-        .jw-thumb {
+        .jw-knob {
             .vertically-centered-rail-element(@rail-height, .7em);
         }
     }

--- a/src/css/skins/bekle.less
+++ b/src/css/skins/bekle.less
@@ -152,16 +152,4 @@
     .jw-menu {
         border-radius: @volume-border-radius;
     }
-
-    .jw-icon-cc {
-        color: @cc-active;
-
-        &.jw-off {
-            color: @cc-inactive;   
-
-            &:before {
-                content: "\e605";
-            }        
-        }
-    }
 }

--- a/src/css/skins/five.less
+++ b/src/css/skins/five.less
@@ -92,7 +92,7 @@
 
 
     .jw-slider-horizontal {
-        .jw-rail-group {
+        .jw-slider-container {
             height: .9em;
         }
 
@@ -107,7 +107,7 @@
             box-shadow: none;
         }
 
-        .jw-thumb {
+        .jw-knob {
             .vertically-centered-rail-element(@rail-height, @thumb-size);
             margin: 0;
 
@@ -146,7 +146,7 @@
             background: #737373;
         }
 
-        .jw-thumb {
+        .jw-knob {
             margin-bottom: 2px/-2;
 
             &:after {

--- a/src/css/skins/five.less
+++ b/src/css/skins/five.less
@@ -157,18 +157,6 @@
         }
     }
 
-    .jw-icon-cc {
-        color: @cc-active;
-
-        &.jw-off {
-            color: @cc-inactive;   
-
-            &:before {
-                content: "\e605";
-            }        
-        }
-    }
-
     .jw-menu {
         .jw-text {
             color: #bbb;

--- a/src/css/skins/glow.less
+++ b/src/css/skins/glow.less
@@ -19,7 +19,7 @@
     #namespace > .basic-skin-styles(); // Using the above local variables
     .skin-element-padding();
 
-    .jw-controlbar {
+    .jw-background-color {
         opacity: 0.8;
     }
 
@@ -113,18 +113,6 @@
         .jw-rail,
         .jw-progress {
             width: .4em;
-        }
-    }
-
-    .jw-icon-cc {
-        color: @cc-active;
-
-        &.jw-off {
-            color: @cc-inactive;   
-
-            &:before {
-                content: "\e605";
-            }        
         }
     }
 }

--- a/src/css/skins/glow.less
+++ b/src/css/skins/glow.less
@@ -86,7 +86,7 @@
         border-radius: @ui-corner-round;
     }
 
-    .jw-thumb {
+    .jw-knob {
         display: none;
     }
     

--- a/src/css/skins/roundster.less
+++ b/src/css/skins/roundster.less
@@ -148,16 +148,4 @@
     .jw-menu {
         bottom: .3em;
     }
-
-    .jw-icon-cc {
-        color: @cc-active;
-
-        &.jw-off {
-            color: @cc-inactive;
-
-            &:before {
-                content: "\e605";
-            }
-        }
-    }
 }

--- a/src/css/skins/roundster.less
+++ b/src/css/skins/roundster.less
@@ -96,7 +96,7 @@
             border-radius: @roundster-corners;
         }
 
-        .jw-thumb {
+        .jw-knob {
 
             &:after {
                 background-color: #fff;
@@ -121,7 +121,7 @@
             }
         }
 
-        .jw-thumb {
+        .jw-knob {
             .vertically-centered-rail-element(@rail-height, @thumb-size);
         }
     }

--- a/src/css/skins/seven.less
+++ b/src/css/skins/seven.less
@@ -127,7 +127,7 @@
         background: @active-color;
     }
 
-    .jw-thumb {
+    .jw-knob {
         width: .6em;
 
         &:after {
@@ -142,7 +142,7 @@
 
     .jw-slider-horizontal {
 
-        .jw-rail-group {
+        .jw-slider-container {
             height: 0.95em;
         }
 
@@ -153,7 +153,7 @@
             border-radius: 0;
         }
 
-        .jw-thumb {
+        .jw-knob {
             .vertically-centered-rail-element(.2em, .6em);
         }
 

--- a/src/css/skins/seven.less
+++ b/src/css/skins/seven.less
@@ -10,8 +10,11 @@
 
     @rail-height: .2em;
 
-    .jw-controlbar {
+    .jw-background-color {
         background: #000;
+    }
+
+    .jw-controlbar {
         border-top: #333 1px solid;
         height: 2.5em;
     }
@@ -58,15 +61,23 @@
         }
     }
 
-    .jw-icon,
     .jw-text {
         color: @inactive-color;
     }
 
-    .jw-icon,
-    .jw-icon:before, {
-        &:hover {
-            color: @active-color;
+    .jw-tooltip-title {
+        color: @inactive-color;
+    }
+
+    .jw-button-color {
+        color: @inactive-color;
+        .hover(@hover-color);
+    }
+
+    .jw-toggle {
+        color: @hover-color;
+        &.jw-off {
+            color: @inactive-color;
         }
     }
 
@@ -102,7 +113,6 @@
     }
 
     .jw-display-icon-container {
-        background: #000;
         border-radius: 50%;
         padding: 0 .3em;
         border: 1px solid #333;
@@ -200,35 +210,18 @@
 
     .jw-dock {
         .jw-dock-button {
-            background: #000;
             border-radius: 50%;
         }
         .jw-overlay {
-            background: #000;
             border-radius: 2.5em;
         }
     }
 
-    .jw-icon-cc .jw-active-option {
-        background-color: @active-color;
-        color: #fff;
-    }
-
-    .jw-icon-hd,
-    .jw-icon-cc {
-        color: @cc-active;
-
-        &.jw-off {
-            color: @cc-inactive;           
+    .jw-icon-tooltip {
+        .jw-active-option {
+            background-color: @active-color;
+            color: #fff;
         }
-    }
-
-    .jw-icon-hd.jw-off:before {
-        content: "\e60a";
-    }
-
-    .jw-icon-cc.jw-off:before {
-        content: "\e605";
     }
 
     .jw-icon-volume {
@@ -254,7 +247,6 @@
     }
     
     .jw-skip {
-        background: #000;
         padding: 0.4em;
         border-radius: 1em;
 

--- a/src/css/skins/six.less
+++ b/src/css/skins/six.less
@@ -128,7 +128,7 @@
     .jw-slider-horizontal,
     .jw-slider-vertical {
 
-        .jw-thumb:after {
+        .jw-knob:after {
             width: @thumb-size;
             height: @thumb-size;
             border-radius: 1em;
@@ -138,7 +138,7 @@
     }
 
     .jw-slider-horizontal {
-        .jw-rail-group {
+        .jw-slider-container {
             height: 1.2em;
         }
 
@@ -148,7 +148,7 @@
             height: @rail-height;
         }
 
-        .jw-thumb {
+        .jw-knob {
             .vertically-centered-rail-element(@rail-height, @thumb-size);
         }
 

--- a/src/css/skins/six.less
+++ b/src/css/skins/six.less
@@ -40,6 +40,10 @@
     #namespace > .basic-skin-styles(); // Using the above local variables
     .skin-element-padding();
 
+    .jw-background-color {
+        background-color: @def-background-color;
+    }
+
     .jw-controlbar {
         .inset-controlbar;
         border: @def-border;
@@ -52,7 +56,6 @@
     }
 
     .jw-display-icon-container {
-        background-color: @def-background-color;
         background: @def-transparent-background-style;
         background-size: @def-background-size;
         border-radius: .3em;
@@ -61,7 +64,6 @@
     }
 
     &:hover .jw-display-icon-container {
-        background-color: @def-background-color;
         background: @def-background-style;
         background-size: @def-background-size;
     }
@@ -196,7 +198,6 @@
         }
     }
 
-
     .jw-icon-cc .jw-option {
         .jw-icon-menu-bullet;
         text-align: left;
@@ -211,25 +212,21 @@
     .jw-time-tip,
     .jw-volume-tip,
     .jw-menu {
-        background-color: @def-background-color;
         background-size: @def-background-size;
         border-radius: @ui-padding;
     }
 
     .jw-dock {
         .jw-dock-button {
-            background-color: @def-background-color;
             background: @def-transparent-background-style;
             background-size: @def-background-size;
             border-radius: @dock-corner-radius;
 
             &:hover {
-                background-color: @def-background-color;
                 background: @def-background-style;
             }
 
             .jw-overlay {
-                background-color: @def-background-color;
                 background: @def-background-style;
                 background-size: @def-background-size;
                 border-radius: @dock-corner-radius;
@@ -238,29 +235,14 @@
     }
 
     .jw-skip {
-        background-color: @def-background-color;
         background: @def-transparent-background-style;
         background-size: @def-background-size;
         border-radius: @ui-corner-round;
         padding: @ui-padding @ui-corner-round;
 
         &:hover {
-            background-color: @def-background-color;
             background: @def-background-style;
             background-size: @def-background-size;
-        }
-    }
-    
-
-    .jw-icon-cc {
-        color: @cc-active;
-
-        &.jw-off {
-            color: @cc-inactive;   
-
-            &:before {
-                content: "\e605";
-            }        
         }
     }
 }

--- a/src/css/skins/stormtrooper.less
+++ b/src/css/skins/stormtrooper.less
@@ -163,14 +163,14 @@
     }
 
     .jw-icon-cc {
-        color: @cc-active;
-
-        &:before {
+        &.jw-off:before {
             content: "\e604";
         }
+    }
 
-        &.jw-off {
-            color: @cc-inactive;           
+    .jw-icon-hd {
+        &.jw-off:before {
+            content: "\e609";
         }
     }
 }

--- a/src/css/skins/stormtrooper.less
+++ b/src/css/skins/stormtrooper.less
@@ -89,21 +89,21 @@
         background-color: @rail-color;
     }
 
-    .jw-rail-group {
+    .jw-slider-container {
         height: 1em;
     }
 
     .jw-rail,
     .jw-buffer,
     .jw-progress,
-    .jw-thumb:after {
+    .jw-knob:after {
         box-sizing: border-box;
         border: 1.5px solid #000;
         border-radius: 2px;
     }
 
     .jw-progress,
-    .jw-thumb {
+    .jw-knob {
         background: @rail-color;
     }
 
@@ -118,7 +118,7 @@
             background: @horiz-rail-gradient;
         }
 
-        .jw-thumb {
+        .jw-knob {
             .vertically-centered-rail-element(.3em,.5em);
 
             &:after {
@@ -150,7 +150,7 @@
             background: @vertical-rail-gradient;
         }
 
-        .jw-thumb {
+        .jw-knob {
             .horizontally-centered-thumb(@rail-height,.5em);
 
             &:after {

--- a/src/css/skins/vapor.less
+++ b/src/css/skins/vapor.less
@@ -79,7 +79,7 @@
         background-color: #1E1E1E;
     }
 
-	.jw-rail-group {
+	.jw-slider-container {
 		height: @rail-height;
 	}
 
@@ -92,14 +92,14 @@
 			height: @rail-height;
 		}
 
-		.jw-thumb,
+		.jw-knob,
 		.jw-cue {
 			&:after {
 				height: 2em;
 			}
 		}
 
-		.jw-thumb {
+		.jw-knob {
 			margin-left: 0;
 
 			&:after {

--- a/src/css/skins/vapor.less
+++ b/src/css/skins/vapor.less
@@ -136,4 +136,16 @@
 
 	}
 
+    .jw-icon-cc {
+        &.jw-off:before {
+            content: "\e604";
+        }
+    }
+
+    .jw-icon-hd {
+        &.jw-off:before {
+            content: "\e609";
+        }
+    }
+
 }

--- a/src/css/states/error.less
+++ b/src/css/states/error.less
@@ -24,7 +24,6 @@ body .jw-error, .jwplayer.jw-state-error {
     &:hover .jw-display-icon-container {
         cursor: default;
         color: #fff;
-        background-color: #000;
         background: #000;
     }
 

--- a/src/js/plugins/loader.js
+++ b/src/js/plugins/loader.js
@@ -109,8 +109,7 @@ define([
                     if (jsPlugin && config.plugins && config.plugins[pluginURL]) {
                         var div = document.createElement('div');
                         div.id = api.id + '_' + pluginName;
-                        div.style.position = 'absolute';
-                        div.style.top = 0;
+                        div.className = 'jw-plugin jw-reset';
                         jsPlugins[pluginName] = pluginObj.getNewInstance(api,
                             _.extend({}, config.plugins[pluginURL]), div);
                         api.onReady(resizer(jsPlugins[pluginName], div, true));

--- a/src/js/view/adskipbutton.js
+++ b/src/js/view/adskipbutton.js
@@ -1,12 +1,11 @@
 define([
     'utils/helpers',
-    'utils/css',
     'events/events',
     'utils/ui',
     'utils/backbone.events',
     'utils/underscore',
     'handlebars-loader!templates/adskipbutton.html'
-], function(utils, cssUtils, events, UI, Events, _, AdSkipTemplate) {
+], function(utils, events, UI, Events, _, AdSkipTemplate) {
 
     var AdSkipButton = function(skipMessageCountdown, skipMessage) {
         this.skipMessage = skipMessage;

--- a/src/js/view/captionsrenderer.js
+++ b/src/js/view/captionsrenderer.js
@@ -39,15 +39,15 @@ define([
             _textContainer;
 
         _display = document.createElement('div');
-        _display.className = 'jw-captions';
+        _display.className = 'jw-captions jw-reset';
 
 
         this.show = function () {
-            _display.className = 'jw-captions jw-captions-enabled';
+            _display.className = 'jw-captions jw-captions-enabled jw-reset';
         };
 
         this.hide = function () {
-            _display.className = 'jw-captions';
+            _display.className = 'jw-captions jw-reset';
         };
 
         /** Assign list of captions to the renderer. **/
@@ -64,7 +64,7 @@ define([
         /** Render the active caption. **/
         function _render(html) {
             html = html || '';
-            var windowClassName = 'jw-captions-window';
+            var windowClassName = 'jw-captions-window jw-reset';
             if (html) {
                 _textContainer.innerHTML = html;
                 _captionsWindow.className = windowClassName + ' jw-captions-window-active';
@@ -146,8 +146,8 @@ define([
 
             _captionsWindow = document.createElement('div');
             _textContainer = document.createElement('span');
-            _captionsWindow.className = 'jw-captions-window';
-            _textContainer.className = 'jw-captions-text';
+            _captionsWindow.className = 'jw-captions-window jw-reset';
+            _textContainer.className = 'jw-captions-text jw-reset';
 
             _style(_captionsWindow, windowStyle);
             _style(_textContainer, textStyle);

--- a/src/js/view/components/chapters.mixin.js
+++ b/src/js/view/components/chapters.mixin.js
@@ -7,9 +7,8 @@ define([
     function Cue(time, text) {
         this.time = time;
         this.text = text;
-        this.el = document.createElement('span');
-
-        this.el.className = 'jw-cue';
+        this.el = document.createElement('div');
+        this.el.className = 'jw-cue jw-reset';
     }
 
     _.extend(Cue.prototype, {

--- a/src/js/view/components/menu.js
+++ b/src/js/view/components/menu.js
@@ -2,10 +2,9 @@ define([
     'view/components/tooltip',
     'utils/helpers',
     'utils/underscore',
-    'events/events',
     'utils/ui',
     'handlebars-loader!templates/menu.html'
-], function(Tooltip, utils, _, events, UI, menuTemplate) {
+], function(Tooltip, utils, _, UI, menuTemplate) {
     var Menu = Tooltip.extend({
         setup : function (list, selectedIndex, options) {
             if(!this.iconUI){
@@ -26,7 +25,12 @@ define([
 
             utils.toggleClass(this.el, 'jw-hidden', (list.length < 2));
 
-            if (list.length > 2 || (list.length === 2 && options && options.toggle === false)) {
+            var isMenu = list.length > 2 || (list.length === 2 && options && options.toggle === false);
+            var isToggle = !isMenu && list.length === 2;
+            utils.toggleClass(this.el, 'jw-toggle', isToggle);
+            utils.toggleClass(this.el, 'jw-button-color', !isToggle);
+
+            if (isMenu) {
                 utils.removeClass(this.el, 'jw-off');
 
                 this.iconUI.on('tap', this.toggleOpenStateListener);
@@ -38,7 +42,7 @@ define([
                 var elem = utils.createElement(innerHtml);
                 this.addContent(elem);
                 this.contentUI = new UI(this.content).on('click tap', this.selectListener);
-            } else if (list.length === 2) {
+            } else if (isToggle) {
                 this.iconUI.on('click tap', this.toggleValueListener);
             }
 

--- a/src/js/view/components/playlist.js
+++ b/src/js/view/components/playlist.js
@@ -25,8 +25,6 @@ define([
             utils.toggleClass(this.el, 'jw-hidden', (list.length < 2));
 
             if (list.length >= 2) {
-                utils.removeClass(this.el, 'jw-off');
-
                 this.iconUI = new UI(this.el).on('tap', this.toggleOpenStateListener);
 
                 this.el.addEventListener('mouseover', this.openTooltipListener);

--- a/src/js/view/components/slider.js
+++ b/src/js/view/components/slider.js
@@ -24,10 +24,10 @@ define([
             };
             this.el = utils.createElement(SliderTemplate(obj));
 
-            this.elementRail = this.el.getElementsByClassName('jw-rail-group')[0];
+            this.elementRail = this.el.getElementsByClassName('jw-slider-container')[0];
             this.elementBuffer = this.el.getElementsByClassName('jw-buffer')[0];
             this.elementProgress = this.el.getElementsByClassName('jw-progress')[0];
-            this.elementThumb = this.el.getElementsByClassName('jw-thumb')[0];
+            this.elementThumb = this.el.getElementsByClassName('jw-knob')[0];
 
             this.userInteract = new UI(this.element());
 

--- a/src/js/view/components/slider.js
+++ b/src/js/view/components/slider.js
@@ -7,7 +7,7 @@ define([
 
     var Slider = Extendable.extend({
         constructor : function(className, orientation) {
-            this.className = className;
+            this.className = className + ' jw-background-color jw-reset';
             this.orientation = orientation;
 
             this.dragStartListener = this.dragStart.bind(this);

--- a/src/js/view/components/timeslider.js
+++ b/src/js/view/components/timeslider.js
@@ -11,11 +11,12 @@ define([
         setup : function() {
 
             this.text = document.createElement('span');
-            this.text.className = 'jw-text';
-            this.img  = document.createElement('span');
+            this.text.className = 'jw-text jw-reset';
+            this.img  = document.createElement('div');
+            this.img.className = 'jw-reset';
 
             var wrapper = document.createElement('div');
-            wrapper.className = 'jw-container jw-time-tip';
+            wrapper.className = 'jw-time-tip jw-reset';
             wrapper.appendChild(this.img);
             wrapper.appendChild(this.text);
 

--- a/src/js/view/components/timeslider.js
+++ b/src/js/view/components/timeslider.js
@@ -16,7 +16,7 @@ define([
             this.img.className = 'jw-reset';
 
             var wrapper = document.createElement('div');
-            wrapper.className = 'jw-time-tip jw-reset';
+            wrapper.className = 'jw-time-tip jw-background-color jw-reset';
             wrapper.appendChild(this.img);
             wrapper.appendChild(this.text);
 

--- a/src/js/view/components/tooltip.js
+++ b/src/js/view/components/tooltip.js
@@ -6,7 +6,7 @@ define([
     var Tooltip = Extendable.extend({
         'constructor' : function(name) {
             this.el = document.createElement('div');
-            this.el.className = 'jw-icon jw-icon-tooltip ' + name + ' jw-hidden jw-reset';
+            this.el.className = 'jw-icon jw-icon-tooltip ' + name + ' jw-button-color jw-reset jw-hidden';
             this.container = document.createElement('div');
             this.container.className = 'jw-overlay jw-reset';
             this.el.appendChild(this.container);

--- a/src/js/view/components/tooltip.js
+++ b/src/js/view/components/tooltip.js
@@ -5,10 +5,10 @@ define([
 
     var Tooltip = Extendable.extend({
         'constructor' : function(name) {
-            this.el = document.createElement('span');
-            this.el.className = 'jw-icon jw-icon-tooltip ' + name + ' jw-hidden';
+            this.el = document.createElement('div');
+            this.el.className = 'jw-icon jw-icon-tooltip ' + name + ' jw-hidden jw-reset';
             this.container = document.createElement('div');
-            this.container.className ='jw-overlay';
+            this.container.className = 'jw-overlay jw-reset';
             this.el.appendChild(this.container);
         },
 

--- a/src/js/view/controlbar.js
+++ b/src/js/view/controlbar.js
@@ -12,7 +12,7 @@ define([
 
     function button(icon, apiAction) {
         var element = document.createElement('div');
-        element.className = 'jw-icon jw-icon-inline jw-reset ' + icon;
+        element.className = 'jw-icon jw-icon-inline jw-button-color jw-reset ' + icon;
         element.style.display = 'none';
 
         if (apiAction) {
@@ -139,7 +139,7 @@ define([
             });
 
             this.el = document.createElement('div');
-            this.el.className = 'jw-controlbar jw-reset';
+            this.el.className = 'jw-controlbar jw-background-color jw-reset';
 
             var leftGroup = buildGroup('left', this.layout.left);
             var centerGroup = buildGroup('center', this.layout.center);

--- a/src/js/view/controlbar.js
+++ b/src/js/view/controlbar.js
@@ -11,8 +11,8 @@ define([
 ], function(utils, _, Events, UI, Slider, TimeSlider, Menu, Playlist, VolumeTooltip) {
 
     function button(icon, apiAction) {
-        var element = document.createElement('span');
-        element.className = 'jw-icon jw-icon-inline ' + icon;
+        var element = document.createElement('div');
+        element.className = 'jw-icon jw-icon-inline jw-reset ' + icon;
         element.style.display = 'none';
 
         if (apiAction) {
@@ -36,7 +36,7 @@ define([
 
     function text(name) {
         var element = document.createElement('span');
-        element.className = 'jw-text ' + name;
+        element.className = 'jw-text jw-reset ' + name;
         return element;
     }
 
@@ -47,8 +47,8 @@ define([
     }
 
     function buildGroup(group, elements) {
-        var elem = document.createElement('span');
-        elem.className = 'jw-group jw-controlbar-' + group+'-group';
+        var elem = document.createElement('div');
+        elem.className = 'jw-group jw-controlbar-' + group+'-group jw-reset';
 
         _.each(elements, function(e) {
             if (e.element) {
@@ -138,8 +138,8 @@ define([
                 return _.isUndefined(ele);
             });
 
-            this.el = document.createElement('span');
-            this.el.className = 'jw-container jw-controlbar';
+            this.el = document.createElement('div');
+            this.el.className = 'jw-controlbar jw-reset';
 
             var leftGroup = buildGroup('left', this.layout.left);
             var centerGroup = buildGroup('center', this.layout.center);

--- a/src/js/view/display.js
+++ b/src/js/view/display.js
@@ -1,12 +1,10 @@
 define([
     'utils/ui',
-    'utils/helpers',
     'events/events',
     'utils/backbone.events',
     'events/states',
-    'utils/stretching',
     'utils/underscore'
-], function(UI, utils, events, Events, states, stretchUtils, _) {
+], function(UI, events, Events, states, _) {
     var Display = function(_model) {
         var _display,
             _alternateClickHandler;

--- a/src/js/view/display.js
+++ b/src/js/view/display.js
@@ -14,7 +14,7 @@ define([
         _.extend(this, Events);
 
         _display = document.createElement('div');
-        _display.className = 'jw-click';
+        _display.className = 'jw-click jw-reset';
 
         this.element = function() { return _display; };
 

--- a/src/js/view/displayicon.js
+++ b/src/js/view/displayicon.js
@@ -1,11 +1,10 @@
 define([
     'utils/helpers',
     'utils/backbone.events',
-    'events/events',
     'utils/ui',
     'handlebars-loader!templates/displayicon.html',
     'utils/underscore'
-], function(utils, Events, events, UI, Template, _) {
+], function(utils, Events, UI, Template, _) {
 
     var DisplayIcon = function(_model) {
         _.extend(this, Events);

--- a/src/js/view/error.js
+++ b/src/js/view/error.js
@@ -1,7 +1,6 @@
 define([
-    'utils/helpers',
     'handlebars-loader!templates/error.html'
-], function(utils, error) {
+], function(error) {
 
     function make(id, skin, title, body) {
         return error({

--- a/src/js/view/preview.js
+++ b/src/js/view/preview.js
@@ -1,6 +1,5 @@
 define([
     'utils/underscore'
-
 ], function(_) {
 
     var Preview = function(_model) {

--- a/src/js/view/rightclick.js
+++ b/src/js/view/rightclick.js
@@ -17,7 +17,7 @@ define([
             var obj = {
                 items : [{
                     title: 'About JW Player ' + majorMinorPatchPre,
-                    feature : 'jw-logo', // we can use any webfont icon here
+                    featured : true,
                     link: '//jwplayer.com/learn-more/?m=h&e=o&v=' + version
                 }]
             };

--- a/src/js/view/title.js
+++ b/src/js/view/title.js
@@ -1,7 +1,6 @@
 define([
-    'utils/helpers',
     'utils/underscore'
-], function(utils, _) {
+], function(_) {
 
     var Title = function(_model) {
         this.model = _model;

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -267,25 +267,27 @@ define([
 
             var cues = [
                 '.jw-cue:after',
-                '.jw-thumb:after'
+                '.jw-knob:after'
             ];
 
             var iconHovers = ['.jw-icon:hover', '.jw-option:hover'];
             var sliders = ['.jw-progress'];
-            var containers = ['.jw-container'];
+            var cbar = ['.jw-controlbar'];
+            var ttip = ['.jw-time-tip'];
 
 
-            addStyle('color', iconHovers, _model.get('skinColorActive'));
-            addStyle('color', icons, _model.get('skinColorInactive'));
-            addStyle('background', cues, _model.get('skinColorInactive'));
-            addStyle('background', sliders, _model.get('skinColorActive'));
-            addStyle('background', containers, _model.get('skinColorBackground'));
+            addStyle('color',       iconHovers,                     _model.get('skinColorActive'));
+            addStyle('color',       ['.jw-active-option'],          _model.get('skinColorActive'));
+            addStyle('color',       ['.jw-icon-hd', '.jw-icon-cc'], _model.get('skinColorActive'));
+            addStyle('background',  sliders,                        _model.get('skinColorActive'));
 
-            addStyle('color', ['.jw-active-option'], _model.get('skinColorActive'));
-            addStyle('background', ['.jw-active-option'], _model.get('skinColorInactive'));
-
-            addStyle('color', ['.jw-icon-hd', '.jw-icon-cc'], _model.get('skinColorActive'));
+            addStyle('background',  ['.jw-active-option'],          _model.get('skinColorInactive'));
+            addStyle('background',  cues,                           _model.get('skinColorInactive'));
+            addStyle('color',       icons,                          _model.get('skinColorInactive'));
             addStyle('color', ['.jw-icon-hd.jw-off', '.jw-icon-cc.jw-off'], _model.get('skinColorInactive'));
+
+            addStyle('background',  cbar,                           _model.get('skinColorBackground'));
+            addStyle('background',  ttip,                           _model.get('skinColorBackground'));
         };
 
         this.setup = function() {
@@ -531,7 +533,7 @@ define([
             _logo.on(events.JWPLAYER_LOGO_CLICK, _logoClickHandler);
 
             var rightside = document.createElement('div');
-            rightside.className = 'jw-controls-right';
+            rightside.className = 'jw-controls-right jw-reset';
             if (_model.get('config').logo) {
                 rightside.appendChild(_logo.element());
             }

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -260,34 +260,18 @@ define([
                 cssUtils.css(elements.join(', '), o);
             }
 
-            var icons = [
-                '.jw-icon',
-                '.jw-text'
-            ];
+            addStyle('color',       ['.jw-button-color'],             _model.get('skinColorInactive'));
+            addStyle('color',       ['.jw-button-color:hover'],       _model.get('skinColorActive'));
 
-            var cues = [
-                '.jw-cue:after',
-                '.jw-knob:after'
-            ];
+            addStyle('color',       ['.jw-option'],                   _model.get('skinColorInactive'));
+            addStyle('color',       ['.jw-active-option'],            _model.get('skinColorActive'));
 
-            var iconHovers = ['.jw-icon:hover', '.jw-option:hover'];
-            var sliders = ['.jw-progress'];
-            var cbar = ['.jw-controlbar'];
-            var ttip = ['.jw-time-tip'];
+            addStyle('color',       ['.jw-toggle'],                   _model.get('skinColorActive'));
+            addStyle('color',       ['.jw-toggle.jw-off'],            _model.get('skinColorInactive'));
 
-
-            addStyle('color',       iconHovers,                     _model.get('skinColorActive'));
-            addStyle('color',       ['.jw-active-option'],          _model.get('skinColorActive'));
-            addStyle('color',       ['.jw-icon-hd', '.jw-icon-cc'], _model.get('skinColorActive'));
-            addStyle('background',  sliders,                        _model.get('skinColorActive'));
-
-            addStyle('background',  ['.jw-active-option'],          _model.get('skinColorInactive'));
-            addStyle('background',  cues,                           _model.get('skinColorInactive'));
-            addStyle('color',       icons,                          _model.get('skinColorInactive'));
-            addStyle('color', ['.jw-icon-hd.jw-off', '.jw-icon-cc.jw-off'], _model.get('skinColorInactive'));
-
-            addStyle('background',  cbar,                           _model.get('skinColorBackground'));
-            addStyle('background',  ttip,                           _model.get('skinColorBackground'));
+            addStyle('background',  ['.jw-progress'],                 _model.get('skinColorActive'));
+            addStyle('background',  ['.jw-cue', '.jw-knob'],          _model.get('skinColorInactive'));
+            addStyle('background',  ['.jw-background-color'],         _model.get('skinColorBackground'));
         };
 
         this.setup = function() {
@@ -318,7 +302,7 @@ define([
             _preview = new Preview(_model);
             _preview.setup(previewElem);
 
-            if (! _model.get('hidetitle')) {
+            if (!_model.get('hidetitle')) {
                 var _titleElement = _playerElement.getElementsByClassName('jw-title')[0];
                 _title = new Title(_model);
                 _title.setup(_titleElement);

--- a/src/templates/adskipbutton.html
+++ b/src/templates/adskipbutton.html
@@ -1,4 +1,4 @@
-<div class="jw-skip jw-hidden">
-    <span class="jw-text jw-skiptext"></span>
-    <span class="jw-icon-inline jw-skip-icon"></span>
+<div class="jw-skip jw-hidden jw-reset">
+    <span class="jw-text jw-skiptext jw-reset"></span>
+    <span class="jw-icon-inline jw-skip-icon jw-reset"></span>
 </div>

--- a/src/templates/adskipbutton.html
+++ b/src/templates/adskipbutton.html
@@ -1,4 +1,4 @@
-<div class="jw-skip jw-hidden jw-reset">
+<div class="jw-skip jw-background-color jw-hidden jw-reset">
     <span class="jw-text jw-skiptext jw-reset"></span>
     <span class="jw-icon-inline jw-skip-icon jw-reset"></span>
 </div>

--- a/src/templates/displayicon.html
+++ b/src/templates/displayicon.html
@@ -1,3 +1,3 @@
-<div class="jw-display-icon-container jw-container">
-    <div class="jw-icon jw-icon-display"></div>
+<div class="jw-display-icon-container jw-container jw-reset">
+    <div class="jw-icon jw-icon-display jw-reset"></div>
 </div>

--- a/src/templates/displayicon.html
+++ b/src/templates/displayicon.html
@@ -1,3 +1,3 @@
-<div class="jw-display-icon-container jw-container jw-reset">
+<div class="jw-display-icon-container jw-background-color jw-reset">
     <div class="jw-icon jw-icon-display jw-reset"></div>
 </div>

--- a/src/templates/dock.html
+++ b/src/templates/dock.html
@@ -1,11 +1,11 @@
-<div class="jw-dock">
+<div class="jw-dock jw-reset">
     {{#each this}}
-    <div class="jw-dock-button jw-container">
-        <div class="jw-icon jw-dock-image" button="{{id}}" style="background-image: url({{img}})"></div>
-        <div class="jw-arrow"></div>
+    <div class="jw-dock-button jw-container jw-reset">
+        <div class="jw-icon jw-dock-image jw-reset" button="{{id}}" style="background-image: url({{img}})"></div>
+        <div class="jw-arrow jw-reset"></div>
         {{#if tooltip}}
-        <div class="jw-overlay jw-container">
-            <span class="jw-text">{{tooltip}}</span>
+        <div class="jw-overlay jw-container jw-reset">
+            <span class="jw-text jw-reset">{{tooltip}}</span>
         </div>
         {{/if}}
     </div>

--- a/src/templates/dock.html
+++ b/src/templates/dock.html
@@ -1,10 +1,10 @@
 <div class="jw-dock jw-reset">
     {{#each this}}
-    <div class="jw-dock-button jw-container jw-reset">
+    <div class="jw-dock-button jw-background-color jw-reset">
         <div class="jw-icon jw-dock-image jw-reset" button="{{id}}" style="background-image: url({{img}})"></div>
         <div class="jw-arrow jw-reset"></div>
         {{#if tooltip}}
-        <div class="jw-overlay jw-container jw-reset">
+        <div class="jw-overlay jw-background-color jw-reset">
             <span class="jw-text jw-reset">{{tooltip}}</span>
         </div>
         {{/if}}

--- a/src/templates/error.html
+++ b/src/templates/error.html
@@ -1,12 +1,12 @@
-<div id="{{id}}"class="jw-skin-{{skin}} jw-error">
-    <div class="jw-title">
-        <div class="jw-title-primary">{{title}}</div>
-        <div class="jw-title-secondary">{{body}}</div>
+<div id="{{id}}"class="jw-skin-{{skin}} jw-error jw-reset">
+    <div class="jw-title jw-reset">
+        <div class="jw-title-primary jw-reset">{{title}}</div>
+        <div class="jw-title-secondary jw-reset">{{body}}</div>
     </div>
 
-    <div class="jw-icon-container">
-        <div class="jw-display-icon-container jw-container">
-            <div class="jw-icon jw-icon-display"></div>
+    <div class="jw-icon-container jw-reset">
+        <div class="jw-display-icon-container jw-container jw-reset">
+            <div class="jw-icon jw-icon-display jw-reset"></div>
         </div>
     </div>
 </div>

--- a/src/templates/error.html
+++ b/src/templates/error.html
@@ -5,7 +5,7 @@
     </div>
 
     <div class="jw-icon-container jw-reset">
-        <div class="jw-display-icon-container jw-container jw-reset">
+        <div class="jw-display-icon-container jw-background-color jw-reset">
             <div class="jw-icon jw-icon-display jw-reset"></div>
         </div>
     </div>

--- a/src/templates/logo.html
+++ b/src/templates/logo.html
@@ -1,1 +1,1 @@
-<img class="jw-logo" {{#if file}}src="{{file}}"{{/if}}>
+<img class="jw-logo jw-reset" {{#if file}}src="{{file}}"{{/if}}>

--- a/src/templates/logo.html
+++ b/src/templates/logo.html
@@ -1,1 +1,3 @@
-<img class="jw-logo jw-reset" {{#if file}}src="{{file}}"{{/if}}>
+<div class="jw-logo jw-reset">
+    <img class="jw-logo-image" {{#if file}}src="{{file}}"{{/if}}>
+</div>

--- a/src/templates/menu.html
+++ b/src/templates/menu.html
@@ -1,5 +1,5 @@
-<ul class="jw-menu jw-container">
+<ul class="jw-menu jw-container jw-reset">
     {{#each this}}
-        <li class='jw-text jw-option item-{{@index}}'>{{this.label}}</li>
+        <li class='jw-text jw-option item-{{@index}} jw-reset'>{{this.label}}</li>
     {{/each}}
 </ul>

--- a/src/templates/menu.html
+++ b/src/templates/menu.html
@@ -1,4 +1,4 @@
-<ul class="jw-menu jw-container jw-reset">
+<ul class="jw-menu jw-background-color jw-reset">
     {{#each this}}
         <li class='jw-text jw-option item-{{@index}} jw-reset'>{{this.label}}</li>
     {{/each}}

--- a/src/templates/player.html
+++ b/src/templates/player.html
@@ -1,11 +1,11 @@
-<div id="{{id}}" class="jwplayer" tabindex="0">
-    <div class="jw-aspect"></div>
-    <div class="jw-media"></div>
-    <div class="jw-preview"></div>
-    <div class="jw-title">
-        <div class="jw-title-primary"></div>
-        <div class="jw-title-secondary"></div>
+<div id="{{id}}" class="jwplayer jw-reset" tabindex="0">
+    <div class="jw-aspect jw-reset"></div>
+    <div class="jw-media jw-reset"></div>
+    <div class="jw-preview jw-reset"></div>
+    <div class="jw-title jw-reset">
+        <div class="jw-title-primary jw-reset"></div>
+        <div class="jw-title-secondary jw-reset"></div>
     </div>
-    <div class="jw-overlays"></div>
-    <div class="jw-controls"></div>
+    <div class="jw-overlays jw-reset"></div>
+    <div class="jw-controls jw-reset"></div>
 </div>

--- a/src/templates/playlist.html
+++ b/src/templates/playlist.html
@@ -1,4 +1,4 @@
-<div class="jw-container jw-menu jw-playlist-container jw-reset">
+<div class="jw-menu jw-playlist-container jw-background-color jw-reset">
 
     <div class="jw-tooltip-title jw-reset">
         <span class="jw-icon jw-icon-inline jw-icon-playlist jw-reset"></span>

--- a/src/templates/playlist.html
+++ b/src/templates/playlist.html
@@ -1,25 +1,25 @@
-<div class="jw-container jw-menu jw-playlist-container">
+<div class="jw-container jw-menu jw-playlist-container jw-reset">
 
-    <div class="jw-tooltip-title">
-        <span class="jw-icon jw-icon-inline jw-icon-playlist"></span>
-        <span class="jw-text">PLAYLIST</span>
+    <div class="jw-tooltip-title jw-reset">
+        <span class="jw-icon jw-icon-inline jw-icon-playlist jw-reset"></span>
+        <span class="jw-text jw-reset">PLAYLIST</span>
         {{!--
         This is a comment block
-        <span class="jw-icon jw-icon-inline jw-icon-close" style="float:right"></span>
+        <span class="jw-icon jw-icon-inline jw-icon-close jw-reset" style="float:right"></span>
         --}}
     </div>
 
-    <ul class="jw-playlist">
+    <ul class="jw-playlist jw-reset-ul">
         {{#each this}}
             {{#if this.active}}
-                <li class='jw-option jw-text jw-active-option item-{{@index}}'>
-                    <span class="jw-label"><span class="jw-icon jw-icon-play"></span></span>
-                    <span class="jw-name">{{this.title}}</span>
+                <li class='jw-option jw-text jw-active-option  item-{{@index}} jw-reset'>
+                    <span class="jw-label jw-reset"><span class="jw-icon jw-icon-play jw-reset"></span></span>
+                    <span class="jw-name jw-reset">{{this.title}}</span>
                 </li>
             {{else}}
-                <li class='jw-option jw-text item-{{@index}}'>
-                    <span class="jw-label">{{this.label}}</span>
-                    <span class="jw-name">{{this.title}}</span>
+                <li class='jw-option jw-text item-{{@index}} jw-reset'>
+                    <span class="jw-label jw-reset">{{this.label}}</span>
+                    <span class="jw-name jw-reset">{{this.title}}</span>
                 </li>
             {{/if}}
         {{/each}}

--- a/src/templates/rightclick.html
+++ b/src/templates/rightclick.html
@@ -1,10 +1,10 @@
-<div class="jw-rightclick">
-    <ul>
+<div class="jw-rightclick jw-reset">
+    <ul class="jw-reset-ul">
     {{#each items}}
-        <li{{#if feature}} class="jw-featured"{{/if}}>
-            <a href="{{link}}">
-                {{#if feature}}
-                <span class="jw-icon jw-icon-{{feature}}"></span>
+        <li{{#if featured}} class="jw-featured"{{/if}}>
+            <a href="{{link}} jw-reset">
+                {{#if featured}}
+                <span class="jw-icon jw-rightlick-logo jw-reset"></span>
                 {{/if}}
                 {{title}}
             </a>

--- a/src/templates/slider.html
+++ b/src/templates/slider.html
@@ -1,8 +1,8 @@
-<span class="{{className}} {{orientation}}">
-    <span class="jw-rail-group">
-        <span class="jw-rail"></span>
-        <span class="jw-buffer"></span>
-        <span class="jw-progress"></span>
-        <span class="jw-thumb"></span>
-    </span>
-</span>
+<div class="{{className}} {{orientation}} jw-reset">
+    <div class="jw-slider-container jw-reset">
+        <div class="jw-rail jw-reset"></div>
+        <div class="jw-buffer jw-reset"></div>
+        <div class="jw-progress jw-reset"></div>
+        <div class="jw-knob jw-reset"></div>
+    </div>
+</div>

--- a/test/manual/css-skins/css/jw-sample-skin.css
+++ b/test/manual/css-skins/css/jw-sample-skin.css
@@ -90,13 +90,13 @@
     background: #ff0046;
 }
 
-.jw-skin-seven .jw-slider-horizontal .jw-thumb,
-.jw-skin-seven .jw-slider-vertical .jw-thumb {
+.jw-skin-seven .jw-slider-horizontal .jw-knob,
+.jw-skin-seven .jw-slider-vertical .jw-knob {
     top: -0.19999999999999998em;
 }
 
-.jw-skin-seven .jw-slider-horizontal .jw-thumb:after,
-.jw-skin-seven .jw-slider-vertical .jw-thumb:after {
+.jw-skin-seven .jw-slider-horizontal .jw-knob:after,
+.jw-skin-seven .jw-slider-vertical .jw-knob:after {
     background-color: #fff;
     box-shadow: 0px 0px 0px 1px #000000;
     width: .6em;
@@ -104,7 +104,7 @@
     border-radius: 1em;
 }
 
-.jw-skin-seven .jw-slider-horizontal .jw-rail-group {
+.jw-skin-seven .jw-slider-horizontal .jw-slider-container {
     height: 0.95em;
 }
 
@@ -115,7 +115,7 @@
     border-radius: 0;
 }
 
-.jw-skin-seven .jw-slider-horizontal .jw-thumb {
+.jw-skin-seven .jw-slider-horizontal .jw-knob {
     top: -15%;
 }
 
@@ -136,7 +136,7 @@
     width: .2em;
 }
 
-.jw-skin-seven .jw-thumb {
+.jw-skin-seven .jw-knob {
     left: -0.04999999999999999em;
 }
 

--- a/test/manual/css-skins/css/jw-sample-skin.css
+++ b/test/manual/css-skins/css/jw-sample-skin.css
@@ -1,0 +1,244 @@
+/* The main class for styling the controlbar. */
+.jw-skin-seven .jw-controlbar {
+    background: #000;
+    border-top: #333 1px solid;
+    height: 2.5em;
+}
+
+
+/* The color for all icons in the control bar when they are not hovered on. */
+.jw-skin-seven .jw-icon,
+.jw-skin-seven .jw-text,
+.jw-skin-seven .jw-icon-inline {
+    color: #ffffff;
+}
+
+/* Sets the spacing between icon containers within the control bar. */
+.jw-skin-seven .jw-text,
+.jw-skin-seven .jw-icon-inline,
+.jw-skin-seven .jw-icon-tooltip {
+    padding: 0 5px 3px 5px;
+}
+
+/* Sets the space between the icons and the border */
+.jw-skin-seven .jw-icon:before {
+    padding-left: .7em;
+}
+
+/* The color for all icons in the control bar when they are hoverd on or are activated. */
+
+.jw-skin-seven .jw-icon:hover,
+.jw-skin-seven .jw-icon:before:hover {
+    color: #ff0046;
+}
+
+
+.jw-skin-seven .jw-icon-playback:before,
+.jw-skin-seven .jw-icon-display:before {
+    padding-left: 0;
+}
+
+/* Sets the font size of the previous and next icons as well as the space between them.*/
+.jw-skin-seven .jw-icon-prev,
+.jw-skin-seven .jw-icon-next {
+    font-size: .7em;
+    padding: 0 0.2em;
+}
+
+
+.jw-skin-seven .jw-icon-prev:before {
+    border-left: 1px solid #666;
+}
+
+.jw-skin-seven .jw-icon-next:before {
+    border-right: 1px solid #666;
+    padding-right: .7em;
+}
+
+/* Default color of the Play, Replay, and Buffering display icons. */
+.jw-skin-seven .jw-icon-display {
+    color: #fff;
+}
+
+/* Sets the shape of the display icon container. This is a circle.*/
+
+.jw-skin-seven .jw-display-icon-container {
+    background: #000;
+    border-radius: 50%;
+    padding: 0 .4em;
+    border: 1px solid #333;
+}
+
+
+.jw-skin-seven.jw-state-idle .jw-display-icon-container {
+    padding: 0 0 0 .5em;
+}
+
+.jw-skin-seven .jw-slider-horizontal .jw-rail,
+.jw-skin-seven .jw-slider-vertical .jw-rail {
+    background-color: #384154;
+    box-shadow: none;
+}
+
+.jw-skin-seven .jw-slider-horizontal .jw-buffer,
+.jw-skin-seven .jw-slider-vertical .jw-buffer {
+    background-color: #666F82;
+}
+
+.jw-skin-seven .jw-slider-horizontal .jw-progress,
+.jw-skin-seven .jw-slider-vertical .jw-progress {
+    background: #ff0046;
+}
+
+.jw-skin-seven .jw-slider-horizontal .jw-thumb,
+.jw-skin-seven .jw-slider-vertical .jw-thumb {
+    top: -0.19999999999999998em;
+}
+
+.jw-skin-seven .jw-slider-horizontal .jw-thumb:after,
+.jw-skin-seven .jw-slider-vertical .jw-thumb:after {
+    background-color: #fff;
+    box-shadow: 0px 0px 0px 1px #000000;
+    width: .6em;
+    height: .6em;
+    border-radius: 1em;
+}
+
+.jw-skin-seven .jw-slider-horizontal .jw-rail-group {
+    height: 0.95em;
+}
+
+.jw-skin-seven .jw-slider-horizontal .jw-rail,
+.jw-skin-seven .jw-slider-horizontal .jw-buffer,
+.jw-skin-seven .jw-slider-horizontal .jw-progress {
+    height: .2em;
+    border-radius: 0;
+}
+
+.jw-skin-seven .jw-slider-horizontal .jw-thumb {
+    top: -15%;
+}
+
+.jw-skin-seven .jw-slider-horizontal .jw-cue {
+    top: -0.04999999999999999em;
+}
+
+.jw-skin-seven .jw-slider-horizontal .jw-cue:after {
+    width: .3em;
+    height: .3em;
+    background-color: #fff;
+    border-radius: 50%;
+}
+
+.jw-skin-seven .jw-slider-vertical .jw-rail,
+.jw-skin-seven .jw-slider-vertical .jw-buffer,
+.jw-skin-seven .jw-slider-vertical .jw-progress {
+    width: .2em;
+}
+
+.jw-skin-seven .jw-thumb {
+    left: -0.04999999999999999em;
+}
+
+.jw-skin-seven .jw-volume-tip {
+    width: 100%;
+    left: -35%;
+}
+
+.jw-skin-seven .jw-text-duration {
+    color: #666F82;
+}
+
+/* The parent wrapper that contains the controlbar element positioning groups.  */
+.jw-skin-seven .jw-group {
+    vertical-align: middle;
+}
+
+.jw-skin-seven .jw-controlbar-right-group .jw-icon-tooltip:before,
+.jw-skin-seven .jw-controlbar-right-group .jw-icon-inline:before {
+    border-left: 1px solid #666;
+}
+
+.jw-skin-seven .jw-controlbar-right-group .jw-icon-inline:first-child:before {
+    border: none;
+}
+
+.jw-skin-seven .jw-dock .jw-dock-button {
+    background: #000;
+    border-radius: 50%;
+}
+
+.jw-skin-seven .jw-dock .jw-overlay {
+    background: #000;
+    border-radius: 2.5em;
+}
+
+.jw-skin-seven .jw-overlay .jw-option.jw-active-option {
+    background-color: #ff0046;
+    color: #fff;
+}
+
+.jw-skin-seven .jw-icon-hd,
+.jw-skin-seven .jw-icon-cc {
+    color: #ff0046;
+}
+
+.jw-skin-seven .jw-icon-hd.jw-off,
+.jw-skin-seven .jw-icon-cc.jw-off {
+    color: white;
+}
+
+/* Sets the character for the HD button */
+.jw-skin-seven .jw-icon-hd.jw-off:before {
+    content: "\e60a";
+}
+
+/* Sets the character for the CC button */
+.jw-skin-seven .jw-icon-cc.jw-off:before {
+    content: "\e605";
+}
+
+/* Sets the border style for the time overlay menus. */
+.jw-skin-seven .jw-time-tip,
+.jw-skin-seven .jw-menu,
+.jw-skin-seven .jw-volume-tip,
+.jw-skin-seven .jw-skip {
+    border: 1px solid #333;
+}
+
+/* Adds padding and margin to the timeslider time tooltip.*/
+.jw-skin-seven .jw-time-tip {
+    padding: 0.2em;
+    bottom: 1.3em;
+}
+
+/* Adjusts the margin of the vertical volume slider for borders spacing*/
+.jw-skin-seven .jw-menu,
+.jw-skin-seven .jw-volume-tip {
+    bottom: .15em;
+}
+
+/* Styles the skip icon wrapper.*/
+.jw-skin-seven .jw-skip {
+    background: #000;
+    padding: 0.4em;
+    border-radius: 1em;
+}
+
+/* Sets the font color and size for the skip text. */
+
+.jw-skin-seven .jw-skip .jw-text,
+.jw-skin-seven .jw-skip .jw-icon-inline {
+    color: #ffffff;
+    font-size: 0.7em;
+}
+
+/* Sets the font color for the CC icon when it is active. */
+.jw-skin-seven .jw-icon-cc {
+    color: #ff0046;
+}
+
+/* Sets the font color for the CC icon when it is not active. */
+.jw-skin-seven .jw-icon-cc.jw-off {
+    color: #ffffff;
+}

--- a/test/manual/css-skins/skin-demo.html
+++ b/test/manual/css-skins/skin-demo.html
@@ -163,11 +163,11 @@
                     <span class="jw-group jw-controlbar-left-group"><span class="jw-icon-inline jw-icon-playback"></span><span class="jw-icon-inline jw-icon-prev" style="display: none;"></span><span class="jw-icon-inline jw-icon-next" style="display: none;"></span><span class="jw-text jw-text-elapsed">00:00</span></span>
                     <span class="jw-group jw-controlbar-center-group">
                         <span class="jw-slider-time jw-slider-horizontal">
-                            <span class="jw-rail-group">
+                            <span class="jw-slider-container">
                                 <span class="jw-rail"></span>
                                 <span class="jw-buffer" style="width: 75%;"></span>
                                 <span class="jw-progress" style="width: 50%;"></span>
-                                <span class="jw-thumb" style="left: 50%;"></span>
+                                <span class="jw-knob" style="left: 50%;"></span>
                                 <span class="jw-icon-tooltip undefined">
                                     <div class="jw-overlay">
                                         <div class="jw-time-tip"><span style="width: 0px; height: 0px;"></span><span></span></div>
@@ -202,11 +202,11 @@
                             </div>
                         </span>
                         <span class="jw-icon-inline jw-icon-volume"></span><span class="jw-slider-volume jw-slider-horizontal">
-                        <span class="jw-rail-group">
+                        <span class="jw-slider-container">
                         <span class="jw-rail"></span>
                         <span class="jw-buffer"></span>
                         <span class="jw-progress" style="width: 50%;"></span>
-                        <span class="jw-thumb" style="left: 50%;"></span>
+                        <span class="jw-knob" style="left: 50%;"></span>
                         </span>
                         </span><span class="jw-icon-inline jw-icon-cast" style="display: none;"></span><span class="jw-icon-inline jw-icon-fullscreen"></span>
                     </span>


### PR DESCRIPTION
- Renamed classes:
  - jw-thumb => jw-knob
  - jw-icon-jw-logo => .jw-rightlick-logo
  - jw-rail-group => .jw-slider-container
- All elements use jw-reset to reset on the element level before other classes are applied
  - insures all elements are reset
  - reset is not more specific than skin styles
- Removed z-index use
  - We should only use DOM manipulation for layering. z-index interferes with host site's css.
- Added .jw-plugin class for plugin overlays
- Added .jw-toggle class for cc and hd buttons when they are not in menu mode
- Add css classes to simplify coloring player
  - .jw-background-color
  - .jw-button-color