### PR TITLE
Click on ad skip button [Fixes #96852744]

### DIFF
--- a/src/css/imports/jwplayerelement.less
+++ b/src/css/imports/jwplayerelement.less
@@ -128,13 +128,13 @@
 }
 
 // Allow pointer events through to the provider
-.jw-preview, .jw-captions, .jw-title, .jw-overlays, .jw-controls, {
+.jw-preview, .jw-captions, .jw-title, .jw-overlays, .jw-controls {
     pointer-events : none;
 }
 
 // These items can intercept pointer-events
 .jw-overlays > div,
-.jw-media, .jw-controlbar, .jw-dock, .jw-logo, .jw-display-icon-container {
+.jw-media, .jw-controlbar, .jw-dock, .jw-logo, .jw-skip, .jw-display-icon-container {
     pointer-events: all;
 }
 


### PR DESCRIPTION
Activates pointer-events for the .jw-skip element, which allows the user to hit the skip button on ads.

This fixes the issue on my local machine using the current version of OS and Commercial.  Should work on develop once jenkins is fixed.

[Fixes #96852744]