### PR TITLE
Hides native iOS play icon

### DIFF
--- a/src/css/imports/jwplayerelement.less
+++ b/src/css/imports/jwplayerelement.less
@@ -73,6 +73,11 @@
     height: 100%;
     margin: auto;
     background: transparent;
+
+    // Hides the native play button pseudoelement in iOS
+    &::-webkit-media-controls-start-playback-button {
+        display: none;
+    }
 }
 
 .jw-controls {


### PR DESCRIPTION
Hides native iOS play icon by adding a style to the pseudoelement in the video's shadow DOM.

[Finishes #96925084]