### PR TITLE
Improve Flash plugin loader error message and simplify queue handling

### DIFF
--- a/src/flash/com/longtailvideo/jwplayer/utils/AssetLoader.as
+++ b/src/flash/com/longtailvideo/jwplayer/utils/AssetLoader.as
@@ -42,6 +42,8 @@ public class AssetLoader extends EventDispatcher {
 
     private var _loader:Loader;
 
+    private var _url:String;
+
     protected function get loader():Loader {
         if (!_loader) {
             _loader = new Loader();
@@ -66,7 +68,12 @@ public class AssetLoader extends EventDispatcher {
         return _urlLoader;
     }
 
+    public function get url():String {
+        return _url;
+    }
+
     public function load(location:String, expectedClass:Class = null, forceLoader:Boolean = false):void {
+        _url = location;
         _errorState = false;
 
         LoadedClass = expectedClass;

--- a/src/js/providers/flash.js
+++ b/src/js/providers/flash.js
@@ -280,9 +280,7 @@ define([
                         this.trigger(events.JWPLAYER_PROVIDER_CHANGED, e);
                     }, this).on(events.JWPLAYER_ERROR, function(event) {
                         utils.log('Error playing media: %o %s', event.code, event.message, event);
-                        this.trigger(events.JWPLAYER_MEDIA_ERROR, {
-                            message: 'Error loading media: File could not be played'
-                        });
+                        this.trigger(events.JWPLAYER_MEDIA_ERROR, event);
                     }, this);
                 },
                 remove: function() {


### PR DESCRIPTION
- Add url to AssetLoader to make it easy to access the url in loader callbacks
- Simplify plugin loading by keeping an count of active loaders rather than dictionary shenanigans
- Include plugin url in plugin loader error, and pass original Flash error message to JS JWPLAYER_MEDIA_ERROR event

These changes to help developers understand and deal with crossdomain setups and Flash errors in general. Any error in the Flash player currently gets masked as 'Error loading media: File could not be played'. That is not helpful at all, when flash hosted on one domain can't access vast or googima.swf on another (caused by some of out custom test setups).