### PR TITLE
Controlbar opacity fix in audio player, .jw-options styles

### DIFF
--- a/src/css/flags/audioplayer.less
+++ b/src/css/flags/audioplayer.less
@@ -10,6 +10,7 @@
         margin: 0;
         width: 100%;
         min-width: 100%;
+        opacity: 1;
 
         .jw-icon-fullscreen {
             display: none;

--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -33,10 +33,6 @@
     top: (@rail-height - @element-height)/2;
 }
 
-.horizontally-centered-thumb(@rail-width:@time-rail-width, @element-width:@thumb-size) {
-    left: (@rail-width - @element-width)/2;
-}
-
 .hover(@color:@hover-color) {
     &:hover {
         color: @color;
@@ -53,9 +49,11 @@
 }
 
 // Less requires namespaced variables/mixins to overwrite globals - https://github.com/less/less.js/issues/1316
+
+/* Mixin for common skin styles with variable colors */
 #namespace() {
     .basic-skin-styles() {
-
+        
         .jw-background-color {
             background: @display-bkgd-color;
         }
@@ -64,11 +62,11 @@
             background: @controlbar-background;
         }
 
-
         .jw-text {
             color: @inactive-color;
         }
-
+        
+        /* Text color in thumbnail that appears upon hovering on the timeline slider */
         .jw-tooltip-title {
             color: @inactive-color;
         }
@@ -88,14 +86,16 @@
                 color: @inactive-color;
             }
         }
-
+        
+        /* Color for list item text in menu lists */
         .jw-option {
             color: @inactive-color;
             &.jw-active-option {
                 color: @hover-color;
             }
         }
-
+        
+        /* Colors for center play and buffering icons */
         .jw-icon-display {
             color: @display-icon-color;
         }
@@ -112,6 +112,8 @@
                 }
             }
         }
+
+        /* Slider colors */
 
         .jw-rail {
             background: @rail-color;
@@ -140,6 +142,7 @@
             }
         }
         
+        /* Styles for menu elements, volume, slider thumbnail */
         .jw-time-tip,
         .jw-volume-tip,
         .jw-menu {
@@ -158,7 +161,8 @@
         .jw-time-tip {
             bottom: 1em;
         }
-
+        
+        /* Dock button styles */
         .jw-dock-button {
             background: @display-bkgd-color;
             border-radius: @ui-corner-round;
@@ -167,7 +171,8 @@
                 background: @display-bkgd-hover-color;
             }
         }
-
+        
+        /* Reset padding on .jw-menu's that are playlists */
         .jw-playlist-container {
             padding: 0;
         }

--- a/src/css/skins/beelden.less
+++ b/src/css/skins/beelden.less
@@ -206,8 +206,6 @@
         }
 
         .jw-knob {
-            .horizontally-centered-thumb(.75em, .7em);
-
             &:after {
                 width: .7em;
                 height: .7em;

--- a/src/css/skins/five.less
+++ b/src/css/skins/five.less
@@ -49,7 +49,6 @@
 
         .jw-option {
             border-bottom: 1px solid #ECECEC;
-            color: @active-color;
             background-color: #fff;
             margin-right: 8px;
 
@@ -57,7 +56,6 @@
             &:hover,
             &.jw-active-option {
                 background-color: #ECECEC;
-                color: @active-color;
             }
 
             // Number turn red when li is hovered
@@ -155,6 +153,17 @@
                 border-radius: 0;
                 height: 2px;
                 width: .6em;
+            }
+        }
+    }
+
+    .jw-icon-cc {
+        .jw-option {
+            color: #bbb;
+
+            &:hover,
+            &.jw-active-option {
+                color: #fff;
             }
         }
     }

--- a/src/css/skins/five.less
+++ b/src/css/skins/five.less
@@ -26,7 +26,7 @@
     @thumb-size: 1em;
     @cue-height: .4em;
     @rail-vert-gradient: linear-gradient(to bottom, #fff 0, #fff 30%, #333 100%);
-
+    
     #namespace > .basic-skin-styles(); // Using the above local variables
     .skin-element-padding();
 
@@ -37,6 +37,15 @@
 
     .jw-display-icon-container {
         border-radius: 0;
+    }
+
+    .jw-option {
+        color: #bbb;
+
+        &:hover,
+        &.jw-active-option {
+            color: #fff;
+        }
     }
     
     .jw-playlist {
@@ -51,11 +60,13 @@
             border-bottom: 1px solid #ECECEC;
             background-color: #fff;
             margin-right: 8px;
+            color: @inactive-color;
 
             // Menu items are black when active, or hovered
             &:hover,
             &.jw-active-option {
                 background-color: #ECECEC;
+                color: @hover-color;
             }
 
             // Number turn red when li is hovered
@@ -157,15 +168,8 @@
         }
     }
 
