### PR TITLE
Use assert test param in all qunit tests

### DIFF
--- a/test/unit/api-config.js
+++ b/test/unit/api-config.js
@@ -22,8 +22,8 @@ define([
 
         var attrs = ['width', 'height', 'base'];
 
-        ok(validWidth(x.width), 'width is a number ' + x.width);
-        ok(validWidth(x.height), 'height is a number ' + x.height);
+        assert.ok(validWidth(x.width), 'width is a number ' + x.width);
+        assert.ok(validWidth(x.height), 'height is a number ' + x.height);
         _.each(attrs, function(a) {
             assert.ok(_.has(x, a), 'Config has ' + a + ' attribute');
         });

--- a/test/unit/api.js
+++ b/test/unit/api.js
@@ -31,10 +31,10 @@ define([
         assert.throws(addListenerWithStringCallback, TypeError, 'passing a string as a callback throws a TypeError');
     });
 
-    test('rendering mode is html5', function() {
+    test('rendering mode is html5', function(assert) {
         var api = createApi('player');
 
-        equal(api.getRenderingMode(), 'html5', 'api.getRenderingMode() returns "html5"');
+        assert.equal(api.getRenderingMode(), 'html5', 'api.getRenderingMode() returns "html5"');
     });
 
     test('can be removed and reused', function(assert) {
@@ -44,7 +44,7 @@ define([
 
         var removeCount = 0;
         api.on('remove', function(event) {
-            equal(++removeCount, 1, 'first remove event callback is triggered first once');
+            assert.equal(++removeCount, 1, 'first remove event callback is triggered first once');
             assert.equal(event.type, 'remove', 'event type is "remove"');
             assert.strictEqual(this, api, 'callback context is the removed api instance');
         });
@@ -52,24 +52,24 @@ define([
         api.remove();
 
         api.setup({}).on('remove', function() {
-            equal(++removeCount, 2, 'second remove event callback is triggered second');
+            assert.equal(++removeCount, 2, 'second remove event callback is triggered second');
         }).remove();
     });
 
-    test('replaces and restores container', function() {
+    test('replaces and restores container', function(assert) {
         var originalContainer = createContainer('player');
         var api = new Api(originalContainer, noop);
 
         var elementInDom = document.getElementById('player');
-        strictEqual(elementInDom, originalContainer, 'container is not replaced before setup');
+        assert.strictEqual(elementInDom, originalContainer, 'container is not replaced before setup');
 
         api.setup({});
         elementInDom = document.getElementById('player');
-        ok(elementInDom !== originalContainer, 'container is replaced after setup');
+        assert.notEqual(elementInDom, originalContainer, 'container is replaced after setup');
 
         api.remove();
         elementInDom = document.getElementById('player');
-        strictEqual(elementInDom, originalContainer, 'container is restored after remove');
+        assert.strictEqual(elementInDom, originalContainer, 'container is restored after remove');
     });
 
     test('event dispatching', function(assert) {
@@ -85,7 +85,7 @@ define([
 
         api.trigger('test', originalEvent);
 
-        equal(originalEvent.type, 'original', 'original event.type is not modified');
+        assert.equal(originalEvent.type, 'original', 'original event.type is not modified');
     });
 
     test('defines methods', function(assert) {
@@ -128,7 +128,7 @@ define([
 
     });
 
-    test('sets up a player with setup(config)', function(assert) {
+    test('has methods that can only be called after setup', function(assert) {
         var done = assert.async();
 
         var api = createApi('player');
@@ -153,7 +153,7 @@ define([
             assert.equal(e.setupTime, qoe.setupTime,
                 'ready event setup time equals QOE setup time');
 
-            assert.ok(api.getMeta() !== meta,
+            assert.notEqual(api.getMeta(), meta,
                 'item meta is reset on ready');
 
             assert.strictEqual(api.getContainer(), document.getElementById('player'),
@@ -199,7 +199,7 @@ define([
 
             done();
         }).on('setupError', function() {
-            ok(false, 'FAIL');
+            assert.ok(false, 'FAIL');
             done();
         });
     });

--- a/test/unit/dxfp.js
+++ b/test/unit/dxfp.js
@@ -7,7 +7,7 @@ define([
     module('dfxp');
 
     test('exceptions', function(assert) {
-        equal(typeof dfxp, 'function', 'dfxp is a function');
+        assert.equal(typeof dfxp, 'function', 'dfxp is a function');
 
         assert.throws(function() {
             dfxp(null);
@@ -15,13 +15,13 @@ define([
 
         var DFXP = '<?xml version="1.0" encoding="UTF-8"?><tt xmlns="http://www.w3.org/2006/10/ttaf1"><head></head><body><div><p begin="00:00:00.5" end="00:00:04">The Peach Open Movie Project presents</p><p begin="00:00:06.5" end="00:00:09">One big rabbit</p><p begin="00:00:11" end="00:00:13">Three rodents</p><p begin="00:00:16.5" end="00:00:19">And one giant payback</p><p begin="00:00:23" end="00:00:25">Get ready</p><p begin="00:00:27" end="00:00:30">Big Buck Bunny</p><p begin="00:00:30" end="00:00:31">Coming soon</p><p begin="00:00:31" end="00:00:33">www.bigbuckbunny.org<br/>Licensed as Creative Commons 3.0 attribution</p></div></body></tt>';
         var captions = parseDFXP(DFXP);
-        equal(captions.length, 8, 'DXFP captions are parsed');
-        equal(captions[7].text.indexOf('www.bigbuckbunny.org'), 0, 'Text is parsed');
+        assert.equal(captions.length, 8, 'DXFP captions are parsed');
+        assert.equal(captions[7].text.indexOf('www.bigbuckbunny.org'), 0, 'Text is parsed');
 
         var DFXPns = '<?xml version="1.0" encoding="UTF-8"?><!-- v1.1 --><tt:tt xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ttp="http://www.w3.org/ns/ttml#parameter" xmlns:tts="http://www.w3.org/ns/ttml#styling" xmlns:tt="http://www.w3.org/ns/ttml" xmlns:ebuttm="urn:ebu:tt:metadata" ttp:timeBase="media" xml:lang="de" ttp:cellResolution="50 30"><tt:body><tt:div><tt:p xml:id="subtitle1" region="bottom" begin="00:00:00.000" end="00:00:02.120" style="textCenter"><tt:span style="textWhite">weiß auf schwarz</tt:span></tt:p></tt:div></tt:body></tt:tt>';
         captions = parseDFXP(DFXPns);
-        equal(captions.length, 1, 'Namespaced DXFP captions are parsed');
-        ok(captions[0].text.indexOf('schwarz') > -1, 'Text is parsed');
+        assert.equal(captions.length, 1, 'Namespaced DXFP captions are parsed');
+        assert.ok(captions[0].text.indexOf('schwarz') > -1, 'Text is parsed');
     });
 
 

--- a/test/unit/embed-swf.js
+++ b/test/unit/embed-swf.js
@@ -6,43 +6,42 @@ define([
 
     module('Embed SWF Util');
 
-    test('embeds a swf', function() {
+    test('embeds a swf', function(assert) {
         var parent = $('<div id="container"></div>')[0];
         var id = 'player_swf_0';
         var swf = createEmbedder(parent, id);
 
-        equal(swf.nodeName, 'OBJECT', 'object node is returned');
-        equal(swf.id, id, 'object id matches specified id');
-        strictEqual(swf.parentNode, parent, 'object is added to specified parent');
+        assert.equal(swf.nodeName, 'OBJECT', 'object node is returned');
+        assert.equal(swf.id, id, 'object id matches specified id');
+        assert.strictEqual(swf.parentNode, parent, 'object is added to specified parent');
 
         // To Flash interface
-        equal(typeof swf.triggerFlash, 'function', 'object.triggerFlash is a function');
+        assert.equal(typeof swf.triggerFlash, 'function', 'object.triggerFlash is a function');
 
         // commenting out this test as it triggers console.error message when flash is not present
         var chainableSwf = swf.triggerFlash('setup', {}).triggerFlash('stop');
-        strictEqual(chainableSwf, swf, 'triggerFlash method is chainable');
+        assert.strictEqual(chainableSwf, swf, 'triggerFlash method is chainable');
 
         // From Flash interface (Backbone.Events)
-        equal(typeof swf.trigger, 'function', 'object.trigger is a function');
-        equal(typeof swf.on, 'function', 'object.on is a function');
-        equal(typeof swf.off, 'function', 'object.off is a function');
-        equal(typeof swf.once, 'function', 'object.once is a function');
+        assert.equal(typeof swf.trigger, 'function', 'object.trigger is a function');
+        assert.equal(typeof swf.on, 'function', 'object.on is a function');
+        assert.equal(typeof swf.off, 'function', 'object.off is a function');
+        assert.equal(typeof swf.once, 'function', 'object.once is a function');
 
         EmbedSwf.remove(swf);
     });
 
-    test('remove a swf', function() {
+    test('remove a swf', function(assert) {
         var parent = $('<div id="container"></div>')[0];
         var id = 'player_swf_1';
         var swf = createEmbedder(parent, id);
         EmbedSwf.remove(swf);
 
-        equal(swf.parentNode, null, 'object is removed from parent');
+        assert.equal(swf.parentNode, null, 'object is removed from parent');
     });
 
     function createEmbedder(parent, id) {
         $('#qunit-fixture').append(parent);
-
 
         return EmbedSwf.embed('../bin-debug/jwplayer.flash.swf', parent, id);
     }

--- a/test/unit/jwplayer-selectplayer.js
+++ b/test/unit/jwplayer-selectplayer.js
@@ -13,28 +13,28 @@ define([
         return $element[0];
     };
 
-    var testInstanceOfApi = function(api) {
-        ok(_.isObject(api), 'jwplayer({dom id}) returned an object');
-        ok(_.isFunction(api.setup), 'object.setup is a function');
+    var testInstanceOfApi = function(assert, api) {
+        assert.ok(_.isObject(api), 'jwplayer({dom id}) returned an object');
+        assert.ok(_.isFunction(api.setup), 'object.setup is a function');
         return api;
     };
 
-    test('is defined', function() {
+    test('is defined', function(assert) {
         // Test jwplayer module
-        ok(_.isFunction(jwplayer), 'jwplayer is a function');
+        assert.ok(_.isFunction(jwplayer), 'jwplayer is a function');
     });
 
-    test('allows plugins to register when no player is found', function() {
+    test('allows plugins to register when no player is found', function(assert) {
         var x = jwplayer();
 
         // It might be preferable to always return an API instance
         // even one not set to replace an element
-        ok(_.isObject(x), 'jwplayer({dom id}) returned an object');
-        ok(_.isFunction(x.registerPlugin), 'object.registerPlugin is a function');
-        strictEqual(x.setup, undefined, 'object.setup is not defined');
+        assert.ok(_.isObject(x), 'jwplayer({dom id}) returned an object');
+        assert.ok(_.isFunction(x.registerPlugin), 'object.registerPlugin is a function');
+        assert.strictEqual(x.setup, undefined, 'object.setup is not defined');
     });
 
-    test('handles invalid queries by returning an object plugins can register', function() {
+    test('handles invalid queries by returning an object plugins can register', function(assert) {
         // test invalid queries after a player is setup
         append('<div id="player"></div>');
 
@@ -44,38 +44,38 @@ define([
 
         // It might be preferable to always return an API instance
         // even one not set to replace an element
-        ok(_.isObject(x), 'jwplayer({dom id}) returned an object');
-        ok(_.isFunction(x.registerPlugin), 'object.registerPlugin is a function');
-        strictEqual(x.setup, undefined, 'object.setup is not defined');
+        assert.ok(_.isObject(x), 'jwplayer({dom id}) returned an object');
+        assert.ok(_.isFunction(x.registerPlugin), 'object.registerPlugin is a function');
+        assert.strictEqual(x.setup, undefined, 'object.setup is not defined');
 
         a.remove();
     });
 
-    test('returns a new api instance when given an element id', function() {
+    test('returns a new api instance when given an element id', function(assert) {
         append('<div id="player"></div>');
 
-        testInstanceOfApi( jwplayer('player') ).remove();
+        testInstanceOfApi( assert, jwplayer('player') ).remove();
     });
 
-    test('returns a new api instance when given an element with an id', function() {
+    test('returns a new api instance when given an element with an id', function(assert) {
         var element = append('<div id="player"></div>');
 
-        testInstanceOfApi( jwplayer(element) ).remove();
+        testInstanceOfApi( assert, jwplayer(element) ).remove();
     });
 
-    test('returns a new api instance when given an element with no id not in the DOM', function() {
+    test('returns a new api instance when given an element with no id not in the DOM', function(assert) {
         var element = $('<div></div>')[0];
 
-        var x = testInstanceOfApi( jwplayer(element) );
+        var x = testInstanceOfApi( assert, jwplayer(element) );
 
         // FIXME: this only works with one player whose id is empty ""
         // TODO: create a lookup table for players? or put the unique id on the element?
-        strictEqual(x, jwplayer(element), 'element selection returns the same instance even without an id');
+        assert.strictEqual(x, jwplayer(element), 'element selection returns the same instance even without an id');
 
         x.remove();
     });
 
-    test('returns the same api instance for matching queries', function() {
+    test('returns the same api instance for matching queries', function(assert) {
         var element = append('<div id="player"></div>');
 
         var x = jwplayer('player');
@@ -93,11 +93,11 @@ define([
         ]);
 
 
-        equal(uniquePlayers.length, 1, 'all queries return the same instance');
-        strictEqual(jwplayer(0), x, 'jwplayer(0) returns the first player');
-        strictEqual(jwplayer(1), y, 'jwplayer(1) returns the seconds player');
+        assert.equal(uniquePlayers.length, 1, 'all queries return the same instance');
+        assert.strictEqual(jwplayer(0), x, 'jwplayer(0) returns the first player');
+        assert.strictEqual(jwplayer(1), y, 'jwplayer(1) returns the seconds player');
 
-        ok(x !== y, 'first player instance does not equal second instance');
+        assert.ok(x !== y, 'first player instance does not equal second instance');
 
         x.remove();
         y.remove();

--- a/test/unit/model-qoe.js
+++ b/test/unit/model-qoe.js
@@ -8,7 +8,7 @@ define([
 
     module('Model QoE');
 
-    test('tracks first frame with provider first frame event', function() {
+    test('tracks first frame with provider first frame event', function(assert) {
         var startTime = _.now();
         var model = new Model().setup({});
 
@@ -21,10 +21,10 @@ define([
         // FIXME: JWPLAYER_PROVIDER_FIRST_FRAME triggers JWPLAYER_MEDIA_FIRST_FRAME : we only need one event
         model.mediaController.trigger(events.JWPLAYER_PROVIDER_FIRST_FRAME);
 
-        validateQoeFirstFrame(model._qoeItem, startTime);
+        validateQoeFirstFrame(assert, model._qoeItem, startTime);
     });
 
-    test('tracks first frame with first increasing time event', function() {
+    test('tracks first frame with first increasing time event', function(assert) {
         var startTime = _.now();
         var model = new Model().setup({});
 
@@ -40,10 +40,10 @@ define([
             position: 1
         });
 
-        validateQoeFirstFrame(model._qoeItem, startTime);
+        validateQoeFirstFrame(assert, model._qoeItem, startTime);
     });
 
-    test('removes media controller event listeners', function() {
+    test('removes media controller event listeners', function(assert) {
         var startTime = _.now();
         var model = new Model().setup({});
 
@@ -53,8 +53,8 @@ define([
         var qoeItem = model._qoeItem;
 
         var qoeDump = qoeItem.dump();
-        ok(validateMeasurement(qoeDump.events.playAttempt, startTime), 'play attempt event was fired');
-        ok(validateMeasurement(qoeDump.events.firstFrame, startTime), 'first frame event was fired');
+        assert.ok(validateMeasurement(qoeDump.events.playAttempt, startTime), 'play attempt event was fired');
+        assert.ok(validateMeasurement(qoeDump.events.firstFrame, startTime), 'first frame event was fired');
 
         // test that listeners are removed by testing that tick events are no longer changed
         qoeItem.tick('playAttempt', -1);
@@ -66,11 +66,11 @@ define([
         model.mediaController.trigger(events.JWPLAYER_PROVIDER_FIRST_FRAME);
 
         qoeDump = qoeItem.dump();
-        equal(qoeDump.events.playAttempt, -1, 'play attempt is unchanged after further media events');
-        equal(qoeDump.events.firstFrame,  -1, 'first frame is unchanged after further media events');
+        assert.equal(qoeDump.events.playAttempt, -1, 'play attempt is unchanged after further media events');
+        assert.equal(qoeDump.events.firstFrame,  -1, 'first frame is unchanged after further media events');
     });
 
-    test('tracks stalled time', function() {
+    test('tracks stalled time', function(assert) {
         var model = new Model().setup({});
 
         model.set('mediaModel', new MediaModel());
@@ -81,10 +81,10 @@ define([
         model.mediaModel.set('state', states.PLAYING);
 
         var qoeDump = model._qoeItem.dump();
-        ok(validateMeasurement(qoeDump.sums.stalled), 'stalled sum is a valid number');
+        assert.ok(validateMeasurement(qoeDump.sums.stalled), 'stalled sum is a valid number');
     });
 
-    test('uses one qoe item per playlist item', function() {
+    test('uses one qoe item per playlist item', function(assert) {
         // Test qoe model observation
         var model = new Model().setup({});
 
@@ -99,16 +99,20 @@ define([
         model.mediaController.trigger(events.JWPLAYER_MEDIA_PLAY_ATTEMPT);
         model.mediaModel.set('state', states.LOADING);
 
-        ok(firstQoeItem !== secondQoeItem, 'qoe items are unique between playlistItem changes');
+        assert.ok(firstQoeItem !== secondQoeItem, 'qoe items are unique between playlistItem changes');
 
         var firstQoeDump = firstQoeItem.dump();
         var secondQoeDump = secondQoeItem.dump();
 
-        ok(firstQoeDump.events.playAttempt === undefined, 'play attempt is was not tracked for first unplayed item');
-        ok(secondQoeDump.events.playAttempt !== undefined, 'play attempt is was tracked for second item');
+        assert.ok(firstQoeDump.events.playAttempt === undefined,
+            'play attempt is was not tracked for first unplayed item');
+        assert.ok(secondQoeDump.events.playAttempt !== undefined,
+            'play attempt is was tracked for second item');
 
-        ok(firstQoeDump.counts.loading === undefined, 'loading was not tracked for first unplayed item');
-        ok(secondQoeDump.counts.loading === 1, 'loading was tracked for second item');
+        assert.ok(firstQoeDump.counts.loading === undefined,
+            'loading was not tracked for first unplayed item');
+        assert.ok(secondQoeDump.counts.loading === 1,
+            'loading was tracked for second item');
 
     });
 
@@ -118,21 +122,21 @@ define([
     };
     _.extend(MediaModel.prototype, Model.prototype);
 
-    function validateQoeFirstFrame(qoeItem, startTime) {
-        ok(!!qoeItem, 'qoeItem is defined');
+    function validateQoeFirstFrame(assert, qoeItem, startTime) {
+        assert.ok(!!qoeItem, 'qoeItem is defined');
 
         var loadTime = qoeItem.between(events.JWPLAYER_MEDIA_PLAY_ATTEMPT, events.JWPLAYER_MEDIA_FIRST_FRAME);
-        ok(validateMeasurement(loadTime), 'time to first frame is a valid number');
+        assert.ok(validateMeasurement(loadTime), 'time to first frame is a valid number');
 
         var qoeDump = qoeItem.dump();
-        equal(qoeDump.counts.idle, 1,       'one idle event');
-        equal(qoeDump.counts.loading, 1, 'one loading event');
-        equal(qoeDump.counts.playing, 1, 'one playing event');
-        ok(validateMeasurement(qoeDump.sums.idle),       'idle sum is a valid number');
-        ok(validateMeasurement(qoeDump.sums.loading), 'loading sum is a valid number');
-        ok(validateMeasurement(qoeDump.events.playlistItem, startTime), 'playlistItem epoch time is ok');
-        ok(validateMeasurement(qoeDump.events.playAttempt, startTime),   'playAttempt epoch time is ok');
-        ok(validateMeasurement(qoeDump.events.firstFrame, startTime),     'firstFrame epoch time is ok');
+        assert.equal(qoeDump.counts.idle, 1,       'one idle event');
+        assert.equal(qoeDump.counts.loading, 1, 'one loading event');
+        assert.equal(qoeDump.counts.playing, 1, 'one playing event');
+        assert.ok(validateMeasurement(qoeDump.sums.idle),       'idle sum is a valid number');
+        assert.ok(validateMeasurement(qoeDump.sums.loading), 'loading sum is a valid number');
+        assert.ok(validateMeasurement(qoeDump.events.playlistItem, startTime), 'playlistItem epoch time is ok');
+        assert.ok(validateMeasurement(qoeDump.events.playAttempt, startTime),   'playAttempt epoch time is ok');
+        assert.ok(validateMeasurement(qoeDump.events.firstFrame, startTime),     'firstFrame epoch time is ok');
     }
 
     function validateMeasurement(value, min) {

--- a/test/unit/playlist-filtering.js
+++ b/test/unit/playlist-filtering.js
@@ -32,73 +32,73 @@ define([
         mixed   : [mp4.tagged, undefined, mp4.tagged]
     };
 
-    function testSource(sourceName, desiredType, isFlash, isAndroidHls) {
+    function testSource(assert, sourceName, desiredType, isFlash, isAndroidHls) {
         var source = sources[sourceName];
 
         var primary = isFlash ? 'flash' : undefined;
 
         if (primary === 'flash' && !helpers.flashVersion()) {
-            ok(true, 'Ignore flash test when plugin is unavailable');
+            assert.ok(true, 'Ignore flash test when plugin is unavailable');
             return;
         }
 
         var filtered = playlist.filterSources(source, new Providers({primary:primary}), !!isAndroidHls);
 
         var title = isFlash ? 'Flash only with ' : 'Html5 only with ';
-        equal(sourcesMatch(filtered), desiredType, title + sourceName + ' results in ' + desiredType);
+        assert.equal(sourcesMatch(filtered), desiredType, title + sourceName + ' results in ' + desiredType);
     }
 
     module('playlist.filterSources');
 
-    test('flash only', function() {
-        testSource('flv_mp4', 'flv', true);
-        testSource('mp4_flv', 'mp4', true);
-        testSource('aac_mp4', 'aac', true);
-        testSource('mp4_aac', 'mp4', true);
-        testSource('invalid', undefined, true);
-        testSource('empty', undefined, true);
-        testSource('mixed', 'mp4', true);
+    test('flash only', function(assert) {
+        testSource(assert, 'flv_mp4', 'flv', true);
+        testSource(assert, 'mp4_flv', 'mp4', true);
+        testSource(assert, 'aac_mp4', 'aac', true);
+        testSource(assert, 'mp4_aac', 'mp4', true);
+        testSource(assert, 'invalid', undefined, true);
+        testSource(assert, 'empty', undefined, true);
+        testSource(assert, 'mixed', 'mp4', true);
     });
 
-    test('html5 only', function() {
-        testSource('flv_mp4', 'mp4', false);
-        testSource('mp4_flv', 'mp4', false);
-        testSource('aac_mp4', 'aac', false);
-        testSource('mp4_aac', 'mp4', false);
-        testSource('invalid', undefined, false);
-        testSource('empty', undefined, false);
-        testSource('mixed', 'mp4', false);
+    test('html5 only', function(assert) {
+        testSource(assert, 'flv_mp4', 'mp4', false);
+        testSource(assert, 'mp4_flv', 'mp4', false);
+        testSource(assert, 'aac_mp4', 'aac', false);
+        testSource(assert, 'mp4_aac', 'mp4', false);
+        testSource(assert, 'invalid', undefined, false);
+        testSource(assert, 'empty', undefined, false);
+        testSource(assert, 'mixed', 'mp4', false);
     });
 
 
     module('playlist.filterPlaylist');
 
-    test('filterplaylist', function() {
+    test('filterplaylist', function(assert) {
         var pl;
         pl = playlist.filterPlaylist(playlists['webm_mp4'], new Providers());
-        equal(sourcesMatch(pl[0].sources), 'webm', 'Webm mp4 first source is webm');
-        equal(sourcesMatch(pl[1].sources), 'mp4', 'Webm mp4 second source is mp4');
+        assert.equal(sourcesMatch(pl[0].sources), 'webm', 'Webm mp4 first source is webm');
+        assert.equal(sourcesMatch(pl[1].sources), 'mp4', 'Webm mp4 second source is mp4');
 
         pl = playlist.filterPlaylist(playlists['mp4_webm'], new Providers());
-        equal(sourcesMatch(pl[0].sources), 'mp4', 'Mp4 webm, first source is mp4');
-        equal(sourcesMatch(pl[1].sources), 'webm', 'mp4 webm, second source is webm');
+        assert.equal(sourcesMatch(pl[0].sources), 'mp4', 'Mp4 webm, first source is mp4');
+        assert.equal(sourcesMatch(pl[1].sources), 'webm', 'mp4 webm, second source is webm');
 
         var androidhls = true;
         pl = playlist.filterPlaylist(playlists['mp4_webm'], new Providers(), androidhls);
-        equal(pl[0].sources[0].androidhls, androidhls, 'androidhls is copied to sources');
+        assert.equal(pl[0].sources[0].androidhls, androidhls, 'androidhls is copied to sources');
 
         var empty = [];
         pl = playlist.filterPlaylist(empty, new Providers());
-        equal(pl.length, 0, 'returns an empty array when playlist is empty');
+        assert.equal(pl.length, 0, 'returns an empty array when playlist is empty');
 
         pl = playlist.filterPlaylist([{sources:[]}], new Providers());
-        equal(pl.length, 0, 'filters items with empty sources');
+        assert.equal(pl.length, 0, 'filters items with empty sources');
 
         pl = playlist.filterPlaylist(playlists['mp4_webm']);
-        equal(pl.length, 2, 'supports legacy plugins with providers not set');
+        assert.equal(pl.length, 2, 'supports legacy plugins with providers not set');
 
         pl = playlist.filterPlaylist(playlists['mp4_webm'], {no: 'choose'});
-        equal(pl.length, 2, 'supports legacy plugins with providers.choose not available');
+        assert.equal(pl.length, 2, 'supports legacy plugins with providers.choose not available');
     });
 
 

--- a/test/unit/playlist-item.js
+++ b/test/unit/playlist-item.js
@@ -7,42 +7,42 @@ define([
     module('playlist item');
 
     // http://support.jwplayer.com/customer/portal/articles/1413113-configuration-options-reference
-    function testItem(config) {
+    function testItem(assert, config) {
         var x = item(config);
 
-        ok(_.isObject(x), 'Item generated from ' + config + ' input');
-        ok(_.isArray(x.sources), 'Item has sources array');
-        ok(_.isArray(x.tracks), 'Item has tracks array');
+        assert.ok(_.isObject(x), 'Item generated from ' + config + ' input');
+        assert.ok(_.isArray(x.sources), 'Item has sources array');
+        assert.ok(_.isArray(x.tracks), 'Item has tracks array');
         return x;
     }
 
     // Check for the attrs which testItem does not
-    function testItemComplete(config) {
-        var item = testItem(config);
+    function testItemComplete(assert, config) {
+        var item = testItem(assert, config);
 
         var attrs = ['image', 'description', 'mediaid', 'title'];
         _.each(attrs, function(a) {
-            ok(_.has(item, a), 'Item has ' + a + ' attribute');
+            assert.ok(_.has(item, a), 'Item has ' + a + ' attribute');
         });
 
         return item;
     }
 
-    test('worst case input arguments are handled', function() {
+    test('worst case input arguments are handled', function(assert) {
 
-        testItem();
-        testItem(undefined);
-        testItem({});
-        testItem(true);
-        testItem(false);
-        testItem({title : 'hi', sources: false});
-        testItem({title : 'hi', sources: {}});
-        testItem({tracks: [{}, null]});
-        testItem({tracks: 1});
+        testItem(assert);
+        testItem(assert, undefined);
+        testItem(assert, {});
+        testItem(assert, true);
+        testItem(assert, false);
+        testItem(assert, {title : 'hi', sources: false});
+        testItem(assert, {title : 'hi', sources: {}});
+        testItem(assert, {tracks: [{}, null]});
+        testItem(assert, {tracks: 1});
     });
 
-    test('input with multiple sources, a default and captions track', function() {
-        var x = testItemComplete({
+    test('input with multiple sources, a default and captions track', function(assert) {
+        var x = testItemComplete(assert, {
             image: 'image.png',
             description: 'desc',
             sources: [
@@ -75,24 +75,24 @@ define([
         });
 
         // Test Sources
-        equal(x.sources[0].file, 'f1.mp4', 'First source file set properly');
-        equal(x.sources[1].file, 'rtmp://f2', 'Second source file set properly');
-        equal(x.sources[2].file, 'https://www.youtube.com/watch?v=zKtAuflyc5w', 'Third source file set properly');
-        equal(x.sources.length, 3, 'Sources whose types cannot be determined are removed');
-        ok(!x.sources[0]['default'], 'First source was not set to default');
-        equal(x.sources[1]['default'], true, 'Second source was set to default');
-        equal(x.sources[0].label, 'f1 label', 'First source label matches input.source[0].label');
-        equal(x.sources[1].label, '1', 'Second source label is assigned 1');
+        assert.equal(x.sources[0].file, 'f1.mp4', 'First source file is correct');
+        assert.equal(x.sources[1].file, 'rtmp://f2', 'Second source file is correct');
+        assert.equal(x.sources[2].file, 'https://www.youtube.com/watch?v=zKtAuflyc5w', 'Third source file is correct');
+        assert.equal(x.sources.length, 3, 'Sources whose types cannot be determined are removed');
+        assert.ok(!x.sources[0]['default'], 'First source was not set to default');
+        assert.equal(x.sources[1]['default'], true, 'Second source was set to default');
+        assert.equal(x.sources[0].label, 'f1 label', 'First source label matches input.source[0].label');
+        assert.equal(x.sources[1].label, '1', 'Second source label is assigned 1');
 
         // Test tracks
-        equal(x.tracks[0].file, 'fake.vtt', 'First track file matches input.tracks[0].file');
-        equal(x.tracks[0].kind, 'captions', 'First track kind defaults to captions');
-        equal(x.tracks[0].label, 'track label', 'First track label matches input.tracks[0].label');
+        assert.equal(x.tracks[0].file, 'fake.vtt', 'First track file matches input.tracks[0].file');
+        assert.equal(x.tracks[0].kind, 'captions', 'First track kind defaults to captions');
+        assert.equal(x.tracks[0].label, 'track label', 'First track label matches input.tracks[0].label');
 
     });
 
-    test('input source type normalization', function() {
-        var x = testItem({
+    test('input source type normalization', function(assert) {
+        var x = testItem(assert, {
             sources: [
                 {
                     file: 'f1.mp4'
@@ -120,18 +120,18 @@ define([
         });
 
         // Test Source types
-        equal(x.sources[0].type, 'mp4', 'First source mp4 type read from file extension');
-        equal(x.sources[1].type, 'rtmp', 'Second source rtmp type read from file protocol');
-        equal(x.sources[2].type, 'youtube', 'Third source youtube type parsed from url');
-        equal(x.sources[3].type, 'mp4', 'Fourth source mp4 type split from MIME type video/mp4');
-        equal(x.sources[4].type, 'hls', 'm3u8 type normailzed to hls');
-        equal(x.sources[5].type, 'rtmp', 'smil type normailzed to rtmp');
-        equal(x.sources[6].type, 'aac', 'm4a type normailzed to aac');
+        assert.equal(x.sources[0].type, 'mp4', 'First source mp4 type read from file extension');
+        assert.equal(x.sources[1].type, 'rtmp', 'Second source rtmp type read from file protocol');
+        assert.equal(x.sources[2].type, 'youtube', 'Third source youtube type parsed from url');
+        assert.equal(x.sources[3].type, 'mp4', 'Fourth source mp4 type split from MIME type video/mp4');
+        assert.equal(x.sources[4].type, 'hls', 'm3u8 type normailzed to hls');
+        assert.equal(x.sources[5].type, 'rtmp', 'smil type normailzed to rtmp');
+        assert.equal(x.sources[6].type, 'aac', 'm4a type normailzed to aac');
 
     });
 
-    test('input.levels are converted to sources', function() {
-        var x = testItem({
+    test('input.levels are converted to sources', function(assert) {
+        var x = testItem(assert, {
             levels: [{
                 file: 'f1.mp4',
                 label : 'f1 label',
@@ -140,11 +140,11 @@ define([
             }]
         });
 
-        equal(x.sources[0].file, 'f1.mp4', 'first source file matches input.levels[0].file');
+        assert.equal(x.sources[0].file, 'f1.mp4', 'first source file matches input.levels[0].file');
     });
 
-    test('input.captions are converted to tracks', function() {
-        var x = testItem({
+    test('input.captions are converted to tracks', function(assert) {
+        var x = testItem(assert, {
             file: 'x',
             captions: [
                 {
@@ -154,11 +154,11 @@ define([
             ]
         });
 
-        equal(x.tracks[0].file, 'fake.vtt', 'First track file matches input.captions[0].file');
+        assert.equal(x.tracks[0].file, 'fake.vtt', 'First track file matches input.captions[0].file');
     });
 
-    test('property passthrough of unknown values', function() {
-        var x = testItem({
+    test('property passthrough of unknown values', function(assert) {
+        var x = testItem(assert, {
             file: 'x',
             randomStr : 'rrr',
             adSchedule: {
@@ -169,11 +169,11 @@ define([
         });
 
         // This is important for passing adschedule data through
-        equal(x.randomStr, 'rrr', 'Passes through unknown values');
+        assert.equal(x.randomStr, 'rrr', 'Passes through unknown values');
     });
 
-    test('input.sources may contain one source object instead of array', function() {
-        var x = testItem({
+    test('input.sources may contain one source object instead of array', function(assert) {
+        var x = testItem(assert, {
             sources: {
                 file: 'f1.mp4',
                 label : 'f1 label',
@@ -182,6 +182,6 @@ define([
             }
         });
 
-        equal(x.sources[0].file, 'f1.mp4', 'First source file matches input.sources.file');
+        assert.equal(x.sources[0].file, 'f1.mp4', 'First source file matches input.sources.file');
     });
 });

--- a/test/unit/playlist.js
+++ b/test/unit/playlist.js
@@ -14,43 +14,43 @@ define([
 
     module('playlist');
 
-    test('Test initialized successfully', function() {
-        expect(3);
+    test('Test initialized successfully', function(assert) {
+        assert.expect(3);
 
-        equal(typeof item, 'function', 'item is defined');
-        equal(typeof source, 'function', 'source is defined');
-        equal(typeof track, 'function', 'track is defined');
+        assert.equal(typeof item, 'function', 'item is defined');
+        assert.equal(typeof source, 'function', 'source is defined');
+        assert.equal(typeof track, 'function', 'track is defined');
     });
 
-    test('Test constructor with single item', function () {
-        expect(3);
+    test('Test constructor with single item', function (assert) {
+        assert.expect(3);
         var p;
 
         p = playlist(mp4.starscape);
-        ok(isValidPlaylistItem(p[0]), 'Initialize single item');
+        assert.ok(isValidPlaylistItem(p[0]), 'Initialize single item');
 
         p = playlist(undefined);
-        ok(isValidPlaylistItem(p[0]), 'Initialize with undefined item');
+        assert.ok(isValidPlaylistItem(p[0]), 'Initialize with undefined item');
 
         // TODO: this doesn't actually work, shouldn't pass
         p = playlist(mp4.starscape.file);
-        ok(isValidPlaylistItem(p[0]), 'Initialize with just file name');
+        assert.ok(isValidPlaylistItem(p[0]), 'Initialize with just file name');
     });
 
-    test('Test constructor with array of items', function () {
-        expect(3);
+    test('Test constructor with array of items', function (assert) {
+        assert.expect(3);
         var p,
             arr = [mp4.starscape, mp4.starscape, mp4.starscape];
 
         p = playlist(arr);
-        equal(p.length, arr.length, 'Same number of items initialized');
+        assert.equal(p.length, arr.length, 'Same number of items initialized');
 
         p = playlist([mp4.starscape]);
-        ok(isValidPlaylistItem(p[0]), 'Initialize single item array');
+        assert.ok(isValidPlaylistItem(p[0]), 'Initialize single item array');
 
         // TODO: inconsistent, this is the only case where it returns an empty array
         p = playlist([]);
-        ok(_.isArray(p) && p.length === 0, 'Initialize with an empty array as argument');
+        assert.ok(_.isArray(p) && p.length === 0, 'Initialize with an empty array as argument');
     });
 
 });

--- a/test/unit/provider.js
+++ b/test/unit/provider.js
@@ -60,7 +60,7 @@ define([
         return description;
     }
 
-    function getProvidersTestRunner(primary) {
+    function getProvidersTestRunner(assert, primary) {
         var providers = new Providers({primary: primary});
 
         return function testChosenProvider(file, providerName, message) {
@@ -69,60 +69,60 @@ define([
             if (!message) {
                 message = providerName + ' is chosen for ' + fileDescription(file);
             }
-            equal(getName(chosenProvider), providerName, message);
+            assert.equal(getName(chosenProvider), providerName, message);
         };
     }
 
     module('provider primary priority');
 
-    test('no primary defined', function () {
+    test('no primary defined', function (assert) {
         var providerList = new Providers().providers;
-		expect(4);
+        assert.expect(4);
 
-		equal(providerList.length, 3, 'There are 3 providers listed');
-		equal(getName(providerList[0]), 'VideoProvider', 'HTML5 is the number 1 provider');
-		equal(getName(providerList[1]), 'FlashProvider', 'Flash is the number 2 provider');
-		equal(getName(providerList[2]), 'YoutubeProvider', 'YouTube is the number 3 provider');
+		assert.equal(providerList.length, 3, 'There are 3 providers listed');
+		assert.equal(getName(providerList[0]), 'VideoProvider', 'HTML5 is the number 1 provider');
+		assert.equal(getName(providerList[1]), 'FlashProvider', 'Flash is the number 2 provider');
+		assert.equal(getName(providerList[2]), 'YoutubeProvider', 'YouTube is the number 3 provider');
     });
 
-    test('html5 primary requested', function () {
+    test('html5 primary requested', function (assert) {
 		var providerList = new Providers({primary: 'html5'}).providers;
-        expect(4);
+        assert.expect(4);
 
-        equal(providerList.length, 3, 'There are 3 providers listed');
-        equal(getName(providerList[0]), 'VideoProvider', 'HTML5 is the number 1 provider');
-        equal(getName(providerList[1]), 'FlashProvider', 'Flash is the number 2 provider');
-        equal(getName(providerList[2]), 'YoutubeProvider', 'YouTube is the number 3 provider');
+        assert.equal(providerList.length, 3, 'There are 3 providers listed');
+        assert.equal(getName(providerList[0]), 'VideoProvider', 'HTML5 is the number 1 provider');
+        assert.equal(getName(providerList[1]), 'FlashProvider', 'Flash is the number 2 provider');
+        assert.equal(getName(providerList[2]), 'YoutubeProvider', 'YouTube is the number 3 provider');
     });
 
 
-    test('flash primary requested', function () {
+    test('flash primary requested', function (assert) {
 		var providerList = new Providers({primary: 'flash'}).providers;
-        expect(4);
+        assert.expect(4);
 
-        equal(providerList.length, 3, 'There are 3 providers listed');
-        equal(getName(providerList[0]), 'FlashProvider', 'Flash is the number 1 provider');
-        equal(getName(providerList[1]), 'VideoProvider', 'HTML5 is the number 2 provider');
-        equal(getName(providerList[2]), 'YoutubeProvider', 'YouTube is the number 3 provider');
+        assert.equal(providerList.length, 3, 'There are 3 providers listed');
+        assert.equal(getName(providerList[0]), 'FlashProvider', 'Flash is the number 1 provider');
+        assert.equal(getName(providerList[1]), 'VideoProvider', 'HTML5 is the number 2 provider');
+        assert.equal(getName(providerList[2]), 'YoutubeProvider', 'YouTube is the number 3 provider');
     });
 
-	test('invalid primary requested', function () {
+	test('invalid primary requested', function (assert) {
 		var providerList = new Providers({primary:'invalid primary value'}).providers;
-        expect(4);
+        assert.expect(4);
 
-        equal(providerList.length, 3, 'There are 3 providers listed');
-        equal(getName(providerList[0]), 'VideoProvider', 'HTML5 is the number 1 provider');
-        equal(getName(providerList[1]), 'FlashProvider', 'Flash is the number 2 provider');
-        equal(getName(providerList[2]), 'YoutubeProvider', 'YouTube is the number 3 provider');
+        assert.equal(providerList.length, 3, 'There are 3 providers listed');
+        assert.equal(getName(providerList[0]), 'VideoProvider', 'HTML5 is the number 1 provider');
+        assert.equal(getName(providerList[1]), 'FlashProvider', 'Flash is the number 2 provider');
+        assert.equal(getName(providerList[2]), 'YoutubeProvider', 'YouTube is the number 3 provider');
 	});
 
 	module('provider.choose tests');
 
 	// HTML5 Primary
-	test('html5 primary', function () {
-        expect(17);
+	test('html5 primary', function (assert) {
+        assert.expect(17);
 
-        var runTest = getProvidersTestRunner('html5');
+        var runTest = getProvidersTestRunner(assert, 'html5');
 
         // We only allow "androidhls" configurations to use hls on 4.1 and higher
         var isAndroidWithHls = (/Android [456]\.[123456789]]/i).test(navigator.userAgent);
@@ -151,10 +151,10 @@ define([
     });
 
 	// Flash Primary
-	test('flash primary', function () {
-        expect(17);
+	test('flash primary', function (assert) {
+        assert.expect(17);
 
-        var runTest = getProvidersTestRunner('flash');
+        var runTest = getProvidersTestRunner(assert, 'flash');
 
         runTest(videoSources.mp4, 'FlashProvider');
         runTest(videoSources.flv, 'FlashProvider');

--- a/test/unit/setup.js
+++ b/test/unit/setup.js
@@ -103,7 +103,7 @@ define([
         setup.destroy();
 
         _.defer(function() {
-            ok(true, 'so far so good');
+            assert.ok(true, 'so far so good');
             done();
         }, 0);
     });
@@ -120,10 +120,10 @@ define([
 
         testSetup(model, function() {
             assert.ok(true, 'setup ok');
-            notEqual(options, optionsOrig, 'config was modified');
+            assert.notEqual(options, optionsOrig, 'config was modified');
         }, function(message) {
             assert.ok(true, 'setup failed with message: ' + message);
-            notEqual(options, optionsOrig, 'config was modified');
+            assert.notEqual(options, optionsOrig, 'config was modified');
         }, assert.async());
     });
 

--- a/test/unit/storage.js
+++ b/test/unit/storage.js
@@ -7,21 +7,21 @@ define([
 
     module('Storage');
 
-    test('provides persistent storage', function() {
+    test('provides persistent storage', function(assert) {
 
         storage.clear();
         var data = storage.getAllItems();
-        strictEqual(_.size(data), 0, 'storage is empty after calling clear');
+        assert.strictEqual(_.size(data), 0, 'storage is empty after calling clear');
 
         storage.setItem('alpha', 'beta');
         data = storage.getAllItems();
-        strictEqual(_.size(data), 1, '1 item is added after calling setItem on a new item');
+        assert.strictEqual(_.size(data), 1, '1 item is added after calling setItem on a new item');
 
-        strictEqual(data.alpha, 'beta', 'value stored and retrieved properly');
-        strictEqual(storage.getItem('alpha'), 'beta', 'a single value can be retrieved wit getItem');
+        assert.strictEqual(data.alpha, 'beta', 'value stored and retrieved properly');
+        assert.strictEqual(storage.getItem('alpha'), 'beta', 'a single value can be retrieved wit getItem');
 
         storage.removeItem('alpha');
         data = storage.getAllItems();
-        strictEqual(_.size(data), 0, 'storage is empty after removing last item');
+        assert.strictEqual(_.size(data), 0, 'storage is empty after removing last item');
     });
 });

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -4,20 +4,20 @@ define([
 ], function ( _, utils) {
     /* jshint qunit: true */
 
-    var testerGenerator = function (method) {
+    var testerGenerator = function (assert, method) {
         return function (left, right, message) {
-            strictEqual(method.apply(this, left), right, message);
+            assert.strictEqual(method.apply(this, left), right, message);
         };
     };
 
     module('utils');
 
-    test('utils.exists', function () {
-        expect(7);
+    test('utils.exists', function(assert) {
+        assert.expect(7);
 
-        equal(typeof utils.exists, 'function', 'This is defined');
+        assert.equal(typeof utils.exists, 'function', 'This is defined');
 
-        var test = testerGenerator(utils.exists);
+        var test = testerGenerator(assert, utils.exists);
         test([true], true);
         test([0],    true);
         test(['ok'], true);
@@ -26,11 +26,11 @@ define([
         test([undefined], false);
     });
 
-    test('utils.getAbsolutePath', function () {
-        expect(9);
-        equal(typeof utils.getAbsolutePath, 'function', 'This is defined');
+    test('utils.getAbsolutePath', function(assert) {
+        assert.expect(9);
+        assert.equal(typeof utils.getAbsolutePath, 'function', 'This is defined');
 
-        var test = testerGenerator(utils.getAbsolutePath);
+        var test = testerGenerator(assert, utils.getAbsolutePath);
         test(['.',   'https://example.com/alpha/beta/gamma'], 'https://example.com/alpha/beta');
         test(['/',   'https://example.com/alpha/beta/gamma'], 'https://example.com/');
         test(['../', 'https://example.com/alpha/beta/gamma'], 'https://example.com/alpha');
@@ -44,42 +44,42 @@ define([
         test(['../hello.mp4', 'https://example.com/hi.html'], 'https://example.com/hello.mp4');
     });
 
-    test('utils.log', function () {
-        expect(2);
-        equal(typeof utils.log, 'function', 'This is defined');
-        strictEqual(utils.log(), undefined, 'utils.log returns undefined');
+    test('utils.log', function(assert) {
+        assert.expect(2);
+        assert.equal(typeof utils.log, 'function', 'This is defined');
+        assert.strictEqual(utils.log(), undefined, 'utils.log returns undefined');
     });
 
-    test('utils browser tests', function () {
-        expect(18);
+    test('utils browser tests', function(assert) {
+        assert.expect(18);
 
-        equal(typeof utils.isFF, 'function', 'This is defined');
-        equal(typeof utils.isIETrident, 'function', 'This is defined');
-        equal(typeof utils.isMSIE, 'function', 'This is defined');
-        equal(typeof utils.isIE, 'function', 'This is defined');
-        equal(typeof utils.isSafari, 'function', 'This is defined');
-        equal(typeof utils.isIOS, 'function', 'This is defined');
-        equal(typeof utils.isAndroidNative, 'function', 'This is defined');
-        equal(typeof utils.isAndroid, 'function', 'This is defined');
-        equal(typeof utils.isMobile, 'function', 'This is defined');
-        
-        equal(typeof utils.isFF(), 'boolean');
-        equal(typeof utils.isIETrident(), 'boolean');
-        equal(typeof utils.isMSIE(), 'boolean');
-        equal(typeof utils.isIE(), 'boolean');
-        equal(typeof utils.isSafari(), 'boolean');
-        equal(typeof utils.isIOS(), 'boolean');
-        equal(typeof utils.isAndroidNative(), 'boolean');
-        equal(typeof utils.isAndroid(), 'boolean');
-        equal(typeof utils.isMobile(), 'boolean');
+        assert.equal(typeof utils.isFF, 'function', 'This is defined');
+        assert.equal(typeof utils.isIETrident, 'function', 'This is defined');
+        assert.equal(typeof utils.isMSIE, 'function', 'This is defined');
+        assert.equal(typeof utils.isIE, 'function', 'This is defined');
+        assert.equal(typeof utils.isSafari, 'function', 'This is defined');
+        assert.equal(typeof utils.isIOS, 'function', 'This is defined');
+        assert.equal(typeof utils.isAndroidNative, 'function', 'This is defined');
+        assert.equal(typeof utils.isAndroid, 'function', 'This is defined');
+        assert.equal(typeof utils.isMobile, 'function', 'This is defined');
+
+        assert.equal(typeof utils.isFF(), 'boolean');
+        assert.equal(typeof utils.isIETrident(), 'boolean');
+        assert.equal(typeof utils.isMSIE(), 'boolean');
+        assert.equal(typeof utils.isIE(), 'boolean');
+        assert.equal(typeof utils.isSafari(), 'boolean');
+        assert.equal(typeof utils.isIOS(), 'boolean');
+        assert.equal(typeof utils.isAndroidNative(), 'boolean');
+        assert.equal(typeof utils.isAndroid(), 'boolean');
+        assert.equal(typeof utils.isMobile(), 'boolean');
     });
 
-    test('utils.isInt', function() {
-        expect(10);
+    test('utils.isInt', function(assert) {
+        assert.expect(10);
 
-        equal(typeof utils.isInt, 'function', 'This is defined');
+        assert.equal(typeof utils.isInt, 'function', 'This is defined');
 
-        var test = testerGenerator(utils.isInt);
+        var test = testerGenerator(assert, utils.isInt);
         test([0],       true);
         test([0x10],    true);
         test([24],      true);
@@ -91,12 +91,12 @@ define([
         test([undefined], false);
     });
 
-    test('utils.typeOf', function() {
-        expect(9);
+    test('utils.typeOf', function(assert) {
+        assert.expect(9);
 
-        equal(typeof utils.typeOf, 'function', 'This is defined');
+        assert.equal(typeof utils.typeOf, 'function', 'This is defined');
 
-        var test = testerGenerator(utils.typeOf);
+        var test = testerGenerator(assert, utils.typeOf);
         test([0],       'number');
         test([''],      'string');
         test([false],   'boolean');
@@ -108,23 +108,23 @@ define([
         test([null],      'null');
     });
 
-    test('utils.flashVersion', function() {
-        expect(2);
+    test('utils.flashVersion', function(assert) {
+        assert.expect(2);
 
         var flashVersion = utils.flashVersion();
 
-        equal(typeof utils.flashVersion, 'function', 'flashVersion is defined');
-        equal(typeof flashVersion, 'number', 'Flash version is ' + flashVersion);
+        assert.equal(typeof utils.flashVersion, 'function', 'flashVersion is defined');
+        assert.equal(typeof flashVersion, 'number', 'Flash version is ' + flashVersion);
     });
 
-    test('utils.getScriptPath', function() {
-        expect(2);
+    test('utils.getScriptPath', function(assert) {
+        assert.expect(2);
 
-        equal(typeof utils.getScriptPath, 'function', 'This is defined');
-        ok(/\S+\:\/\/.+\/$/.test(utils.getScriptPath('utils.js')));
+        assert.equal(typeof utils.getScriptPath, 'function', 'This is defined');
+        assert.ok(/\S+\:\/\/.+\/$/.test(utils.getScriptPath('utils.js')));
     });
 
-    test('utils.isYouTube', function() {
+    test('utils.isYouTube', function(assert) {
         var sampleUrls = [
             'http://www.youtube.com/watch?v=YE7VzlLtp-4',
             'http://youtu.be/YE7VzlLtp-4',
@@ -134,16 +134,16 @@ define([
             '//youtu.be/YE7VzlLtp-4?extra=foo&extra2=bar'
         ];
 
-        expect(sampleUrls.length+2);
-        equal(typeof utils.isYouTube, 'function', 'This is defined');
+        assert.expect(sampleUrls.length+2);
+        assert.equal(typeof utils.isYouTube, 'function', 'This is defined');
         _.each(sampleUrls, function(value) {
-            equal(utils.isYouTube(value), true, 'Checking utils.isYouTube for ' + value);
+            assert.equal(utils.isYouTube(value), true, 'Checking utils.isYouTube for ' + value);
         });
         var notYoutube = 'http://www.jwplayer.com/video.mp4';
-        equal(utils.isYouTube('value'), false, 'Checking utils.isYouTube for ' + notYoutube);
+        assert.equal(utils.isYouTube('value'), false, 'Checking utils.isYouTube for ' + notYoutube);
     });
 
-    test('utils.youTubeID', function() {
+    test('utils.youTubeID', function(assert) {
         var ytVideoId = 'YE7VzlLtp-4';
 
         var sampleUrls = [
@@ -160,10 +160,10 @@ define([
             ytVideoId
         ];
 
-        expect(sampleUrls.length+1);
-        equal(typeof utils.youTubeID, 'function', 'This is defined');
+        assert.expect(sampleUrls.length+1);
+        assert.equal(typeof utils.youTubeID, 'function', 'This is defined');
         _.each(sampleUrls, function(value) {
-            equal(utils.youTubeID(value), ytVideoId, 'Checking utils.youTubeID for ' + value);
+            assert.equal(utils.youTubeID(value), ytVideoId, 'Checking utils.youTubeID for ' + value);
         });
     });
 
@@ -176,48 +176,48 @@ define([
     // between (clamp)
     // seconds
 
-    test('utils.addClass', function () {
-        expect(4);
-        equal(typeof utils.addClass, 'function', 'This is defined');
+    test('utils.addClass', function (assert) {
+        assert.expect(4);
+        assert.equal(typeof utils.addClass, 'function', 'This is defined');
         
         var element = document.createElement('div');
-        strictEqual(element.className, '', 'Created an element with no classes');
+        assert.strictEqual(element.className, '', 'Created an element with no classes');
 
         utils.addClass(element, 'class1');
-        equal(element.className, 'class1', 'Added first class to element');
+        assert.equal(element.className, 'class1', 'Added first class to element');
 
         utils.addClass(element, 'class2');
-        equal(element.className, 'class1 class2', 'Added second class to element');
+        assert.equal(element.className, 'class1 class2', 'Added second class to element');
     });
 
-    test('utils.removeClass', function () {
-        expect(4);
-        equal(typeof utils.removeClass, 'function', 'This is defined');
+    test('utils.removeClass', function (assert) {
+        assert.expect(4);
+        assert.equal(typeof utils.removeClass, 'function', 'This is defined');
         
         var element = document.createElement('div');
         element.className = 'class1 class2';
-        equal(element.className, 'class1 class2', 'Created an element with two classes');
+        assert.equal(element.className, 'class1 class2', 'Created an element with two classes');
 
         utils.removeClass(element, 'class2');
-        equal(element.className, 'class1', 'Removed second to last class from element');
+        assert.equal(element.className, 'class1', 'Removed second to last class from element');
 
         utils.removeClass(element, 'class1');
-        equal(element.className, '', 'Removed last class from element');
+        assert.equal(element.className, '', 'Removed last class from element');
     });
 
-    test('utils.indexOf', function () {
-        expect(1);
-        equal(typeof utils.indexOf, 'function', 'This is defined');
+    test('utils.indexOf', function (assert) {
+        assert.expect(1);
+        assert.equal(typeof utils.indexOf, 'function', 'This is defined');
         // provided by underscore 1.6
     });
 
-    test('utils.serialize', function () {
-        equal(typeof utils.serialize, 'function', 'utils.serialize is defined');
+    test('utils.serialize', function (assert) {
+        assert.equal(typeof utils.serialize, 'function', 'utils.serialize is defined');
 
         var array = [];
         var object = {};
 
-        var test = testerGenerator(utils.serialize);
+        var test = testerGenerator(assert, utils.serialize);
         test([undefined], null, 'undefined returns null');
         test([null], null, 'null is passed through');
         test([array], array, 'arrays are passed through');


### PR DESCRIPTION
Updated qunit tests to use assert object methods rather than global methods like `equals`, `ok`,  etc...