### PR TITLE
Don't execute command queue until plugins are loaded

### DIFF
--- a/src/flash/com/longtailvideo/jwplayer/player/Player.as
+++ b/src/flash/com/longtailvideo/jwplayer/player/Player.as
@@ -43,7 +43,6 @@ public class Player extends Sprite implements IPlayer {
         _controller.addEventListener(PlayerEvent.JWPLAYER_READY, playerReady, false, -1);
         _controller.addEventListener(PlayerEvent.JWPLAYER_SETUP_ERROR, setupError, false, -1);
 
-
         _controller.runSetupInterface();
     }
 
@@ -163,20 +162,23 @@ public class Player extends Sprite implements IPlayer {
     }
 
     protected function setupPlayer(config:Object):void {
-        var commands:Array = config.commands as Array;
-        delete config.commands;
         delete config.playlist;
 
         _model.setConfig(config);
 
         // do it a second time
         _controller.runSetupPlugins(function():void {
-            // run this once setup is complete (plugins are loaded)
-            for (var i:uint = 0; i < commands.length; i++) {
-                var args:Array = commands[i] as Array;
-                SwfEventRouter.trigger(args);
-            }
+            SwfEventRouter.triggerJsEvent('pluginsLoaded');
         });
+    }
+
+    protected function setupPlayerCommandQueue(commands:Array) {
+        // run this once setup is complete (plugins are loaded)
+        trace('setup player command queue');
+        for (var i:uint = 0; i < commands.length; i++) {
+            var args:Array = commands[i] as Array;
+            SwfEventRouter.trigger(args);
+        }
     }
 
     protected function stretch(stretch:String = null):void {
@@ -208,6 +210,7 @@ public class Player extends Sprite implements IPlayer {
         // listen to JavaScript for player commands
         SwfEventRouter.off()
                 .on('setup', setupPlayer)
+                .on('setupCommandQueue', setupPlayerCommandQueue)
                 .on('load', load)
                 .on('play', play)
                 .on('pause', pause)

--- a/src/js/providers/flash.js
+++ b/src/js/providers/flash.js
@@ -122,12 +122,17 @@ define([
 
                     // listen to events triggered from flash
                     _swf.once('ready', function() {
-                        // setup flash player
-                        var config = _.extend({
-                            commands: _swf.__commandQueue
-                        }, _playerConfig);
 
+                        // After plugins load, then execute commandqueue
+                        _swf.once('pluginsLoaded', function() {
+                            _swf.queueCommands = false;
+                            _flashCommand('setupCommandQueue', _swf.__commandQueue);
+                        });
+
+                        // setup flash player
+                        var config = _.extend({}, _playerConfig);
                         _flashCommand('setup', config);
+
                         _swf.__ready = true;
                         _swf.__commandQueue = [];
 

--- a/src/js/utils/embedswf.js
+++ b/src/js/utils/embedswf.js
@@ -72,10 +72,11 @@ define([
         // flash can trigger events
         _.extend(swf, Events);
 
+        swf.queueCommands = true;
         // javascript can trigger SwfEventRouter callbacks
         swf.triggerFlash = function(name) {
             var swfInstance = this;
-            if (!swfInstance.__externalCall) {
+            if (name !== 'setup' && swfInstance.queueCommands) {
                 var commandQueue = swfInstance.__commandQueue;
                 // remove any earlier commands with the same name
                 for (var i = commandQueue.length; i--;) {


### PR DESCRIPTION
This fixes a bug where plugins were calling flash commands before they were fully loaded.

The trick is to allow the flash players "setup" command to continue without queueing and then have every other command wait to execute until the "pluginsReady" event fires.