### PR TITLE
Ignore displaytitle config setting when displaying errors

### DIFF
--- a/src/js/utils/trycatch.js
+++ b/src/js/utils/trycatch.js
@@ -20,9 +20,10 @@ define([
         }
     };
 
-    var jwError = function (name, message) {
+    var jwError = function (name, error) {
         this.name = name;
-        this.message = message;
+        this.message = error.message || error.toString();
+        this.error = error;
     };
 
     return {

--- a/src/js/view/title.js
+++ b/src/js/view/title.js
@@ -30,19 +30,27 @@ define([
 
         playlistItem : function(model, item) {
             if (model.get('displaytitle') || model.get('displaydescription')) {
-                this.updateText(model, item);
+                var data = {
+                    title: '',
+                    description: ''
+                };
+                if (item.title && model.get('displaytitle')) {
+                    data.title = item.title;
+                }
+                if (item.description && model.get('displaydescription')) {
+                    data.description = item.description;
+                }
+                this.updateText(model, data);
             } else {
                 this.hide();
             }
         },
 
-        updateText: function(model, playlistItem) {
-            this.title.innerHTML = (playlistItem.title && model.get('displaytitle')) ?
-                playlistItem.title : '';
-            this.description.innerHTML = (playlistItem.description && model.get('displaydescription')) ?
-                playlistItem.description : '';
+        updateText: function(model, data) {
+            this.title.innerHTML = data.title;
+            this.description.innerHTML = data.description;
 
-            if(this.title.firstChild || this.description.firstChild){
+            if (this.title.firstChild || this.description.firstChild) {
                 this.show();
             } else {
                 this.hide();

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -895,7 +895,11 @@ define([
 
         function _errorHandler(evt) {
             _stateHandler(_model, states.ERROR);
-            _title.updateText(_model, {'title': evt.message});
+            var data = {
+                title: evt.name || evt.message,
+                description: evt.name ? evt.message : ''
+            };
+            _title.updateText(_model, data);
         }
 
         function _isCasting() {


### PR DESCRIPTION
Error messages will now display even when displaytitle is set to false (that setting is only intended to disable playlist item titles). Now we'll also show the error name and message. Message is the error message (not `error.toString()` which usually reads "Error: Error: ...", and a new property `error` gives access to the original exception error (to look at the stack...).

JW7-1488