### PR TITLE
Hide controls a set time after user activity

### DIFF
--- a/src/css/flags/audioplayer.less
+++ b/src/css/flags/audioplayer.less
@@ -1,4 +1,4 @@
-.jwplayer.jw-flag-audio-player {
+.jw-flag-audio-player {
     background-color: transparent;
 
     .jw-preview {
@@ -27,4 +27,8 @@
             display : none;
         }
     }
+}
+// This has higher specificity to overwrite jw-flag-user-inactive
+.jwplayer.jw-flag-audio-player .jw-controlbar {
+    display: table;
 }

--- a/src/css/flags/media-audio.less
+++ b/src/css/flags/media-audio.less
@@ -1,0 +1,4 @@
+// This has higher specificity to overwrite jw-flag-user-inactive
+.jwplayer.jw-flag-media-audio .jw-controlbar {
+    display: table;
+}

--- a/src/css/flags/user-inactive.less
+++ b/src/css/flags/user-inactive.less
@@ -1,11 +1,9 @@
-.jwplayer.jw-flag-user-inactive {
-    &.jw-state-playing {
-        .jw-controlbar, .jw-dock {
-            display : none;
-        }
+.jw-flag-user-inactive.jw-state-playing {
+      .jw-controlbar, .jw-dock {
+          display : none;
+      }
 
-        .jw-logo.jw-hide {
-            display : none;
-        }
-    }
+      .jw-logo.jw-hide {
+          display : none;
+      }
 }

--- a/src/css/jwplayer.less
+++ b/src/css/jwplayer.less
@@ -23,10 +23,10 @@
 @import "states/error.less";
 
 @import "flags/skinloading.less";
-@import "flags/audioplayer.less";
 @import "flags/fullscreen.less";
 @import "flags/live.less";
 @import "flags/user-inactive.less";
+@import "flags/audioplayer.less";
 @import "flags/ads.less";
 @import "flags/rightclick-open";
 

--- a/src/css/jwplayer.less
+++ b/src/css/jwplayer.less
@@ -27,6 +27,7 @@
 @import "flags/live.less";
 @import "flags/user-inactive.less";
 @import "flags/audioplayer.less";
+@import "flags/media-audio.less";
 @import "flags/ads.less";
 @import "flags/rightclick-open";
 

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -691,9 +691,7 @@ define([
         function _checkAudioMode(height) {
             _audioMode = _isAudioMode(height);
             if (_controlbar) {
-                if (_audioMode) {
-                    _showVideo(false);
-                } else {
+                if (!_audioMode) {
                     var model = _instreamMode ? _instreamModel : _model;
                     _updateState(model.get('state'));
                 }
@@ -853,11 +851,6 @@ define([
             _controlsTimeout = setTimeout(_userInactive, _timeoutDuration);
         }
 
-        function _showVideo(state) {
-            state = state && !_audioMode;
-            _model.getVideo().setVisibility(state);
-        }
-
         function _playlistCompleteHandler() {
             _replayState = true;
             _fullscreen(false);
@@ -870,6 +863,10 @@ define([
             if (_castDisplay) {
                 _castDisplay.setState(_model.get('state'));
             }
+
+            var isAudioFile = _isAudioFile();
+            utils.toggleClass(_playerElement, 'jw-flag-media-audio', isAudioFile);
+
             _model.mediaModel.on('change:isLive', function(model, isLive){
                 utils.toggleClass(_playerElement, 'jw-flag-live', isLive);
                 _this.setAltText((isLive) ? 'Live Broadcast' : '');
@@ -918,28 +915,17 @@ define([
             // player display
             switch (state) {
                 case states.PLAYING:
-                    _userActivity();
-                    if (_isAudioFile()) {
-                        _showVideo(false);
-                    } else {
-                        _showVideo(true);
-
-                        _resizeMedia();
-                    }
+                    _resizeMedia();
                     break;
                 case states.IDLE:
                 case states.ERROR:
                 case states.COMPLETE:
-                    _showVideo(false);
                     if (!_audioMode) {
                         _showDisplay();
                     }
                     break;
                 case states.BUFFERING:
                     _showDisplay();
-                    if (_isMobile) {
-                        _showVideo(true);
-                    }
                     break;
                 case states.PAUSED:
                     _userActivity();

--- a/test/manual/index.html
+++ b/test/manual/index.html
@@ -84,12 +84,6 @@
     };
 
     var jwp = jwplayer('video-container').setup(config);
-    jwp.on('all', function(name, e) {
-        console.log('Event:', name, e);
-        if (name !== e.type) {
-            console.error('Event name "'+name+'" does not match event.type "'+e.type+'"');
-        }
-    });
 
     jwp.addButton(
             'css-skins/icons/both.png',


### PR DESCRIPTION
This unites a few different strategies for hiding the controlbar into one.
Now it is hidden x seconds after the last user activity is recorded.
This fixes the use-case where the mouse would hover over the controlbar and slide
off of the player without hovering over the video element again.

[Delivers #96999912]