### PR TITLE
Make api getter calls safe before setup

### DIFF
--- a/src/js/api/api-mutators.js
+++ b/src/js/api/api-mutators.js
@@ -76,7 +76,10 @@ define([
         // getters
         _.each(passthroughs, function(func) {
             _api[func] = function() {
-                return _controller[func].apply(_controller, arguments);
+                if (_controller[func]) {
+                    return _controller[func].apply(_controller, arguments);
+                }
+                return null;
             };
         });
         // setters (chainable)


### PR DESCRIPTION
Fixes a regression where getState does not throw an exception if called before setup. `!jwplayer(x).getState()` could be used previously to see if a player has been setup on an element or not (hls/adaptive-display.html). With this change all getters will return null if the controller is not setup.