### PR TITLE
Clicking LIVE on DVR stream seeks to current content [Delivers #79026678]

### DIFF
--- a/src/js/view/controlbar.js
+++ b/src/js/view/controlbar.js
@@ -226,6 +226,14 @@ define([
             this.elements.audiotracks.on('select', function(value){
                 this._model.getVideo().setCurrentAudioTrack(value);
             }, this);
+
+            new UI(this.elements.duration).on('click tap', function(){
+                if (utils.adaptiveType(this._model.get('duration')) === 'DVR') {
+                    // -0.1 places the playhead at the most recent time.
+                    // this._api.seek(0) puts the user at the oldest DVR segment available.
+                    this._api.seek(-0.1);
+                }
+            }, this);
         },
 
         onCaptionsList: function(model, tracks) {


### PR DESCRIPTION
Clicking LIVE on DVR stream seeks to current content.  In the code it's seeking to -0.1 since the Flash provider will consider 0 to be the beginning of the oldest DVR segment because of how the AdaptiveController interprets 0 for a DVR stream.

[Delivers #79026678]