### PR TITLE
Fix Vapor controlbar styling issues in Firefox [Delivers #96304012]

### DIFF
--- a/src/css/skins/vapor.less
+++ b/src/css/skins/vapor.less
@@ -17,7 +17,7 @@
     @rail-color: rgba(255, 255, 255, 0.4);
     @thumb-color: @progress-color;
     
-    @rail-height: 100%;
+    @rail-height: 2em;
     @cue-size: .66em;
 
     @volume-background: @inactive-color;


### PR DESCRIPTION
@rail-height is set to 100% for .jw-slider-horizontal, .jw-slider-container, and .jw-rail, .jw-progress, .jw-buffer, but .jw-knob, and .jw-cue is set to 2em, it is causing the time slider to display incorrectly in Firefox. Settings this to 2em as well fixes the issue. 