### PR TITLE
Allow non-secure http pages to communicate with secure https hosted swf

### DIFF
--- a/src/flash/com/longtailvideo/jwplayer/player/Player.as
+++ b/src/flash/com/longtailvideo/jwplayer/player/Player.as
@@ -27,7 +27,11 @@ public class Player extends Sprite implements IPlayer {
     protected var _instream:InstreamPlayer;
 
     public function Player() {
-        Security.allowDomain("*");
+        try {
+            Security.allowDomain("*");
+            Security.allowInsecureDomain("*");
+        } catch(e:SecurityError) {}
+
 
         RootReference.init(this);
         this.addEventListener(Event.ADDED_TO_STAGE, stageReady);


### PR DESCRIPTION
Same update to vast.swf and googima.swf in their respective projects. While the behavior manifested itself a new bug, the same kind of setup in 6.12 would break all api calls that attempt to call internal flash methods.

This is a new feature that should stop support requests from users with improper setups that embed https swfs on http pages.

[Delivers #100055722]