### PR TITLE
Titles updateText method signature should be more precise

### DIFF
--- a/src/js/view/title.js
+++ b/src/js/view/title.js
@@ -30,25 +30,25 @@ define([
 
         playlistItem : function(model, item) {
             if (model.get('displaytitle') || model.get('displaydescription')) {
-                var data = {
-                    title: '',
-                    description: ''
-                };
+                var title = '';
+                var description = '';
+
                 if (item.title && model.get('displaytitle')) {
-                    data.title = item.title;
+                    title = item.title;
                 }
                 if (item.description && model.get('displaydescription')) {
-                    data.description = item.description;
+                    description = item.description;
                 }
-                this.updateText(model, data);
+
+                this.updateText(title, description);
             } else {
                 this.hide();
             }
         },
 
-        updateText: function(model, data) {
-            this.title.innerHTML = data.title;
-            this.description.innerHTML = data.description;
+        updateText: function(title, description) {
+            this.title.innerHTML = title;
+            this.description.innerHTML = description;
 
             if (this.title.firstChild || this.description.firstChild) {
                 this.show();

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -895,11 +895,12 @@ define([
 
         function _errorHandler(evt) {
             _stateHandler(_model, states.ERROR);
-            var data = {
-                title: evt.name || evt.message,
-                description: evt.name ? evt.message : ''
-            };
-            _title.updateText(_model, data);
+
+            if (evt.name) {
+                _title.updateText(evt.name, evt.message);
+            } else {
+                _title.updateText(evt.message, '');
+            }
         }
 
         function _isCasting() {


### PR DESCRIPTION
The previous params for updateText looked like a listener for changes to an object.
This didn't match how it was used, so this brings it inline.