### PR TITLE
Remove androidhls from default config value

### DIFF
--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -7,7 +7,7 @@ define([
 
     // Defaults
     var Defaults = {
-        androidhls: true,
+        //androidhls: true,
         autostart: false,
         controls: true,
         cookies: true,

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -35,8 +35,8 @@ define([
 
     function _useAndroidHLS(source) {
         if (source.type === 'hls') {
-            //when androidhls is set to true, allow HLS playback on Android 4.1 and up
-            if (source.androidhls) {
+            //when androidhls is not set to false, allow HLS playback on Android 4.1 and up
+            if (source.androidhls !== false) {
                 var isAndroidNative = utils.isAndroidNative;
                 if (isAndroidNative(2) || isAndroidNative(3) || isAndroidNative('4.0')) {
                     return false;


### PR DESCRIPTION
The behaviour is unchanged, by checking for false instead of truthiness checking.

[Delivers #99084726]