### PR TITLE
Instream should not trigger play and pause events [Delivers #97561262]

### DIFF
--- a/src/flash/com/longtailvideo/jwplayer/player/InstreamPlayer.as
+++ b/src/flash/com/longtailvideo/jwplayer/player/InstreamPlayer.as
@@ -69,7 +69,7 @@ public class InstreamPlayer extends Sprite {
     }
 
     public function pause():Boolean {
-        if (_provider && _provider.state == PlayerState.PLAYING || PlayerState.isBuffering(_provider.state)) {
+        if (_provider && (_provider.state == PlayerState.PLAYING || PlayerState.isBuffering(_provider.state))) {
             _provider.pause();
         }
         return true;

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -53,6 +53,9 @@ define([
             _instream.on(events.JWPLAYER_MEDIA_COMPLETE, _instreamItemComplete, this);
             _instream.init();
 
+            // Make sure the original player's provider stops broadcasting events (pseudo-lock...)
+            _oldProvider.detachMedia();
+
             if (_controller.checkBeforePlay() || (_oldpos === 0 && !_oldProvider.checkComplete())) {
                 // make sure video restarts after preroll
                 _oldpos = 0;
@@ -70,8 +73,6 @@ define([
                 // pause must be called before detachMedia
                 _oldProvider.pause();
             }
-            // Make sure the original player's provider stops broadcasting events (pseudo-lock...)
-            _oldProvider.detachMedia();
 
             // Show instream state instead of normal player state
             _view.setupInstream(_instream._adModel);

--- a/src/js/controller/instream-flash.js
+++ b/src/js/controller/instream-flash.js
@@ -32,11 +32,9 @@ define([
                 switch (evt.newstate) {
                     case states.PLAYING:
                         this.trigger('play');
-                        this.model.set('state', evt.newstate);
                         this._adModel.set('state', evt.newstate);
                         break;
                     case states.PAUSED:
-                        this.model.set('state', evt.newstate);
                         this._adModel.set('state', evt.newstate);
                         break;
                 }

--- a/src/js/controller/instream-html5.js
+++ b/src/js/controller/instream-html5.js
@@ -55,7 +55,7 @@ define([
                 return;
             }
 
-            _adModel.off('fullscreenchange', _nativeFullscreenHandler);
+            _adModel.off();
 
             // We don't want the instream provider to be attached to the video tag anymore
             _this.off();
@@ -64,7 +64,6 @@ define([
                 _currentProvider.resetEventListeners();
                 _currentProvider.destroy();
             }
-            _adModel.off();
 
             // Return the view to its normal state
             _adModel = null;
@@ -118,11 +117,9 @@ define([
         function stateHandler(evt) {
             switch (evt.newstate) {
                 case states.PLAYING:
-                    _model.set('state', evt.newstate);
                     _adModel.set('state', evt.newstate);
                     break;
                 case states.PAUSED:
-                    _model.set('state', evt.newstate);
                     _adModel.set('state', evt.newstate);
                     break;
             }

--- a/src/js/providers/flash.js
+++ b/src/js/providers/flash.js
@@ -288,6 +288,14 @@ define([
                     _eventDispatcher = null;
                 }
         });
+
+        // Overwrite the event dispatchers to block on certain occasions
+        this.sendEvent = function() {
+            if (!_attached) {
+                return;
+            }
+            _eventDispatcher.sendEvent.apply(this, arguments);
+        };
     }
 
 

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -115,7 +115,7 @@ define([
             // Last sent buffer amount
             _bufferPercent = -1,
             // Whether or not we're listening to video tag events
-            _attached = false,
+            _attached = true,
             // Quality levels
             _levels,
             // Current quality level index
@@ -128,8 +128,9 @@ define([
 
         // Overwrite the event dispatchers to block on certain occasions
         this.sendEvent = function() {
-            if (!_attached) { return; }
-
+            if (!_attached) {
+                return;
+            }
             _dispatcher.sendEvent.apply(this, arguments);
         };
 
@@ -152,9 +153,6 @@ define([
         // Enable AirPlay
         _videotag.setAttribute('x-webkit-airplay', 'allow');
         _videotag.setAttribute('webkit-playsinline', '');
-
-
-        _attached = true;
 
         function _onClickHandler(evt) {
             _this.sendEvent('click', evt);

--- a/src/js/view/adskipbutton.js
+++ b/src/js/view/adskipbutton.js
@@ -99,9 +99,10 @@ define([
         destroy : function() {
             if (this.el) {
                 this.el.removeEventListener('click', this.skipAdOnce);
-                this.el.parentElement.removeChild(this.el);
+                if (this.el.parentElement) {
+                    this.el.parentElement.removeChild(this.el);
+                }
             }
-
             delete this.skippable;
             delete this.itemDuration;
             delete this.waitPercentage;

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -323,8 +323,8 @@ define([
             }
 
             _model.on('change:controls', _onChangeControls);
-
             _model.on('change:state', _stateHandler);
+
             _model.mediaController.on(events.JWPLAYER_MEDIA_ERROR, _errorHandler);
             _api.onPlaylistComplete(_playlistCompleteHandler);
             _api.onPlaylistItem(_playlistItemHandler);
@@ -940,7 +940,9 @@ define([
 
         this.setupInstream = function(instreamModel) {
             _instreamModel = instreamModel;
-            _instreamModel.on('change:controls', _onChangeControls);
+            _instreamModel.on('change:controls', _onChangeControls, this);
+            _instreamModel.on('change:state', _stateHandler, this);
+
             _instreamMode = true;
             utils.addClass(_playerElement, 'jw-flag-ads');
             // don't trigger api play/pause on display click
@@ -957,6 +959,10 @@ define([
 
         this.destroyInstream = function() {
             _instreamMode = false;
+            if (_instreamModel) {
+                _instreamModel.off(null, null, this);
+                _instreamModel = null;
+            }
             this.setAltText('');
             utils.removeClass(_playerElement, 'jw-flag-ads');
             utils.removeClass(_playerElement, 'jw-flag-ads-hide-controls');


### PR DESCRIPTION
- fix nullp in InstreamPlayer.as pause()
- detachMedia before media provider is paused
- instream players should not set player model state, causing play & plause api events to be fired
- flash provider should not dispatch events when detached
- view listens to instream model for state events in instream mode