### PR TITLE
Optimize 'css' and 'clearCss' utils. Use camel case / dot syntax for inline styles

### DIFF
--- a/src/js/utils/helpers.js
+++ b/src/js/utils/helpers.js
@@ -3,12 +3,13 @@ define([
     'utils/underscore',
     'utils/browser',
     'utils/dom',
+    'utils/css',
     'utils/parser',
     'utils/ajax',
     'utils/validator',
     'utils/playerutils',
     'utils/trycatch'
-], function(strings, _, browser, dom, parser, ajax, validator, playerutils, trycatch) {
+], function(strings, _, browser, dom, css, parser, ajax, validator, playerutils, trycatch) {
 
     var utils = {};
 
@@ -55,7 +56,7 @@ define([
     utils.prefix = strings.prefix;
     utils.suffix = strings.suffix;
 
-    _.extend(utils, parser, validator, browser, ajax, dom, playerutils, trycatch);
+    _.extend(utils, parser, validator, browser, ajax, dom, css, playerutils, trycatch);
 
     return utils;
 });

--- a/src/js/view/components/thumbnails.mixin.js
+++ b/src/js/view/components/thumbnails.mixin.js
@@ -52,7 +52,7 @@ define([
             var style = {
                 display: 'block',
                 margin: '0 auto',
-                'background-position': '0 0'
+                backgroundPosition: '0 0'
             };
 
             var hashIndex = url.indexOf('#xywh');
@@ -60,7 +60,7 @@ define([
                 try {
                     var matched = (/(.+)\#xywh=(\d+),(\d+),(\d+),(\d+)/).exec(url);
                     url = matched[1];
-                    style['background-position'] = (matched[2] * -1) + 'px ' + (matched[3] * -1) + 'px';
+                    style.backgroundPosition = (matched[2] * -1) + 'px ' + (matched[3] * -1) + 'px';
                     style.width = matched[4];
                     style.height = matched[5];
                 } catch (e) {
@@ -78,7 +78,7 @@ define([
                 }
             }
 
-            style['background-image'] = url;
+            style.backgroundImage = url;
 
             return style;
         },
@@ -92,9 +92,9 @@ define([
 
         resetThumbnails : function() {
             this.timeTip.image({
-                'background-image' : '',
-                'width' : 0,
-                'height' : 0
+                backgroundImage : '',
+                width : 0,
+                height : 0
             });
             this.thumbnails = [];
         }

--- a/src/js/view/logo.js
+++ b/src/js/view/logo.js
@@ -66,7 +66,7 @@ define([
 
         this.offset = function(offset) {
             _styles(_logo, {
-                'margin-bottom': offset
+                marginBottom: offset
             });
         };
 

--- a/src/js/view/preview.js
+++ b/src/js/view/preview.js
@@ -22,7 +22,7 @@ define([
                 img = encodeURI(img);
                 this.el.style.backgroundImage = 'url("' + img + '")';
             } else {
-                this.el.style['background-image'] = '';
+                this.el.style.backgroundImage = '';
             }
         },
         element : function() {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -12,12 +12,11 @@ define([
     'view/preview',
     'view/rightclick',
     'view/title',
-    'utils/css',
     'utils/underscore',
     'handlebars-loader!templates/player.html'
 ], function(utils, events, Events, states,
             CaptionsRenderer, ClickHandler, DisplayIcon, Dock, Logo,
-            Controlbar, Preview, RightClick, Title, cssUtils, _, playerTemplate) {
+            Controlbar, Preview, RightClick, Title, _, playerTemplate) {
 
     var _styles = utils.style,
         _bounds = utils.bounds,
@@ -250,58 +249,61 @@ define([
 
         this.handleColorOverrides = function() {
             var id = _model.get('id');
-            function addStyle(attr, elements, color) {
-                if (!color) { return; }
+
+            function addStyle(elements, attr, value) {
+                if (!value) {
+                    return;
+                }
 
                 elements = utils.prefix(elements, '#' + id + ' ');
 
                 var o = {};
-                o[attr] = color;
-                cssUtils.css(elements.join(', '), o);
+                o[attr] = value;
+                utils.css(elements.join(', '), o);
             }
 
             // We can assume that the user will define both an active and inactive color because otherwise it doesn't
             // look good.
             var activeColor = _model.get('skinColorActive'),
-                inactiveColor =_model.get('skinColorInactive'),
+                inactiveColor = _model.get('skinColorInactive'),
                 backgroundColor = _model.get('skinColorBackground');
 
             // Control bar icon coloring
-            addStyle('color',               ['.jw-button-color'],                                   inactiveColor);
-            addStyle('color',               ['.jw-button-color:hover'],                             activeColor);
+            addStyle(['.jw-button-color'], 'color', inactiveColor);
+            addStyle(['.jw-button-color:hover'], 'color', activeColor);
 
             // Control bar men
-            addStyle('color',               ['.jw-option'],                                         inactiveColor);
-            addStyle('background-color',    ['.jw-active-option'],                                  activeColor);
+            addStyle(['.jw-option'], 'color', inactiveColor);
+            addStyle(['.jw-active-option'], 'background-color', activeColor);
 
             // Toggle button styling
-            addStyle('color',               ['.jw-toggle'],                                         activeColor);
-            addStyle('color',               ['.jw-toggle.jw-off'],                                  inactiveColor);
+            addStyle(['.jw-toggle'], 'color', activeColor);
+            addStyle(['.jw-toggle.jw-off'], 'color', inactiveColor);
 
             // Time Bar Styling
-            addStyle('background',          ['.jw-progress'],                                       activeColor);
-            addStyle('background',          ['.jw-cue', '.jw-knob'],                                inactiveColor);
-            addStyle('background',          ['.jw-background-color'],                               backgroundColor);
+            addStyle(['.jw-progress'], 'background', activeColor);
+            addStyle(['.jw-cue', '.jw-knob'], 'background', inactiveColor);
+            addStyle(['.jw-background-color'], 'background', backgroundColor);
 
             // Text, tooltip, and Skip button text
-            addStyle('color',               ['.jw-text'],                                           inactiveColor);
-            addStyle('color',               ['.jw-tooltip-title', '.jw-skip .jw-skip-icon'],        inactiveColor);
+            addStyle(['.jw-text'], 'color', inactiveColor);
+            addStyle(['.jw-tooltip-title', '.jw-skip .jw-skip-icon'], 'color', inactiveColor);
 
             // Playlist Styling
-            addStyle('background-color', [
-                    '.jw-playlist-container .jw-option.jw-active-option',
-                    '.jw-playlist-container .jw-option:hover'
-                ], activeColor);
+            addStyle([
+                '.jw-playlist-container .jw-option.jw-active-option',
+                '.jw-playlist-container .jw-option:hover'
+            ], 'background-color', activeColor);
 
-            addStyle('color', ['.jw-playlist-container .jw-icon'], inactiveColor);
-            addStyle('border-bottom-color', ['.jw-playlist-container .jw-option'], inactiveColor);
+            addStyle(['.jw-playlist-container .jw-icon'], 'color', inactiveColor);
+            addStyle(['.jw-playlist-container .jw-option'], 'border-bottom-color', inactiveColor);
 
-            addStyle('background-color', [
-                    '.jw-tooltip-title',
-                    '.jw-playlist',
-                    '.jw-playlist-container .jw-option'
-                ], backgroundColor);
-            addStyle('border-color', ['.jw-playlist-container ::-webkit-scrollbar'], backgroundColor);
+            addStyle([
+                '.jw-tooltip-title',
+                '.jw-playlist',
+                '.jw-playlist-container .jw-option'
+            ], 'background-color', backgroundColor);
+            addStyle(['.jw-playlist-container ::-webkit-scrollbar'], 'border-color', backgroundColor);
         };
 
         this.setup = function() {
@@ -638,7 +640,7 @@ define([
                 if (_playerElement.className !== className) {
                     _playerElement.className = className;
                 }
-                cssUtils.style(_playerElement, {
+                utils.style(_playerElement, {
                     display: 'block'
                 }, resetAspectMode);
             }
@@ -994,8 +996,7 @@ define([
             if (_instreamMode) {
                 this.destroyInstream();
             }
-
-            cssUtils.clearCss('#'+_model.get('id'));
+            utils.clearCss('#'+_model.get('id'));
         };
     };
 

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -259,7 +259,7 @@ define([
 
                 var o = {};
                 o[attr] = value;
-                utils.css.css(elements.join(', '), o);
+                utils.css(elements.join(', '), o);
             }
 
             // We can assume that the user will define both an active and inactive color because otherwise it doesn't

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -259,7 +259,7 @@ define([
 
                 var o = {};
                 o[attr] = value;
-                utils.css(elements.join(', '), o);
+                utils.css.css(elements.join(', '), o);
             }
 
             // We can assume that the user will define both an active and inactive color because otherwise it doesn't
@@ -268,42 +268,59 @@ define([
                 inactiveColor = _model.get('skinColorInactive'),
                 backgroundColor = _model.get('skinColorBackground');
 
-            // Control bar icon coloring
-            addStyle(['.jw-button-color'], 'color', inactiveColor);
-            addStyle(['.jw-button-color:hover'], 'color', activeColor);
+            // These will use standard style names for CSS since they are added directly to a style sheet
+            // Using background instead of background-color so we don't have to clear gradients with background-image
 
-            // Control bar men
-            addStyle(['.jw-option'], 'color', inactiveColor);
-            addStyle(['.jw-active-option'], 'background-color', activeColor);
-
-            // Toggle button styling
-            addStyle(['.jw-toggle'], 'color', activeColor);
-            addStyle(['.jw-toggle.jw-off'], 'color', inactiveColor);
-
-            // Time Bar Styling
-            addStyle(['.jw-progress'], 'background', activeColor);
-            addStyle(['.jw-cue', '.jw-knob'], 'background', inactiveColor);
-            addStyle(['.jw-background-color'], 'background', backgroundColor);
-
-            // Text, tooltip, and Skip button text
-            addStyle(['.jw-text'], 'color', inactiveColor);
-            addStyle(['.jw-tooltip-title', '.jw-skip .jw-skip-icon'], 'color', inactiveColor);
-
-            // Playlist Styling
+            // Apply active color
             addStyle([
+                // Toggle and menu button active colors
+                '.jw-toggle',
+                '.jw-button-color:hover'
+            ], 'color', activeColor);
+            addStyle([
+                // menu active option
+                '.jw-active-option',
+                // slider fill color
+                '.jw-progress',
                 '.jw-playlist-container .jw-option.jw-active-option',
                 '.jw-playlist-container .jw-option:hover'
-            ], 'background-color', activeColor);
+            ], 'background', activeColor);
 
-            addStyle(['.jw-playlist-container .jw-icon'], 'color', inactiveColor);
-            addStyle(['.jw-playlist-container .jw-option'], 'border-bottom-color', inactiveColor);
-
+            // Apply inactive color
             addStyle([
+                // text color of many ui elements
+                '.jw-text',
+                // menu option text
+                '.jw-option',
+                // controlbar button colors
+                '.jw-button-color',
+                // toggle button
+                '.jw-toggle.jw-off',
+                '.jw-tooltip-title',
+                '.jw-skip .jw-skip-icon',
+                '.jw-playlist-container .jw-icon'
+            ], 'color', inactiveColor);
+            addStyle([
+                // slider children
+                '.jw-cue',
+                '.jw-knob'
+            ], 'background', inactiveColor);
+            addStyle([
+                '.jw-playlist-container .jw-option'
+            ], 'border-bottom-color', inactiveColor);
+
+            // Apply background color
+            addStyle([
+                // general background color
+                '.jw-background-color',
                 '.jw-tooltip-title',
                 '.jw-playlist',
                 '.jw-playlist-container .jw-option'
-            ], 'background-color', backgroundColor);
-            addStyle(['.jw-playlist-container ::-webkit-scrollbar'], 'border-color', backgroundColor);
+            ], 'background', backgroundColor);
+            addStyle([
+                // area around scrollbar on the playlist.  skin fix required to remove
+                '.jw-playlist-container ::-webkit-scrollbar'
+            ], 'border-color', backgroundColor);
         };
 
         this.setup = function() {


### PR DESCRIPTION
@jw-kaurand Please see if we can reduce the number of css calls in view.js `handleColorOverrides`
```
<style type="text/css">
{{#if inactive}}
#{{id}} .jw-button-color,
#{{id}} .jw-option,
#{{id}} .jw-toggle.jw-off,
#{{id}} .jw-text,
#{{id}} .jw-tooltip-title,
#{{id}} .jw-skip .jw-skip-icon,
#{{id}} .jw-playlist-container .jw-icon\{color:{{inactive}}\}
#{{id}} .jw-cue,
#{{id}} .jw-knob\{background-color:{{inactive}}\}
#{{id}} .jw-playlist-container .jw-option\{border-bottom-color:{{inactive}}\}
{{/if}}
{{#if active}}
#{{id}} .jw-button-color:hover,
#{{id}} .jw-toggle\{color:{{active}}\}
#{{id}} .jw-active-option,
#{{id}} .jw-progress,
#{{id}} .jw-playlist-container .jw-option.jw-active-option,
#{{id}} .jw-playlist-container .jw-option:hover\{background-color:{{active}}\}
{{/if}}
{{#if background}}
#{{id}} .jw-background-color,
#{{id}} .jw-tooltip-title,
#{{id}} .jw-playlist,
#{{id}} .jw-playlist-container .jw-option\{background-color:{{background}}\}
#{{id}} .jw-playlist-container ::-webkit-scrollbar\{border-color:{{background}}\}
{{/if}}
</style>
```