### PR TITLE
Adding the pointer cursor to the video [Delivers #94696812]

### DIFF
--- a/src/css/flags/controls-disabled.less
+++ b/src/css/flags/controls-disabled.less
@@ -1,0 +1,9 @@
+.jw-flag-controls-disabled {
+    .jw-controls {
+        display: none;
+    }
+
+    .jw-media {
+        cursor: auto;
+    }
+}

--- a/src/css/imports/jwplayerelement.less
+++ b/src/css/imports/jwplayerelement.less
@@ -63,6 +63,7 @@
 
 .jw-media {
     overflow: hidden;
+    cursor: pointer;
 }
 
 .jw-media.jw-media-show {

--- a/src/css/jwplayer.less
+++ b/src/css/jwplayer.less
@@ -30,6 +30,7 @@
 @import "flags/media-audio.less";
 @import "flags/ads.less";
 @import "flags/rightclick-open";
+@import "flags/controls-disabled";
 
 // Skins
 //@import "skins/beelden.less";

--- a/src/flash/com/longtailvideo/jwplayer/model/Model.as
+++ b/src/flash/com/longtailvideo/jwplayer/model/Model.as
@@ -150,6 +150,14 @@ public class Model extends GlobalEventDispatcher {
         }
     }
 
+    public function get controls():Boolean {
+        return _config.controls;
+    }
+
+    public function set controls(on:Boolean):void {
+        _config.controls = on;
+    }
+
     public function get stretching():String {
         return _config.stretching;
     }

--- a/src/flash/com/longtailvideo/jwplayer/model/PlayerConfig.as
+++ b/src/flash/com/longtailvideo/jwplayer/model/PlayerConfig.as
@@ -7,6 +7,8 @@ import com.longtailvideo.jwplayer.utils.RootReference;
 import flash.events.EventDispatcher;
 import flash.media.SoundTransform;
 import flash.utils.getQualifiedClassName;
+import flash.ui.Mouse;
+import flash.ui.MouseCursor;
 
 public dynamic class PlayerConfig extends EventDispatcher {
 
@@ -19,6 +21,7 @@ public dynamic class PlayerConfig extends EventDispatcher {
 
     protected var _soundTransform:SoundTransform;
     protected var _volume:Number = 0.9;
+    protected var _controls:Boolean = true;
 
     public var captionLabel:String;
     public var qualityLabel:String;
@@ -209,10 +212,12 @@ public dynamic class PlayerConfig extends EventDispatcher {
     }
 
     public function get controls():Boolean {
-        return true;
+        return _controls;
     }
 
-    public function set controls(x:Boolean):void {
+    public function set controls(show:Boolean):void {
+        _controls = show;
+        Mouse.cursor = (_controls) ? MouseCursor.BUTTON : MouseCursor.AUTO;
     }
 
     public function setConfig(config:Object):void {
@@ -228,6 +233,7 @@ public dynamic class PlayerConfig extends EventDispatcher {
         // this.fullscreen = config.fullscreen;
         this.plugins    = config.flashPlugins;
 
+        this.controls = config.controls;
         this.captionLabel = config.captionLabel;
         this.qualityLabel = config.qualityLabel;
     }

--- a/src/flash/com/longtailvideo/jwplayer/player/Player.as
+++ b/src/flash/com/longtailvideo/jwplayer/player/Player.as
@@ -143,6 +143,10 @@ public class Player extends Sprite implements IPlayer {
         _model.currentQuality = index;
     }
 
+    public function setControls(show:Boolean):void {
+        _model.controls = show;
+    }
+
     public function getCaptionsList():Array {
         return [];
     }
@@ -229,6 +233,7 @@ public class Player extends Sprite implements IPlayer {
                 .on('fullscreen', fullscreen)
                 .on('mute', mute)
                 .on('volume', volume)
+                .on('setControls', setControls)
                 .on('stretch', stretch)
                 .on('setCurrentQuality', setCurrentQuality)
                 .on('setSubtitlesTrack', setSubtitlesTrack)

--- a/src/js/providers/flash.js
+++ b/src/js/providers/flash.js
@@ -33,7 +33,9 @@ define([
         };
 
         var _flashCommand = function() {
-            _swf.triggerFlash.apply(_swf, arguments);
+            if(_swf) {
+                _swf.triggerFlash.apply(_swf, arguments);
+            }
         };
 
         var _eventDispatcher = new eventdispatcher('flash.provider');
@@ -303,8 +305,8 @@ define([
                         _flashCommand('stretch', stretching);
                     }
                 },
-                setControls: function() {
-
+                setControls: function(show) {
+                    _flashCommand('setControls', show);
                 },
                 setFullscreen: function(value) {
                     _fullscreen = value;

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -662,6 +662,11 @@ define([
         };
 
         this.setControls = function(state) {
+            // Auto-disable controls when its not fullscreen and mobile.  Android has controls == false
+            // automatically somehow.
+            if (!(_isMobile && _fullscreenState)) {
+                state = false;
+            }
             _videotag.controls = !!state;
         };
 

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -439,11 +439,13 @@ define([
         }
 
         var toggleControls = function() {
-            if (_model.get('controls')) {
-                utils.removeClass(_controlsLayer, 'jw-controls-disabled');
+            var controls = _model.get('controls');
+            if (controls) {
+                utils.removeClass(_playerElement, 'jw-flag-controls-disabled');
             } else {
-                utils.addClass(_controlsLayer, 'jw-controls-disabled');
+                utils.addClass(_playerElement, 'jw-flag-controls-disabled');
             }
+            _model.getVideo().setControls(controls);
         };
 
         function _doubleClickFullscreen() {
@@ -527,8 +529,6 @@ define([
         }
 
         function _onChangeControls(model, bool) {
-            utils.toggleClass(_controlsLayer, 'jw-hidden', bool);
-
             if (bool) {
                 // model may be instream or normal depending on who triggers this
                 _stateHandler(model, model.get('state'));
@@ -843,10 +843,8 @@ define([
         }
 
         function _showDisplay() {
-            // debug this, find out why
-            if (!(_isMobile && _model.get('fullscreen'))) {
-                _model.getVideo().setControls(false);
-            }
+            // Controls the display of native controls on mobile.
+            _model.getVideo().setControls(_model.get('controls'));
         }
 
         function _userInactive() {


### PR DESCRIPTION
Adding the pointer cursor to the video elements and providers.  This implies that the video is clickable for pause/playback toggling.  The pointer is toggled on/off as a result of 'controls' being set to true or false since that also dictates whether you can click to pause.
Flash has its pointer/arrow cursor set based on the controls value.
jw-controls-disabled changed to a flag so it can toggle cursor state.
Moved code that was dictating whether to show the HTML5 native controls to the HTML5 provider.

[Delivers #94696812]