### PR TITLE
No right click dragging, creates tap handler

### DIFF
--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -39,13 +39,16 @@ define([
         }
 
         function interactStartHandler(evt) {
+            var isMouseEvt = evt instanceof MouseEvent;
             _touchListenerTarget = evt.target;
 
             if(_enableDrag) {
-                if(_isDesktop){
-                    document.addEventListener('mousemove', interactDragHandler);
+                if(!isMouseEvt || (isMouseEvt && !isRightClick(evt))){
+                    if(_isDesktop){
+                        document.addEventListener('mousemove', interactDragHandler);
+                    }
+                    _touchListenerTarget.addEventListener('touchmove', interactDragHandler);
                 }
-                _touchListenerTarget.addEventListener('touchmove', interactDragHandler);
             }
 
             if(_isDesktop){

--- a/src/js/view/components/slider.js
+++ b/src/js/view/components/slider.js
@@ -14,6 +14,8 @@ define([
             this.dragMoveListener = this.dragMove.bind(this);
             this.dragEndListener = this.dragEnd.bind(this);
 
+            this.tapListener = this.tap.bind(this);
+
             this.setup();
         },
         setup : function() {
@@ -35,8 +37,7 @@ define([
             this.userInteract.on('drag', this.dragMoveListener);
             this.userInteract.on('dragEnd', this.dragEndListener);
 
-            this.userInteract.on('tap', this.dragMoveListener);
-            this.userInteract.on('click', this.dragMoveListener);
+            this.userInteract.on('tap click', this.tapListener);
         },
         dragStart : function() {
             this.trigger('dragStart');
@@ -48,7 +49,7 @@ define([
         },
         dragMove : function(evt) {
             var dimension,
-                bounds = (this.railBounds) ? this.railBounds : utils.bounds(this.elementRail),
+                bounds = this.railBounds = (this.railBounds) ? this.railBounds : utils.bounds(this.elementRail),
                 percentage;
 
             if (this.orientation === 'horizontal'){
@@ -75,6 +76,10 @@ define([
             this.update(percentage);
 
             return false;
+        },
+        tap : function(evt){
+            this.railBounds = utils.bounds(this.elementRail);
+            this.dragMove(evt);
         },
 
         update : function(percentage) {


### PR DESCRIPTION
Prevents the user from scrubbing using a right click. This also creates a specific handler for tap/click actions. This solves the issue by ensuring the correct rail bounds are set via the handler before firing the drag handler.

[Fixes #97035132]