### PR TITLE
JW7-1082 JW7-1002 JW7-1339  Menu logic improvements and bugfixes

### DIFF
--- a/src/css/imports/tooltip.less
+++ b/src/css/imports/tooltip.less
@@ -26,12 +26,12 @@
 }
 
 
-.jw-overlay:after {
+.jw-overlay:before {
     position: absolute;
-    bottom: -0.5em;
+    top: 0;
+    bottom: 0;
     left: -50%;
     width: 100%;
-    height: 15%;
     background-color: rgba(0, 0, 0, 0);
     content: " ";
 }

--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -188,19 +188,21 @@ define([
             if (_hasMoved) {
                 triggerEvent(touchEvents.DRAG_END, evt);
             } else {
-                if(_usePointerEvents && evt instanceof window.PointerEvent){
-                    if(evt.pointerType === 'touch'){
-                        triggerEvent(touchEvents.TAP, evt);
-                    } else {
+                if(!options.directSelect || evt.target === elem) {
+                    if (_usePointerEvents && evt instanceof window.PointerEvent) {
+                        if (evt.pointerType === 'touch') {
+                            triggerEvent(touchEvents.TAP, evt);
+                        } else {
+                            triggerEvent(touchEvents.CLICK, evt);
+                        }
+                    } else if (_useMouseEvents) {
                         triggerEvent(touchEvents.CLICK, evt);
-                    }
-                } else if (_useMouseEvents) {
-                    triggerEvent(touchEvents.CLICK, evt);
-                } else {
-                    triggerEvent(touchEvents.TAP, evt);
+                    } else {
+                        triggerEvent(touchEvents.TAP, evt);
 
-                    // preventDefault to not dispatch the 300ms delayed click after a tap
-                    preventDefault(evt);
+                        // preventDefault to not dispatch the 300ms delayed click after a tap
+                        preventDefault(evt);
+                    }
                 }
             }
 

--- a/src/js/view/components/drawer.js
+++ b/src/js/view/components/drawer.js
@@ -13,7 +13,7 @@ define([
         },
         setup : function (list, isCompactMode) {
             if(!this.iconUI){
-                this.iconUI = new UI(this.el);
+                this.iconUI = new UI(this.el, { 'directSelect': true });
 
                 this.toggleOpenStateListener = this.toggleOpenState.bind(this);
                 this.openTooltipListener = this.openTooltip.bind(this);
@@ -33,12 +33,10 @@ define([
             if (isCompactMode && hasActiveContents) {
                 utils.removeClass(this.el, 'jw-off');
 
-                this.iconUI.on('tap', function (evt) {
-                    if (evt.target === this.el) {
-                        this.isOpen = !this.isOpen;
-                        utils.toggleClass(this.el, this.openClass, this.isOpen);
-                        this.trigger('drawer-open', {'isOpen': this.isOpen});
-                    }
+                this.iconUI.on('tap', function () {
+                    this.isOpen = !this.isOpen;
+                    utils.toggleClass(this.el, this.openClass, this.isOpen);
+                    this.trigger('drawer-open', {'isOpen': this.isOpen});
                 }, this);
 
                 this.el.addEventListener('mouseover', this.openTooltipListener);

--- a/src/js/view/components/drawer.js
+++ b/src/js/view/components/drawer.js
@@ -13,7 +13,7 @@ define([
         },
         setup : function (list, isCompactMode) {
             if(!this.iconUI){
-                this.iconUI = new UI(this.el, { 'directSelect': true });
+                this.iconUI = new UI(this.el, { 'useHover' : true, 'directSelect': true });
 
                 this.toggleOpenStateListener = this.toggleOpenState.bind(this);
                 this.openTooltipListener = this.openTooltip.bind(this);
@@ -36,15 +36,15 @@ define([
             if (isCompactMode && this.activeContents.length > 1) {
                 utils.removeClass(this.el, 'jw-off');
 
-                this.iconUI.on('tap', function () {
-                    this.isOpen = !this.isOpen;
-                    utils.toggleClass(this.el, this.openClass, this.isOpen);
-                    this.trigger('drawer-open', {'isOpen': this.isOpen});
-                }, this);
-
-                this.el.addEventListener('mouseover', this.openTooltipListener);
-                this.el.addEventListener('mouseout', this.closeTooltipListener);
-
+                this.iconUI
+                    .on('tap', function () {
+                        this.isOpen = !this.isOpen;
+                        utils.toggleClass(this.el, this.openClass, this.isOpen);
+                        this.trigger('drawer-open', {'isOpen': this.isOpen});
+                    }, this)
+                    .on('over', this.openTooltipListener)
+                    .on('out', this.closeTooltipListener);
+                
                 _.each(list, function (menu) {
                     this.container.appendChild(menu.el);
                 }, this);
@@ -57,9 +57,6 @@ define([
                 this.contentUI.off().destroy();
             }
             this.removeContent();
-
-            this.el.removeEventListener('mouseover', this.openTooltipListener);
-            this.el.removeEventListener('mouseout', this.closeTooltipListener);
         }
     });
 

--- a/src/js/view/components/drawer.js
+++ b/src/js/view/components/drawer.js
@@ -10,6 +10,7 @@ define([
 
             this.container.className = 'jw-overlay-horizontal jw-reset';
             this.openClass = 'jw-open-drawer';
+            this.componentType = 'drawer';
         },
         setup : function (list, isCompactMode) {
             if(!this.iconUI){
@@ -37,11 +38,7 @@ define([
                 utils.removeClass(this.el, 'jw-off');
 
                 this.iconUI
-                    .on('tap', function () {
-                        this.isOpen = !this.isOpen;
-                        utils.toggleClass(this.el, this.openClass, this.isOpen);
-                        this.trigger('drawer-open', {'isOpen': this.isOpen});
-                    }, this)
+                    .on('tap', this.toggleOpenStateListener)
                     .on('over', this.openTooltipListener)
                     .on('out', this.closeTooltipListener);
                 

--- a/src/js/view/components/drawer.js
+++ b/src/js/view/components/drawer.js
@@ -24,13 +24,16 @@ define([
 
             list = _.isArray(list) ? list : [];
 
-            var hasActiveContents = _.any(list, function (ele) {
-                return ele.hasContent();
+            // Check how many icons we'd actually hide
+            this.activeContents = _.filter(list, function (ele) {
+                return ele.isActive;
             });
 
-            utils.toggleClass(this.el, 'jw-hidden', !isCompactMode || !hasActiveContents);
+            // If we'd only hide no icons or 1 icon then it isn't worth using the drawer.
+            utils.toggleClass(this.el, 'jw-hidden', !isCompactMode || this.activeContents.length < 2);
 
-            if (isCompactMode && hasActiveContents) {
+            // If we'd hide more than one icon, use the drawer.
+            if (isCompactMode && this.activeContents.length > 1) {
                 utils.removeClass(this.el, 'jw-off');
 
                 this.iconUI.on('tap', function () {
@@ -46,7 +49,6 @@ define([
                     this.container.appendChild(menu.el);
                 }, this);
             }
-            // else, spit the menus back out
         },
         reset : function() {
             utils.addClass(this.el, 'jw-off');

--- a/src/js/view/components/menu.js
+++ b/src/js/view/components/menu.js
@@ -8,7 +8,7 @@ define([
     var Menu = Tooltip.extend({
         setup : function (list, selectedIndex, options) {
             if(!this.iconUI){
-                this.iconUI = new UI(this.el, {'useHover': true});
+                this.iconUI = new UI(this.el, {'useHover': true, 'directSelect': true});
 
                 this.toggleValueListener= this.toggleValue.bind(this);
 

--- a/src/js/view/components/menu.js
+++ b/src/js/view/components/menu.js
@@ -29,6 +29,7 @@ define([
             var isToggle = !isMenu && list.length === 2;
             utils.toggleClass(this.el, 'jw-toggle', isToggle);
             utils.toggleClass(this.el, 'jw-button-color', !isToggle);
+            this.isActive = isMenu || isToggle;
 
             if (isMenu) {
                 utils.removeClass(this.el, 'jw-off');

--- a/src/js/view/components/tooltip.js
+++ b/src/js/view/components/tooltip.js
@@ -10,6 +10,7 @@ define([
             this.container = document.createElement('div');
             this.container.className = 'jw-overlay jw-reset';
             this.openClass = 'jw-open';
+            this.componentType = 'tooltip';
 
             this.el.appendChild(this.container);
         },
@@ -35,12 +36,12 @@ define([
             return this.el;
         },
         openTooltip: function(evt) {
-            this.trigger('tooltip-opened', evt);
+            this.trigger('open-'+this.componentType, evt, {'isOpen': true});
             this.isOpen = true;
             utils.toggleClass(this.el, this.openClass, this.isOpen);
         },
         closeTooltip: function(evt) {
-            this.trigger('tooltip-closed', evt);
+            this.trigger('close-'+this.componentType, evt, {'isOpen': false});
             this.isOpen = false;
             utils.toggleClass(this.el, this.openClass, this.isOpen);
         },

--- a/src/js/view/components/tooltip.js
+++ b/src/js/view/components/tooltip.js
@@ -34,17 +34,22 @@ define([
         element: function(){
             return this.el;
         },
-        openTooltip: function() {
+        openTooltip: function(evt) {
+            this.trigger('tooltip-opened', evt);
             this.isOpen = true;
             utils.toggleClass(this.el, this.openClass, this.isOpen);
         },
-        closeTooltip: function() {
+        closeTooltip: function(evt) {
+            this.trigger('tooltip-closed', evt);
             this.isOpen = false;
             utils.toggleClass(this.el, this.openClass, this.isOpen);
         },
-        toggleOpenState: function(){
-            this.isOpen = !this.isOpen;
-            utils.toggleClass(this.el, this.openClass, this.isOpen);
+        toggleOpenState: function(evt){
+            if(this.isOpen){
+                this.closeTooltip(evt);
+            } else {
+                this.openTooltip(evt);
+            }
         }
     });
 

--- a/src/js/view/components/volumetooltip.js
+++ b/src/js/view/components/volumetooltip.js
@@ -17,7 +17,7 @@ define([
                 this.trigger('update', evt);
             }, this);
 
-            utils.toggleClass(this.el, 'jw-hidden', false);
+            utils.removeClass(this.el, 'jw-hidden');
 
             new UI(this.el, {'useHover': true, 'directSelect': true})
                 .on('click', this.toggleValue, this)

--- a/src/js/view/components/volumetooltip.js
+++ b/src/js/view/components/volumetooltip.js
@@ -19,7 +19,7 @@ define([
 
             utils.toggleClass(this.el, 'jw-hidden', false);
 
-            new UI(this.el, {'useHover': true})
+            new UI(this.el, {'useHover': true, 'directSelect': true})
                 .on('click', this.toggleValue, this)
                 .on('tap', this.toggleOpenState, this)
                 .on('over', this.openTooltip, this)
@@ -27,10 +27,8 @@ define([
 
             this._model.on('change:volume', this.onVolume, this);
         },
-        toggleValue : function(evt){
-            if(evt.target === this.el){
-                this.trigger('toggleValue');
-            }
+        toggleValue : function(){
+            this.trigger('toggleValue');
         }
     });
 

--- a/src/js/view/controlbar.js
+++ b/src/js/view/controlbar.js
@@ -261,7 +261,7 @@ define([
             // When the control bar is interacted with, trigger a user action event
             new UI(this.el).on('click tap drag', function(){ this.trigger('userAction'); }, this);
 
-            this.elements.drawer.on('drawer-open', function(props){
+            this.elements.drawer.on('open-drawer close-drawer', function(evt, props){
                 utils.toggleClass(this.el, 'jw-drawer-expanded', props.isOpen);
                 if(!props.isOpen){
                     this.closeMenus();
@@ -269,7 +269,7 @@ define([
             }, this);
 
             _.each(this.menus, function(ele){
-                ele.on('tooltip-opened', this.closeMenus, this);
+                ele.on('open-tooltip', this.closeMenus, this);
             }, this);
         },
 
@@ -322,7 +322,7 @@ define([
             this._model.mediaModel.on('change:state', function(model, state) {
                 if(state === 'complete') {
                     this.elements.drawer.closeTooltip();
-                    utils.toggleClass(this.el, 'jw-drawer-expanded', false);
+                    utils.removeClass(this.el, 'jw-drawer-expanded');
                 }
             }, this);
         },
@@ -458,7 +458,7 @@ define([
             this.elements.drawer.setup(this.layout.drawer, isCompact);
 
             // If we're not in compact mode or we're not hiding icons, then put them back where they came from.
-            if(!isCompact || this.elements.drawer.activeContents < 2){
+            if(!isCompact || this.elements.drawer.activeContents.length < 2){
                 _.each(this.layout.drawer,function(ele){
                     this.elements.right.insertBefore(ele.el, this.elements.drawer.el);
                 }, this);

--- a/src/js/view/controlbar.js
+++ b/src/js/view/controlbar.js
@@ -420,7 +420,7 @@ define([
             this._maxCompactWidth = -1;
             this._model.set('compactUI', false);
         },
-        // Sets this._maxCompactWidth and this._minCompactWidth so we calculate less per call of isCompactMode
+        // Sets this._maxCompactWidth so we calculate less per call of isCompactMode
         setCompactModeBounds : function(){
             if(this.element().offsetWidth > 0 ){
                 var leftGroupExpandedSize = this.elements.left.offsetWidth,
@@ -458,7 +458,8 @@ define([
 
             this.elements.drawer.setup(this.layout.drawer, isCompact);
 
-            if(!isCompact){
+            // If we're not in compact mode or we're not hiding icons, then put them back where they came from.
+            if(!isCompact || this.elements.drawer.activeContents < 2){
                 _.each(this.layout.drawer,function(ele){
                     this.elements.right.insertBefore(ele.el, this.elements.drawer.el);
                 }, this);

--- a/src/js/view/controlbar.js
+++ b/src/js/view/controlbar.js
@@ -86,10 +86,6 @@ define([
                 volumeTooltip,
                 muteButton;
 
-            drawer.on('drawer-open', function(props){
-                utils.toggleClass(this.el, 'jw-drawer-expanded', props.isOpen);
-            }, this);
-
             // Create the playlistTooltip as long as visualplaylist from the config is not false
             if(this._model.get('visualplaylist') !== false) {
                 playlistTooltip = new Playlist('jw-icon-playlist');
@@ -156,6 +152,12 @@ define([
                     //this.elements.volumetooltip
                 ]
             };
+
+            this.menus = [
+                this.elements.hd,
+                this.elements.cc,
+                this.elements.audiotracks
+            ];
 
             // Remove undefined layout elements.  They are invalid for the current platform.
             // (e.g. volume and volumetooltip on mobile)
@@ -255,6 +257,20 @@ define([
                     // this._api.seek(0) puts the user at the oldest DVR segment available.
                     this._api.seek(-0.1);
                 }
+            }, this);
+
+            // When the control bar is interacted with, trigger a user action event
+            new UI(this.el).on('click tap drag', function(){ this.trigger('userAction'); }, this);
+
+            this.elements.drawer.on('drawer-open', function(props){
+                utils.toggleClass(this.el, 'jw-drawer-expanded', props.isOpen);
+                if(!props.isOpen){
+                    this.closeMenus();
+                }
+            }, this);
+
+            _.each(this.menus, function(ele){
+                ele.on('tooltip-opened', this.closeMenus, this);
             }, this);
         },
 
@@ -387,6 +403,18 @@ define([
                 }, this);
                 this.elements.time.drawCues();
             }
+        },
+        closeMenus : function(evt){
+            _.each(this.menus, function(ele){
+                if(!evt || evt.target !== ele.el) {
+                    ele.closeTooltip();
+                }
+            });
+        },
+        hideComponents : function(){
+            this.closeMenus();
+            this.elements.drawer.closeTooltip();
+            utils.toggleClass(this.el, 'jw-drawer-expanded', false);
         },
         clearCompactMode : function() {
             this._maxCompactWidth = -1;

--- a/src/js/view/controlbar.js
+++ b/src/js/view/controlbar.js
@@ -403,6 +403,7 @@ define([
                 this.elements.time.drawCues();
             }
         },
+        // Close menus if it has no event.  Otherwise close all but the event's target.
         closeMenus : function(evt){
             _.each(this.menus, function(ele){
                 if(!evt || evt.target !== ele.el) {
@@ -413,7 +414,7 @@ define([
         hideComponents : function(){
             this.closeMenus();
             this.elements.drawer.closeTooltip();
-            utils.toggleClass(this.el, 'jw-drawer-expanded', false);
+            utils.removeClass(this.el, 'jw-drawer-expanded');
         },
         clearCompactMode : function() {
             this._maxCompactWidth = -1;
@@ -453,7 +454,7 @@ define([
             }
         },
         onCompactUI : function(model, isCompact) {
-            utils.toggleClass(this.el, 'jw-drawer-expanded', false);
+            utils.removeClass(this.el, 'jw-drawer-expanded');
 
             this.elements.drawer.setup(this.layout.drawer, isCompact);
 

--- a/src/js/view/controlbar.js
+++ b/src/js/view/controlbar.js
@@ -147,17 +147,16 @@ define([
                     this.elements.hd,
                     this.elements.cc,
                     this.elements.audiotracks
-                    //this.elements.mute,
-                    //this.elements.volume,
-                    //this.elements.volumetooltip
                 ]
             };
 
-            this.menus = [
+            this.menus = _.compact([
+                this.elements.playlist,
                 this.elements.hd,
                 this.elements.cc,
-                this.elements.audiotracks
-            ];
+                this.elements.audiotracks,
+                this.elements.volumetooltip
+            ]);
 
             // Remove undefined layout elements.  They are invalid for the current platform.
             // (e.g. volume and volumetooltip on mobile)
@@ -407,7 +406,7 @@ define([
         closeMenus : function(evt){
             _.each(this.menus, function(ele){
                 if(!evt || evt.target !== ele.el) {
-                    ele.closeTooltip();
+                    ele.closeTooltip(evt);
                 }
             });
         },

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -807,6 +807,7 @@ define([
             _showing = false;
 
             clearTimeout(_controlsTimeout);
+            _controlbar.hideComponents();
             utils.addClass(_playerElement, 'jw-flag-user-inactive');
         }
 


### PR DESCRIPTION
JW7-1082 Menus should close after selecting an option from them
JW7-1002 Fixes large menus having unselectable bottom items
JW7-1339 Active Toggle buttons should also be collapsed into the drawers

Other fixes - 
Only one menu can be open at a time
Do not collapse into drawer if it would hide only 1 item
The timeout for determining the user to inactive refreshes each time the user interacts with part of the controller
Menus and drawer close when the ui hides from inactivity or is toggled closed
Added 'directSelect' parameter to UI for interactions where the event should only be fired if the target is the listened element and not its children
Some comment fixes
Fixes issues with hovering the drawer on PointerEvents devices and issues with closing menus