### PR TITLE
Reset position and duration when loading video [Delivers #97588488 #97586798]

### DIFF
--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -291,6 +291,8 @@ define([
                 var idx = this.get('item');
                 item = this.get('playlist')[idx];
             }
+            this.set('position', item.starttime || 0);
+            this.set('duration', item.duration || 0);
             _provider.load(item);
         };
 


### PR DESCRIPTION
When loading a new playlist item, or resuming playback after an ad, position and duration should be reset.

This fixes an issue on iPad where replaying or going to playlist item 2, with a preroll would leave the model position at 33 seconds (duration of the previous item). As a result of the model not having it's position reset, after the preroll, all ads scheduled up to that time would be triggered and the content would not have a chance to play.

Using item starttime and duration also provides a more seemless transition in the control bar between ads and the main content.