### PR TITLE
Restored player hover state for display icon container [#96678312]

### DIFF
--- a/src/css/imports/jwplayerelement.less
+++ b/src/css/imports/jwplayerelement.less
@@ -42,6 +42,13 @@
         outline: none;
     }
 
+    &:hover {
+        .jw-display-icon-container {
+            background-color: @display-bkgd-color;
+            background: @display-bkgd-color;
+            background-size: @display-bkgd-color
+        }
+    }
 }
 
 .jw-media, .jw-preview, .jw-overlays, .jw-controls {


### PR DESCRIPTION
Restored styles for .jwplayer:hover .jw-display-icon-container