### PR TITLE
Knob no longer uses :after [Delivers #98114578]

### DIFF
--- a/src/css/imports/icons.less
+++ b/src/css/imports/icons.less
@@ -19,8 +19,6 @@
     font-style: normal;
 }
 
-
-.jw-knob,
 .jw-icon-inline,
 .jw-icon-tooltip,
 .jw-icon-display,
@@ -65,12 +63,6 @@
 .jw-icon-menu-bullet {
     &:before {
         content: "\e606";
-    }
-}
-
-.jw-slider-horizontal .jw-knob,
-.jw-slider-vertical .jw-knob {
-    &:before {
     }
 }
 

--- a/src/css/imports/slider.less
+++ b/src/css/imports/slider.less
@@ -29,11 +29,6 @@
 .jw-knob {
     position: absolute;
     cursor: pointer;
-
-    &:after {
-        content: "";
-        display: block;
-    }
 }
 
 .jw-cue {
@@ -45,11 +40,9 @@
 }
 
 .jw-knob {
-    &:after {
-        background-color: #aaa;
-        width: .4em;
-        height: .4em;
-    }
+    background-color: #aaa;
+    width: .4em;
+    height: .4em;
 }
 
 .jw-slider-horizontal {

--- a/src/css/skins/beelden.less
+++ b/src/css/skins/beelden.less
@@ -135,12 +135,10 @@
     }
 
     .jw-knob {
-        &:after {
-            background-color: #bbb5b7;
-            box-shadow: inset 0 0px 5px 0px rgba(255,255,255,0.5);
-            border: 1px solid #000;
-            border-radius: 50%;
-        }
+        background-color: #bbb5b7;
+        box-shadow: inset 0 0px 5px 0px rgba(255,255,255,0.5);
+        border: 1px solid #000;
+        border-radius: 50%;
     }
 
     .jw-slider-horizontal {
@@ -171,11 +169,9 @@
         .jw-knob {
             .vertically-centered-rail-element(@rail-height, .8em);
 
-            &:after {
-                box-sizing: border-box;
-                width: .8em;
-                height: .8em;
-            }
+            box-sizing: border-box;
+            width: .8em;
+            height: .8em;
         }
     }
 
@@ -196,10 +192,8 @@
         }
 
         .jw-knob {
-            &:after {
-                width: .7em;
-                height: .7em;
-            }
+            width: .7em;
+            height: .7em;
         }
     }
 

--- a/src/css/skins/bekle.less
+++ b/src/css/skins/bekle.less
@@ -85,13 +85,10 @@
         }
 
         .jw-knob {
-
-            &:after {
-                background-color: #fff;
-                width: .7em;
-                height: .7em;
-                border-radius: 50%;
-            }
+            background-color: #fff;
+            width: .7em;
+            height: .7em;
+            border-radius: 50%;
         }
     }
 

--- a/src/css/skins/five.less
+++ b/src/css/skins/five.less
@@ -123,12 +123,10 @@
             .vertically-centered-rail-element(@rail-height, @thumb-size);
             margin: 0;
 
-            &:after {
-                background-color: #000;
-                border-radius: @five-border-radius;
-                width: 1px;
-                height: @thumb-size;
-            }
+            background-color: #000;
+            border-radius: @five-border-radius;
+            width: 1px;
+            height: @thumb-size;
         }
 
         .jw-cue {
@@ -162,12 +160,10 @@
             margin-bottom: 2px/-2;
             width: .6em;
 
-            &:after {
-                background: @rail-vert-gradient;
-                border-radius: @five-border-radius;
-                height: 2px;
-                width: 100%;
-            }
+            background: @rail-vert-gradient;
+            border-radius: @five-border-radius;
+            height: 2px;
+            width: 100%;
         }
     }
     

--- a/src/css/skins/roundster.less
+++ b/src/css/skins/roundster.less
@@ -94,14 +94,11 @@
     }
 
     .jw-knob {
-
-        &:after {
-            background-color: #fff;
-            width: @thumb-size;
-            height: @thumb-size;
-            border-radius: 50%;
-            box-shadow: 0px 1px 5px 1px rgba(134,142,163,1);
-        }
+        background-color: #fff;
+        width: @thumb-size;
+        height: @thumb-size;
+        border-radius: 50%;
+        box-shadow: 0px 1px 5px 1px rgba(134,142,163,1);
     }
     
     /* Timeline and horizontal volume slider */

--- a/src/css/skins/seven.less
+++ b/src/css/skins/seven.less
@@ -150,14 +150,10 @@
 
     .jw-knob {
         width: .6em;
-
-        &:after {
-            background-color: #fff;
-            box-shadow: 0px 0px 0px 1px rgba(0,0,0,1);
-            width: 100%;
-            height: .6em;
-            border-radius: 1em;
-        }
+        height: .6em;
+        background-color: #fff;
+        box-shadow: 0px 0px 0px 1px rgba(0,0,0,1);
+        border-radius: 1em;
     }
 
     /* Timeline and horizontal volume slider */

--- a/src/css/skins/six.less
+++ b/src/css/skins/six.less
@@ -144,7 +144,7 @@
         box-shadow: @rail-glow;
     }
 
-    .jw-knob:after {
+    .jw-knob {
         width: @thumb-size;
         height: @thumb-size;
         border-radius: 1em;

--- a/src/css/skins/stormtrooper.less
+++ b/src/css/skins/stormtrooper.less
@@ -90,7 +90,7 @@
     .jw-rail,
     .jw-buffer,
     .jw-progress,
-    .jw-knob:after {
+    .jw-knob {
         box-sizing: border-box;
         border: 1.5px solid #000;
         border-radius: 2px;
@@ -116,13 +116,11 @@
         .jw-knob {
             .vertically-centered-rail-element(.3em,.5em);
 
-            &:after {
-                background: @vertical-rail-gradient;
-                width: .3em;
-                height: .5em;
-                border-width: 1px;
-                border-radius: 0;
-            }
+            background: @vertical-rail-gradient;
+            width: .3em;
+            height: .5em;
+            border-width: 1px;
+            border-radius: 0;
         }
 
         .jw-cue {
@@ -149,12 +147,10 @@
         .jw-knob {
             width: .5em;
 
-            &:after {
-                background: @horiz-rail-gradient;
-                height: .2em;
-                width: .5em;
-                border-width: 1px;
-            }
+            background: @horiz-rail-gradient;
+            height: .2em;
+            width: .5em;
+            border-width: 1px;
         }
     }
 

--- a/src/css/skins/vapor.less
+++ b/src/css/skins/vapor.less
@@ -104,18 +104,14 @@
 
 		.jw-knob,
 		.jw-cue {
-			&:after {
-				height: 2em;
-			}
+			height: 2em;
 		}
 
 		.jw-knob {
 			margin-left: 0;
 
-			&:after {
-				background-color: #fff;
-				width: .2em;
-			}
+            background-color: #fff;
+            width: .2em;
 		}
 
 		.jw-cue {


### PR DESCRIPTION
Moved the styles to style the knob from the :after on the element to the element itself.  This makes the simple skin customization easier to do and more consistent.

[Delivers #98114578]