### PR TITLE
Call provider.remove before instantiating new provider

### DIFF
--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -148,20 +148,26 @@ define([
             }
         };
 
-        this.setVideoProvider = function(provider) {
+        this.changeVideoProvider = function(Provider) {
+            var container;
 
             if (_provider) {
                 _provider.removeGlobalListener(_videoEventHandler);
-                var container = _provider.getContainer();
+                container = _provider.getContainer();
                 if (container) {
                     _provider.remove();
-                    provider.setContainer(container);
                 }
             }
 
-            this.set('provider', provider.getName());
+            _currentProvider = new Provider(_this.id, _this.config);
 
-            _provider = provider;
+            if (container) {
+                _currentProvider.setContainer(container);
+            }
+
+            this.set('provider', _currentProvider.getName());
+
+            _provider = _currentProvider;
             _provider.volume(_this.volume);
             _provider.mute(_this.mute);
             _provider.addGlobalListener(_videoEventHandler.bind(this));
@@ -231,9 +237,7 @@ define([
 
             // If we are changing video providers
             if (!(_currentProvider instanceof Provider)) {
-                _currentProvider = new Provider(_this.id, _this.config);
-
-                _this.setVideoProvider(_currentProvider);
+                _this.changeVideoProvider(Provider);
             }
 
             // this allows the Youtube provider to load preview images


### PR DESCRIPTION
This issue arose from sharing the video tag between the html5
provider and the shakajs provider. The problem was that when switching
playlist items, the new provider would be constructed before the previous
one was removed from the page.

On construction, the providers look for the presence of a video tag, and if found,
bind events to it. When the previous provider destroys it wipes out the video tag.
Until they learn how to share nicely, all providers will destroy and recreate their
own tag instead of reusing one.

This will need to be revisited for ads in dash playback on mobile,
where you are forced to share a video tag.

[#96552088]