### PR TITLE
Allow mouse events to target the provider, handle playback toggling through jw-media

### DIFF
--- a/src/css/imports/jwplayerelement.less
+++ b/src/css/imports/jwplayerelement.less
@@ -128,18 +128,13 @@
 }
 
 // Allow pointer events through to the provider
-.jw-overlays, .jw-click, .jw-controls, .jw-preview {
+.jw-preview, .jw-captions, .jw-title, .jw-overlays, .jw-controls, {
     pointer-events : none;
-}
-.jwplayer.jw-flag-user-inactive {
-    .jw-overlays, .jw-click, .jw-controls {
-        pointer-events: all;
-    }
 }
 
 // These items can intercept pointer-events
 .jw-overlays > div,
-.jw-controlbar, .jw-dock, .jw-logo, .jw-display-icon-container {
+.jw-media, .jw-controlbar, .jw-dock, .jw-logo, .jw-display-icon-container {
     pointer-events: all;
 }
 

--- a/src/css/imports/title.less
+++ b/src/css/imports/title.less
@@ -4,6 +4,7 @@
 .jw-title {
     display: none;
     position: absolute;
+    top:0;
     width:100%;
     font-size: 14/16em;
     height: 8em;

--- a/src/js/controller/instream.js
+++ b/src/js/controller/instream.js
@@ -154,7 +154,7 @@ define([
             _adModel.on(events.JWPLAYER_ERROR, errorHandler);
 
             // start listening for ad click
-            _view.displayComp().setAlternateClickHandler(function(evt) {
+            _view.clickHandler().setAlternateClickHandler(function(evt) {
                 evt = evt || {};
                 evt.hasControls = !!modelGet('controls');
 
@@ -172,7 +172,7 @@ define([
             });
 
             if (utils.isMSIE()) {
-                _oldProvider.parentElement.addEventListener('click', _view.displayComp().clickHandler);
+                _oldProvider.parentElement.addEventListener('click', _view.clickHandler().clickHandler);
             }
 
             _view.on(events.JWPLAYER_AD_SKIPPED, _skipAd);
@@ -211,11 +211,11 @@ define([
             // Return the view to its normal state
             var adsVideo = _adModel.getVideo();
             _view.destroyInstream((adsVideo) ? adsVideo.isAudioFile() : false);
-            if (_view.displayComp()) {
+            if (_view.clickHandler()) {
                 if (_oldProvider && _oldProvider.parentElement) {
-                    _oldProvider.parentElement.removeEventListener('click', _view.displayComp().clickHandler);
+                    _oldProvider.parentElement.removeEventListener('click', _view.clickHandler().clickHandler);
                 }
-                _view.displayComp().revertAlternateClickHandler();
+                _view.clickHandler().revertAlternateClickHandler();
             }
             _adModel = null;
 

--- a/src/js/providers/flash.js
+++ b/src/js/providers/flash.js
@@ -250,7 +250,6 @@ define([
                 },
                 setVisibility: function(visible) {
                     visible = !!visible;
-                    _container.style.visibility = visible ? 'visible':'hidden';
                     _container.style.opacity = visible ? 1:0;
                 },
                 resize: function(width, height, stretching) {

--- a/src/js/view/clickhandler.js
+++ b/src/js/view/clickhandler.js
@@ -5,25 +5,19 @@ define([
     'events/states',
     'utils/underscore'
 ], function(UI, events, Events, states, _) {
-    var Display = function(_model) {
+    var ClickHandler = function(_model, _ele) {
         var _display,
             _alternateClickHandler;
 
         _.extend(this, Events);
 
-        _display = document.createElement('div');
-        _display.className = 'jw-click jw-reset';
+        _display = _ele;
 
         this.element = function() { return _display; };
 
-        //_display.addEventListener('click', _clickHandler, false);
-        var userInteract = new UI(this.element(), {'enableDoubleTap': true});
+        var userInteract = new UI(_display, {'enableDoubleTap': true});
         userInteract.on('click tap', _clickHandler);
         userInteract.on('doubleClick doubleTap', _doubleClickHandler);
-
-        _model.mediaController.on('click', function(evt) {
-            userInteract.triggerEvent(events.touchEvents.CLICK, evt);
-        });
 
         this.clickHandler = _clickHandler;
 
@@ -60,5 +54,5 @@ define([
     };
 
 
-    return Display;
+    return ClickHandler;
 });

--- a/src/js/view/components/slider.js
+++ b/src/js/view/components/slider.js
@@ -29,7 +29,7 @@ define([
             this.elementProgress = this.el.getElementsByClassName('jw-progress')[0];
             this.elementThumb = this.el.getElementsByClassName('jw-knob')[0];
 
-            this.userInteract = new UI(this.element());
+            this.userInteract = new UI(this.element(), {enableDrag: true});
 
             this.userInteract.on('dragStart', this.dragStartListener);
             this.userInteract.on('drag', this.dragMoveListener);

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -6,7 +6,7 @@ define([
     'events/states',
     'cast/display',
     'view/captionsrenderer',
-    'view/display',
+    'view/clickhandler',
     'view/displayicon',
     'view/dock',
     'view/logo',
@@ -18,7 +18,7 @@ define([
     'utils/underscore',
     'handlebars-loader!templates/player.html'
 ], function(utils, events, UI, Events, states, CastDisplay,
-            CaptionsRenderer, Display, DisplayIcon, Dock, Logo,
+            CaptionsRenderer, ClickHandler, DisplayIcon, Dock, Logo,
             Controlbar, Preview, RightClick, Title, cssUtils, _, playerTemplate) {
 
     var _styles = utils.style,
@@ -46,7 +46,7 @@ define([
             _instreamMode = false,
             _controlbar,
             _preview,
-            _display,
+            _displayClickHandler,
             _castDisplay,
             _dock,
             _logo,
@@ -378,9 +378,8 @@ define([
             _stateHandler(null, states.IDLE);
 
             if (!_isMobile) {
-                _controlsLayer.addEventListener('mouseout', _mouseoutHandler, false);
-
-                _controlsLayer.addEventListener('mousemove', _startFade, false);
+                _displayClickHandler.element().addEventListener('mouseout', _mouseoutHandler, false);
+                _displayClickHandler.element().addEventListener('mousemove', _startFade, false);
             }
             _componentFadeListeners(_controlbar);
             _componentFadeListeners(_logo);
@@ -484,20 +483,19 @@ define([
             toggleControls();
             _model.on('change:controls', toggleControls);
 
-            _display = new Display(_model);
-            _display.on('click', function() {
+            _displayClickHandler = new ClickHandler(_model, _videoLayer);
+            _displayClickHandler.on('click', function() {
                 forward({type : events.JWPLAYER_DISPLAY_CLICK});
                 _api.play();
             });
-            _display.on('tap', function() {
+            _displayClickHandler.on('tap', function() {
                 forward({type : events.JWPLAYER_DISPLAY_CLICK});
                 _touchHandler();
             });
-            _display.on('doubleClick', function() {
+            _displayClickHandler.on('doubleClick', function() {
                 _api.setFullscreen();
             });
-            _controlsLayer.appendChild(_display.element());
-
+            
             var displayIcon = new DisplayIcon(_model);
             //toggle playback
             displayIcon.on('click tap', function() {
@@ -542,12 +540,12 @@ define([
                 _this.forceControls(true);
             }
 
-            _playerElement.onmousedown = handleMouseDown;
             _playerElement.onfocusin = handleFocus;
-            _playerElement.addEventListener('focus', handleFocus);
             _playerElement.onfocusout = handleBlur;
+            _playerElement.addEventListener('focus', handleFocus);
             _playerElement.addEventListener('blur', handleBlur);
             _playerElement.addEventListener('keydown', handleKeydown);
+            _playerElement.onmousedown = handleMouseDown;
         }
 
         function _onChangeControls(model, bool) {
@@ -600,7 +598,7 @@ define([
                 // clickthrough callback
                 var clickAd = evt.onClick;
                 if (clickAd !== undefined) {
-                    _display.setAlternateClickHandler(function() {
+                    _displayClickHandler.setAlternateClickHandler(function() {
                         clickAd(evt);
                     });
                 }
@@ -631,7 +629,7 @@ define([
                 _castDisplay.setState(_model.get('state'));
             }
             // display click reset
-            _display.revertAlternateClickHandler();
+            _displayClickHandler.revertAlternateClickHandler();
         }
 
         /**
@@ -1020,8 +1018,8 @@ define([
             }
         };
 
-        this.displayComp = function() {
-            return _display;
+        this.clickHandler = function() {
+            return _displayClickHandler;
         };
 
         this.controlsContainer = function() {
@@ -1084,8 +1082,8 @@ define([
                 _castDisplay = null;
             }
             if (_controlsLayer) {
-                _controlsLayer.removeEventListener('mousemove', _startFade);
-                _controlsLayer.removeEventListener('mouseout', _mouseoutHandler);
+                _displayClickHandler.element().removeEventListener('mousemove', _startFade);
+                _displayClickHandler.element().removeEventListener('mouseout', _mouseoutHandler);
             }
             if (_instreamMode) {
                 this.destroyInstream();


### PR DESCRIPTION
Moves handling of the toggle play/pause and double click to fullscreen to the jw-media container.  This is done by allowing click events on the video area to hit the provider and bubble up to the jw-media container. Also removes some code from the flash provider that ended up blocking clicks into the flash container, which prevented clicking on nonlinear ads.

[Finishes #94887836 #96677846 #96678804 #96455340]