### PR TITLE
JW7-1340 Remove event listener we don't need that was breaking Win7 IE 11

### DIFF
--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -127,7 +127,6 @@ define([
                         }
                         elem.addEventListener('pointermove', interactDragHandler);
                         elem.addEventListener('pointerup', interactEndHandler);
-                        elem.addEventListener('lostpointercapture', interactEndHandler);
                         elem.addEventListener('pointercancel', interactEndHandler);
                     }
                 } else if(_useMouseEvents){
@@ -173,7 +172,6 @@ define([
                     elem.releasePointerCapture(_pointerId);
                 }
                 elem.removeEventListener('pointermove', interactDragHandler);
-                elem.removeEventListener('lostpointercapture', interactEndHandler);
                 elem.removeEventListener('pointercancel', interactEndHandler);
                 elem.removeEventListener('pointerup', interactEndHandler);
             } else if (_useMouseEvents) {
@@ -244,7 +242,6 @@ define([
                 }
                 elem.removeEventListener('pointerdown', interactStartHandler);
                 elem.removeEventListener('pointermove', interactDragHandler);
-                elem.removeEventListener('lostpointercapture', interactEndHandler);
                 elem.removeEventListener('pointercancel', interactEndHandler);
                 elem.removeEventListener('pointerup', interactEndHandler);
             }


### PR DESCRIPTION
JW7-1340 Remove event listener we don't need that was breaking Win7 IE 11.  The listener is pretty much just listening to when releasePointerCapture is being called.