### PR TITLE
JW7-815 - Control Compact Mode and Menu Drawer

### DIFF
--- a/src/css/flags/compact-player.less
+++ b/src/css/flags/compact-player.less
@@ -1,0 +1,9 @@
+.jw-flag-compact-player {
+    .jw-icon-playlist,
+    .jw-icon-next,
+    .jw-icon-prev,
+    .jw-text-elapsed,
+    .jw-text-duration {
+        display: none;
+    }
+}

--- a/src/css/imports/controlbar.less
+++ b/src/css/imports/controlbar.less
@@ -12,6 +12,11 @@
     .jw-hidden {
         display: none;
     }
+
+    &.jw-drawer-expanded .jw-controlbar-left-group,
+    &.jw-drawer-expanded .jw-controlbar-center-group {
+        opacity: 0;
+    }
 }
 
 .jw-background-color {

--- a/src/css/imports/tooltip.less
+++ b/src/css/imports/tooltip.less
@@ -1,5 +1,5 @@
 @import "vars";
-@import "../imports/icons";
+@import "icons";
 
 .jw-icon-tooltip.jw-open .jw-overlay {
     opacity: 1;

--- a/src/css/imports/tooltip.less
+++ b/src/css/imports/tooltip.less
@@ -1,4 +1,5 @@
 @import "vars";
+@import "../imports/icons";
 
 .jw-icon-tooltip.jw-open .jw-overlay {
     opacity: 1;
@@ -8,6 +9,21 @@
 .jw-icon-tooltip.jw-hidden {
     display: none;
 }
+
+.jw-overlay-horizontal {
+    display: none;
+}
+
+.jw-icon-tooltip.jw-open-drawer {
+    .jw-icon-close;
+}
+
+.jw-icon-tooltip.jw-open-drawer .jw-overlay-horizontal {
+    opacity: 1;
+    display: inline-block;
+    vertical-align: top;
+}
+
 
 .jw-overlay:after {
     position: absolute;

--- a/src/css/jwplayer.less
+++ b/src/css/jwplayer.less
@@ -34,6 +34,7 @@
 @import "flags/rightclick-open";
 @import "flags/controls-disabled";
 @import "flags/touch";
+@import "flags/compact-player";
 
 // Skins
 @import "skins/seven";

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -37,6 +37,7 @@ define([
                 // Initial state, upon setup
                 state: states.IDLE,
                 fullscreen: false,
+                compactUI: false,
                 scrubbing : false,
                 duration: 0,
                 position: 0,

--- a/src/js/view/components/drawer.js
+++ b/src/js/view/components/drawer.js
@@ -1,0 +1,67 @@
+define([
+    'view/components/tooltip',
+    'utils/helpers',
+    'utils/underscore',
+    'utils/ui'
+], function(Tooltip, utils, _, UI) {
+    var Drawer = Tooltip.extend({
+        constructor: function(name) {
+            this.constructor.__super__.constructor(name);
+
+            this.container.className = 'jw-overlay-horizontal jw-reset';
+            this.openClass = 'jw-open-drawer';
+        },
+        setup : function (list, isCompactMode) {
+            if(!this.iconUI){
+                this.iconUI = new UI(this.el);
+
+                this.toggleOpenStateListener = this.toggleOpenState.bind(this);
+                this.openTooltipListener = this.openTooltip.bind(this);
+                this.closeTooltipListener = this.closeTooltip.bind(this);
+            }
+
+            this.reset();
+
+            list = _.isArray(list) ? list : [];
+
+            var hasActiveContents = _.any(list, function (ele) {
+                return ele.hasContent();
+            });
+
+            utils.toggleClass(this.el, 'jw-hidden', !isCompactMode || !hasActiveContents);
+
+            if (isCompactMode && hasActiveContents) {
+                utils.removeClass(this.el, 'jw-off');
+
+                this.iconUI.on('tap', function (evt) {
+                    if (evt.target === this.el) {
+                        this.isOpen = !this.isOpen;
+                        utils.toggleClass(this.el, this.openClass, this.isOpen);
+                        this.trigger('drawer-open', {'isOpen': this.isOpen});
+                    }
+                }, this);
+
+                this.el.addEventListener('mouseover', this.openTooltipListener);
+                this.el.addEventListener('mouseout', this.closeTooltipListener);
+
+                _.each(list, function (menu) {
+                    this.container.appendChild(menu.el);
+                }, this);
+            }
+            // else, spit the menus back out
+        },
+        reset : function() {
+            utils.addClass(this.el, 'jw-off');
+            this.iconUI.off();
+            if(this.contentUI) {
+                this.contentUI.off().destroy();
+            }
+            this.removeContent();
+
+            this.el.removeEventListener('mouseover', this.openTooltipListener);
+            this.el.removeEventListener('mouseout', this.closeTooltipListener);
+        }
+    });
+
+    return Drawer;
+});

--- a/src/js/view/components/drawer.js
+++ b/src/js/view/components/drawer.js
@@ -6,7 +6,7 @@ define([
 ], function(Tooltip, utils, _, UI) {
     var Drawer = Tooltip.extend({
         constructor: function(name) {
-            this.constructor.__super__.constructor(name);
+            Tooltip.call(this, name);
 
             this.container.className = 'jw-overlay-horizontal jw-reset';
             this.openClass = 'jw-open-drawer';

--- a/src/js/view/components/tooltip.js
+++ b/src/js/view/components/tooltip.js
@@ -9,6 +9,8 @@ define([
             this.el.className = 'jw-icon jw-icon-tooltip ' + name + ' jw-button-color jw-reset jw-hidden';
             this.container = document.createElement('div');
             this.container.className = 'jw-overlay jw-reset';
+            this.openClass = 'jw-open';
+
             this.el.appendChild(this.container);
         },
 
@@ -26,20 +28,23 @@ define([
                 this.content = null;
             }
         },
+        hasContent: function(){
+            return !!this.content;
+        },
         element: function(){
             return this.el;
         },
         openTooltip: function() {
             this.isOpen = true;
-            utils.toggleClass(this.el, 'jw-open', this.isOpen);
+            utils.toggleClass(this.el, this.openClass, this.isOpen);
         },
         closeTooltip: function() {
             this.isOpen = false;
-            utils.toggleClass(this.el, 'jw-open', this.isOpen);
+            utils.toggleClass(this.el, this.openClass, this.isOpen);
         },
         toggleOpenState: function(){
             this.isOpen = !this.isOpen;
-            utils.toggleClass(this.el, 'jw-open', this.isOpen);
+            utils.toggleClass(this.el, this.openClass, this.isOpen);
         }
     });
 

--- a/src/js/view/controlbar.js
+++ b/src/js/view/controlbar.js
@@ -65,7 +65,6 @@ define([
         this._api = _api;
         this._model = _model;
         this._isMobile = utils.isMobile();
-        this._isCompactMode = false;
         this._compactModeMaxSize = 400;
 
         this._leftGroupExpandedSize = false;
@@ -203,6 +202,7 @@ define([
             this._model.on('change:fullscreen', this.onFullscreen, this);
             this._model.on('change:captionsList', this.onCaptionsList, this);
             this._model.on('change:captionsIndex', this.onCaptionsIndex, this);
+            this._model.on('change:compactUI', this.onCompactUI, this);
 
             // Event listeners
 
@@ -283,7 +283,7 @@ define([
 
             this._leftGroupExpandedSize = false;
             this._rightGroupExpandedSize = false;
-            this.setCompactMode(false);
+            this._model.set('compactUI', false);
 
             var itemIdx = model.get('item');
             if(this.elements.playlist) {
@@ -388,7 +388,7 @@ define([
                 this.elements.time.drawCues();
             }
         },
-        isCompactMode : function(containerWidth) {
+        checkCompactMode : function(containerWidth) {
             if(this.element().offsetWidth > 0){
                 if (!this._leftGroupExpandedSize && this.elements.left.offsetWidth) {
                     this._leftGroupExpandedSize = this.elements.left.offsetWidth;
@@ -400,25 +400,21 @@ define([
                     containerRequiredSize = this._leftGroupExpandedSize + this._rightGroupExpandedSize +
                         (this.elements.center.offsetWidth - this.elements.time.el.offsetWidth);
 
-                if(!this._isCompactMode){
-                    // Enter if we're in a small player or our timeslider is too small.
-                    if( containerWidth <= this._compactModeMaxSize || (timeSliderSize && timeSliderShare < 0.25) ){
-                        return true;
-                    }
-                } else {
+                if(this._model.get('compactUI')){
                     // If we're in compact mode and we have enough space to exit it, then do so
                     if( containerWidth > this._compactModeMaxSize &&
                         (containerWidth - containerRequiredSize) / containerWidth >= 0.275) {
-                        return false;
+                        this._model.set('compactUI', false);
+                    }
+                } else {
+                    // Enter if we're in a small player or our timeslider is too small.
+                    if( containerWidth <= this._compactModeMaxSize || (timeSliderSize && timeSliderShare < 0.25) ){
+                        this._model.set('compactUI', true);
                     }
                 }
             }
-
-            // if no conditions to exit a mode occur, or we have no info, then stay in the current mode
-            return this._isCompactMode;
         },
-        setCompactMode : function(isCompact) {
-            this._isCompactMode = isCompact;
+        onCompactUI : function(model, isCompact) {
             utils.toggleClass(this.el, 'jw-drawer-expanded', false);
 
             this.elements.drawer.setup(this.layout.drawer, isCompact);

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -413,6 +413,10 @@ define([
             utils.addClass(_playerElement, 'jw-stretch-' + newVal);
         }
 
+        function _onCompactUIChange(model, newVal) {
+            utils.toggleClass(_playerElement, 'jw-flag-compact-player', newVal);
+        }
+
         function _componentFadeListeners(comp) {
             if (comp && !_isMobile) {
                 comp.element().addEventListener('mousemove', _overControlElement, false);
@@ -539,6 +543,7 @@ define([
             _controlbar = new Controlbar(_api, _model);
             _controlbar.on(events.JWPLAYER_USER_ACTION, _userActivity);
             _model.on('change:scrubbing', _dragging);
+            _model.on('change:compactUI', _onCompactUIChange);
 
             _controlsLayer.appendChild(_controlbar.element());
 
@@ -671,13 +676,6 @@ define([
             utils.toggleClass(_playerElement, 'jw-flag-audio-player', _audioMode);
         }
 
-        function _checkCompactMode(containerWidth) {
-            var compactMode = _controlbar.isCompactMode(containerWidth);
-
-            _controlbar.setCompactMode(compactMode);
-            utils.toggleClass(_playerElement, 'jw-flag-compact-player', compactMode);
-        }
-
         function _isAudioMode(height) {
             if (_model.get('aspectratio')) {
                 return false;
@@ -727,7 +725,7 @@ define([
             }
             _captionsRenderer.resize();
 
-            _checkCompactMode(width);
+            _controlbar.checkCompactMode(width);
         }
 
         this.resize = function(width, height) {
@@ -816,7 +814,7 @@ define([
             _showing = true;
             utils.removeClass(_playerElement, 'jw-flag-user-inactive');
 
-            _checkCompactMode(_videoLayer.clientWidth);
+            _controlbar.checkCompactMode(_videoLayer.clientWidth);
 
             clearTimeout(_controlsTimeout);
             _controlsTimeout = setTimeout(_userInactive, _timeoutDuration);

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -52,8 +52,6 @@ define([
             _title,
             _captionsRenderer,
             _audioMode,
-            _compactMode = false,
-            _compactModeMaxSize = 400,
             _errorState = false,
             _showing = false,
             _replayState,
@@ -674,9 +672,10 @@ define([
         }
 
         function _checkCompactMode(containerWidth) {
-            _compactMode = containerWidth <= _compactModeMaxSize;
+            var compactMode = _controlbar.isCompactMode(containerWidth);
 
-            utils.toggleClass(_playerElement, 'jw-flag-compact-player', _compactMode);
+            _controlbar.setCompactMode(compactMode);
+            utils.toggleClass(_playerElement, 'jw-flag-compact-player', compactMode);
         }
 
         function _isAudioMode(height) {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -52,6 +52,8 @@ define([
             _title,
             _captionsRenderer,
             _audioMode,
+            _compactMode = false,
+            _compactModeMaxSize = 400,
             _errorState = false,
             _showing = false,
             _replayState,
@@ -215,6 +217,7 @@ define([
             var bounds = _bounds(_playerElement),
                 containerWidth = Math.round(bounds.width),
                 containerHeight = Math.round(bounds.height);
+
             if (!document.body.contains(_playerElement)) {
                 window.removeEventListener('resize', _responsiveListener);
                 if (_isMobile) {
@@ -226,6 +229,7 @@ define([
                     _lastHeight = containerHeight;
                     clearTimeout(_resizeMediaTimeout);
                     _resizeMediaTimeout = setTimeout(_resizeMedia, 50);
+
                     _this.trigger(events.JWPLAYER_RESIZE, {
                         width: containerWidth,
                         height: containerHeight
@@ -669,6 +673,12 @@ define([
             utils.toggleClass(_playerElement, 'jw-flag-audio-player', _audioMode);
         }
 
+        function _checkCompactMode(containerWidth) {
+            _compactMode = containerWidth <= _compactModeMaxSize;
+
+            utils.toggleClass(_playerElement, 'jw-flag-compact-player', _compactMode);
+        }
+
         function _isAudioMode(height) {
             if (_model.get('aspectratio')) {
                 return false;
@@ -717,6 +727,8 @@ define([
                 _resizeMediaTimeout = setTimeout(_resizeMedia, 250);
             }
             _captionsRenderer.resize();
+
+            _checkCompactMode(width);
         }
 
         this.resize = function(width, height) {
@@ -819,7 +831,6 @@ define([
             if (_castDisplay) {
                 _castDisplay.setState(_model.get('state'));
             }
-
             _model.mediaModel.on('change:mediaType', function(model, val) {
                 var isAudioFile = (val ==='audio');
                 utils.toggleClass(_playerElement, 'jw-flag-media-audio', isAudioFile);

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -816,6 +816,8 @@ define([
             _showing = true;
             utils.removeClass(_playerElement, 'jw-flag-user-inactive');
 
+            _checkCompactMode(_videoLayer.clientWidth);
+
             clearTimeout(_controlsTimeout);
             _controlsTimeout = setTimeout(_userInactive, _timeoutDuration);
         }

--- a/test/manual/mobile.html
+++ b/test/manual/mobile.html
@@ -8,7 +8,7 @@
 
     <style>
         body {
-            padding: 15px;
+            padding: 5px;
         }
     </style>
 
@@ -134,7 +134,7 @@
             file: 'http://content.bitsontherun.com/videos/3XnJSIm4-I3ZmuSFT.m4a',
             image: 'http://content.bitsontherun.com/thumbs/3XnJSIm4-480.jpg',
             height: "65",
-            width: "300"
+            width: "100%"
         });
     })(window.jwplayer);
 </script>


### PR DESCRIPTION
This manages setting the player into compact mode, which will limit the number of icons which will appear in the controlbar.  In compact mode, we will place extra menu icons into a drawer, which will allow the user to toggle the visibility of the icons when necessary.  Individual commit messages describe each step.

Delivers subtasks JW7-1279 JW7-1281 JW7-1282 JW7-1280 JW7-1283