### PR TITLE
Renamed classes for menu items for safety

### DIFF
--- a/src/js/view/components/menu.js
+++ b/src/js/view/components/menu.js
@@ -54,10 +54,12 @@ define([
         select: function (evt) {
             if(evt.target.parentElement === this.content) {
                 var classes = utils.classList(evt.target);
-                // find the class with a name of the form 'item-1'
-                var item = _.find(classes, function(c) { return c.indexOf('item') === 0;});
-                this.trigger('select', parseInt(item.split('-')[1]));
-                this.closeTooltipListener();
+                // find the class with a name of the form 'jw-item-1'
+                var item = _.find(classes, function(c) { return c.indexOf('jw-item') === 0;});
+                if(item){
+                    this.trigger('select', parseInt(item.split('-')[2]));
+                    this.closeTooltipListener();
+                }
             }
         },
         selectItem : function(selectedIndex) {

--- a/src/js/view/components/playlist.js
+++ b/src/js/view/components/playlist.js
@@ -63,10 +63,10 @@ define([
             }
 
             var classes = utils.classList(elem);
-            // find the class with a name of the form 'item-1'
-            var item = _.find(classes, function(c) { return c.indexOf('item') === 0;});
+            // find the class with a name of the form 'jw-item-1'
+            var item = _.find(classes, function(c) { return c.indexOf('jw-item') === 0;});
             if (item) {
-                this.trigger('select', parseInt(item.split('-')[1]));
+                this.trigger('select', parseInt(item.split('-')[2]));
                 // Only close the tooltip if we are selecting an options
                 this.closeTooltip();
             }

--- a/src/templates/menu.html
+++ b/src/templates/menu.html
@@ -1,5 +1,5 @@
 <ul class="jw-menu jw-background-color jw-reset">
     {{#each this}}
-        <li class='jw-text jw-option item-{{@index}} jw-reset'>{{this.label}}</li>
+        <li class='jw-text jw-option jw-item-{{@index}} jw-reset'>{{this.label}}</li>
     {{/each}}
 </ul>

--- a/src/templates/playlist.html
+++ b/src/templates/playlist.html
@@ -12,12 +12,12 @@
     <ul class="jw-playlist jw-reset">
         {{#each this}}
             {{#if this.active}}
-                <li class='jw-option jw-text jw-active-option  item-{{@index}} jw-reset'>
+                <li class='jw-option jw-text jw-active-option jw-item-{{@index}} jw-reset'>
                     <span class="jw-label jw-reset"><span class="jw-icon jw-icon-play jw-reset"></span></span>
                     <span class="jw-name jw-reset">{{this.title}}</span>
                 </li>
             {{else}}
-                <li class='jw-option jw-text item-{{@index}} jw-reset'>
+                <li class='jw-option jw-text jw-item-{{@index}} jw-reset'>
                     <span class="jw-label jw-reset">{{this.label}}</span>
                     <span class="jw-name jw-reset">{{this.title}}</span>
                 </li>


### PR DESCRIPTION
Renamed classes for menu items for safety. Now in the format of "jw-item-#" instead of "item-#" to protect against CSS pollution.