### PR TITLE
Put InstreamPlayer between media and plugins layer [Delivers #97578138]

### DIFF
--- a/src/flash/com/longtailvideo/jwplayer/player/InstreamPlayer.as
+++ b/src/flash/com/longtailvideo/jwplayer/player/InstreamPlayer.as
@@ -44,11 +44,20 @@ public class InstreamPlayer extends Sprite {
 
         lock(_plugin, _lockCallback);
 
+        this.mouseEnabled = false;
+        this.mouseChildren = false;
+
         _mediaLayer = new Sprite();
         _mediaLayer.visible = false;
         this.addChild(_mediaLayer);
 
-        _setupView();
+        CONFIG::debugging {
+            this.name = 'instreamPlayer';
+            _mediaLayer.name = 'instreamMedia';
+        }
+
+        // Put Instream on top of media layer, under plugins layer
+        _view.addChildAt(this, 1);
 
         RootReference.stage.addEventListener(Event.RESIZE, resizeHandler);
     }
@@ -59,7 +68,6 @@ public class InstreamPlayer extends Sprite {
     }
 
     public function play():Boolean {
-        _setupView();
         if (_provider) {
             if (_provider.state == PlayerState.PLAYING || PlayerState.isBuffering(_provider.state)) {
                 _provider.pause();
@@ -126,10 +134,6 @@ public class InstreamPlayer extends Sprite {
             message: 'Unsupported Instream Format; only video or rtmp are currently supported'
         });
         return null;
-    }
-
-    private function _setupView():void {
-        _view.addChild(this);
     }
 
     public function _destroyFromJS():void {

--- a/src/flash/com/longtailvideo/jwplayer/player/Player.as
+++ b/src/flash/com/longtailvideo/jwplayer/player/Player.as
@@ -34,10 +34,12 @@ public class Player extends Sprite implements IPlayer {
         this.tabEnabled = false;
         this.tabChildren = false;
         this.focusRect = false;
+        this.buttonMode = true;
 
         _model = newModel(new PlayerConfig(this.soundTransform));
 
         _view = newView(_model);
+        this.addChild(_view);
 
         _controller = newController(_model, _view);
         _controller.addEventListener(PlayerEvent.JWPLAYER_READY, playerReady, false, -1);

--- a/src/flash/com/longtailvideo/jwplayer/view/View.as
+++ b/src/flash/com/longtailvideo/jwplayer/view/View.as
@@ -26,9 +26,21 @@ public class View extends Sprite {
     private static function rightClickHandler(e:Event):void {}
 
     public function View(model:Model) {
+        _plugins = {};
+
         _model = model;
         _model.addEventListener(MediaEvent.JWPLAYER_MEDIA_LOADED, mediaLoaded);
-        setupLayers();
+
+        _mediaLayer = new Sprite();
+        _pluginsLayer = new Sprite();
+
+        this.addChild(_mediaLayer);
+        this.addChild(_pluginsLayer);
+
+        CONFIG::debugging {
+            _mediaLayer.name = 'media';
+            _pluginsLayer.name = 'plugins';
+        }
     }
 
     public function setupView():void {
@@ -36,7 +48,6 @@ public class View extends Sprite {
         RootReference.stage.align = StageAlign.TOP_LEFT;
         RootReference.stage.addEventListener('rightClick', rightClickHandler);
         RootReference.stage.addEventListener(Event.RESIZE, resizeHandler);
-        RootReference.stage.addChildAt(this, 0);
         redraw();
     }
 
@@ -104,21 +115,6 @@ public class View extends Sprite {
 
     public function getPlugin(id:String):IPlugin6 {
         return _plugins[id] as IPlugin6;
-    }
-
-    private function setupLayers():void {
-        _mediaLayer = new Sprite();
-        _mediaLayer.name = 'media';
-        this.addChild(_mediaLayer);
-
-        _pluginsLayer = new Sprite();
-        _pluginsLayer.name = 'plugins';
-        this.addChild(_pluginsLayer);
-
-        _mediaLayer.mouseEnabled = false;
-        _mediaLayer.mouseChildren = false;
-
-        _plugins = {};
     }
 
     private function resizeMedia(width:Number, height:Number):void {

--- a/src/js/view/clickhandler.js
+++ b/src/js/view/clickhandler.js
@@ -2,9 +2,8 @@ define([
     'utils/ui',
     'events/events',
     'utils/backbone.events',
-    'events/states',
     'utils/underscore'
-], function(UI, events, Events, states, _) {
+], function(UI, events, Events, _) {
     var ClickHandler = function(_model, _ele) {
         var _display,
             _alternateClickHandler,
@@ -42,10 +41,9 @@ define([
             _this.trigger('doubleClick');
         }
 
-        /** NOT SUPPORTED : Using this for now to hack around instream API **/
         this.setAlternateClickHandlers = function(clickHandler, doubleClickHandler) {
             _alternateClickHandler = clickHandler;
-            _alternateDoubleClickHandler = doubleClickHandler;
+            _alternateDoubleClickHandler = doubleClickHandler || null;
         };
 
         this.revertAlternateClickHandlers = function() {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -958,8 +958,6 @@ define([
 
             _instreamMode = true;
             utils.addClass(_playerElement, 'jw-flag-ads');
-            // don't trigger api play/pause on display click
-            _displayClickHandler.setAlternateClickHandlers(utils.noop, _api.setFullscreen);
         };
 
         this.setAltText = function(text) {


### PR DESCRIPTION
@chazmatazz InstreamPlayer was intercepting clicks in Flash. Fix was to add it under the plugins layer (InstreamPlayer:line 60). Had to put some click handlers in Flash, name sprites and the get MonsterDebugger to get the full picture.