### PR TITLE
Updates to ad skip button styles for skins [Fixes #99791878]

### DIFF
--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -155,6 +155,15 @@
             padding: @volume-padding;
         }
 
+        .jw-skip {
+            background: @controlbar-background;
+            padding: @volume-padding;
+
+            .jw-skip-icon {
+                color: @inactive-color;
+            }
+        }
+
         .jw-time-tip,
         .jw-dock-button {
             .jw-text {

--- a/src/css/imports/skipad.less
+++ b/src/css/imports/skipad.less
@@ -27,6 +27,8 @@
     .jw-text, .jw-skip-icon {
         color: @inactive-color;
         vertical-align: middle;
+        line-height: 1em;
+        font-size: 0.7em;
     }
 
     &.jw-skippable:hover {

--- a/src/css/skins/beelden.less
+++ b/src/css/skins/beelden.less
@@ -38,7 +38,8 @@
     .skin-element-padding();
 
     .inset-controlbar();
-    .jw-controlbar {
+    .jw-controlbar,
+    .jw-skip {
         box-shadow: inset 0px 7px 1px -5px rgba(128,128,128,1);
         border-radius: .3em;
     }
@@ -216,6 +217,5 @@
             color: @cc-inactive;
         }
     }
-
 }
 

--- a/src/css/skins/bekle.less
+++ b/src/css/skins/bekle.less
@@ -134,7 +134,8 @@
 
     .jw-time-tip,
     .jw-volume-tip,
-    .jw-menu {
+    .jw-menu,
+    .jw-skip {
         border-radius: .3em;
     }
 

--- a/src/css/skins/roundster.less
+++ b/src/css/skins/roundster.less
@@ -153,4 +153,9 @@
             border-radius: 2.5em;
         }
     }
+
+    .jw-skip {
+        border-radius: @roundster-corners;
+        padding: @roundster-corners/4 @roundster-corners;
+    }
 }

--- a/src/css/skins/seven.less
+++ b/src/css/skins/seven.less
@@ -268,7 +268,6 @@
         .jw-text, 
         .jw-icon-inline {
             color: @inactive-color;
-            font-size: 0.7em;
         }
     }
 

--- a/src/css/skins/six.less
+++ b/src/css/skins/six.less
@@ -244,7 +244,7 @@
     .jw-skip {
         background: @def-transparent-background-style;
         background-size: @def-background-size;
-        border-radius: @ui-corner-round;
+        border-radius: .3em;
         padding: @ui-padding @ui-corner-round;
 
         &:hover {


### PR DESCRIPTION
Updates to ad skip button.  Added some basic style inheritance in the basic-skin-styles mixin and a specific font-size and line-height to make sure the ad skip button doesn't vertically shift in size once the skip icon appears.  Skins also add minor corner rounding to skip buttons to make them look more consistent with the rest of the skin

[Fixes #99791878]