### PR TITLE
Fixed Flash resize [Delivers #89415726]

### DIFF
--- a/src/flash/com/longtailvideo/jwplayer/controller/Controller.as
+++ b/src/flash/com/longtailvideo/jwplayer/controller/Controller.as
@@ -243,14 +243,13 @@ public class Controller extends GlobalEventDispatcher {
     }
 
     public function fullscreen(mode:Boolean):Boolean {
-        if (mode != _model.fullscreen) {
+        if (mode !== _model.fullscreen) {
             _model.fullscreen = mode;
             _view.fullscreen(mode);
-            dispatchEvent(new PlayerEvent(PlayerEvent.JWPLAYER_FULLSCREEN, mode.toString()));
+            //dispatchEvent(new PlayerEvent(PlayerEvent.JWPLAYER_FULLSCREEN, mode.toString()));
             return true;
-        } else {
-            return false;
         }
+        return false;
     }
 
     public function checkBeforePlay():Boolean {

--- a/src/flash/com/longtailvideo/jwplayer/media/MediaProvider.as
+++ b/src/flash/com/longtailvideo/jwplayer/media/MediaProvider.as
@@ -235,19 +235,13 @@ public class MediaProvider extends Sprite implements IMediaProvider {
     /**
      * Resizes the display.
      *
-     * @param width        The new width of the display.
+     * @param width     The new width of the display.
      * @param height    The new height of the display.
      **/
     public function resize(width:Number, height:Number):void {
         _width = width;
         _height = height;
-
         if (_media) {
-            // Fix some rounding errors by resetting the media container size before stretching
-            if (_media.numChildren > 0) {
-                _media.width = _media.getChildAt(0).width;
-                _media.height = _media.getChildAt(0).height;
-            }
             Stretcher.stretch(_media, width, height, _config.stretching);
         }
     }

--- a/src/flash/com/longtailvideo/jwplayer/model/Model.as
+++ b/src/flash/com/longtailvideo/jwplayer/model/Model.as
@@ -154,24 +154,6 @@ public class Model extends GlobalEventDispatcher {
         }
     }
 
-    public function get width():Number {
-        if (RootReference.stage) {
-            return RootReference.stage.stageWidth;
-        }
-        return 0;
-    }
-
-    public function get height():Number {
-        if (RootReference.stage) {
-            return RootReference.stage.stageHeight;
-        }
-        return 0;
-    }
-
-    public function set width(n:Number):void {}
-
-    public function set height(n:Number):void {}
-
     public function get stretching():String {
         return _config.stretching;
     }

--- a/src/flash/com/longtailvideo/jwplayer/player/Player.as
+++ b/src/flash/com/longtailvideo/jwplayer/player/Player.as
@@ -149,7 +149,7 @@ public class Player extends Sprite implements IPlayer {
     }
 
     public function getSafeRegion():Rectangle {
-        return _view.getBounds(RootReference.root);
+        return _view.getSafeRegion();
     }
 
     public function getItem():PlaylistItem {

--- a/src/flash/com/longtailvideo/jwplayer/player/SwfEventRouter.as
+++ b/src/flash/com/longtailvideo/jwplayer/player/SwfEventRouter.as
@@ -115,5 +115,21 @@ function(id, name, json) {
         });
     }
 
+    static private var _consoleLog:XML = <script><![CDATA[
+function() {
+    if (typeof console.log === 'object') {
+        console.log(Array.prototype.slice.call(arguments, 0));
+        return;
+    }
+    console.log.apply(console, arguments);
+}]]></script>;
+
+    static public function consoleLog(...args):void {
+        trace.apply(null, ['<<'].concat(args));
+        if (ExternalInterface.available) {
+            ExternalInterface.call.apply(null, [_consoleLog].concat(args));
+        }
+    }
+
 }
 }

