### PR TITLE
Set Controls to hide on initial user interaction, toggles afterwards

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -403,10 +403,17 @@ define([
         }
 
         function _touchHandler() {
-            if(_model.get('state') === states.IDLE && _model.get('controls')) {
+            if( (_model.get('state') === states.IDLE || _model.get('state') === states.COMPLETE) &&
+                _model.get('controls')) {
                 _api.play();
             }
-            _userActivity();
+
+            // Toggle visibility of the controls when clicking the media or play icon
+            if(!_showing) {
+                _userActivity();
+            } else {
+                _userInactive();
+            }
         }
 
         function _logoClickHandler(evt){
@@ -466,9 +473,13 @@ define([
             
             var displayIcon = new DisplayIcon(_model);
             //toggle playback
-            displayIcon.on('click tap', function() {
+            displayIcon.on('click', function() {
                 forward({type : events.JWPLAYER_DISPLAY_CLICK});
                 _api.play();
+            });
+            displayIcon.on('tap', function() {
+                forward({type : events.JWPLAYER_DISPLAY_CLICK});
+                _touchHandler();
             });
             _controlsLayer.appendChild(displayIcon.element());
 
@@ -842,6 +853,7 @@ define([
         function _userInactive() {
             _showing = false;
 
+            clearTimeout(_controlsTimeout);
             utils.addClass(_playerElement, 'jw-flag-user-inactive');
         }
 


### PR DESCRIPTION
Changes which make the tapping the display icon and the background work identically.  When either are tapped, we toggle the controls display via _userActivity() and _userInactive().  _userInactive clears the _controlsTimeout now to ensure the timeout gets cleared if the user taps the player to toggle control visibility.

[Delivers #97568192]