### PR TITLE
Limited Font Faces in Use, Six doesn't import icons sheet [Delivers #99324726]

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -201,20 +201,12 @@ module.exports = function(grunt) {
                                     '!less?compress'
                         },
                         {
-                            test: /\.eot(\?v=\d+\.\d+\.\d+)?$/,
-                            loader: 'file?name=[name].[ext]'
-                        },
-                        {
                             test: /\.woff(\?v=\d+\.\d+\.\d+)?$/,
                             loader: 'url?limit=10000&mimetype=application/font-woff'
                         },
                         {
                             test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/,
                             loader: 'url?limit=10000&mimetype=application/octet-stream'
-                        },
-                        {
-                            test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
-                            loader: 'url?name=[name].[ext]&limit=10000&mimetype=image/svg+xml'
                         }
                     ]
                 }

--- a/src/css/imports/icons.less
+++ b/src/css/imports/icons.less
@@ -1,20 +1,10 @@
 @import "vars";
 @import "mixins";
 
-// This is IE8 only
 @font-face {
     font-family: 'jw-icons';
-    src: url('../../../assets/fonts/jw-icons.eot');
-    font-weight: normal;
-    font-style: normal;
-}
-// This cascades and overwrites for non IE8 browsers
-@font-face {
-    font-family: 'jw-icons';
-    src: url('../../../assets/fonts/jw-icons.eot') format('embedded-opentype'),
-    url('../../../assets/fonts/jw-icons.woff') format('woff'),
-    url('../../../assets/fonts/jw-icons.ttf') format('truetype'),
-    url('../../../assets/fonts/jw-icons.svg') format('svg');
+    src: url('../../../assets/fonts/jw-icons.woff') format('woff'),
+         url('../../../assets/fonts/jw-icons.ttf') format('truetype');
     font-weight: normal;
     font-style: normal;
 }

--- a/src/css/skins/six.less
+++ b/src/css/skins/six.less
@@ -1,5 +1,4 @@
 @import "../imports/vars";
-@import "../imports/icons";
 @import "../imports/mixins";
 
 .jw-skin-six {
@@ -73,7 +72,12 @@
 
     /* Styles for menu list items */
     .jw-option {
-        .jw-icon-menu-bullet;
+        .jw-icon-menu-bullet {
+            &:before {
+                content: "\e606";
+            }
+        }
+
         text-align: left;
 
         &:before {


### PR DESCRIPTION
Reduces the formats of fonts that we're including in the player.  Since IE8 is dropped, we're removing EOT fonts as IE9 supports WOFF.  IE9 in compatibility mode would need EOT fonts, but the player is not functional in compatibility mode there is no point in including them.  WOFF and TTF alone should be sufficient to cover all necessary circumstances.

Removes the @import "../imports/icons" from six since it's causing the broken fonts on the test pages.  It attempts to load fonts which do not exist and the request fails before the browser has finishes decoding the base64 encoded fonts.  This causes the browser to assume the font is broken so it displays character codes instead.  The font afterwords finishes decoding and displays correctly.  Adding the only bit needed from @import "../imports/icons" to the six skin.

[Delivers #99324726]