### PR TITLE
Fixes IE11 is centering issue [Delivers #96808212]

### DIFF
--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -25,7 +25,7 @@
 .inset-controlbar() {
     .jw-controlbar {
         display: block;
-        margin: 0 auto;
+        margin: 0 2%;
         max-width: 96%;
         bottom: .7em;
     }


### PR DESCRIPTION
Fixes an issue with how IE11 is centering issue.  Since we don't have any max-width logic relating to skins we're not gaining any advantage from using "margin: 0 auto;" instead of 2% to match our width.

[Delivers #96808212]