### PR TITLE
Only add resize handlers for plugins when they need it

### DIFF
--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -131,8 +131,11 @@ define([
             this.plugins = this.plugins || {};
             this.plugins[name] = pluginInstance;
 
-            this.onReady(pluginInstance.readyHandler);
-            this.onResize(pluginInstance.resizeHandler);
+            // A swf plugin may rely on resize events
+            if (pluginInstance.resize) {
+                this.onReady(pluginInstance.readyHandler);
+                this.onResize(pluginInstance.resizeHandler);
+            }
         };
 
         this.setup = function (options) {


### PR DESCRIPTION
This will simplify code in our sharing plugin