### PR TITLE
Place media model in buffering state on instream init [Delivers #98862516]

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -77,7 +77,6 @@ define([
             _oldpos = _model.position;
             _olditem = _model.playlist[_model.item];
 
-
             _instream.on('all', _instreamForward, this);
             _instream.on(events.JWPLAYER_MEDIA_TIME, _instreamTime, this);
             _instream.on(events.JWPLAYER_MEDIA_COMPLETE, _instreamItemComplete, this);
@@ -85,6 +84,8 @@ define([
 
             // Make sure the original player's provider stops broadcasting events (pseudo-lock...)
             _oldProvider.detachMedia();
+
+            _model.mediaModel.set('state', states.BUFFERING);
 
             if (_controller.checkBeforePlay() || (_oldpos === 0 && !_oldProvider.checkComplete())) {
                 // make sure video restarts after preroll


### PR DESCRIPTION
Places the video's mediaModel into the buffering state when instream starts.  This is done to prevent an issue where the media model's state would not change to "playing" when an ad errors out because the old media model was already in the "playing" state.  This also better reflects the actual state of the media at that point  and IDLE (which potentially makes the most sense) causes larger issues.

[Delivers #98862516]