### PR TITLE
Only load Youtube provider when needed [Delivers #99737136]

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -223,6 +223,7 @@ define([
                         break;
                     case 'object':
                         _model.setPlaylist(item);
+                        _model.setItem(0);
                         break;
                     case 'number':
                         _model.setItem(item);

--- a/src/js/controller/instream-html5.js
+++ b/src/js/controller/instream-html5.js
@@ -37,6 +37,7 @@ define([
         _this.load = function(item) {
             // Make sure it chooses a provider
             _adModel.setPlaylist([item]);
+            _adModel.setItem(0);
 
             // check provider after item change
             _checkProvider();

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -180,7 +180,6 @@ define([
             }
         };
 
-        // TODO: make this a synchronous action; throw error if playlist is empty
         this.setPlaylist = function(p) {
             var playlist = Playlist(p);
 
@@ -194,13 +193,11 @@ define([
                 });
                 return;
             }
-            
-            this.setItem(0);
         };
 
         // Give the option for a provider to be forced
         this.chooseProvider = function(source) {
-            return _providers.choose(source);
+            return _providers.choose(source).provider;
         };
 
         this.setItem = function(index) {

--- a/src/js/playlist/playlist.js
+++ b/src/js/playlist/playlist.js
@@ -63,15 +63,11 @@ define([
 
     //  Choose from the sources a type which matches our most preferred provider
     function _chooseType(sources, providers) {
-        var m = _.map(sources, function(s) {
-            var provider = providers.choose(s);
-            var priority = providers.priority(provider);
+        var m = _.map(sources, providers.choose, providers);
 
-            return {
-                priority : priority,
-                type : s.type
-            };
-        });
+
+        // Remove sources which don't have a provider
+        m = _.compact(m);
 
         var best = _.max(m, _.property('priority'));
         if (best.priority > -1) {

--- a/src/js/providers/flash.js
+++ b/src/js/providers/flash.js
@@ -363,39 +363,10 @@ define([
     }
 
 
-    var flashExtensions = {
-        'flv': 'video',
-        'f4v': 'video',
-        'mov': 'video',
-        'm4a': 'video',
-        'm4v': 'video',
-        'mp4': 'video',
-        'aac': 'video',
-        'f4a': 'video',
-        'mp3': 'sound',
-        'mpeg': 'sound',
-        'smil': 'rtmp'
-    };
-    var PLAYABLE = _.keys(flashExtensions);
-
     // Register provider
     var F = function(){};
     F.prototype = DefaultProvider;
     FlashProvider.prototype = new F();
-    FlashProvider.supports = function (source) {
-        if(!utils.isFlashSupported()) {
-            return false;
-        }
-
-        var file = source.file;
-        var type = source.type;
-
-        if (utils.isRtmp(file, type)) {
-            return true;
-        }
-
-        return _.contains(PLAYABLE, type);
-    };
 
     return FlashProvider;
 });

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -6,9 +6,8 @@ define([
     'events/events',
     'events/states',
     'utils/eventdispatcher',
-    'providers/default',
-    'utils/video'
-], function(cssUtils, utils, stretchUtils, _, events, states, eventdispatcher, DefaultProvider, video) {
+    'providers/default'
+], function(cssUtils, utils, stretchUtils, _, events, states, eventdispatcher, DefaultProvider) {
 
     var clearInterval = window.clearInterval,
         STALL_DELAY = 256,
@@ -736,61 +735,10 @@ define([
         };
     }
 
-    var MimeTypes = {
-        'aac': 'audio/mp4',
-        'mp4': 'video/mp4',
-        'f4v': 'video/mp4',
-        'm4v': 'video/mp4',
-        'mov': 'video/mp4',
-        //'m4a': 'audio/x-m4a', // converted to aac by source.js
-        'mp3': 'audio/mpeg',
-        'mpeg': 'audio/mpeg',
-        'ogv': 'video/ogg',
-        'ogg': 'video/ogg',
-        'oga': 'video/ogg',
-        'vorbis': 'video/ogg',
-        'webm': 'video/webm',
-
-        // The following are not expected to work in Chrome
-        'f4a': 'video/aac',
-        'm3u8': 'application/vnd.apple.mpegurl',
-        'm3u': 'application/vnd.apple.mpegurl',
-        'hls': 'application/vnd.apple.mpegurl'
-    };
-
-
     // Register provider
     var F = function(){};
     F.prototype = DefaultProvider;
     VideoProvider.prototype = new F();
-    VideoProvider.supports = function(source) {
-
-        var file = source.file;
-        var type = source.type;
-
-        var isAndroidHLS = _useAndroidHLS(source);
-        if (isAndroidHLS !== null) {
-            return isAndroidHLS;
-        }
-
-        // Ensure RTMP files are not seen as videos
-        if (utils.isRtmp(file, type)) {
-            return false;
-        }
-
-        // Not OK to use HTML5 with no extension
-        if (!MimeTypes[type]) {
-            return false;
-        }
-
-        // Last, but not least, we ask the browser
-        // (But only if it's a video with an extension known to work in HTML5)
-        if (video.canPlayType) {
-            var result = video.canPlayType(MimeTypes[type]);
-            return !!result;
-        }
-        return false;
-    };
 
     return VideoProvider;
 

--- a/src/js/providers/providers-loaded.js
+++ b/src/js/providers/providers-loaded.js
@@ -1,0 +1,12 @@
+define([
+    'providers/html5',
+    'providers/flash',
+], function(html5, flash) {
+
+    var Store = {
+        html5: html5,
+        flash: flash
+    };
+
+    return Store;
+});

--- a/src/js/providers/providers-supported.js
+++ b/src/js/providers/providers-supported.js
@@ -1,0 +1,126 @@
+define([
+    'utils/helpers',
+    'utils/underscore',
+    'utils/video'
+], function(utils, _, video) {
+
+    function _useAndroidHLS(source) {
+        if (source.type === 'hls') {
+            //when androidhls is not set to false, allow HLS playback on Android 4.1 and up
+            if (source.androidhls !== false) {
+                var isAndroidNative = utils.isAndroidNative;
+                if (isAndroidNative(2) || isAndroidNative(3) || isAndroidNative('4.0')) {
+                    return false;
+                } else if (utils.isAndroid()) { //utils.isAndroidNative()) {
+                    // skip canPlayType check
+                    // canPlayType returns '' in native browser even though HLS will play
+                    return true;
+                }
+            } else if (utils.isAndroid()) {
+                return false;
+            }
+        }
+        return null;
+    }
+
+    var SupportsMatrix = [
+        {
+            name: 'youtube',
+            supports: function (source) {
+                return (utils.isYouTube(source.file, source.type));
+            }
+        },
+        {
+            name: 'html5',
+            supports: function (source) {
+                var MimeTypes = {
+                    'aac': 'audio/mp4',
+                    'mp4': 'video/mp4',
+                    'f4v': 'video/mp4',
+                    'm4v': 'video/mp4',
+                    'mov': 'video/mp4',
+                    //'m4a': 'audio/x-m4a', // converted to aac by source.js
+                    'mp3': 'audio/mpeg',
+                    'mpeg': 'audio/mpeg',
+                    'ogv': 'video/ogg',
+                    'ogg': 'video/ogg',
+                    'oga': 'video/ogg',
+                    'vorbis': 'video/ogg',
+                    'webm': 'video/webm',
+
+                    // The following are not expected to work in Chrome
+                    'f4a': 'video/aac',
+                    'm3u8': 'application/vnd.apple.mpegurl',
+                    'm3u': 'application/vnd.apple.mpegurl',
+                    'hls': 'application/vnd.apple.mpegurl'
+                };
+
+                var file = source.file;
+                var type = source.type;
+
+                var isAndroidHLS = _useAndroidHLS(source);
+                if (isAndroidHLS !== null) {
+                    return isAndroidHLS;
+                }
+
+                // Ensure RTMP files are not seen as videos
+                if (utils.isRtmp(file, type)) {
+                    return false;
+                }
+
+                // Not OK to use HTML5 with no extension
+                if (!MimeTypes[type]) {
+                    return false;
+                }
+
+                // Last, but not least, we ask the browser
+                // (But only if it's a video with an extension known to work in HTML5)
+                if (video.canPlayType) {
+                    var result = video.canPlayType(MimeTypes[type]);
+                    return !!result;
+                }
+                return false;
+            }
+        },
+        {
+            name: 'flash',
+            supports: function (source) {
+                var flashExtensions = {
+                    'flv': 'video',
+                    'f4v': 'video',
+                    'mov': 'video',
+                    'm4a': 'video',
+                    'm4v': 'video',
+                    'mp4': 'video',
+                    'aac': 'video',
+                    'f4a': 'video',
+                    'mp3': 'sound',
+                    'mpeg': 'sound',
+                    'smil': 'rtmp'
+                };
+                var PLAYABLE = _.keys(flashExtensions);
+                if (!utils.isFlashSupported()) {
+                    return false;
+                }
+
+                var file = source.file;
+                var type = source.type;
+
+                if (utils.isRtmp(file, type)) {
+                    return true;
+                }
+
+                return _.contains(PLAYABLE, type);
+            }
+        }
+    ];
+
+    /*
+     _.each(SupportsMatrix, function(supports, name) {
+
+     });
+     */
+
+    return SupportsMatrix;
+
+});

--- a/src/js/providers/youtube.js
+++ b/src/js/providers/youtube.js
@@ -618,16 +618,14 @@ define([
         };
     }
 
-    function supports(source) {
-        return (utils.isYouTube(source.file, source.type));
-    }
+    YoutubeProvider.getName = function() {
+        return { name: 'youtube' };
+    };
 
-    // Required configs
-    var F = function(){};
-    F.prototype = DefaultProvider;
-    YoutubeProvider.prototype = new F();
-    YoutubeProvider.supports = supports;
-
-    return YoutubeProvider;
+    return {
+        register : function(jwplayer) {
+            jwplayer.api.registerProvider(YoutubeProvider);
+        }
+    };
 
 });

--- a/test/config.js
+++ b/test/config.js
@@ -74,9 +74,7 @@ require.config({
     map: {
         // make sure the text plugin is used to load templates
         '*' : {
-            '../css/jwplayer.less': 'less!css/jwplayer'
-        },
-        'providers/html5' : {
+            '../css/jwplayer.less': 'less!css/jwplayer',
             'utils/video': mock + '/video.js'
         }
     },

--- a/test/unit/provider.js
+++ b/test/unit/provider.js
@@ -80,9 +80,9 @@ define([
         assert.expect(4);
 
 		assert.equal(providerList.length, 3, 'There are 3 providers listed');
-		assert.equal(getName(providerList[0]), 'VideoProvider', 'HTML5 is the number 1 provider');
-		assert.equal(getName(providerList[1]), 'FlashProvider', 'Flash is the number 2 provider');
-		assert.equal(getName(providerList[2]), 'YoutubeProvider', 'YouTube is the number 3 provider');
+		assert.equal(getName(providerList[1]), 'html5', 'HTML5 is the number 1 provider');
+		assert.equal(getName(providerList[2]), 'flash', 'Flash is the number 2 provider');
+		assert.equal(getName(providerList[0]), 'youtube', 'YouTube is the number 3 provider');
     });
 
     test('html5 primary requested', function (assert) {
@@ -90,9 +90,9 @@ define([
         assert.expect(4);
 
         assert.equal(providerList.length, 3, 'There are 3 providers listed');
-        assert.equal(getName(providerList[0]), 'VideoProvider', 'HTML5 is the number 1 provider');
-        assert.equal(getName(providerList[1]), 'FlashProvider', 'Flash is the number 2 provider');
-        assert.equal(getName(providerList[2]), 'YoutubeProvider', 'YouTube is the number 3 provider');
+        assert.equal(getName(providerList[1]), 'html5', 'HTML5 is the number 1 provider');
+        assert.equal(getName(providerList[2]), 'flash', 'Flash is the number 2 provider');
+        assert.equal(getName(providerList[0]), 'youtube', 'YouTube is the number 3 provider');
     });
 
 
@@ -101,9 +101,9 @@ define([
         assert.expect(4);
 
         assert.equal(providerList.length, 3, 'There are 3 providers listed');
-        assert.equal(getName(providerList[0]), 'FlashProvider', 'Flash is the number 1 provider');
-        assert.equal(getName(providerList[1]), 'VideoProvider', 'HTML5 is the number 2 provider');
-        assert.equal(getName(providerList[2]), 'YoutubeProvider', 'YouTube is the number 3 provider');
+        assert.equal(getName(providerList[1]), 'flash', 'Flash is the number 1 provider');
+        assert.equal(getName(providerList[2]), 'html5', 'HTML5 is the number 2 provider');
+        assert.equal(getName(providerList[0]), 'youtube', 'YouTube is the number 3 provider');
     });
 
 	test('invalid primary requested', function (assert) {
@@ -111,9 +111,9 @@ define([
         assert.expect(4);
 
         assert.equal(providerList.length, 3, 'There are 3 providers listed');
-        assert.equal(getName(providerList[0]), 'VideoProvider', 'HTML5 is the number 1 provider');
-        assert.equal(getName(providerList[1]), 'FlashProvider', 'Flash is the number 2 provider');
-        assert.equal(getName(providerList[2]), 'YoutubeProvider', 'YouTube is the number 3 provider');
+        assert.equal(getName(providerList[1]), 'html5', 'HTML5 is the number 1 provider');
+        assert.equal(getName(providerList[2]), 'flash', 'Flash is the number 2 provider');
+        assert.equal(getName(providerList[0]), 'youtube', 'YouTube is the number 3 provider');
 	});
 
 	module('provider.choose tests');
@@ -127,24 +127,24 @@ define([
         // We only allow "androidhls" configurations to use hls on 4.1 and higher
         var isAndroidWithHls = (/Android [456]\.[123456789]]/i).test(navigator.userAgent);
 
-        runTest(videoSources.mp4, 'VideoProvider');
-        runTest(videoSources.f4v, 'VideoProvider');
-        runTest(videoSources.m4v, 'VideoProvider');
-        runTest(videoSources.m4a, 'VideoProvider');
-        runTest(videoSources.aac, 'VideoProvider');
-        runTest(videoSources.mp3, 'VideoProvider');
-        runTest(videoSources.ogg, 'VideoProvider');
-        runTest(videoSources.oga, 'VideoProvider');
-        runTest(videoSources.webm,'VideoProvider');
-        runTest(videoSources.mov, 'VideoProvider');
+        runTest(videoSources.mp4, 'html5');
+        runTest(videoSources.f4v, 'html5');
+        runTest(videoSources.m4v, 'html5');
+        runTest(videoSources.m4a, 'html5');
+        runTest(videoSources.aac, 'html5');
+        runTest(videoSources.mp3, 'html5');
+        runTest(videoSources.ogg, 'html5');
+        runTest(videoSources.oga, 'html5');
+        runTest(videoSources.webm,'html5');
+        runTest(videoSources.mov, 'html5');
 
         // The video stub defined in this test cannot handle these types
         runTest(videoSources.m3u8,'None chosen');
         runTest(videoSources.hls, 'None chosen');
-        runTest(videoSources.flv, 'FlashProvider');
-        runTest(videoSources.smil,'FlashProvider');
+        runTest(videoSources.flv, 'flash');
+        runTest(videoSources.smil,'flash');
         runTest(videoSources.hls_androidhls_false, 'None chosen');
-        runTest(videoSources.youtube, 'YoutubeProvider');
+        runTest(videoSources.youtube, 'youtube');
 
         // our android androidhls logic in the video provider circumvents the canPlayType check
         runTest(videoSources.hls_androidhls_true,  isAndroidWithHls ? 'None chosen' : 'None chosen');
@@ -156,24 +156,24 @@ define([
 
         var runTest = getProvidersTestRunner(assert, 'flash');
 
-        runTest(videoSources.mp4, 'FlashProvider');
-        runTest(videoSources.flv, 'FlashProvider');
-        runTest(videoSources.smil,'FlashProvider');
-        runTest(videoSources.f4v, 'FlashProvider');
-        runTest(videoSources.m4v, 'FlashProvider');
-        runTest(videoSources.m4a, 'FlashProvider');
-        runTest(videoSources.aac, 'FlashProvider');
-        runTest(videoSources.mp3, 'FlashProvider');
+        runTest(videoSources.mp4, 'flash');
+        runTest(videoSources.flv, 'flash');
+        runTest(videoSources.smil,'flash');
+        runTest(videoSources.f4v, 'flash');
+        runTest(videoSources.m4v, 'flash');
+        runTest(videoSources.m4a, 'flash');
+        runTest(videoSources.aac, 'flash');
+        runTest(videoSources.mp3, 'flash');
         runTest(videoSources.m3u8,'None chosen');
         runTest(videoSources.hls, 'None chosen');
         runTest(videoSources.hls_androidhls_true,  'None chosen');
         runTest(videoSources.hls_androidhls_false, 'None chosen');
-        runTest(videoSources.mov, 'FlashProvider');
+        runTest(videoSources.mov, 'flash');
 
         // The Flash provider cannot play these types
-        runTest(videoSources.ogg, 'VideoProvider');
-        runTest(videoSources.oga, 'VideoProvider');
-        runTest(videoSources.webm,'VideoProvider');
-        runTest(videoSources.youtube, 'YoutubeProvider');
+        runTest(videoSources.ogg, 'html5');
+        runTest(videoSources.oga, 'html5');
+        runTest(videoSources.webm,'html5');
+        runTest(videoSources.youtube, 'youtube');
     });
 });


### PR DESCRIPTION
This commit accomplishes a few things.

1. Allow open source player to register providers
2. Separate the array of providers into two data structures
  * The first is ProvidersSupported - an ordered array of providers by load priority. It contains the name and "supports" method for that provider
  * The second is ProvidersLoaded - a hash of providers, from name to Object
3. Allows ProvidersLoaded to be populated by register provider
4. Allows Youtube to be loaded based off of playlist