### PR TITLE
Fix dock for clicks outside of button

### DIFF
--- a/src/js/view/dock.js
+++ b/src/js/view/dock.js
@@ -21,13 +21,26 @@ define([
             this.el = utils.createElement(html);
             new UI (this.el).on('click tap', clickHandler);
         },
-        click : function(evt) {
-            var btnId = evt.target.getAttribute('button');
+        getDockButton : function(evt) {
+            if (utils.hasClass(evt.target, 'jw-dock-button')) {
+                // Clicks on button container
+                return evt.target;
+            } else if (utils.hasClass(evt.target, 'jw-dock-text')) {
+                // Clicks on the text overlay
+                return evt.target.parentElement.parentElement;
+            }
 
+            // Clicks on any other children
+            return evt.target.parentElement;
+        },
+        click : function(evt) {
+            var elem = this.getDockButton(evt);
+
+            var btnId = elem.getAttribute('button');
             var buttons = this.model.get('dock');
             var btn = _.findWhere(buttons, {id : btnId});
 
-            if (btn.callback) {
+            if (btn && btn.callback) {
                 btn.callback();
             }
         },

--- a/src/templates/dock.html
+++ b/src/templates/dock.html
@@ -1,11 +1,11 @@
 <div class="jw-dock jw-reset">
     {{#each this}}
-    <div class="jw-dock-button jw-background-color jw-reset">
-        <div class="jw-icon jw-dock-image jw-reset" button="{{id}}" style="background-image: url({{img}})"></div>
+    <div class="jw-dock-button jw-background-color jw-reset" button="{{id}}">
+        <div class="jw-icon jw-dock-image jw-reset" style="background-image: url({{img}})"></div>
         <div class="jw-arrow jw-reset"></div>
         {{#if tooltip}}
         <div class="jw-overlay jw-background-color jw-reset">
-            <span class="jw-text jw-reset">{{tooltip}}</span>
+            <span class="jw-text jw-dock-text jw-reset">{{tooltip}}</span>
         </div>
         {{/if}}
     </div>


### PR DESCRIPTION
This allows you to click on the text overlay and around the icon without having
to directly hit the icon itself.
[Delivers #98127482]