### PR TITLE
Model contains 'captionsList' not 'captions'

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -185,14 +185,11 @@ define([
                     index: _model.get('item'),
                     item: _model.get('playlistItem')
                 });
-
-                // Only dispatch captionsList event when there are captions tracks
-                if (_model.get('captions')) {
-                    _this.trigger(events.JWPLAYER_CAPTIONS_LIST, {
-                        tracks: _model.get('captions'),
-                        track: _model.get('captionsIndex')
-                    });
-                }
+                
+                _this.trigger(events.JWPLAYER_CAPTIONS_LIST, {
+                    tracks: _model.get('captionsList'),
+                    track: _model.get('captionsIndex')
+                });
 
                 if (_model.get('autostart') && !utils.isMobile()) {
                     _play();


### PR DESCRIPTION
Closing the loop on this captions issue from Friday. When the player is ready, we were expecting the list of captions to be in model.captions but it is in model.captionsList.

[Delivers #97426820]