### PR TITLE
BUGFIX: jwplayer 7 does not play any video with flash 11.2

### DIFF
--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -117,7 +117,7 @@ define([
         if (plugins) {
             flash = plugins['Shockwave Flash'];
             if (flash && flash.description) {
-                return parseFloat(flash.description.replace(/\D+(\d+)\..*/, '$1'));
+                return parseFloat(flash.description.replace(/\D+(\d+\.?\d*).*/, '$1'));
             }
         }
 


### PR DESCRIPTION
The problem is in the function browser.flashVersion(), which, although
the flash plugin description is "Shockwave Flash 11.2 r202", returns
11 instead of 11.2, which in turns, makes browser.isFlashSupported()
fail because of the test flashVersion >= __FLASH_VERSION__, with
__FLASH_VERSION__ defined as 11.2.

This is caused by the erroneous regexp /\D+(\d+)\..*/ in the call
to replace() in browser.flashVersion, which searches only the first
digit sequence, but discards the dot and the decimal part.

Fix that by replacing the regexp by /\D+(\d+\.?\d*).*/, which will
search for a digit sequence followed by an optional dot and decimal
part, and answer "11.2", and let browser.isFlashSupported succeed,
and the videos play.

Signed-off-by: Philippe De Muyter <phdm@macqel.be>