### PR TITLE
jw-flag-cast-available needs appid to apply the class [Delivers #100152244]

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -399,8 +399,11 @@ define([
             utils.toggleClass(_playerElement, 'jw-flag-casting', val);
         }
         function _onCastAvailable(model, val) {
-            utils.toggleClass(_playerElement, 'jw-flag-cast-available', val);
-            utils.toggleClass(_controlsLayer, 'jw-flag-cast-available', val);
+            var cast = _model.get('cast');
+            if(cast && cast.appid){
+                utils.toggleClass(_playerElement, 'jw-flag-cast-available', val);
+                utils.toggleClass(_controlsLayer, 'jw-flag-cast-available', val);
+            }
         }
 
         function _onStretchChange(model, newVal, oldVal) {


### PR DESCRIPTION
Requires an cast appid to be set in the config for the cast button to display when chrome casts are available.

[Delivers #100152244]