### PR TITLE
Close play only when a menu item is selected [Delivers #98119168]

### DIFF
--- a/src/js/utils/helpers.js
+++ b/src/js/utils/helpers.js
@@ -594,6 +594,14 @@ define([
         return val;
     };
 
+    utils.classList = function(element) {
+        if(element.classList) {
+            return element.classList;
+        } else {
+            return element.className.split(' ');
+        }
+    };
+
     utils.hasClass = jqueryfuncs.hasClass;
 
     utils.addClass = function (element, classes) {

--- a/src/js/view/components/menu.js
+++ b/src/js/view/components/menu.js
@@ -53,7 +53,7 @@ define([
         },
         select: function (evt) {
             if(evt.target.parentElement === this.content) {
-                var classes = evt.target.classList;
+                var classes = utils.classList(evt.target);
                 // find the class with a name of the form 'item-1'
                 var item = _.find(classes, function(c) { return c.indexOf('item') === 0;});
                 this.trigger('select', parseInt(item.split('-')[1]));

--- a/src/js/view/components/playlist.js
+++ b/src/js/view/components/playlist.js
@@ -54,19 +54,22 @@ define([
 
         onSelect: function(evt) {
             var elem = evt.target;
-            if(elem.tagName !== 'UL') {
+            if(elem.tagName === 'UL'){
+                // skip if the target is not a menu option
+                return;
+            } else if(elem.tagName !== 'LI') {
                 // some menus have an extra level of nesting, this normalizes that
                 elem = elem.parentElement;
             }
 
-            var classes = elem.classList;
+            var classes = utils.classList(elem);
             // find the class with a name of the form 'item-1'
             var item = _.find(classes, function(c) { return c.indexOf('item') === 0;});
             if (item) {
                 this.trigger('select', parseInt(item.split('-')[1]));
+                // Only close the tooltip if we are selecting an options
+                this.closeTooltip();
             }
-
-            this.closeTooltip();
         },
 
         selectItem : function(item) {


### PR DESCRIPTION
Closes the playlist only when one of the menu items are selected.  Adds some optimization to end the function of the target element is the UL (usually when the user is scrolling by dragging the control bar) and removed the usage of element.classList from menu.js and playlist.js since it requires a shim to work in all browsers.

[Delivers #98119168]