### PR TITLE
Remove concept of "showing" from logo

### DIFF
--- a/src/js/view/logo.js
+++ b/src/js/view/logo.js
@@ -19,8 +19,7 @@ define([
         var _this = this,
             _logo,
             _settings,
-            _logoConfig = _.extend({}, _model.get('config').logo),
-            _showing = false;
+            _logoConfig = _.extend({}, _model.get('config').logo);
 
         _.extend(this, Events);
 
@@ -85,7 +84,6 @@ define([
             }
 
             _this.trigger(events.JWPLAYER_LOGO_CLICK, {
-                showing: _showing,
                 link: _settings.link,
                 linktarget: _settings.linktarget
             });

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -448,12 +448,10 @@ define([
         }
 
         function _logoClickHandler(evt){
-            if (!evt.showing || !evt.link) {
+            if (!evt.link) {
                 //_togglePlay();
                 _api.play();
-            }
-
-            if (evt.showing && evt.link) {
+            } else {
                 _api.pause(true);
                 _api.setFullscreen(false);
                 window.open(evt.link, evt.linktarget);


### PR DESCRIPTION
This is a bugfix for the click on a logo not opening up a link.
The problem originated because logo click events always sent a value
of "showing:false" which told the view not to open the link.

However this value was only false because we are no longer toggling
logo visibility programmatically, instead using CSS classes.

[Delivers #96118744]