### PR TITLE
Use player semver repo url

### DIFF
--- a/src/js/utils/helpers.js
+++ b/src/js/utils/helpers.js
@@ -6,9 +6,6 @@ define([
     'version'
 ], function(Constants, strings, _, jqueryfuncs, version) {
 
-    // TODO:: the next lines are a holdover until we update our CDN w/ plugins for 7.0
-    var cdnVersion = '6.12.0';
-
     var utils = {};
 
     /**
@@ -330,14 +327,11 @@ define([
 
     /** Gets the repository location **/
     utils.repo = function () {
-        var repo = 'http://p.jwpcdn.com/' + cdnVersion.split(/\W/).splice(0, 2).join('/') + '/';
-
-        utils.tryCatch(function() {
-            if (_isHTTPS()) {
-                repo = repo.replace('http://', 'https://ssl.');
-            }
-        });
-
+        var semver = version.split('+')[0];
+        var repo = 'http://p.jwpcdn.com/player/v/' + semver + '/';
+        if (_isHTTPS()) {
+            return repo.replace('http://', 'https://ssl.');
+        }
         return repo;
     };
 


### PR DESCRIPTION
Each version of the player needs to know where it can download plugins from. The player will pull plugins from a url that contains the specific release version of the player.

The next release build which will be tagged 7.0.0-rc.2. With this change, the player will attempt to load plugins from:

http://p.jwpcdn.com/player/v/7.0.0-rc.2/{plugin-filename}