-    .jw-icon-cc {
-        .jw-option {
-            color: #bbb;
-
-            &:hover,
-            &.jw-active-option {
-                color: #fff;
-            }
-        }
+    .jw-controlbar-right-group {
+        
     }
 
     .jw-dock-button {

--- a/src/css/skins/five.less
+++ b/src/css/skins/five.less
@@ -152,7 +152,7 @@
                 background: @rail-vert-gradient;
                 border-radius: 0;
                 height: 2px;
-                width: .6em;
+                width: 100%;
             }
         }
     }

--- a/src/css/skins/seven.less
+++ b/src/css/skins/seven.less
@@ -143,7 +143,7 @@
         &:after {
             background-color: #fff;
             box-shadow: 0px 0px 0px 1px rgba(0,0,0,1);
-            width: .6em;
+            width: 100%;
             height: .6em;
             border-radius: 1em;
         }

--- a/src/css/skins/seven.less
+++ b/src/css/skins/seven.less
@@ -19,18 +19,22 @@
         height: 2.5em;
     }
 
+    /* Contains icons, time text, and slider */
     .jw-group {
         vertical-align: middle;
     }
     
+    /* Playlist container */
     .jw-playlist {
         background-color: rgba(0, 0, 0, 0.8);
     }
-
+    
+    /* ul container */
     .jw-playlist-container {
         left: -43%;
         background-color: rgba(0, 0, 0, 0.8);
-    
+        
+        /* li list option */
         .jw-option {
             border-bottom: 1px solid #444;
             
@@ -40,7 +44,7 @@
                 background-color: black;
             }
 
-            // Number turn red when li is hovered
+            // Number color when li is hovered
             &:hover {
                 .jw-label {
                     color: @active-color;
@@ -52,7 +56,7 @@
             margin-left: 0;
         }
 
-        // play icon is always red
+        // play icon is always active
         .jw-label .jw-icon-play {
             color: @active-color;
             &:before {

--- a/src/css/skins/seven.less
+++ b/src/css/skins/seven.less
@@ -24,27 +24,27 @@
         vertical-align: middle;
     }
     
-    /* Playlist container */
+    /* Playlist container - needed to overwrite the .jw-background-color class */
     .jw-playlist {
-        background-color: rgba(0, 0, 0, 0.8);
+        background-color: rgba(0, 0, 0, 0.5);
     }
     
     /* ul container */
     .jw-playlist-container {
         left: -43%;
-        background-color: rgba(0, 0, 0, 0.8);
+        background-color: rgba(0, 0, 0, 0.5);
         
         /* li list option */
         .jw-option {
             border-bottom: 1px solid #444;
             
-            // Menu items are black when active, or hovered
+            /* Playlist items are black when active, or hovered */
             &:hover,
             &.jw-active-option {
                 background-color: black;
             }
 
-            // Number color when li is hovered
+            /* Number color when li is hovered */
             &:hover {
                 .jw-label {
                     color: @active-color;
@@ -64,6 +64,13 @@
             }
         }
     }
+
+    /* Playlist title */
+    .jw-tooltip-title {
+        background-color: #000;
+    }
+
+    /* Colors, padding for icons text */
 
     .jw-text {
         color: @inactive-color;

--- a/src/css/skins/six.less
+++ b/src/css/skins/six.less
@@ -63,15 +63,29 @@
         border: 1px solid #000;
     }
 
-    &:hover .jw-display-icon-container {
-        background: @def-background-style;
-        background-size: @def-background-size;
+    &:hover {
+        .jw-display-icon-container {
+            background: @def-background-style;
+            background-size: @def-background-size;
+        }
     }
 
+    /* Styles for menu list items */
+    .jw-option {
+        .jw-icon-menu-bullet;
+        text-align: left;
+
+        &:before {
+            font-size: .4em;
+            vertical-align: middle;
+            margin-right: .4em;
+        }
+    }
+    
+    /* Playlist */
     .jw-playlist-container {
         left: -41%;
 
-        .jw-option,
         .jw-text,
         .jw-icon {
             color: @progress-color;
@@ -80,8 +94,13 @@
         .jw-option {
             border-bottom: 1px solid #2F2F31;
             color: #878787;
+            
+            /* Remove the option bullet */
+            &:before {
+                content: "";
+            }
 
-            // Menu items are black when active, or hovered
+            /* Menu items are white when active or hovered */
             &:hover,
             &.jw-active-option {
                 background-color: #2F2F31;
@@ -197,25 +216,16 @@
             border-top-left-radius: 0;
         }
     }
-
-    .jw-icon-cc .jw-option {
-        .jw-icon-menu-bullet;
-        text-align: left;
-
-        &:before {
-            font-size: .4em;
-            vertical-align: middle;
-            margin-right: .4em;
-        }
-    }
-
+    
+    /* For the overlay containers */
     .jw-time-tip,
     .jw-volume-tip,
     .jw-menu {
         background-size: @def-background-size;
         border-radius: @ui-padding;
     }
-
+    
+    /* Dock styles */
     .jw-dock {
         .jw-dock-button {
             background: @def-transparent-background-style;

--- a/src/css/skins/vapor.less
+++ b/src/css/skins/vapor.less
@@ -163,4 +163,10 @@
         }
     }
 
+    &.jw-flag-audio-player {
+        .jw-controlbar {
+            background: @inactive-color;
+        }
+    }
+
 }

--- a/src/css/skins/vapor.less
+++ b/src/css/skins/vapor.less
@@ -79,7 +79,6 @@
         background-color: #1E1E1E;
     }
 
-	
 
 	.jw-slider-horizontal {
 		height: @rail-height;

--- a/src/css/skins/vapor.less
+++ b/src/css/skins/vapor.less
@@ -32,6 +32,16 @@
         bottom: .3em;
     }
 
+    .jw-option {
+        color: @active-color;
+        
+        &:hover,
+        &.jw-active-option {
+            color: @progress-color;
+        }
+    }
+
+    /* Playlist */
 	.jw-playlist-container {
         left: -42%;
         bottom: 0;
@@ -47,15 +57,16 @@
         .jw-option {
             border-bottom: 1px solid #000;
             background-color: #1E1E1E;
-
-            // Menu items are black when active, or hovered
+            color: #a8a8a8;
+            
+           // Menu items are green when active or hovered
             &:hover,
             &.jw-active-option {
                 color: @progress-color;
             }
         }
 
-        // play icon is always red
+        // play icon is always active
         .jw-label .jw-icon-play {
             color: @progress-color;
         }
@@ -79,7 +90,7 @@
         background-color: #1E1E1E;
     }
 
-
+    /* Horizontal (timeline & horz volume) slider */
 	.jw-slider-horizontal {
 		height: @rail-height;
 
@@ -118,7 +129,8 @@
 			}
 		}
 	}
-
+    
+    /* Volume slider */
 	.jw-slider-vertical {
 		padding: .4em;
 		bottom: 3px;
@@ -140,28 +152,21 @@
 		}
 
 	}
-
+       
+    /* Toggle icons */
     .jw-icon-cc {
         &.jw-off:before {
             content: "\e604";
         }
-
-        .jw-option {
-            color: #fff;
-            
-            &:hover,
-            &.jw-active-option {
-                color: @progress-color;
-            }
-        }
     }
-
+    
     .jw-icon-hd {
         &.jw-off:before {
             content: "\e609";
         }
     }
-
+    
+    /* Audio player only */
     &.jw-flag-audio-player {
         .jw-controlbar {
             background: @inactive-color;

--- a/src/css/skins/vapor.less
+++ b/src/css/skins/vapor.less
@@ -149,7 +149,8 @@
 
         .jw-option {
             color: #fff;
-
+            
+            &:hover,
             &.jw-active-option {
                 color: @progress-color;
             }


### PR DESCRIPTION
Increased opacity in audio player controlbar for controlbars that have <1 opacity. Also fixed wrong colors of cc option list items in five and vapor skins.