### PR TITLE
Controlbar fades on desktop. Doesn't fade on mobile.

### DIFF
--- a/src/css/flags/ads.less
+++ b/src/css/flags/ads.less
@@ -5,8 +5,6 @@
     }
 
     .jw-controlbar {
-        display: table;
-
         .jw-icon-inline,
         .jw-icon-tooltip,
         .jw-text,
@@ -38,6 +36,12 @@
 
 .jwplayer.jw-flag-ads-hide-controls {
     .jw-controls {
-      display : none !important;
+        display : none !important;
+    }
+}
+
+.jwplayer.jw-flag-ads-mobile {
+    .jw-controlbar {
+        display: table;
     }
 }

--- a/src/css/flags/ads.less
+++ b/src/css/flags/ads.less
@@ -40,7 +40,7 @@
     }
 }
 
-.jwplayer.jw-flag-ads-mobile {
+.jwplayer.jw-flag-ads.jw-flag-touch-screen {
     .jw-controlbar {
         display: table;
     }

--- a/src/css/flags/user-inactive.less
+++ b/src/css/flags/user-inactive.less
@@ -1,5 +1,6 @@
 .jw-flag-user-inactive.jw-state-playing {
-      .jw-controlbar, .jw-dock {
+      .jw-controlbar,
+      .jw-dock {
           display : none;
       }
 

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -396,7 +396,7 @@ define([
         }
 
         function _componentFadeListeners(comp) {
-            if (comp) {
+            if (comp && !_isMobile) {
                 comp.element().addEventListener('mousemove', _overControlElement, false);
                 comp.element().addEventListener('mouseout', _offControlElement, false);
             }
@@ -960,6 +960,12 @@ define([
             utils.addClass(_playerElement, 'jw-flag-ads');
             // don't trigger api play/pause on display click
             _displayClickHandler.setAlternateClickHandlers(utils.noop, _api.setFullscreen);
+
+            // trigger _userActivity to display the UI temporarily for the start of the ad
+            _userActivity();
+            if(_isMobile) {
+                utils.addClass(_playerElement, 'jw-flag-ads-mobile');
+            }
         };
 
         this.setAltText = function(text) {
@@ -978,6 +984,7 @@ define([
             }
             this.setAltText('');
             utils.removeClass(_playerElement, 'jw-flag-ads');
+            utils.removeClass(_playerElement, 'jw-flag-ads-mobile');
             utils.removeClass(_playerElement, 'jw-flag-ads-hide-controls');
             if (_model.getVideo) {
                 var provider = _model.getVideo();

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -388,7 +388,7 @@ define([
             }, 0);
         };
 
-        function _onStretchChange (model, newVal, oldVal) {
+        function _onStretchChange(model, newVal, oldVal) {
             if(oldVal){
                 utils.removeClass(_playerElement, 'jw-stretch-' + oldVal);
             }
@@ -502,9 +502,10 @@ define([
 
             // captions should be place behind controls, and not hidden when controls are hidden
             _controlsLayer.parentNode.insertBefore(_captionsRenderer.element(), _title.element());
-
-
-            if (!_isMobile) {
+            
+            if (_isMobile) {
+                utils.addClass(_playerElement, 'jw-flag-touch-screen');
+            } else {
                 _rightClickMenu = new RightClick();
                 _rightClickMenu.setup(_model, _playerElement, _playerElement);
             }
@@ -963,9 +964,6 @@ define([
 
             // trigger _userActivity to display the UI temporarily for the start of the ad
             _userActivity();
-            if(_isMobile) {
-                utils.addClass(_playerElement, 'jw-flag-ads-mobile');
-            }
         };
 
         this.setAltText = function(text) {
@@ -984,7 +982,6 @@ define([
             }
             this.setAltText('');
             utils.removeClass(_playerElement, 'jw-flag-ads');
-            utils.removeClass(_playerElement, 'jw-flag-ads-mobile');
             utils.removeClass(_playerElement, 'jw-flag-ads-hide-controls');
             if (_model.getVideo) {
                 var provider = _model.getVideo();


### PR DESCRIPTION
Removes the display: table; on the jw-flag-ads since it was preventing the controller from naturally being removed when jw-flag-user-inactive was applied.  It was previously there to ensure that the control bar was displayed when we calculate the position of the ad skip button, but that is now the responsibility of the skin.
added a flag for mobile that will make sure that the control bar is displayed during ads.  this flag toggles on and off when its mobile and we're entering instream mode.  _userActivity fired at the beginning of instream mode so that the user can see the new controller state and know its an ad.
!isMobile is added to _componentFadeListeners as we aren't concerned about adding mouse listeners on mobile and it caused a rare issue if the user clicks the control bar a lot during an ad where the control bar wouldn't fade away.

[Finishes #97402648]