### PR TITLE
Set ad model to buffering after creation

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -105,6 +105,7 @@ define([
 
             // Show instream state instead of normal player state
             _view.setupInstream(_instream._adModel);
+            _instream._adModel.set('state', states.BUFFERING);
 
             // don't trigger api play/pause on display click
             _view.clickHandler().setAlternateClickHandlers(utils.noop, null);


### PR DESCRIPTION
This allows you to see the buffering icon after switching into ad mode,
before the ad is loaded.

[Fixes #98605218]