### PR TITLE
added video tag ended test to stall check for IE [Delivers #97642274]

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -26,7 +26,7 @@ define([
     var stallCheckGenerator = function(videotag, stalledHandler) {
         var lastChecked = -1;
         return function() {
-            if (videotag.paused) { return; }
+            if (videotag.paused || videotag.ended) { return; }
             if (videotag.currentTime === lastChecked) {
                 stalledHandler();
             }


### PR DESCRIPTION
Video paused is not true in IE after playback ends. Added ended check so that stall checker doesn't change the state to buffering.

In the future we'll make sure to only run this check when playback is active. It would be idea to repurpose  _bufferInterval to perform this check as well, since we shouldn't expect stalls after the buffer is full.