### PR TITLE
Pause/Ended check moved to handler

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -26,7 +26,6 @@ define([
     var stallCheckGenerator = function(videotag, stalledHandler) {
         var lastChecked = -1;
         return function() {
-            if (videotag.paused || videotag.ended) { return; }
             if (videotag.currentTime === lastChecked) {
                 stalledHandler();
             }
@@ -265,6 +264,10 @@ define([
 
         function _stalledHandler() {
             if (!_attached) {
+                return;
+            }
+
+            if (_videotag.paused || _videotag.ended) {
                 return;
             }
 


### PR DESCRIPTION
Moved the _videotag.paused and _videotag.ended check to the stall handler so that events fired by the tag will make this check as well instead of just the polled check.  this handles some bugs in newer versions of Android Chrome.

[Delivers #98317556 #98207722]