### PR TITLE
Model expects attributes to be set with get/set methods

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -76,9 +76,6 @@ define([
             _captions = new Captions(_api, _model);
             _setup = new Setup(_api, _model, _view);
 
-            // Legacy, should be removed
-            _this.id = this._model.id;
-
             _setup.on(events.JWPLAYER_READY, _playerReady, this);
             _setup.on(events.JWPLAYER_SETUP_ERROR, function(evt) {
                 _this.setupError(evt.message);
@@ -438,7 +435,7 @@ define([
 
             function _getVisualQuality() {
                 if (this._model.mediaModel) {
-                    return this._model.mediaModel.visualQuality;
+                    return this._model.mediaModel.get('visualQuality');
                 }
                 // if quality is not implemented in the provider,
                 // return quality info based on current level
@@ -567,7 +564,6 @@ define([
             // Model passthroughs
             this.setVolume = _model.setVolume;
             this.setMute = _model.setMute;
-            this.seekDrag = _model.seekDrag;
             this.getProvider = function(){ return _model.get('provider'); };
             this.getWidth = function() { return _model.get('containerWidth'); };
             this.getHeight = function() { return _model.get('containerHeight'); };
@@ -665,7 +661,7 @@ define([
             if (!document.documentElement.contains(this.currentContainer)) {
                 // This implies the player was removed from the DOM before setup completed
                 //   or a player has been "re" setup after being removed from the DOM
-                this.currentContainer = document.getElementById(this.id);
+                this.currentContainer = document.getElementById(this._model.get('id'));
                 if (!this.currentContainer) {
                     return;
                 }

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -58,7 +58,7 @@ define([
             if (!_instream || !_instream._adModel) {
                 return;
             }
-            if (_instream._adModel.state === states.PAUSED) {
+            if (_instream._adModel.get('state') === states.PAUSED) {
                 if (_model.get('controls')) {
                     _controller.setFullscreen();
                     _controller.play();
@@ -129,7 +129,7 @@ define([
 
         function _instreamItemComplete(e) {
             // Allow 'play' state change to trigger next adPlay event in ad pods
-            _instream._adModel.state = 'complete';
+            _instream._adModel.set('state', 'complete');
 
             if (_array && _arrayIndex + 1 < _array.length) {
                 // destroy skip button


### PR DESCRIPTION
- `getVisualQuality` returns undefined (JW7-1438)
- `controller.id` is undefined and no longer used
- `controller.showView` had some logic that passed undefined to `document.getElementById`
- `instream-adapter` had invalid `model.state` checks, preventing double-click to fullscreen from working. It should have implications with ad-pod functionality too, but seems to work as-is and after these fixes.