### PR TITLE
Fix styling for media which are audio only

### DIFF
--- a/src/css/flags/media-audio.less
+++ b/src/css/flags/media-audio.less
@@ -1,4 +1,12 @@
 // This has higher specificity to overwrite jw-flag-user-inactive
-.jwplayer.jw-flag-media-audio .jw-controlbar {
-    display: table;
+.jwplayer.jw-flag-media-audio {
+    .jw-controlbar {
+        display: table;
+    }
+    .jw-icon-fullscreen {
+        display : none;
+    }
+    .jw-preview {
+        display: block;
+    }
 }

--- a/src/css/flags/media-audio.less
+++ b/src/css/flags/media-audio.less
@@ -3,9 +3,6 @@
     .jw-controlbar {
         display: table;
     }
-    .jw-icon-fullscreen {
-        display : none;
-    }
     .jw-preview {
         display: block;
     }

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -65,6 +65,10 @@ define([
                     this.set(evt.type, evt[evt.type]);
                     return;
 
+                case events.JWPLAYER_MEDIA_TYPE:
+                    this.mediaModel.set('mediaType', evt.mediaType);
+                    break;
+
                 case events.JWPLAYER_PLAYER_STATE:
                     this.mediaModel.set('state', evt.newstate);
 

--- a/src/js/events/events.js
+++ b/src/js/events/events.js
@@ -54,6 +54,7 @@ define([], function() {
         // Model Changes
         JWPLAYER_MEDIA_BUFFER: 'bufferChange',
         JWPLAYER_MEDIA_TIME: 'time',
+        JWPLAYER_MEDIA_TYPE: 'mediaType',
         JWPLAYER_MEDIA_VOLUME: 'volume',
         JWPLAYER_MEDIA_MUTE: 'mute',
         JWPLAYER_MEDIA_META: 'meta',

--- a/src/js/providers/default.js
+++ b/src/js/providers/default.js
@@ -34,9 +34,6 @@ define([
         // Sets the parent element, causing provider to append <video> into it
         setContainer : returnFalse,
 
-        isAudioFile : returnFalse,
-        supportsFullscreen : returnFalse,
-
         getName: noop,
         getQualityLevels : noop,
         getCurrentQuality : noop,
@@ -62,6 +59,16 @@ define([
 
             this.sendEvent(events.JWPLAYER_PLAYER_STATE, {
                 newstate: state
+            });
+        },
+
+        sendMediaType : function(levels) {
+            var type = levels[0].type;
+            var isAudioFile = (type === 'oga' || type === 'aac' || type === 'mp3' ||
+                type === 'mpeg' || type === 'vorbis');
+
+            this.sendEvent(events.JWPLAYER_MEDIA_TYPE, {
+                mediaType : isAudioFile ? 'audio' : 'video'
             });
         }
     };

--- a/src/js/providers/flash.js
+++ b/src/js/providers/flash.js
@@ -111,6 +111,7 @@ define([
                     _beforecompleted = false;
                     this.setState(states.LOADING);
                     _flashCommand('load', item);
+                    this.sendMediaType(item.sources);
                 },
                 play: function() {
                     _flashCommand('play');
@@ -315,13 +316,6 @@ define([
                 getFullScreen: function() {
                     return _fullscreen;
                 },
-                isAudioFile: function() {
-                    if (_item) {
-                        var type = _item.sources[0].type;
-                        return (type === 'oga' || type === 'aac' || type === 'mp3' || type === 'vorbis');
-                    }
-                    return false;
-                },
                 setCurrentQuality: function(quality) {
                     _flashCommand('setCurrentQuality', quality);
                 },
@@ -349,7 +343,6 @@ define([
                 setCurrentAudioTrack : function(audioTrack) {
                     _flashCommand('setCurrentAudioTrack', audioTrack);
                 },
-                supportsFullscreen: _.constant(true),
                 destroy: function() {
                     this.remove();
                     if (_swf) {

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -428,6 +428,7 @@ define([
             }
 
             _setLevels(item.sources);
+            this.sendMediaType(item.sources);
 
             _completeLoad(item.starttime || 0, item.duration || 0);
         };
@@ -661,8 +662,6 @@ define([
                 _videotag.videoWidth, _videotag.videoHeight);
         };
 
-        this.supportsFullscreen = _.constant(true);
-
         this.setFullscreen = function(state) {
             state = !!state;
 
@@ -700,14 +699,6 @@ define([
 
         _this.getFullScreen = function() {
             return _fullscreenState || !!_videotag.webkitDisplayingFullscreen;
-        };
-
-        this.isAudioFile = function() {
-            if (!_levels) {
-                return false;
-            }
-            var type = _levels[0].type;
-            return (type === 'oga' || type === 'aac' || type === 'mp3' || type === 'mpeg' || type === 'vorbis');
         };
 
         this.setCurrentQuality = function(quality) {

--- a/src/js/providers/youtube.js
+++ b/src/js/providers/youtube.js
@@ -517,17 +517,6 @@ define([
             return _container;
         };
 
-        this.supportsFullscreen = function() {
-            return !!(_container && (_container.requestFullscreen ||
-                _container.requestFullScreen ||
-                _container.webkitRequestFullscreen ||
-                _container.webkitRequestFullScreen ||
-                _container.webkitEnterFullscreen ||
-                _container.webkitEnterFullScreen ||
-                _container.mozRequestFullScreen ||
-                _container.msRequestFullscreen));
-        };
-
         this.remove = function() {
             _stopVideo();
 

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -323,7 +323,9 @@ define([
             }
 
             _model.on('change:controls', _onChangeControls);
+            _onChangeControls(_model, _model.get('controls'));
             _model.on('change:state', _stateHandler);
+            _model.on('change:duration', _setLiveMode, this);
 
             _model.mediaController.on(events.JWPLAYER_MEDIA_ERROR, _errorHandler);
             _api.onPlaylistComplete(_playlistCompleteHandler);
@@ -453,14 +455,20 @@ define([
             _this.trigger(evt.type, evt);
         }
 
-        var toggleControls = function() {
-            var controls = _model.get('controls');
-            if (controls) {
+        var _onChangeControls = function(model, bool) {
+            if (bool) {
+                var state = (_instreamMode) ? _instreamModel.get('state') : _model.get('state');
+                // model may be instream or normal depending on who triggers this
+                _stateHandler(model, state);
+            }
+
+            if (bool) {
                 utils.removeClass(_playerElement, 'jw-flag-controls-disabled');
             } else {
                 utils.addClass(_playerElement, 'jw-flag-controls-disabled');
             }
-            _model.getVideo().setControls(controls);
+
+            model.getVideo().setControls(bool);
         };
 
         function _doubleClickFullscreen() {
@@ -470,8 +478,6 @@ define([
         }
 
         function _setupControls() {
-            toggleControls();
-            _model.on('change:controls', toggleControls);
 
             _displayClickHandler = new ClickHandler(_model, _videoLayer);
             _displayClickHandler.on('click', function() {
@@ -537,14 +543,6 @@ define([
             _playerElement.addEventListener('blur', handleBlur);
             _playerElement.addEventListener('keydown', handleKeydown);
             _playerElement.onmousedown = handleMouseDown;
-        }
-
-        function _onChangeControls(model, bool) {
-            if (bool) {
-                var state = (_instreamMode) ? _instreamModel.get('state') : _model.get('state');
-                // model may be instream or normal depending on who triggers this
-                _stateHandler(model, state);
-            }
         }
 
         function stopDragging(model) {
@@ -822,10 +820,10 @@ define([
                 _castDisplay.setState(_model.get('state'));
             }
 
-            var isAudioFile = _isAudioFile();
-            utils.toggleClass(_playerElement, 'jw-flag-media-audio', isAudioFile);
-
-            _model.on('change:duration', _setLiveMode, this);
+            _model.mediaModel.on('change:mediaType', function(model, val) {
+                var isAudioFile = (val ==='audio');
+                utils.toggleClass(_playerElement, 'jw-flag-media-audio', isAudioFile);
+            });
         }
 
         function _setLiveMode(model, duration){
@@ -842,15 +840,6 @@ define([
         function _errorHandler(evt) {
             _stateHandler(_model, states.ERROR);
             _title.updateText(_model, {'title': evt.message});
-        }
-
-        function _isAudioFile() {
-            var model = _instreamMode ? _instreamModel : _model;
-            var provider = model.getVideo();
-            if (provider) {
-                return provider.isAudioFile();
-            }
-            return false;
         }
 
         function _isCasting() {


### PR DESCRIPTION
This addresses two bugs
~~1. Fullscreen icon being visible with audio files~~
2. No poster image being visible with audio files

The fix is to store the type of media in our mediaModel, and ensure the view
reflects this state as a flag jw-flag-media-audio.

When this flag is present we simply apply the necessary styles.

[Delivers #93928228]