### PR TITLE
Wrap api callbacks in try/catch

### DIFF
--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -51,7 +51,13 @@ define([
                 throw new TypeError('eval callbacks depricated');
             }
 
-            return Events.on.apply(_this, arguments);
+            var safeCallback = function() {
+                try {
+                    callback.apply(this, arguments);
+                } catch(e) {}
+            };
+
+            return Events.on.call(_this, name, safeCallback);
         };
 
         // Required by vast

--- a/src/js/utils/underscore.js
+++ b/src/js/utils/underscore.js
@@ -323,6 +323,14 @@ define([], function() {
     // often you call it. Useful for lazy initialization.
     _.once = _.partial(_.before, 2);
 
+    // Returns the first function passed as an argument to the second,
+    // allowing you to adjust arguments, run code before and after, and
+    // conditionally execute the original function.
+    _.wrap = function(func, wrapper) {
+        return _.partial(wrapper, func);
+    };
+
+
     // Memoize an expensive function by storing its results.
     _.memoize = function (func, hasher) {
         var memo = {};

--- a/src/js/utils/underscore.js
+++ b/src/js/utils/underscore.js
@@ -326,9 +326,9 @@ define([], function() {
     // Returns the first function passed as an argument to the second,
     // allowing you to adjust arguments, run code before and after, and
     // conditionally execute the original function.
-    _.wrap = function(func, wrapper) {
-        return _.partial(wrapper, func);
-    };
+    //_.wrap = function(func, wrapper) {
+    //    return _.partial(wrapper, func);
+    //};
 
 
     // Memoize an expensive function by storing its results.


### PR DESCRIPTION
This is a 6.x feature which ensures that if one callback
throws an error, the rest will continue working.

[Delivers #95439688]