### PR TITLE
Detect when Flash is blocked and remove UI

### DIFF
--- a/src/css/flags/flash-blocked.less
+++ b/src/css/flags/flash-blocked.less
@@ -1,0 +1,9 @@
+.jw-flag-flash-blocked {
+    .jw-controls {
+        display: none;
+    }
+
+    .jw-preview {
+        display: none;
+    }
+}

--- a/src/css/jwplayer.less
+++ b/src/css/jwplayer.less
@@ -33,6 +33,7 @@
 @import "flags/ads.less";
 @import "flags/rightclick-open";
 @import "flags/controls-disabled";
+@import "flags/flash-blocked";
 @import "flags/touch";
 @import "flags/compact-player";
 

--- a/src/css/states/idle.less
+++ b/src/css/states/idle.less
@@ -1,6 +1,6 @@
 @import "../imports/icons";
 
-.jwplayer.jw-state-idle {
+.jw-state-idle {
     .jw-preview {
         display: block;
     }

--- a/src/flash/com/longtailvideo/jwplayer/controller/PlayerSetup.as
+++ b/src/flash/com/longtailvideo/jwplayer/controller/PlayerSetup.as
@@ -103,6 +103,7 @@ public class PlayerSetup extends EventDispatcher {
     }
 
     private function waitForSwfEventsRouter():void {
+        // This may take a moment to setup with early versions of IE
         if (SwfEventRouter.available) {
             tasker.success();
             return;

--- a/src/flash/com/longtailvideo/jwplayer/player/Player.as
+++ b/src/flash/com/longtailvideo/jwplayer/player/Player.as
@@ -27,6 +27,9 @@ public class Player extends Sprite implements IPlayer {
     protected var _instream:InstreamPlayer;
 
     public function Player() {
+        // Send embedded event so we know flash isn't blocked
+        SwfEventRouter.triggerJsEvent('embedded');
+
         Security.allowDomain("*");
 
         RootReference.init(this);

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -97,18 +97,11 @@ define([
             }, this);
 
             // If we attempt to load flash, assume it is blocked if we don't hear back within a second
-            var _flashBlockTimeout = -1;
-            _model.mediaController.on('flashEmbedAttempt', function() {
-                // give it a second to load
-                _flashBlockTimeout = setTimeout(function() {
-                    _model.set('flashBlocked', true);
-                    _this.trigger(events.JWPLAYER_ERROR, { message: 'Flash plugin is blocked'});
-                }, 1000);
-            });
-            _model.mediaController.on('flashEmbedSuccess', function() {
-                clearTimeout(_flashBlockTimeout);
-                _model.set('flashBlocked', false);
-            });
+            _model.on('change:flashBlocked', function(model, isBlocked) {
+                if (isBlocked) {
+                    this.trigger(events.JWPLAYER_ERROR, { message: 'Flash plugin is blocked'});
+                }
+            }, this);
 
             function initMediaModel() {
                 _model.mediaModel.on('change:state', function(mediaModel, state) {

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -96,6 +96,20 @@ define([
                 this.trigger(evtClone.type, evtClone);
             }, this);
 
+            // If we attempt to load flash, assume it is blocked if we don't hear back within a second
+            var _flashBlockTimeout = -1;
+            _model.mediaController.on('flashEmbedAttempt', function() {
+                // give it a second to load
+                _flashBlockTimeout = setTimeout(function() {
+                    _model.set('flashBlocked', true);
+                    _this.trigger(events.JWPLAYER_ERROR, { message: 'Flash plugin is blocked'});
+                }, 1000);
+            });
+            _model.mediaController.on('flashEmbedSuccess', function() {
+                clearTimeout(_flashBlockTimeout);
+                _model.set('flashBlocked', false);
+            });
+
             function initMediaModel() {
                 _model.mediaModel.on('change:state', function(mediaModel, state) {
                     var modelState = normalizeState(state);

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -36,6 +36,8 @@ define([
             _.extend(this.attributes, config, _cookies, {
                 // Initial state, upon setup
                 state: states.IDLE,
+                // Initially we don't assume Flash is needed
+                flashBlocked : false,
                 fullscreen: false,
                 compactUI: false,
                 scrubbing : false,

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -66,6 +66,13 @@ define([
 
         function _videoEventHandler(type, data) {
             switch (type) {
+                case 'flashBlocked':
+                    this.set('flashBlocked', true);
+                    return;
+                case 'flashUnblocked':
+                    this.set('flashBlocked', false);
+                    return;
+
                 case 'volume':
                 case 'mute':
                     this.set(type, data[type]);

--- a/src/js/providers/flash.js
+++ b/src/js/providers/flash.js
@@ -17,6 +17,7 @@ define([
         var _container;
         var _swf;
         var _item = null;
+        var _flashBlockedTimeout = -1;
         var _beforecompleted = false;
         var _currentQuality = -1;
         var _qualityLevels = null;
@@ -183,8 +184,12 @@ define([
                     _swf = this.getSwfObject(parent);
 
                     // The browser may block the flash object until user enables it
-                    this.trigger('flashEmbedAttempt');
-                    _swf.once('embedded', function() { this.trigger('flashEmbedSuccess'); }, this);
+                    var _this = this;
+                    _flashBlockedTimeout = setTimeout(function() { _this.trigger('flashBlocked'); }, 1000);
+                    _swf.once('embedded', function() {
+                        clearTimeout(_flashBlockedTimeout);
+                        this.trigger('flashUnblocked');
+                    }, this);
 
                     // listen to events sendEvented from flash
                     _swf.once('ready', function() {

--- a/src/js/view/rightclick.js
+++ b/src/js/view/rightclick.js
@@ -136,6 +136,7 @@ define([
         },
 
         destroy : function() {
+            this.playerElement.oncontextmenu = null;
             this.model.off('change:provider', this.updateHtml);
             document.removeEventListener('mousedown', this.hideMenuCallback);
             this.hideMenuCallback = null;

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -381,6 +381,9 @@ define([
             _model.on('change:state', _stateHandler);
             _model.on('change:duration', _setLiveMode, this);
 
+            _model.on('change:flashBlocked', _onChangeFlashBlocked);
+            _onChangeFlashBlocked(_model, _model.get('flashBlocked'));
+
             _model.mediaController.on(events.JWPLAYER_MEDIA_ERROR, _errorHandler);
             _api.onPlaylistComplete(_playlistCompleteHandler);
             _api.onPlaylistItem(_playlistItemHandler);
@@ -485,6 +488,16 @@ define([
 
         function forward(evt) {
             _this.trigger(evt.type, evt);
+        }
+
+        function _onChangeFlashBlocked(model, isBlocked) {
+            if (isBlocked) {
+                utils.addClass(_playerElement, 'jw-flag-flash-blocked');
+                _rightClickMenu.destroy();
+            } else {
+                utils.removeClass(_playerElement,'jw-flag-flash-blocked');
+                _rightClickMenu.setup(_model, _playerElement, _playerElement);
+            }
         }
 
         var _onChangeControls = function(model, bool) {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -493,10 +493,14 @@ define([
         function _onChangeFlashBlocked(model, isBlocked) {
             if (isBlocked) {
                 utils.addClass(_playerElement, 'jw-flag-flash-blocked');
-                _rightClickMenu.destroy();
+                if (_rightClickMenu) {
+                    _rightClickMenu.destroy();
+                }
             } else {
                 utils.removeClass(_playerElement,'jw-flag-flash-blocked');
-                _rightClickMenu.setup(_model, _playerElement, _playerElement);
+                if (_rightClickMenu) {
+                    _rightClickMenu.setup(_model, _playerElement, _playerElement);
+                }
             }
         }
 


### PR DESCRIPTION
The goal here is to wait a second after flash has been embedded to hear back from
the flash player. If we don't hear the comfirmation "embedded" event, then we know it's
been blocked. When we enable the plugin it will send the event and player will resume
normally.

JW7-1389