### PR TITLE
Remove skipButton before recreating it

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -138,6 +138,9 @@ define([
             this.addClickHandler();
 
             if (_options.skipoffset) {
+                if (this._skipButton) {
+                    this._skipButton.destroy();
+                }
                 this._skipButton = new AdSkipButton(_options.skipMessage, _options.skipText);
                 this._skipButton.on(events.JWPLAYER_AD_SKIPPED, this.skipAd, this);
                 this._skipButton.setWaitTime(_options.skipoffset);


### PR DESCRIPTION
This fixes a bug with ad pods, where the new skipButton was created above the previous one,
instead of removing the old one.

[Delivers #97299612]