### PR TITLE
Load skins from config.base (defaults to CDN) [Delivers #99183750]

### DIFF
--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -45,7 +45,7 @@ define([
         if (config.base === '.') {
             config.base = utils.getScriptPath('jwplayer.js');
         }
-        config.base = config.base || utils.repo();
+        config.base = (config.base || utils.repo()).replace(/\/?$/, '/');
         __webpack_public_path__ = config.base;
         config.width  = _normalizeSize(config.width);
         config.height = _normalizeSize(config.height);

--- a/src/js/controller/setup-steps.js
+++ b/src/js/controller/setup-steps.js
@@ -1,14 +1,11 @@
 define([
     'plugins/plugins',
     'playlist/loader',
-    'playlist/playlist',
     'utils/scriptloader',
-    'utils/helpers',
-    'utils/backbone.events',
     'utils/constants',
     'utils/underscore',
     'events/events'
-], function(plugins, PlaylistLoader, Playlist, ScriptLoader, utils, Events, Constants, _, events) {
+], function(plugins, PlaylistLoader, ScriptLoader, Constants, _, events) {
 
     var _pluginLoader,
         _playlistLoader;
@@ -120,9 +117,9 @@ define([
         }
     }
 
-    function skinToLoad(skin) {
+    function skinToLoad(skin, base) {
         if(_.contains(Constants.SkinsLoadable, skin)) {
-            return utils.getSkinUrl(skin);
+            return base + 'skins/' + skin + '.css';
         }
     }
 
@@ -147,8 +144,8 @@ define([
         }
 
         if (!skinUrl) {
-            // if a user doesn't specify a url, we assume it comes from our CDN
-            skinUrl = skinToLoad(skinName);
+            // if a user doesn't specify a url, we assume it comes from our CDN or config.base
+            skinUrl = skinToLoad(skinName, _model.get('base'));
         }
 
         if (_.isString(skinUrl) && !isSkinLoaded(skinUrl)) {

--- a/src/js/plugins/loader.js
+++ b/src/js/plugins/loader.js
@@ -137,9 +137,9 @@ define([
             _status = scriptloader.loaderstatus.LOADING;
 
             /** First pass to create the plugins and add listeners **/
-            _.each(_config, function(value, plugin) {
-                if (utils.exists(plugin)) {
-                    var pluginObj = model.addPlugin(plugin);
+            _.each(_config, function(value, pluginUrl) {
+                if (utils.exists(pluginUrl)) {
+                    var pluginObj = model.addPlugin(pluginUrl);
                     pluginObj.on(events.COMPLETE, _checkComplete);
                     pluginObj.on(events.ERROR, _pluginError);
                 }
@@ -161,8 +161,6 @@ define([
             _destroyed = true;
             this.off();
         };
-
-        this.pluginFailed = _pluginError;
 
         this.getStatus = function () {
             return _status;

--- a/src/js/plugins/plugin.js
+++ b/src/js/plugins/plugin.js
@@ -43,24 +43,26 @@ define([
         }
 
         this.load = function() {
-            if (_status === scriptloader.loaderstatus.NEW) {
-                if (url.lastIndexOf('.swf') > 0) {
-                    _flashPath = url;
-                    _status = scriptloader.loaderstatus.COMPLETE;
-                    _this.trigger(events.COMPLETE);
-                    return;
-                } else if (pluginsUtils.getPluginPathType(url) === pluginsUtils.pluginPathType.CDN) {
-                    _status = scriptloader.loaderstatus.COMPLETE;
-                    _this.trigger(events.COMPLETE);
-                    return;
-                }
-                _status = scriptloader.loaderstatus.LOADING;
-                var _loader = new scriptloader(getJSPath());
-                // Complete doesn't matter - we're waiting for registerPlugin
-                _loader.on(events.COMPLETE, completeHandler);
-                _loader.on(events.ERROR, errorHandler);
-                _loader.load();
+            if (_status !== scriptloader.loaderstatus.NEW) {
+                return;
             }
+            if (url.lastIndexOf('.swf') > 0) {
+                _flashPath = url;
+                _status = scriptloader.loaderstatus.COMPLETE;
+                _this.trigger(events.COMPLETE);
+                return;
+            }
+            if (pluginsUtils.getPluginPathType(url) === pluginsUtils.pluginPathType.CDN) {
+                _status = scriptloader.loaderstatus.COMPLETE;
+                _this.trigger(events.COMPLETE);
+                return;
+            }
+            _status = scriptloader.loaderstatus.LOADING;
+            var _loader = new scriptloader(getJSPath());
+            // Complete doesn't matter - we're waiting for registerPlugin
+            _loader.on(events.COMPLETE, completeHandler);
+            _loader.on(events.ERROR, errorHandler);
+            _loader.load();
         };
 
         this.registerPlugin = function(id, target, arg1, arg2) {
@@ -101,11 +103,6 @@ define([
                             return utils.getAbsolutePath(_flashPath, window.location.href);
                         }
                         return utils.getAbsolutePath(_flashPath, getJSPath());
-//                    case utils.pluginPathType.CDN:
-//                        if (_flashPath.indexOf('-') > -1){
-//                            return _flashPath+'h';
-//                        }
-//                        return _flashPath+'-h';
                 }
             }
             return null;

--- a/src/js/utils/helpers.js
+++ b/src/js/utils/helpers.js
@@ -340,10 +340,6 @@ define([
         return repo;
     });
 
-    utils.getSkinUrl = function(skin) {
-        return utils.repo() + 'skins/' + skin + '.css';
-    };
-
     utils.addStyleSheet = function(url) {
         var link = document.createElement('link');
         link.rel = 'stylesheet';


### PR DESCRIPTION
Use model 'base' to load skins. If not set by the user, base defaults to our CDN:

https://github.com/jwplayer/jwplayer/blob/master/src/js/api/config.js#L48

Removed `utils.getSkinUrl`. This was the only place using it, and the more dependencies we can remove from modules the better.