### PR TITLE
Enable autostart from API load

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -191,7 +191,7 @@ define([
                     track: _model.get('captionsIndex')
                 });
 
-                if (_model.get('autostart') && !utils.isMobile()) {
+                if (_model.get('autostart')) {
                     _play();
                 }
 
@@ -205,6 +205,10 @@ define([
 
             function _load(item) {
                 _stop(true);
+
+                if (_model.get('autostart')) {
+                    _model.once('setItem', _play);
+                }
 
                 switch (typeof item) {
                     case 'string':
@@ -280,6 +284,9 @@ define([
             }
 
             function _stop(internal) {
+                // Reset the autostart play
+                _model.off('setItem', _play);
+
                 var fromApi = !internal;
 
                 _actionOnAttach = null;

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -65,6 +65,11 @@ define([
                 buffer: 0
             });
 
+            // Mobile doesn't support autostart
+            if (utils.isMobile()) {
+                this.autostart = false;
+            }
+
             this.updateProviders();
 
             return this;


### PR DESCRIPTION
This feature was present in JW 6 when using flash mode. After loading a new file or playlist
from the API, it will autoplay when the config was set to autoplay.

[Delivers #97659106]