### PR TITLE
Revert "JW7-1343 Add support for x-flv video type"

### DIFF
--- a/src/js/providers/providers-supported.js
+++ b/src/js/providers/providers-supported.js
@@ -86,7 +86,6 @@ define([
             name: 'flash',
             supports: function (source) {
                 var flashExtensions = {
-                    'x-flv': 'video',
                     'flv': 'video',
                     'f4v': 'video',
                     'mov': 'video',


### PR DESCRIPTION
This reverts commit b79324356044b3de88c8fff48392673b2caab0cb. when the type is a mime type like "video/x-flv", rather than simply splitting by forward slash, we should also remove the x- (will add this change in another PR).