### PR TITLE
Adds config option to disable visual playlist [Delivers #91596012]

### DIFF
--- a/src/css/skins/seven.less
+++ b/src/css/skins/seven.less
@@ -95,8 +95,15 @@
         padding: 0 .7em;
     }
 
+    // Styling for the playlist, next and previous icons so it looks correct if the playlist icon is disabled
+    .jw-controlbar .jw-icon-prev:before {
+        padding-right: 0.25em;
+    }
     .jw-controlbar .jw-icon-playlist:before {
-        padding: 0;
+        padding: 0 0.45em;
+    }
+    .jw-controlbar .jw-icon-next:before {
+        padding-left: 0.25em;
     }
 
     .jw-icon-prev,

--- a/src/js/view/controlbar.js
+++ b/src/js/view/controlbar.js
@@ -76,10 +76,15 @@ define([
 
         build : function() {
             var timeSlider = new TimeSlider(this._model, this._api),
-                playlistTooltip = new Playlist('jw-icon-playlist'),
+                playlistTooltip,
                 volumeSlider,
                 volumeTooltip,
                 muteButton;
+
+            // Create the playlistTooltip as long as visualplaylist from the config is not false
+            if(this._model.get('visualplaylist') !== false) {
+                playlistTooltip = new Playlist('jw-icon-playlist');
+            }
 
             // Do not initialize volume sliders on mobile.
             if(!utils.isMobile()){
@@ -132,11 +137,18 @@ define([
                 ]
             };
 
+
+            function removeUndefinedElements(eleList){
+                return _.reject(eleList, function(ele){
+                    return _.isUndefined(ele);
+                });
+            }
+
             // Remove undefined layout elements.  They are invalid for the current platform.
             // (e.g. volume and volumetooltip on mobile)
-            this.layout.right = _.reject(this.layout.right, function(ele){
-                return _.isUndefined(ele);
-            });
+            this.layout.left = removeUndefinedElements(this.layout.left);
+            this.layout.center = removeUndefinedElements(this.layout.center);
+            this.layout.right = removeUndefinedElements(this.layout.right);
 
             this.el = document.createElement('div');
             this.el.className = 'jw-controlbar jw-background-color jw-reset';
@@ -194,12 +206,14 @@ define([
                 }, this);
             }
 
-            this.elements.playlist.on('select', function(value) {
-                this._model.once('setItem', function() {
-                    this._api.play();
+            if(this.elements.playlist) {
+                this.elements.playlist.on('select', function (value) {
+                    this._model.once('setItem', function () {
+                        this._api.play();
+                    }, this);
+                    this._api.load(value);
                 }, this);
-                this._api.load(value);
-            }, this);
+            }
 
             this.elements.hd.on('select', function(value){
                 this._model.getVideo().setCurrentQuality(value);
@@ -232,8 +246,9 @@ define([
             var display = (playlist.length > 1);
             this.elements.next.toggle(display);
             this.elements.prev.toggle(display);
-
-            this.elements.playlist.setup(playlist, model.get('item'));
+            if(this.elements.playlist) {
+                this.elements.playlist.setup(playlist, model.get('item'));
+            }
         },
         onPlaylistItem : function(model/*, item*/) {
             this.elements.time.updateBuffer(0);
@@ -242,7 +257,9 @@ define([
             this.elements.elapsed.innerHTML = '00:00';
 
             var itemIdx = model.get('item');
-            this.elements.playlist.selectItem(itemIdx);
+            if(this.elements.playlist) {
+                this.elements.playlist.selectItem(itemIdx);
+            }
 
             this.elements.audiotracks.setup();
 


### PR DESCRIPTION
This adds the ability to disable the visual playlist by setting "visualplaylist" to false in the config of the player. Visual playlist will no be included on the page when this is true.
Also modifies the styling of the next, previous, and playlist buttons so that it will automatically handle the spacing between the elements if the playlist icon is removed.

[Delivers #91596012]