### PR TITLE
Run polyfills after loading them

### DIFF
--- a/src/js/controller/setup-steps.js
+++ b/src/js/controller/setup-steps.js
@@ -52,7 +52,10 @@ define([
 
     function _loadPolyfills(resolve) {
         if (!window.btoa || !window.atob) {
-            require.ensure(['polyfills/base64'], resolve);
+            require.ensure(['polyfills/base64'], function(require) {
+                require('polyfills/base64');
+                resolve();
+            });
         } else {
             resolve();
         }


### PR DESCRIPTION
Webpack will not initialize a loaded module until it is triggered using the "require" method.

[Fixes #99737876]