### PR TITLE
JW7-1343 Remove -x from source types when converting mime types like 'video/x-flv'

### DIFF
--- a/src/js/playlist/source.js
+++ b/src/js/playlist/source.js
@@ -25,8 +25,9 @@ define([
         _source.file = strings.trim('' + _source.file);
 
         // if type is given as a mimetype
-        if (_source.type && _source.type.indexOf('/') > 0) {
-            _source.type = _source.type.split('/')[1];
+        var mimetypeRegEx = /^[^\/]+\/(?:x-)?([^\/]+)$/;
+        if (mimetypeRegEx.test(_source.type)) {
+            _source.type = _source.type.replace(mimetypeRegEx, '$1');
         }
 
         // If type not included, we infer it from extension


### PR DESCRIPTION
Adds support for playing creatives that have the mimetype video/x-flv or audio/x-m4a