### PR TITLE
Adds displaydescription config option to hide descriptions [Delivers #93363260]

### DIFF
--- a/src/css/imports/title.less
+++ b/src/css/imports/title.less
@@ -15,6 +15,8 @@
 .jw-title-primary,
 .jw-title-secondary {
     padding: @ui-margin/2 @ui-margin;
+    // require a certain height in case the titles are empty
+    min-height: @ui-margin + 1em;
     width: 75%;
     color: white;
     white-space: nowrap;

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -12,6 +12,7 @@ define([
         controls: true,
         cookies: true,
         displaytitle : true,
+        displaydescription: true,
         mobilecontrols: false,
         repeat: false,
         skin: 'seven',

--- a/src/js/view/title.js
+++ b/src/js/view/title.js
@@ -29,7 +29,7 @@ define([
         },
 
         playlistItem : function(model, item) {
-            if (model.get('displaytitle')) {
+            if (model.get('displaytitle') || model.get('displaydescription')) {
                 this.updateText(model, item);
             } else {
                 this.hide();
@@ -37,17 +37,12 @@ define([
         },
 
         updateText: function(model, playlistItem) {
+            this.title.innerHTML = (playlistItem.title && model.get('displaytitle')) ?
+                playlistItem.title : '';
+            this.description.innerHTML = (playlistItem.description && model.get('displaydescription')) ?
+                playlistItem.description : '';
 
-            var title = playlistItem.title;
-            var description = playlistItem.description || '';
-
-            if (title) {
-                this.show();
-                this.title.innerHTML = title;
-                this.description.innerHTML = description;
-            } else {
-                this.hide();
-            }
+            this.show();
         },
 
         element: function(){


### PR DESCRIPTION
Adds displaydescription config option to hide descriptions.  Additionally allows the display of the jw-title element when displaydescription is true but displaytitle is not.  Descriptions will also display in the correct location if there is no title or the title is disabled.

Related to a test update in commercial - https://github.com/jwplayer/jwplayer-commercial/pull/719

[Delivers #93363260]