### PR TITLE
Default skin fix for simple skin customization [Delivers #99320002]

### DIFF
--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -36,7 +36,6 @@ define([
     }
 
     var config = function(options) {
-
         var allOptions = _.extend({}, (window.jwplayer || {}).defaults, options);
 
         _deserialize(allOptions);
@@ -53,13 +52,7 @@ define([
             config.skinColorInactive = config.skin.inactive; // default icon color
             config.skinColorActive = config.skin.active;  // icon hover, on, slider color
             config.skinColorBackground = config.skin.background; // control elements background
-
-            if (config.skin.name) {
-                config.skin = config.skin.name;
-            } else {
-                // we actively delete the value so it won't overwrite the model's default
-                delete config.skin;
-            }
+            config.skin = _.isString(config.skin.name) ? config.skin.name : Defaults.skin; // get skin name if it exists
         }
 
         if (_.isString(config.skin) && config.skin.indexOf('.xml') > 0) {


### PR DESCRIPTION
No default value was being set when skin.name wasn't defined in the skin object for simple skin customization.  If "name" isn't defined in that object, we use the default skin instead.

[Delivers #99320002]