### PR TITLE
CSS-skins bug fixes

### DIFF
--- a/src/css/skins/seven.less
+++ b/src/css/skins/seven.less
@@ -227,6 +227,7 @@
     .jw-dock {
         .jw-dock-button {
             border-radius: 50%;
+            border: 1px solid #666;
         }
         .jw-overlay {
             border-radius: 2.5em;
@@ -263,7 +264,7 @@
     /* Position of remaining overlay containers */
     .jw-menu,
     .jw-volume-tip {
-        bottom: .15em;
+        bottom: .24em;
     }
     
     /* Skip icon and text styles */

--- a/src/css/skins/stormtrooper.less
+++ b/src/css/skins/stormtrooper.less
@@ -87,10 +87,6 @@
     }
     
     /* Rail/slider styles */
-    .jw-slider-container {
-        height: 1em;
-    }
-
     .jw-rail,
     .jw-buffer,
     .jw-progress,


### PR DESCRIPTION
Removed unnecessary height declaration for Stormtrooper slider containers
Adjusted bottom value for Seven menus, added a grey border around the dock buttons