### PR TITLE
Flash provider support [Delivers #91604828]

### DIFF
--- a/src/flash/com/longtailvideo/jwplayer/media/MediaProvider.as
+++ b/src/flash/com/longtailvideo/jwplayer/media/MediaProvider.as
@@ -12,42 +12,6 @@ import flash.display.Sprite;
 import flash.events.Event;
 
 public class MediaProvider extends Sprite implements IMediaProvider {
-    public function MediaProvider(provider:String) {
-        _provider = provider;
-        _dispatcher = new GlobalEventDispatcher();
-    }
-    /** Most recent buffer data **/
-    protected var _bufferPercent:Number;
-    protected var _width:Number;
-    protected var _height:Number;
-    /** Handles event dispatching **/
-    private var _dispatcher:GlobalEventDispatcher;
-    /** Queue buffer full event if it occurs while the player is paused. **/
-    private var _queuedBufferFull:Boolean;
-
-    /** Name of the MediaProvider **/
-    private var _provider:String;
-
-    /** Name of the MediaProvider. */
-    public function get provider():String {
-        return _provider;
-    }
-
-    /** Reference to the currently active playlistitem. **/
-    protected var _item:PlaylistItem;
-
-    /** Currently playing PlaylistItem **/
-    public function get item():PlaylistItem {
-        return _item;
-    }
-
-    /** The current position inside the file. **/
-    protected var _position:Number = 0;
-
-    /** Current position, in seconds **/
-    public function get position():Number {
-        return _position;
-    }
 
     public static const LIVE_DURATION:Number = Infinity;
     public static const UNKNOWN_DURATION:Number = 0;
@@ -56,8 +20,45 @@ public class MediaProvider extends Sprite implements IMediaProvider {
         return duration > 0 && duration !== LIVE_DURATION;
     }
 
-    /** The current volume of the audio output stream **/
+    protected var _item:PlaylistItem;
+    protected var _config:PlayerConfig;
+    protected var _media:Sprite;
+    protected var _width:Number;
+    protected var _height:Number;
+    protected var _position:Number;
+    protected var _bufferPercent:Number;
+    protected var _currentQuality:Number = -1;
+    protected var _currentAudioTrack:Number = -1;
+    protected var _currentSubtitlesTrack:Number = -1;
+
+    private var _dispatcher:GlobalEventDispatcher;
+    private var _provider:String;
+    private var _state:String;
     private var _volume:Number;
+    /** Queue buffer full event if it occurs while the player is paused. **/
+    private var _queuedBufferFull:Boolean;
+
+
+    public function MediaProvider(provider:String) {
+        _provider = provider;
+        _position = 0;
+        _dispatcher = new GlobalEventDispatcher();
+    }
+
+    /** Name of the MediaProvider. */
+    public function get provider():String {
+        return _provider;
+    }
+
+    /** Currently playing PlaylistItem **/
+    public function get item():PlaylistItem {
+        return _item;
+    }
+
+    /** Current position, in seconds **/
+    public function get position():Number {
+        return _position;
+    }
 
     /**
      * The current volume of the playing media
@@ -66,9 +67,6 @@ public class MediaProvider extends Sprite implements IMediaProvider {
     public function get volume():Number {
         return _volume;
     }
-
-    /** The playback state for the currently loaded media.  @see com.longtailvideo.jwplayer.model.ModelStates **/
-    private var _state:String;
 
     /**
      * Current state of the MediaProvider.
@@ -79,9 +77,6 @@ public class MediaProvider extends Sprite implements IMediaProvider {
     }
 
     /** Current quality level **/
-    protected var _currentQuality:Number = -1;
-
-    /** Current quality level getter **/
     public function get currentQuality():Number {
         return _currentQuality;
     }
@@ -90,8 +85,6 @@ public class MediaProvider extends Sprite implements IMediaProvider {
     public function set currentQuality(quality:Number):void {
         _currentQuality = quality;
     }
-
-    protected var _currentAudioTrack:Number = -1;
 
     /** Current audio track getter **/
     public function get currentAudioTrack():Number {
@@ -103,7 +96,6 @@ public class MediaProvider extends Sprite implements IMediaProvider {
         _currentAudioTrack = audioTrack;
     }
 
-    protected var _currentSubtitlesTrack:Number = -1;
 
     /** Current subtitles track getter **/
     public function get currentSubtitlesTrack():Number {
@@ -140,31 +132,17 @@ public class MediaProvider extends Sprite implements IMediaProvider {
         return null;
     }
 
-    /** Reference to the player configuration. **/
-    protected var _config:PlayerConfig;
-
-    /**
-     * The current config
-     */
+    /** The current config **/
     protected function get config():PlayerConfig {
         return _config;
     }
 
-    /** Clip containing graphical representation of the currently playing media **/
-    protected var _media:Sprite;
-
-    /**
-     * Gets the graphical representation of the media.
-     *
-     */
+    /** Gets the graphical representation of the media **/
     protected function get media():DisplayObject {
         return _media;
     }
 
-    /**
-     * Sets the graphical representation of the media.
-     *
-     */
+    /** Sets the graphical representation of the media **/
     protected function set media(m:DisplayObject):void {
         if (m) {
             _media = new Sprite();
@@ -179,8 +157,12 @@ public class MediaProvider extends Sprite implements IMediaProvider {
         sendMediaEvent(MediaEvent.JWPLAYER_MEDIA_LOADED);
     }
 
-    public function initializeMediaProvider(cfg:PlayerConfig):void {
-        _config = cfg;
+    /**
+     * Called after construction to initialize provider with player settings.
+     * @param config The player configuration passed to jwplayer().setup({config})
+     */
+    public function initializeMediaProvider(config:PlayerConfig):void {
+        _config = config;
         _state = PlayerState.IDLE;
     }
 
@@ -212,7 +194,6 @@ public class MediaProvider extends Sprite implements IMediaProvider {
 
     /**
      * Seek to a certain position in the item.
-     *
      * @param pos    The position in seconds.
      **/
     public function seek(pos:Number):void {
@@ -227,21 +208,20 @@ public class MediaProvider extends Sprite implements IMediaProvider {
 
     /**
      * Change the playback volume of the item.
-     *
      * @param vol    The new volume (0 to 100).
      **/
-    public function setVolume(vol:Number):void {}
+    public function setVolume(vol:Number):void {
+    }
 
     /**
      * Changes the mute state of the item.
-     *
      * @param muted    The new mute state.
      **/
-    public function mute(muted:Boolean):void {}
+    public function mute(muted:Boolean):void {
+    }
 
     /**
      * Resizes the display.
-     *
      * @param width     The new width of the display.
      * @param height    The new height of the display.
      **/
@@ -269,7 +249,6 @@ public class MediaProvider extends Sprite implements IMediaProvider {
 
     /** Puts the video into a buffer state **/
     protected function buffer():void {
-
     }
 
     /** Completes video playback **/
@@ -330,7 +309,6 @@ public class MediaProvider extends Sprite implements IMediaProvider {
 
     /**
      * Gets a property from the player configuration
-     *
      * @param property The property to be retrieved.
      * **/
     protected function getConfigProperty(property:String):* {
@@ -370,9 +348,6 @@ public class MediaProvider extends Sprite implements IMediaProvider {
         dispatchEvent(qualityEvent);
     }
 
-    /**
-     * @inheritDoc
-     */
     public override function dispatchEvent(event:Event):Boolean {
         _dispatcher.dispatchEvent(event);
         return super.dispatchEvent(event);

--- a/src/flash/com/longtailvideo/jwplayer/media/MediaProvider.as
+++ b/src/flash/com/longtailvideo/jwplayer/media/MediaProvider.as
@@ -354,12 +354,11 @@ public class MediaProvider extends Sprite implements IMediaProvider {
     }
 
     /**
-     * DEPREICATED IN JW7
-     *
+     * DEPRECATED IN JW7
      * _stretch - no longer stored in provider
-     *
      */
-    private function noop(...args):void {}
+    private function noop(...args):void {
+    }
 
     protected function get _stretch():Boolean {
         return false;

--- a/src/flash/com/longtailvideo/jwplayer/media/MediaProvider.as
+++ b/src/flash/com/longtailvideo/jwplayer/media/MediaProvider.as
@@ -352,5 +352,21 @@ public class MediaProvider extends Sprite implements IMediaProvider {
         _dispatcher.dispatchEvent(event);
         return super.dispatchEvent(event);
     }
+
+    /**
+     * DEPREICATED IN JW7
+     *
+     * _stretch - no longer stored in provider
+     *
+     */
+    private function noop(...args):void {}
+
+    protected function get _stretch():Boolean {
+        return false;
+    }
+
+    protected function set _stretch(v:Boolean):void {
+    }
+
 }
 }

--- a/src/flash/com/longtailvideo/jwplayer/model/Model.as
+++ b/src/flash/com/longtailvideo/jwplayer/model/Model.as
@@ -222,7 +222,9 @@ public class Model extends GlobalEventDispatcher {
 
         if (_currentMedia !== newMedia) {
             if (_currentMedia) {
-                if (_currentMedia.state != PlayerState.IDLE) _currentMedia.stop();
+                if (_currentMedia.state !== PlayerState.IDLE) {
+                    _currentMedia.stop();
+                }
                 _currentMedia.removeGlobalListener(forwardEvents);
             }
             newMedia.addGlobalListener(forwardEvents);

--- a/src/flash/com/longtailvideo/jwplayer/model/PlayerConfig.as
+++ b/src/flash/com/longtailvideo/jwplayer/model/PlayerConfig.as
@@ -3,18 +3,19 @@ import com.longtailvideo.jwplayer.player.PlayerVersion;
 import com.longtailvideo.jwplayer.plugins.PluginConfig;
 import com.longtailvideo.jwplayer.utils.Logger;
 import com.longtailvideo.jwplayer.utils.RootReference;
+import com.longtailvideo.jwplayer.utils.Stretcher;
 
 import flash.events.EventDispatcher;
 import flash.media.SoundTransform;
-import flash.utils.getQualifiedClassName;
 import flash.ui.Mouse;
 import flash.ui.MouseCursor;
+import flash.utils.getQualifiedClassName;
 
 public dynamic class PlayerConfig extends EventDispatcher {
 
     protected var _debug:String = Logger.NONE;
     protected var _id:String = "";
-    protected var _stretching:String = "uniform";
+    protected var _stretching:String = Stretcher.UNIFORM;
     protected var _fullscreen:Boolean = false;
     protected var _plugins:Array = [];
     protected var _pluginConfig:Object = {};
@@ -78,16 +79,27 @@ public dynamic class PlayerConfig extends EventDispatcher {
         return 0;
     }
 
-    public function set width(w:Number):void {}
+    public function set width(w:Number):void {
+    }
 
-    public function set height(h:Number):void {}
+    public function set height(h:Number):void {
+    }
 
     public function get stretching():String {
         return _stretching;
     }
 
     public function set stretching(mode:String):void {
-        _stretching = mode ? mode.toLowerCase() : "";
+        mode = mode.toLowerCase();
+        switch (mode) {
+            case Stretcher.EXACTFIT:
+            case Stretcher.FILL:
+            case Stretcher.NONE:
+            case Stretcher.UNIFORM:
+                _stretching = mode;
+                return;
+        }
+        _stretching = Stretcher.UNIFORM;
     }
 
     public function get plugins():Array {
@@ -221,19 +233,27 @@ public dynamic class PlayerConfig extends EventDispatcher {
     }
 
     public function setConfig(config:Object):void {
-        this.id    = config.id;
+        // add dynamic properties from js config
+        for (var key:String in config) {
+            // exclude builtin properties
+            if (!this.hasOwnProperty(key)) {
+                this[key] = config[key];
+            }
+        }
+
+        // make sure these setters are invoked
+        this.id = config.id;
         this.debug = config.debug;
+        this.volume = config.volume;
+        this.mute = config.mute;
+        this.controls = config.controls;
+
         if (config.stretching) {
             this.stretching = config.stretching;
         }
 
-        this.volume = config.volume;
-        this.mute   = config.mute;
+        this.plugins = config.flashPlugins;
 
-        // this.fullscreen = config.fullscreen;
-        this.plugins    = config.flashPlugins;
-
-        this.controls = config.controls;
         this.captionLabel = config.captionLabel;
         this.qualityLabel = config.qualityLabel;
     }


### PR DESCRIPTION
Ignore the first 'cleanup' commit to see the changes:

- setup config properties are copied for 3rd party providers that rely on custom config settings in `initializeMediaProvider(config:PlayerConfig)`
- `_stretch` property access supported for jw6 provider support

Cleanup was just to organize and remove redundant comments on static/protected/private members, getter/setters and methods of MediaProvider.