### PR TITLE
JW7-1307 Adds class to button targeted to place icons in.  Fix for plugin issues

### DIFF
--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -131,9 +131,10 @@ define([
             this.plugins = this.plugins || {};
             this.plugins[name] = pluginInstance;
 
+            this.onReady(pluginInstance.readyHandler);
+
             // A swf plugin may rely on resize events
             if (pluginInstance.resize) {
-                this.onReady(pluginInstance.readyHandler);
                 this.onResize(pluginInstance.resizeHandler);
             }
         };

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -583,12 +583,13 @@ define([
             //this.releaseState = _view.releaseState;
             this.setCues = _view.addCues;
             this.setFullscreen = _view.fullscreen;
-            this.addButton = function(img, tooltip, callback, id) {
+            this.addButton = function(img, tooltip, callback, id, btnClass) {
                 var btn = {
                     img : img,
                     tooltip : tooltip,
                     callback : callback,
-                    id : id
+                    id : id,
+                    class : btnClass
                 };
 
                 var dock = _model.get('dock');

--- a/src/js/plugins/loader.js
+++ b/src/js/plugins/loader.js
@@ -135,8 +135,8 @@ define([
                         var pluginOptions = _.extend({}, pluginsConfig[pluginURL]);
                         var pluginInstance = pluginObj.getNewInstance(api, pluginOptions, div);
 
-                        pluginInstance.readyHandler = _resizePlugin(_this, pluginInstance, div, true);
-                        pluginInstance.resizeHandler = _resizePlugin(_this, pluginInstance, div);
+                        pluginInstance.readyHandler = _resizePlugin(api, pluginInstance, div, true);
+                        pluginInstance.resizeHandler = _resizePlugin(api, pluginInstance, div);
 
                         api.addPlugin(pluginName, pluginInstance, div);
                     }

--- a/src/templates/dock.html
+++ b/src/templates/dock.html
@@ -1,7 +1,7 @@
 <div class="jw-dock jw-reset">
     {{#each this}}
-    <div class="jw-dock-button jw-background-color jw-reset" button="{{id}}">
-        <div class="jw-icon jw-dock-image jw-reset" style="background-image: url({{img}})"></div>
+    <div class="jw-dock-button jw-background-color {{#if class}}{{class}}{{/if}} jw-reset" button="{{id}}">
+        <div class="jw-icon jw-dock-image jw-reset" {{#if img}}style='background-image: url("{{img}}")'{{/if}}></div>
         <div class="jw-arrow jw-reset"></div>
         {{#if tooltip}}
         <div class="jw-overlay jw-background-color jw-reset">


### PR DESCRIPTION
Added a class that will be applied to dock buttons so that we can place icons inside them in a targeted manner.
Made ready handler fire when the player becomes ready so that plugins are added to the overlays correctly.
changed parameters sent into _resizePlugin call that were undefined