### PR TITLE
dock icons fade with controls

### DIFF
--- a/src/css/flags/user-inactive.less
+++ b/src/css/flags/user-inactive.less
@@ -1,6 +1,6 @@
 .jwplayer.jw-flag-user-inactive {
     &.jw-state-playing {
-        .jw-controlbar {
+        .jw-controlbar, .jw-dock {
             display : none;
         }
 


### PR DESCRIPTION
dock icons also have their display set to none along with the controls while the user is inactive. [Finishes #96486082]