### PR TITLE
JW7-815 JW7-1282 JW7-1283 Bugfixes for display consistency

### DIFF
--- a/src/css/flags/touch.less
+++ b/src/css/flags/touch.less
@@ -1,6 +1,16 @@
+@import "../imports/icons";
+
 .jw-flag-touch {
     .jw-controlbar {
         font-size: 1.5em;
+    }
+
+    .jw-icon-tooltip.jw-open-drawer {
+        &:before {
+            display: inline;
+        }
+
+        .jw-icon-close;
     }
 }
 

--- a/src/css/imports/tooltip.less
+++ b/src/css/imports/tooltip.less
@@ -1,5 +1,4 @@
 @import "vars";
-@import "icons";
 
 .jw-icon-tooltip.jw-open .jw-overlay {
     opacity: 1;
@@ -15,7 +14,9 @@
 }
 
 .jw-icon-tooltip.jw-open-drawer {
-    .jw-icon-close;
+    &:before {
+        display: none;
+    }
 }
 
 .jw-icon-tooltip.jw-open-drawer .jw-overlay-horizontal {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -811,10 +811,12 @@ define([
         }
 
         function _userActivity() {
-            _showing = true;
-            utils.removeClass(_playerElement, 'jw-flag-user-inactive');
+            if(!_showing){
+                utils.removeClass(_playerElement, 'jw-flag-user-inactive');
+                _controlbar.checkCompactMode(_videoLayer.clientWidth);
+            }
 
-            _controlbar.checkCompactMode(_videoLayer.clientWidth);
+            _showing = true;
 
             clearTimeout(_controlsTimeout);
             _controlsTimeout = setTimeout(_userInactive, _timeoutDuration);

--- a/test/manual/mobile.html
+++ b/test/manual/mobile.html
@@ -8,7 +8,8 @@
 
     <style>
         body {
-            padding: 5px;
+            padding: 0 5px;
+            margin: 0;
         }
     </style>
 
@@ -87,11 +88,6 @@
                     sources: [
                         {file: '//content.bitsontherun.com/videos/bkaovAYt-52qL9xLP.mp4'},
                         {file: '//content.bitsontherun.com/videos/bkaovAYt-27m5HpIu.webm'}
-                    ],
-                    tracks: [
-                        {file: '//playertest.longtailvideo.com/chapters/bunny-chapters.vtt', kind: 'chapters'},
-                        {file: '//playertest.longtailvideo.com/captions/bunny-en.srt', label: 'English'},
-                        {file: '//playertest.longtailvideo.com/captions/bunny-ned.txt', label: 'Dutch'}
                     ],
                     title: 'Big Buck Bunny'
                 }


### PR DESCRIPTION
Touch only has the "X" close button for the drawer.
clearCompactMode called when something which updates the content of the control bar is called so that its always up-to-date
_userActivity only removes classes and checks for compact mode if we were previously not showing the UI.
Pre-calculate the breakpoint for quicker execution and greater consistency for switching between display modes.