### PR TITLE
Do not get caught in play->load->setItem loop on replay with autostart [Delivers #98116146]

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -59,7 +59,6 @@ define([
                 _view,
                 _captions,
                 _setup,
-                _loadOnPlay = -1,
                 _preplay = false,
                 _actionOnAttach,
                 _stopPlaylist = false, // onComplete, should we play next item or not?
@@ -246,9 +245,9 @@ define([
                 if(_model.get('state') === states.ERROR) {
                     return;
                 }
-                if (_loadOnPlay >= 0) {
-                    _load(_loadOnPlay);
-                    _loadOnPlay = -1;
+                if (_model.get('state') === states.COMPLETE) {
+                    _stop(true);
+                    _model.setItem(0);
                 }
                 if (!_preplay) {
                     _preplay = true;
@@ -356,7 +355,8 @@ define([
             }
 
             function _item(index) {
-                _load(index);
+                _stop(true);
+                _model.setItem(index);
                 _play();
             }
 
@@ -387,7 +387,6 @@ define([
                         _next();
                     } else {
                         _model.set('state', states.COMPLETE);
-                        _loadOnPlay = 0;
                         _this.trigger(events.JWPLAYER_PLAYLIST_COMPLETE, {});
                     }
                     return;


### PR DESCRIPTION
Removes use of `_load` method between playlist items. When autostart is true, `_load` adds a play callback for the `setItem` event which we only want when loading a new playlist. That allows autostart to run when a playlist is set or api load method is called, not when restarting playback or going to or setting next and previous playlist item index.

[Delivers #98116146]