### PR TITLE
Relative paths in Flash [Fixed #100739214]

### DIFF
--- a/src/flash/com/longtailvideo/jwplayer/media/VideoMediaProvider.as
+++ b/src/flash/com/longtailvideo/jwplayer/media/VideoMediaProvider.as
@@ -333,7 +333,7 @@ public class VideoMediaProvider extends MediaProvider {
             return;
         }
 
-        var url:String = Strings.getAbsolutePath(levels[_currentQuality].file, config.base);
+        var url:String = Strings.getAbsolutePath(levels[_currentQuality].file);
         var prm:Number = _offset.byte;
         if (_item.type == 'mp4') {
             prm = _offset.time;


### PR DESCRIPTION
Using config.base in this method to match JS helpers.getAbsolutePath was a mistake. Media urls are supposed to always be relative to the page. config.base is replaced with the CND or script location before being passed to Flash. Media will never be hosted there. It might have worked as a feature if we passed along the original config.base value. Not a legacy use case as far as I know, so going back to the previous getAbsolutePath in Flash.