### PR TITLE
Bugfix for mute during instream

### DIFF
--- a/src/flash/com/longtailvideo/jwplayer/player/InstreamPlayer.as
+++ b/src/flash/com/longtailvideo/jwplayer/player/InstreamPlayer.as
@@ -29,8 +29,6 @@ public class InstreamPlayer extends Sprite {
     protected var _plugin:IPlugin;
     protected var _mediaLayer:Sprite;
 
-    private var _lastVolume:Number;
-
     public function InstreamPlayer(target:IPlugin, model:Model, view:View, controller:Controller) {
 
         _plugin = target;
@@ -147,19 +145,14 @@ public class InstreamPlayer extends Sprite {
     }
 
     public function setVolume(volume:Number):void {
-        _lastVolume = volume;
         if (_provider) {
             _provider.setVolume(volume);
         }
     }
 
     public function setMute(bool:Boolean):void {
-        if (_provider) {
-            if (bool) {
-                _provider.setVolume(0);
-            } else {
-                _provider.setVolume(_lastVolume);
-            }
+        if (bool && _provider) {
+            _provider.setVolume(0);
         }
     }
 

--- a/src/flash/com/longtailvideo/jwplayer/player/Player.as
+++ b/src/flash/com/longtailvideo/jwplayer/player/Player.as
@@ -82,14 +82,17 @@ public class Player extends Sprite implements IPlayer {
         if (_instream) {
             _instream.setVolume(volume);
         }
+
         return _controller.setVolume(volume);
     }
 
     public function mute(muted:Boolean):void {
+        // Set the models value, and update video provider
+        _controller.mute(muted);
+
         if (_instream) {
             _instream.setMute(muted);
         }
-        _controller.mute(muted);
     }
 
     public function play():Boolean {


### PR DESCRIPTION
This was fixed by following the strategy used in Model.as for the setter of "mute"

[Delivers #98110622]