### PR TITLE
The resize handler and onready handler should be distinct

### DIFF
--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -131,7 +131,8 @@ define([
             this.plugins = this.plugins || {};
             this.plugins[name] = pluginInstance;
 
-            this.onReady(pluginInstance.readyHandler);
+
+            this.onReady(pluginInstance.addToPlayer);
 
             // A swf plugin may rely on resize events
             if (pluginInstance.resize) {

--- a/src/js/plugins/loader.js
+++ b/src/js/plugins/loader.js
@@ -7,24 +7,32 @@ define([
     'utils/scriptloader'
 ], function(pluginsUtils, utils, events, Events, _, scriptloader) {
 
-    function _resizePlugin(_api, plugin, div, onready) {
-        var id = _api.id;
+    function _addToPlayerGenerator(_api, pluginInstance, div) {
         return function() {
-            var displayarea = document.querySelector('#' + id + ' .jw-overlays');
-            if (displayarea && onready) {
-                displayarea.appendChild(div);
-            }
-            if (typeof plugin.resize === 'function') {
-                plugin.resize(displayarea.clientWidth, displayarea.clientHeight);
-                setTimeout(function() {
-                    plugin.resize(displayarea.clientWidth, displayarea.clientHeight);
-                }, 400);
+            var overlaysElement = _api.getContainer().getElementsByClassName('jw-overlays')[0];
+
+            // This should probably be an error
+            if (!overlaysElement) {
+                return;
             }
 
-            if (displayarea && displayarea.style) {
-                div.left = displayarea.style.left;
-                div.top = displayarea.style.top;
-            }
+            overlaysElement.appendChild(div);
+            div.left = overlaysElement.style.left;
+            div.top = overlaysElement.style.top;
+
+            pluginInstance.displayArea = overlaysElement;
+        };
+    }
+
+    function _pluginResizeGenerator(pluginInstance) {
+        return function() {
+            var displayarea = pluginInstance.displayArea;
+            pluginInstance.resize(displayarea.clientWidth, displayarea.clientHeight);
+
+            // Sometimes a mobile device may trigger resize before the new sizes are finalized
+            setTimeout(function() {
+                pluginInstance.resize(displayarea.clientWidth, displayarea.clientHeight);
+            }, 400);
         };
     }
 
@@ -135,8 +143,8 @@ define([
                         var pluginOptions = _.extend({}, pluginsConfig[pluginURL]);
                         var pluginInstance = pluginObj.getNewInstance(api, pluginOptions, div);
 
-                        pluginInstance.readyHandler = _resizePlugin(api, pluginInstance, div, true);
-                        pluginInstance.resizeHandler = _resizePlugin(api, pluginInstance, div);
+                        pluginInstance.addToPlayer   = _addToPlayerGenerator(api, pluginInstance, div);
+                        pluginInstance.resizeHandler = _pluginResizeGenerator(pluginInstance);
 
                         api.addPlugin(pluginName, pluginInstance, div);
                     }

--- a/src/js/plugins/loader.js
+++ b/src/js/plugins/loader.js
@@ -25,14 +25,16 @@ define([
     }
 
     function _pluginResizeGenerator(pluginInstance) {
-        return function() {
+        function resize() {
             var displayarea = pluginInstance.displayArea;
-            pluginInstance.resize(displayarea.clientWidth, displayarea.clientHeight);
-
-            // Sometimes a mobile device may trigger resize before the new sizes are finalized
-            setTimeout(function() {
+            if (displayarea) {
                 pluginInstance.resize(displayarea.clientWidth, displayarea.clientHeight);
-            }, 400);
+            }
+        }
+        return function() {
+            resize();
+            // Sometimes a mobile device may trigger resize before the new sizes are finalized
+            setTimeout(resize, 400);
         };
     }
 


### PR DESCRIPTION
Previously, the resizehandler is being used for two different purposes
1. To add the plugins div into the dom
2. To resize the plugin

Behavior was toggled based off of a flag passed into the generator for the resize method.

Now there are two separate methods named after what they are intended to do: addToPlayer, resizeHandler