### PR TITLE
Flash RTMP provider config properties are in config [Delivers #100776556]

### DIFF
--- a/src/flash/com/longtailvideo/jwplayer/media/MediaProvider.as
+++ b/src/flash/com/longtailvideo/jwplayer/media/MediaProvider.as
@@ -312,7 +312,11 @@ public class MediaProvider extends Sprite implements IMediaProvider {
      * @param property The property to be retrieved.
      * **/
     protected function getConfigProperty(property:String):* {
-        return _config.pluginConfig(provider)[property];
+        var providerConfig:Object = _config[provider];
+        if (providerConfig) {
+            return providerConfig[property];
+        }
+        return null;
     }
 
     /** Translate sources into quality levels. **/

--- a/src/flash/com/longtailvideo/jwplayer/media/RTMPMediaProvider.as
+++ b/src/flash/com/longtailvideo/jwplayer/media/RTMPMediaProvider.as
@@ -202,9 +202,6 @@ public class RTMPMediaProvider extends MediaProvider {
 
     /** Pause playback. **/
     override public function pause():void {
-        CONFIG::debugging {
-            trace('pause', new Error().getStackTrace());
-        }
         // Pause VOD or close live stream
         if (_stream) {
             if (isVOD(_item.duration)) {
@@ -220,9 +217,6 @@ public class RTMPMediaProvider extends MediaProvider {
 
     /** Resume playing. **/
     override public function play():void {
-        CONFIG::debugging {
-            trace('play', new Error().getStackTrace());
-        }
         if (_loading) {
             _afterLoading = play;
             return;
@@ -272,9 +266,6 @@ public class RTMPMediaProvider extends MediaProvider {
 
     /** Close the stream; reset all variables. **/
     override public function stop():void {
-        CONFIG::debugging {
-            trace('stop', new Error().getStackTrace());
-        }
         if (_stream && _stream.time) {
             _stream.close();
         }


### PR DESCRIPTION
Fixes a regression in 7.0 where RTMP config settings were no longer being passed through the ActionScript provider. Not sure how/why these were in 'pluginConfig'. They can be retrieved from the config directly by provider name since 7.0.1.