### PR TITLE
Handle Flash setup error

### DIFF
--- a/src/js/providers/flash.js
+++ b/src/js/providers/flash.js
@@ -204,9 +204,13 @@ define([
 
                         // setup flash player
                         var config = _.extend({}, _playerConfig);
-                        _flashCommand('setup', config);
+                        var result = _swf.triggerFlash('setup', config);
+                        if (result === _swf) {
+                            _swf.__ready = true;
+                        } else {
+                            this.trigger(events.JWPLAYER_MEDIA_ERROR, result);
+                        }
 
-                        _swf.__ready = true;
                     }, this);
 
                     var forwardEventsWithData = [

--- a/src/js/utils/embedswf.js
+++ b/src/js/utils/embedswf.js
@@ -98,7 +98,11 @@ define([
             });
 
             if (status instanceof utils.Error) {
-                console.error({command : name, error : status});
+                console.error(name, status);
+                if (name === 'setup') {
+                    status.name = 'Failed to setup flash';
+                    return status;
+                }
             }
             return swfInstance;
         };


### PR DESCRIPTION
Handle the exception that occurs when calling setup on a bad flash embed.

``` javascript
    jwplayer("container").setup({
        file: 'file.mp4',
        primary: 'flash',
        flashplayer: 'https://xx/jwplayer.flash.swf'  // loading from a domain that restricts script access
    });
```

The swf embeds but cannot be setup. Rather than buffer indefinitely, forward the error for display.

JW7-1489