--- a/src/flash/com/longtailvideo/jwplayer/utils/Stretcher.as
+++ b/src/flash/com/longtailvideo/jwplayer/utils/Stretcher.as
@@ -25,9 +25,12 @@ public class Stretcher {
      * @param typ    The stretching type.
      **/
     public static function stretch(clp:DisplayObject, wid:Number, hei:Number, typ:String = 'uniform'):void {
+        clp.scaleX = clp.scaleY = 1;
         var xsc:Number = wid / clp.width;
         var ysc:Number = hei / clp.height;
         switch (typ.toLowerCase()) {
+            case Stretcher.NONE:
+                break;
             case Stretcher.EXACTFIT:
                 clp.width = wid;
                 clp.height = hei;
@@ -40,10 +43,6 @@ public class Stretcher {
                     clp.width *= ysc;
                     clp.height *= ysc;
                 }
-                break;
-            case Stretcher.NONE:
-                clp.scaleX = 1;
-                clp.scaleY = 1;
                 break;
             case Stretcher.UNIFORM:
             default:
@@ -62,12 +61,12 @@ public class Stretcher {
                 }
                 break;
         }
-        clp.x = Math.round(wid / 2 - clp.width / 2);
-        clp.y = Math.round(hei / 2 - clp.height / 2);
-        if (clp.width > 0) {
+        if (clp.width ) {
             clp.width = Math.ceil(clp.width);
+            clp.x = Math.round((wid - clp.width) / 2);
         }
-        if (clp.height > 0) {
+        if (clp.height) {
+            clp.y = Math.round((hei - clp.height) / 2);
             clp.height = Math.ceil(clp.height);
         }
     }

--- a/src/flash/com/longtailvideo/jwplayer/view/View.as
+++ b/src/flash/com/longtailvideo/jwplayer/view/View.as
@@ -2,50 +2,36 @@ package com.longtailvideo.jwplayer.view {
 import com.longtailvideo.jwplayer.events.MediaEvent;
 import com.longtailvideo.jwplayer.model.Model;
 import com.longtailvideo.jwplayer.player.IInstreamPlayer;
+import com.longtailvideo.jwplayer.player.SwfEventRouter;
 import com.longtailvideo.jwplayer.plugins.IPlugin;
 import com.longtailvideo.jwplayer.plugins.IPlugin6;
-import com.longtailvideo.jwplayer.plugins.PluginConfig;
-import com.longtailvideo.jwplayer.utils.Logger;
 import com.longtailvideo.jwplayer.utils.RootReference;
 import com.longtailvideo.jwplayer.utils.Stretcher;
 
 import flash.display.DisplayObject;
 import flash.display.Sprite;
 import flash.display.StageAlign;
-import flash.display.StageDisplayState;
 import flash.display.StageScaleMode;
-import flash.events.ErrorEvent;
 import flash.events.Event;
 import flash.geom.Rectangle;
 
 public class View extends Sprite {
 
     protected var _model:Model;
-    protected var _preserveAspect:Boolean = false;
-    protected var _normalScreen:Rectangle;
     protected var _mediaLayer:Sprite;
-    protected var _componentsLayer:Sprite;
     protected var _pluginsLayer:Sprite;
+    protected var _instreamLayer:Sprite;
+
     protected var _plugins:Object;
 
-    // Indicates whether the instream player is being displayed
-    protected var _allPlugins:Vector.<IPlugin>;
-    protected var _instreamMode:Boolean = false;
-    protected var _instreamPlayer:IInstreamPlayer;
-    protected var _instreamLayer:Sprite;
     protected var _instreamPlugin:IPlugin;
+    protected var _instreamPlayer:IInstreamPlayer;
+    protected var _instreamMode:Boolean = false;
+
 
     public function View(model:Model) {
         _model = model;
         _model.addEventListener(MediaEvent.JWPLAYER_MEDIA_LOADED, mediaLoaded);
-
-        _normalScreen = new Rectangle(
-                0,
-                0,
-                _model.width,
-                _model.height
-        );
-
         setupLayers();
     }
 
@@ -60,60 +46,56 @@ public class View extends Sprite {
         redraw();
     }
 
-    public function fullscreen(mode:Boolean = true):void {
-        try {
-            RootReference.stage.displayState = mode ? StageDisplayState.FULL_SCREEN : StageDisplayState.NORMAL;
-        } catch (e:Error) {
-            Logger.log("Could not enter fullscreen mode: " + e.message);
-        }
+    public function getSafeRegion():Rectangle {
+        var width:Number  = RootReference.stage.stageWidth;
+        var height:Number = RootReference.stage.stageHeight;
+        return new Rectangle(0, 0, width, height);
     }
 
-    /** Redraws the plugins and player components **/
+    public function fullscreen(mode:Boolean = true):void {
+        // Flash fullscreen is not allowed in jw7. Browser DOM fullscreen must be used to show controls.
+        redraw();
+    }
+
     public function redraw():void {
-        if (!_model.fullscreen) {
-            _normalScreen.width  = RootReference.stage.stageWidth;
-            _normalScreen.height = RootReference.stage.stageHeight;
+        var width:Number  = RootReference.stage.stageWidth;
+        var height:Number = RootReference.stage.stageHeight;
+        // Don't need to resize the media if width/height are 0 (i.e. player is hidden in the DOM)
+        if (width * height === 0) {
+            return;
         }
-
-        if (_preserveAspect) {
-            if (!_model.fullscreen && _model.stretching != Stretcher.EXACTFIT) {
-                _preserveAspect = false;
-            }
-        } else {
-            if (_model.fullscreen && _model.stretching == Stretcher.EXACTFIT) {
-                _preserveAspect = true;
-            }
-        }
-
-        resizeMedia(_model.width, _model.height);
-
-        _instreamLayer.graphics.clear();
-        _instreamLayer.graphics.beginFill(0);
-        _instreamLayer.graphics.drawRect(0, 0, _model.width, _model.height);
-        _instreamLayer.graphics.endFill();
+        resizeMedia(width, height);
+        resizePlugins(width, height);
+        resizeInstream(width, height);
     }
 
     public function addPlugin(id:String, plugin:IPlugin):void {
         if (!(plugin is IPlugin6)) {
             throw new Error("Incompatible plugin version");
         }
-        try {
-            _allPlugins.push(plugin);
-            var plugDO:DisplayObject = plugin as DisplayObject;
-            if (!_plugins[id] && plugDO) {
-                _plugins[id] = plugDO;
-                _pluginsLayer.addChild(plugDO);
+        var pluginDisplay:DisplayObject = plugin as DisplayObject;
+        if (!_plugins[id] && pluginDisplay) {
+            _plugins[id] = pluginDisplay;
+            _pluginsLayer.addChild(pluginDisplay);
+            var width:Number  = RootReference.stage.stageWidth;
+            var height:Number = RootReference.stage.stageHeight;
+            if (width * height === 0) {
+                return;
             }
-        } catch (e:Error) {
-            dispatchEvent(new ErrorEvent(ErrorEvent.ERROR, false, false, e.message));
+            try {
+                plugin.resize(width, height);
+            } catch (e:Error) {
+                SwfEventRouter.error(e.code, e.message);
+            }
         }
     }
 
     public function removePlugin(plugin:IPlugin):void {
-        var id:String = plugin.id.toLowerCase();
-        if (id && _plugins[id] is IPlugin) {
-            _pluginsLayer.removeChild(_plugins[id]);
-            delete _plugins[id];
+        var pluginDisplay:DisplayObject = plugin as DisplayObject;
+        if (pluginDisplay) {
+            if (_pluginsLayer.contains(pluginDisplay)) {
+                _pluginsLayer.removeChild(pluginDisplay);
+            }
         }
     }
 
@@ -131,11 +113,6 @@ public class View extends Sprite {
         return _plugins[id] as IPlugin6;
     }
 
-    public function bringPluginToFront(id:String):void {
-        var plugin:IPlugin = getPlugin(id);
-        _pluginsLayer.setChildIndex(plugin as DisplayObject, _pluginsLayer.numChildren - 1);
-    }
-
     public function setupInstream(instreamPlayer:IInstreamPlayer, instreamDisplay:DisplayObject, plugin:IPlugin):void {
         _instreamPlayer = instreamPlayer;
         _instreamPlugin = plugin;
@@ -144,16 +121,11 @@ public class View extends Sprite {
             _instreamLayer.addChild(instreamDisplay);
         }
         _mediaLayer.visible = false;
-        _componentsLayer.visible = false;
 
-        try {
-            var pluginDO:DisplayObject = plugin as DisplayObject;
-            if (pluginDO) {
-                _pluginsLayer.removeChild(pluginDO);
-                _instreamLayer.addChild(pluginDO);
-            }
-        } catch (e:Error) {
-            Logger.log("Could not add instream plugin to display stack");
+        var pluginDisplay:DisplayObject = plugin as DisplayObject;
+        if (pluginDisplay && _pluginsLayer.contains(pluginDisplay)) {
+            _pluginsLayer.removeChild(pluginDisplay);
+            _instreamLayer.addChild(pluginDisplay);
         }
 
         _instreamMode = true;
@@ -164,7 +136,6 @@ public class View extends Sprite {
             _pluginsLayer.addChild(_instreamPlugin as DisplayObject);
         }
         _mediaLayer.visible = true;
-        _componentsLayer.visible = true;
 
         while (_instreamLayer.numChildren > 0) {
             _instreamLayer.removeChildAt(0);
@@ -181,12 +152,13 @@ public class View extends Sprite {
         var currentLayer:uint = 0;
 
         _mediaLayer = setupLayer("media", currentLayer++);
-        _componentsLayer = setupLayer("components", currentLayer++);
         _pluginsLayer = setupLayer("plugins", currentLayer++);
-        _instreamLayer = setupLayer("instream", currentLayer++);
+        _instreamLayer = setupLayer("instream", currentLayer);
+
+        _mediaLayer.mouseEnabled = false;
+        _mediaLayer.mouseChildren = false;
 
         _plugins = {};
-        _allPlugins = new Vector.<IPlugin>;
 
         _instreamLayer.visible = false;
     }
@@ -199,38 +171,36 @@ public class View extends Sprite {
     }
 
     protected function resizeMedia(width:Number, height:Number):void {
-        // Don't need to resize the media if width/height are 0 (i.e. player is hidden in the DOM)
-        if (width * height === 0) {
-            return;
-        }
         if (_mediaLayer.numChildren > 0 && _model.media.display) {
-            if (_preserveAspect) {
-                if (_model.fullscreen && _model.stretching === Stretcher.EXACTFIT) {
-                    _model.media.resize(_normalScreen.width, _normalScreen.height);
-                    Stretcher.stretch(_mediaLayer, width, height, Stretcher.UNIFORM);
-                } else {
-                    _model.media.resize(width, height);
-                    _mediaLayer.scaleX = _mediaLayer.scaleY = 1;
-                    _mediaLayer.x = _mediaLayer.y = 0;
-                }
+            var preserveAspect:Boolean = (_model.fullscreen && _model.stretching === Stretcher.EXACTFIT);
+            if (preserveAspect) {
+                _model.config.stretching = Stretcher.UNIFORM;
+                _model.media.resize(width, height);
+                _model.config.stretching = Stretcher.EXACTFIT;
             } else {
                 _model.media.resize(width, height);
-                _mediaLayer.x = _mediaLayer.y = 0;
             }
         }
     }
 
-    protected function resizeHandler(event:Event):void {
-        var width:Number = RootReference.stage.stageWidth;
-        var height:Number = RootReference.stage.stageHeight;
-        var fullscreen:Boolean = (RootReference.stage.displayState === StageDisplayState.FULL_SCREEN);
+    protected function resizePlugins(width:Number, height:Number):void {
+        for (var pluginId:String in _plugins) {
+            var plugin:IPlugin = _plugins[pluginId] as IPlugin;
+            if (plugin) {
+                plugin.resize(width, height);
+            }
+        }
+    }
 
-        if (_model.fullscreen !== fullscreen) {
-            _model.fullscreen = fullscreen;
-        }
-        if (width && height) {
-            redraw();
-        }
+    private function resizeInstream(width:Number, height:Number):void {
+        _instreamLayer.graphics.clear();
+        _instreamLayer.graphics.beginFill(0);
+        _instreamLayer.graphics.drawRect(0, 0, width, height);
+        _instreamLayer.graphics.endFill();
+    }
+
+    protected function resizeHandler(event:Event):void {
+        redraw();
     }
 
     protected function mediaLoaded(evt:MediaEvent):void {
@@ -241,7 +211,12 @@ public class View extends Sprite {
             }
             if (disp) {
                 _mediaLayer.addChild(disp);
-                resizeMedia(_model.width, _model.height);
+                var width:Number  = RootReference.stage.stageWidth;
+                var height:Number = RootReference.stage.stageHeight;
+                if (width * height === 0) {
+                    return;
+                }
+                resizeMedia(width, height);
             }
         }
     }

--- a/src/flash/com/longtailvideo/jwplayer/view/View.as
+++ b/src/flash/com/longtailvideo/jwplayer/view/View.as
@@ -13,6 +13,7 @@ import flash.display.Sprite;
 import flash.display.StageAlign;
 import flash.display.StageScaleMode;
 import flash.events.Event;
+import flash.events.MouseEvent;
 import flash.geom.Rectangle;
 
 public class View extends Sprite {
@@ -28,6 +29,7 @@ public class View extends Sprite {
     protected var _instreamPlayer:IInstreamPlayer;
     protected var _instreamMode:Boolean = false;
 
+    private static function noop():void {}
 
     public function View(model:Model) {
         _model = model;
@@ -37,7 +39,10 @@ public class View extends Sprite {
 
     public function setupView():void {
         RootReference.stage.scaleMode = StageScaleMode.NO_SCALE;
-        RootReference.stage.stage.align = StageAlign.TOP_LEFT;
+        RootReference.stage.align = StageAlign.TOP_LEFT;
+
+
+        RootReference.stage.addEventListener('rightClick', noop);
 
         RootReference.stage.addChildAt(this, 0);
 

--- a/src/js/providers/flash.js
+++ b/src/js/providers/flash.js
@@ -2,12 +2,11 @@ define([
     'utils/helpers',
     'utils/underscore',
     'events/events',
-    'utils/ui',
     'events/states',
     'utils/eventdispatcher',
     'utils/embedswf',
     'providers/default'
-], function(utils, _, events, UI, states, eventdispatcher, EmbedSwf, DefaultProvider) {
+], function(utils, _, events, states, eventdispatcher, EmbedSwf, DefaultProvider) {
 
     var _providerId = 0;
     function getObjectId(playerId) {
@@ -27,6 +26,7 @@ define([
         var _audioTracks = null;
         var _flashProviderType;
         var _attached = true;
+        var _fullscreen = false;
 
         var _ready = function() {
             return _swf && _swf.__ready;
@@ -152,6 +152,12 @@ define([
                         events.JWPLAYER_MEDIA_BUFFER_FULL
                     ];
 
+                    _swf.on('all', function(type, e) {
+                        if (!/time/i.test(type + (e && e.type))) {
+                            console.log('[fl]', type, e);
+                        }
+                    }, this);
+
                     // jwplayer 6 flash player events (forwarded from AS3 Player, Controller, Model)
                     _swf.on(events.JWPLAYER_MEDIA_LEVELS, function(e) {
                         _currentQuality = e.currentQuality;
@@ -197,24 +203,16 @@ define([
                             this.setState(states.COMPLETE);
                             this.sendEvent(e.type);
                         }
-                    }, this);
-
-                    _swf.on(events.JWPLAYER_MEDIA_SEEK, function(e) {
+                    }, this).on(events.JWPLAYER_MEDIA_SEEK, function(e) {
                         this.sendEvent(events.JWPLAYER_MEDIA_SEEK, e);
-                    }, this);
-
-                    _swf.on('visualQuality', function(e) {
+                    }, this).on('visualQuality', function(e) {
                         e.reason = e.reason || 'api'; // or 'user selected';
                         this.sendEvent('visualQuality', e);
                         this.sendEvent(events.JWPLAYER_PROVIDER_FIRST_FRAME, {});
-                    }, this);
-
-                    _swf.on(events.JWPLAYER_PROVIDER_CHANGED, function(e) {
+                    }, this).on(events.JWPLAYER_PROVIDER_CHANGED, function(e) {
                         _flashProviderType = e.message;
                         this.sendEvent(events.JWPLAYER_PROVIDER_CHANGED, e);
-                    }, this);
-
-                    _swf.on(events.JWPLAYER_ERROR, function(event) {
+                    }, this).on(events.JWPLAYER_ERROR, function(event) {
                         console.error(event.code, event.message, event, this);
                         this.sendEvent(events.JWPLAYER_MEDIA_ERROR, {
                             message: 'Error loading media: File could not be played'
@@ -236,11 +234,12 @@ define([
                 setControls: function() {
 
                 },
-                setFullscreen: function() {
-
+                setFullscreen: function(value) {
+                    _fullscreen = value;
+                    _flashCommand('fullscreen', value);
                 },
                 getFullScreen: function() {
-                    return false;
+                    return _fullscreen;
                 },
                 isAudioFile: function() {
                     if (_item) {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -649,6 +649,7 @@ define([
             }
 
             // If it supports DOM fullscreen
+            var provider = _model.getVideo();
             if (_elementSupportsFullscreen) {
                 if (state) {
                     _requestFullscreen.apply(_playerElement);
@@ -664,8 +665,13 @@ define([
                     if (_instreamModel && _instreamModel.getVideo()) {
                        _instreamModel.getVideo().setFullscreen(state);
                     }
-                   _model.getVideo().setFullscreen(state);
+                    provider.setFullscreen(state);
                 }
+            }
+            // pass fullscreen state to Flash provider
+            // provider.getName() is the same as _api.getProvider() or _model.get('provider')
+            if (provider && provider.getName().name.indexOf('flash') === 0) {
+                provider.setFullscreen(state);
             }
         };
 


### PR DESCRIPTION
Flash view was resizing both the media layer when in fullscreen with EXACTFIT or it's child media display object in all other cases. Scaling both parent and child easily led to bugs when the parent was not reset.

Now we only scale the media, and we've preserved the behavior of scaling using the UNIFORM method, when in fullscreen with the player configured to use EXACTFIT. For that to work, view.js send the Browser fullscreen state to Flash since we no longer use Flash stage fullscreen.