### PR TITLE
Optimize CSS routines for JW7-831

### DIFF
--- a/src/js/utils/css.js
+++ b/src/js/utils/css.js
@@ -3,46 +3,8 @@ define([
     'utils/strings'
 ], function(utils, Strings) {
 
-    var MAX_CSS_RULES = 50000,
-        _styleSheets = {},
-        _styleSheet,
-        _rules = {},
-        _ruleIndexes = {},
-        _exists = utils.exists;
+    var _exists = utils.exists;
 
-    function _createStylesheet(debugText) {
-        var styleSheet = document.createElement('style');
-        if (debugText) {
-            styleSheet.appendChild(document.createTextNode(debugText));
-        }
-        styleSheet.type = 'text/css';
-        document.getElementsByTagName('head')[0].appendChild(styleSheet);
-        return styleSheet;
-    }
-
-    var _css = function (selector, styles, important) {
-        important = important || false;
-
-        if (!_rules[selector]) {
-            _rules[selector] = {};
-        }
-
-        if (!_updateStyles(_rules[selector], styles, important)) {
-            //no change in css
-            return;
-        }
-
-        if (!_styleSheets[selector]) {
-            // set stylesheet for selector
-            var numberRules = _styleSheet && _styleSheet.sheet && _styleSheet.sheet.cssRules &&
-                _styleSheet.sheet.cssRules.length || 0;
-            if (!_styleSheet || numberRules > MAX_CSS_RULES) {
-                _styleSheet = _createStylesheet();
-            }
-            _styleSheets[selector] = _styleSheet;
-        }
-        _updateStylesheet(selector);
-    };
 
     var _style = function (elements, styles) {
         if (elements === undefined || elements === null) {
@@ -72,28 +34,11 @@ define([
         }
     };
 
-    function _updateStyles(cssRules, styles, important) {
-        var dirty = false,
-            style, val;
-        for (style in styles) {
-            val = _styleValue(style, styles[style], important);
-            if (val !== '') {
-                if (val !== cssRules[style]) {
-                    cssRules[style] = val;
-                    dirty = true;
-                }
-            } else if (cssRules[style] !== undefined) {
-                delete cssRules[style];
-                dirty = true;
-            }
-        }
-        return dirty;
-    }
-
-
-
     function _styleAttributeName(name) {
         name = name.split('-');
+        if (name.length > 1) {
+            console.error('Use CamelCase!!!');
+        }
         for (var i = 1; i < name.length; i++) {
             name[i] = name[i].charAt(0).toUpperCase() + name[i].slice(1);
         }
@@ -125,61 +70,6 @@ define([
         return Math.ceil(value) + 'px' + importantString;
     }
 
-    function _updateStylesheet(selector) {
-        var sheet = _styleSheets[selector].sheet,
-            cssRules,
-            ruleIndex,
-            ruleText;
-        if (sheet) {
-            cssRules = sheet.cssRules;
-            ruleIndex = _ruleIndexes[selector];
-            ruleText = _getRuleText(selector);
-
-            if (ruleIndex !== undefined && ruleIndex < cssRules.length &&
-                cssRules[ruleIndex].selectorText === selector) {
-                if (ruleText === cssRules[ruleIndex].cssText) {
-                    //no update needed
-                    return;
-                }
-                sheet.deleteRule(ruleIndex);
-            } else {
-                ruleIndex = cssRules.length;
-                _ruleIndexes[selector] = ruleIndex;
-            }
-            _insertRule(sheet, ruleText, ruleIndex);
-        }
-    }
-
-    function _insertRule(sheet, text, index) {
-        utils.tryCatch(function() {
-            sheet.insertRule(text, index);
-        });
-    }
-
-    function _getRuleText(selector) {
-        var styles = _rules[selector];
-        selector += ' { ';
-        for (var style in styles) {
-            selector += style + ': ' + styles[style] + '; ';
-        }
-        return selector + '}';
-    }
-
-
-    // Removes all css elements which match a particular style
-    var _clearCss = function (filter) {
-        for (var rule in _rules) {
-            if (rule.indexOf(filter) >= 0) {
-                delete _rules[rule];
-            }
-        }
-        for (var selector in _styleSheets) {
-            if (selector.indexOf(filter) >= 0) {
-                _updateStylesheet(selector);
-            }
-        }
-    };
-
     var transform = function (element, value) {
         var transform = 'transform',
             style = {};
@@ -189,11 +79,7 @@ define([
         style['-ms-' + transform] = value;
         style['-moz-' + transform] = value;
         style['-o-' + transform] = value;
-        if (typeof element === 'string') {
-            _css(element, style);
-        } else {
-            _style(element, style);
-        }
+        _style(element, style);
     };
 
     var hexToRgba = function (hexColor, opacity) {
@@ -221,9 +107,7 @@ define([
     utils.style = _style;
 
     return {
-        css : _css,
         style : _style,
-        clearCss : _clearCss,
         transform : transform,
         hexToRgba : hexToRgba
     };

--- a/src/js/utils/css.js
+++ b/src/js/utils/css.js
@@ -1,10 +1,6 @@
 define([
-    'utils/helpers',
     'utils/strings'
-], function(utils, Strings) {
-
-    var _exists = utils.exists;
-
+], function(Strings) {
 
     var _style = function (elements, styles) {
         if (elements === undefined || elements === null) {
@@ -46,7 +42,7 @@ define([
     }
 
     function _styleValue(style, value, important) {
-        if (!_exists(value)) {
+        if (value === undefined || value === null) {
             return '';
         }
         var importantString = important ? ' !important' : '';
@@ -103,8 +99,6 @@ define([
         }
         return style + '(' + channels.join(',') + ')';
     };
-
-    utils.style = _style;
 
     return {
         style : _style,

--- a/src/js/utils/helpers.js
+++ b/src/js/utils/helpers.js
@@ -3,12 +3,13 @@ define([
     'utils/underscore',
     'utils/browser',
     'utils/dom',
+    'utils/css',
     'utils/parser',
     'utils/ajax',
     'utils/validator',
     'utils/playerutils',
     'utils/trycatch'
-], function(strings, _, browser, dom, parser, ajax, validator, playerutils, trycatch) {
+], function(strings, _, browser, dom, css, parser, ajax, validator, playerutils, trycatch) {
 
     var utils = {};
 
@@ -55,7 +56,7 @@ define([
     utils.prefix = strings.prefix;
     utils.suffix = strings.suffix;
 
-    _.extend(utils, parser, validator, browser, ajax, dom, playerutils, trycatch);
+    _.extend(utils, parser, validator, browser, ajax, dom, css, playerutils, trycatch);
 
     return utils;
 });

--- a/src/js/view/components/thumbnails.mixin.js
+++ b/src/js/view/components/thumbnails.mixin.js
@@ -52,7 +52,7 @@ define([
             var style = {
                 display: 'block',
                 margin: '0 auto',
-                'background-position': '0 0'
+                backgroundPosition: '0 0'
             };
 
             var hashIndex = url.indexOf('#xywh');
@@ -60,7 +60,7 @@ define([
                 try {
                     var matched = (/(.+)\#xywh=(\d+),(\d+),(\d+),(\d+)/).exec(url);
                     url = matched[1];
-                    style['background-position'] = (matched[2] * -1) + 'px ' + (matched[3] * -1) + 'px';
+                    style.backgroundPosition = (matched[2] * -1) + 'px ' + (matched[3] * -1) + 'px';
                     style.width = matched[4];
                     style.height = matched[5];
                 } catch (e) {
@@ -78,7 +78,7 @@ define([
                 }
             }
 
-            style['background-image'] = url;
+            style.backgroundImage = url;
 
             return style;
         },
@@ -92,9 +92,9 @@ define([
 
         resetThumbnails : function() {
             this.timeTip.image({
-                'background-image' : '',
-                'width' : 0,
-                'height' : 0
+                backgroundImage : '',
+                width : 0,
+                height : 0
             });
             this.thumbnails = [];
         }

--- a/src/js/view/logo.js
+++ b/src/js/view/logo.js
@@ -66,7 +66,7 @@ define([
 
         this.offset = function(offset) {
             _styles(_logo, {
-                'margin-bottom': offset
+                marginBottom: offset
             });
         };
 

--- a/src/js/view/preview.js
+++ b/src/js/view/preview.js
@@ -22,7 +22,7 @@ define([
                 img = encodeURI(img);
                 this.el.style.backgroundImage = 'url("' + img + '")';
             } else {
-                this.el.style['background-image'] = '';
+                this.el.style.backgroundImage = '';
             }
         },
         element : function() {

--- a/src/templates/customstyles.html
+++ b/src/templates/customstyles.html
@@ -1,0 +1,29 @@
+<style type="text/css">
+{{#if inactive}}
+#{{id}} .jw-button-color,
+#{{id}} .jw-option,
+#{{id}} .jw-toggle.jw-off,
+#{{id}} .jw-text,
+#{{id}} .jw-tooltip-title,
+#{{id}} .jw-skip .jw-skip-icon,
+#{{id}} .jw-playlist-container .jw-icon\{color:{{inactive}}\}
+#{{id}} .jw-cue,
+#{{id}} .jw-knob\{background-color:{{inactive}}\}
+#{{id}} .jw-playlist-container .jw-option\{border-bottom-color:{{inactive}}\}
+{{/if}}
+{{#if active}}
+#{{id}} .jw-button-color:hover,
+#{{id}} .jw-toggle\{color:{{active}}\}
+#{{id}} .jw-active-option,
+#{{id}} .jw-progress,
+#{{id}} .jw-playlist-container .jw-option.jw-active-option,
+#{{id}} .jw-playlist-container .jw-option:hover\{background-color:{{active}}\}
+{{/if}}
+{{#if background}}
+#{{id}} .jw-background-color,
+#{{id}} .jw-tooltip-title,
+#{{id}} .jw-playlist,
+#{{id}} .jw-playlist-container .jw-option\{background-color:{{background}}\}
+#{{id}} .jw-playlist-container ::-webkit-scrollbar\{border-color:{{background}}\}
+{{/if}}
+</style>


### PR DESCRIPTION
Using a template for the color config options simplifies this routine in the view and allows us to finally get rid of old css utils making the player smaller.

I also noticed a bunch of places where we were using hyphen-delimited syntax to set inline styles in JavaScript. Our style utility has to replace all of these with camel case on the fly because setting properties on a style object must be done in "camelCase". Instead of making it do extra work and mixing up syntaxes just always use camel case for style json.