### PR TITLE
Centering and max-width for skins without full width [Delivers #99798716 #96808212]

### DIFF
--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -24,10 +24,15 @@
 
 .inset-controlbar() {
     .jw-controlbar {
-        display: block;
+        // for correct display in IE browsers
+        display: inline-block;
+        // width assignment is required for IE11 to center correctly
+        width: 96%;
+        max-width: 50em;
         margin: 0 auto;
-        max-width: 96%;
         bottom: .7em;
+        left: 2%;
+        right: 2%;
     }
     &.jw-flag-audio-player .jw-controlbar {
         bottom: 0; // overwrite the inset-controlbar mixin

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -15,6 +15,7 @@ define([
         displaydescription: true,
         mobilecontrols: false,
         repeat: false,
+        castAvailable: false,
         skin: 'seven',
         stretching: stretchUtils.UNIFORM,
         mute: false,


### PR DESCRIPTION
Assigns some styles for centering in IE11 as well as maxwidth in other browsers.  Some additional styles are added for IE based browsers to format correctly.  castAvailable is erroneously assigning values for IE browsers where the chromecast is not supported so a default value was added.

[Delivers #99798716 #96808212]