### PR TITLE
Fix for volume looping below 0

### DIFF
--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -260,7 +260,7 @@ define([
                 _provider.mute(state);
             }
             if (!state) {
-                var volume = Math.max(20, _this.get('volume'));
+                var volume = Math.max(10, _this.get('volume'));
                 this.setVolume(volume);
             }
         };

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -479,7 +479,10 @@ define([
         }
 
         this.volume = function(vol) {
-            _videotag.volume = Math.min(Math.max(0, (vol||90) / 100), 1);
+            // volume must be 0.0 - 1.0
+            vol = utils.between(vol/100, 0, 1);
+
+            _videotag.volume = vol;
         };
 
         function _volumeHandler() {


### PR DESCRIPTION
The intention of the code was to use a default value of 90 when no value was given to the html5 provider. However since it was done with an || instead of
checking if the value is defined, it converted volumes of 0 to 90.

This default is not necessary since html5Provider.volume is an internal function,
and we can guarantee there will always be a value.

[Delivers #100580948]