### PR TITLE
Restore missing wmode parameter

### DIFF
--- a/src/js/providers/flash.js
+++ b/src/js/providers/flash.js
@@ -167,7 +167,7 @@ define([
                         return found;
                     }
 
-                    return EmbedSwf.embed(_playerConfig.flashplayer, parent, getObjectId(_playerId));
+                    return EmbedSwf.embed(_playerConfig.flashplayer, parent, getObjectId(_playerId), _playerConfig.wmode);
                 },
 
                 getContainer: function() {


### PR DESCRIPTION
The wmode config parameter isn't passed any more, restoring it