### PR TITLE
Allow clickthrough to provider

### DIFF
--- a/src/css/imports/jwplayerelement.less
+++ b/src/css/imports/jwplayerelement.less
@@ -124,3 +124,21 @@
 .jw-tab-focus:focus {
     outline: solid 2px #0b7ef4;
 }
+
+// Allow pointer events through to the provider
+.jw-overlays, .jw-click, .jw-controls {
+    pointer-events : none;
+}
+.jwplayer.jw-flag-user-inactive {
+    .jw-overlays, .jw-click, .jw-controls {
+        pointer-events: all;
+    }
+}
+
+// These items can intercept pointer-events
+.jw-overlays > div,
+.jw-controlbar, .jw-dock, .jw-logo, .jw-display-icon-container {
+    pointer-events: all;
+}
+
+

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -155,8 +155,8 @@ define([
 
         _attached = true;
 
-        function _onClickHandler() {
-            _this.sendEvent(events.JWPLAYER_PROVIDER_CLICK);
+        function _onClickHandler(evt) {
+            _this.sendEvent('click', evt);
         }
 
         function _durationUpdateHandler() {

--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -3,6 +3,10 @@ define([
     'events/events',
     'utils/underscore'
 ], function(Events, events, _) {
+    /*global TouchEvent*/
+
+    var TouchEvent = window.TouchEvent || {};
+
     var UI = function (elem, options) {
         var _elem = elem,
             _enableDoubleTap = (options && options.enableDoubleTap),
@@ -77,7 +81,7 @@ define([
 
         function normalizeUIEvent(type, srcEvent) {
             var source;
-            if(srcEvent instanceof MouseEvent) {
+            if(srcEvent instanceof MouseEvent || (!srcEvent.touches && !srcEvent.changedTouches)) {
                 source = srcEvent;
             } else {
                 if (srcEvent.touches && srcEvent.touches.length) {
@@ -97,6 +101,12 @@ define([
 
         // Preventdefault to prevent click events
         function preventDefault(evt) {
+            // Because sendEvent from utils.eventdispatcher clones evt objects instead of passing them
+            //  we cannot call evt.preventDefault() on them
+            if (! (evt instanceof MouseEvent) && ! (evt instanceof TouchEvent)) {
+                return;
+            }
+
             if (evt.preventManipulation) {
                 evt.preventManipulation();
             }
@@ -122,6 +132,8 @@ define([
 
             return false;
         }
+
+        this.triggerEvent = triggerEvent;
 
         this.destroy = function() {
             elem.removeEventListener('touchstart', interactStartHandler);

--- a/src/js/view/display.js
+++ b/src/js/view/display.js
@@ -23,7 +23,9 @@ define([
         userInteract.on('click tap', _clickHandler);
         userInteract.on('doubleClick doubleTap', _doubleClickHandler);
 
-        _model.mediaController.on(events.JWPLAYER_PROVIDER_CLICK, _clickHandler);
+        _model.mediaController.on('click', function(evt) {
+            userInteract.triggerEvent(events.touchEvents.CLICK, evt);
+        });
 
         this.clickHandler = _clickHandler;
 

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -74,9 +74,6 @@ define([
             _this = _.extend(this, Events);
 
         _playerElement = utils.createElement(playerTemplate({id: _model.get('id')}));
-        new UI(_playerElement).on('click', function() {
-            _this.trigger(events.JWPLAYER_DISPLAY_CLICK);
-        });
 
         var width = _model.get('width'),
             height = _model.get('height');


### PR DESCRIPTION
The idea is that we want all non-clickable elements above the
provider to ignore pointer-events so that the provider (and ads!)
can receive them.

To make play/pause work when clicking on the video,
we need to pass through click events on the provider (ie when they aren't
handled by ads). These events are passed through to the display, where
they simulate a normal click event.

The other non-intuitive part is that we enable pointer-events when the flag
jw-flag-user-inactive appears. This is so that we don't have to forward
mousemove events from the provider.

[Delivers #96455340]