### PR TITLE
Handle Flash plugin blocked

### DIFF
--- a/src/css/flags/flash-blocked.less
+++ b/src/css/flags/flash-blocked.less
@@ -1,0 +1,10 @@
+// This has higher specificity to overwrite .jwplayer.jw-state-idle
+.jwplayer.jw-flag-flash-blocked {
+    .jw-controls {
+        display: none;
+    }
+
+    .jw-preview {
+        display: none;
+    }
+}

--- a/src/css/jwplayer.less
+++ b/src/css/jwplayer.less
@@ -33,6 +33,7 @@
 @import "flags/ads.less";
 @import "flags/rightclick-open";
 @import "flags/controls-disabled";
+@import "flags/flash-blocked";
 @import "flags/touch";
 @import "flags/compact-player";
 

--- a/src/flash/com/longtailvideo/jwplayer/player/Player.as
+++ b/src/flash/com/longtailvideo/jwplayer/player/Player.as
@@ -29,6 +29,9 @@ public class Player extends Sprite implements IPlayer {
     public function Player() {
         Security.allowDomain("*");
 
+        // Send embedded event so we know flash isn't blocked
+        SwfEventRouter.triggerJsEvent('embedded');
+
         RootReference.init(this);
         this.addEventListener(Event.ADDED_TO_STAGE, stageReady);
         this.tabEnabled = false;
@@ -214,6 +217,9 @@ public class Player extends Sprite implements IPlayer {
     }
 
     protected function playerReady(evt:PlayerEvent):void {
+        // Send embedded event so we know flash isn't blocked
+        SwfEventRouter.triggerJsEvent('embedded');
+
         // Only handle Setup Events once
         _controller.removeEventListener(PlayerEvent.JWPLAYER_READY, playerReady);
 
@@ -292,6 +298,9 @@ public class Player extends Sprite implements IPlayer {
     }
 
     protected function setupError(evt:PlayerEvent):void {
+        // Send embedded event so we know flash isn't blocked
+        SwfEventRouter.triggerJsEvent('embedded');
+
         // Only handle Setup Events once
         _controller.removeEventListener(PlayerEvent.JWPLAYER_READY, playerReady);
         _controller.removeEventListener(PlayerEvent.JWPLAYER_SETUP_ERROR, setupError);

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -36,6 +36,8 @@ define([
             _.extend(this.attributes, config, _cookies, {
                 // Initial state, upon setup
                 state: states.IDLE,
+                // Initially we don't assume Flash is needed
+                flashBlocked : false,
                 fullscreen: false,
                 compactUI: false,
                 scrubbing : false,
@@ -64,6 +66,13 @@ define([
 
         function _videoEventHandler(type, data) {
             switch (type) {
+                case 'flashBlocked':
+                    this.set('flashBlocked', true);
+                    return;
+                case 'flashUnblocked':
+                    this.set('flashBlocked', false);
+                    return;
+
                 case 'volume':
                 case 'mute':
                     this.set(type, data[type]);

--- a/src/js/providers/flash.js
+++ b/src/js/providers/flash.js
@@ -17,6 +17,7 @@ define([
         var _container;
         var _swf;
         var _item = null;
+        var _flashBlockedTimeout = -1;
         var _beforecompleted = false;
         var _currentQuality = -1;
         var _qualityLevels = null;
@@ -172,6 +173,7 @@ define([
                 getContainer: function() {
                     return _container;
                 },
+
                 setContainer: function(parent) {
                     if (_container === parent) {
                         // ignore instream's attempt to put provider back in it's place
@@ -180,6 +182,16 @@ define([
                     _container = parent;
 
                     _swf = this.getSwfObject(parent);
+
+                    // The browser may block the flash object until user enables it
+                    var _this = this;
+                    _flashBlockedTimeout = setTimeout(function() {
+                        _this.trigger('flashBlocked');
+                    }, 2000);
+                    _swf.once('embedded', function() {
+                        clearTimeout(_flashBlockedTimeout);
+                        this.trigger('flashUnblocked');
+                    }, this);
 
                     // listen to events sendEvented from flash
                     _swf.once('ready', function() {
@@ -196,7 +208,6 @@ define([
                         _flashCommand('setup', config);
 
                         _swf.__ready = true;
-
                     }, this);
 
                     var forwardEventsWithData = [
@@ -222,63 +233,82 @@ define([
                         _currentQuality = e.currentQuality;
                         _qualityLevels = e.levels;
                         this.trigger(e.type, e);
+                    }, this);
 
-                    }, this).on(events.JWPLAYER_MEDIA_LEVEL_CHANGED, function(e) {
+                    _swf.on(events.JWPLAYER_MEDIA_LEVEL_CHANGED, function(e) {
                         _labelLevels(e.levels);
                         _currentQuality = e.currentQuality;
                         _qualityLevels = e.levels;
                         this.trigger(e.type, e);
 
-                    }, this).on(events.JWPLAYER_AUDIO_TRACKS, function(e) {
+                    }, this);
+
+                    _swf.on(events.JWPLAYER_AUDIO_TRACKS, function(e) {
                         _currentAudioTrack = e.currentTrack;
                         _audioTracks = e.tracks;
                         this.trigger(e.type, e);
+                    }, this);
 
-                    }, this).on(events.JWPLAYER_AUDIO_TRACK_CHANGED, function(e) {
+                    _swf.on(events.JWPLAYER_AUDIO_TRACK_CHANGED, function(e) {
                         _currentAudioTrack = e.currentTrack;
                         _audioTracks = e.tracks;
                         this.trigger(e.type, e);
+                    }, this);
 
-                    }, this).on(events.JWPLAYER_PLAYER_STATE, function(e) {
+                    _swf.on(events.JWPLAYER_PLAYER_STATE, function(e) {
                         var state = e.newstate;
                         if (state === states.IDLE) {
                             return;
                         }
                         this.setState(state);
+                    }, this);
 
-                    }, this).on(forwardEventsWithDataDuration.join(' '), function(e) {
+                    _swf.on(forwardEventsWithDataDuration.join(' '), function(e) {
                         if(e.duration === 'Infinity') {
                             e.duration = Infinity;
                         }
                         this.trigger(e.type, e);
+                    }, this);
 
-                    }, this).on(forwardEventsWithData.join(' '), function(e) {
+                    _swf.on(forwardEventsWithData.join(' '), function(e) {
                         this.trigger(e.type, e);
+                    }, this);
 
-                    }, this).on(forwardEvents.join(' '), function(e) {
+                    _swf.on(forwardEvents.join(' '), function(e) {
                         this.trigger(e.type);
+                    }, this);
 
-                    }, this).on(events.JWPLAYER_MEDIA_BEFORECOMPLETE, function(e){
+                    _swf.on(events.JWPLAYER_MEDIA_BEFORECOMPLETE, function(e){
                         _beforecompleted = true;
                         this.trigger(e.type);
                         if(_attached === true) {
                             _beforecompleted = false;
                         }
-                    }, this).on(events.JWPLAYER_MEDIA_COMPLETE, function(e) {
+                    }, this);
+
+                    _swf.on(events.JWPLAYER_MEDIA_COMPLETE, function(e) {
                         if(!_beforecompleted){
                             this.setState(states.COMPLETE);
                             this.trigger(e.type);
                         }
-                    }, this).on(events.JWPLAYER_MEDIA_SEEK, function(e) {
+                    }, this);
+
+                    _swf.on(events.JWPLAYER_MEDIA_SEEK, function(e) {
                         this.trigger(events.JWPLAYER_MEDIA_SEEK, e);
-                    }, this).on('visualQuality', function(e) {
+                    }, this);
+
+                    _swf.on('visualQuality', function(e) {
                         e.reason = e.reason || 'api'; // or 'user selected';
                         this.trigger('visualQuality', e);
                         this.trigger(events.JWPLAYER_PROVIDER_FIRST_FRAME, {});
-                    }, this).on(events.JWPLAYER_PROVIDER_CHANGED, function(e) {
+                    }, this);
+
+                    _swf.on(events.JWPLAYER_PROVIDER_CHANGED, function(e) {
                         _flashProviderType = e.message;
                         this.trigger(events.JWPLAYER_PROVIDER_CHANGED, e);
-                    }, this).on(events.JWPLAYER_ERROR, function(event) {
+                    }, this);
+
+                    _swf.on(events.JWPLAYER_ERROR, function(event) {
                         utils.log('Error playing media: %o %s', event.code, event.message, event);
                         this.trigger(events.JWPLAYER_MEDIA_ERROR, event);
                     }, this);

--- a/src/js/view/rightclick.js
+++ b/src/js/view/rightclick.js
@@ -136,6 +136,7 @@ define([
         },
 
         destroy : function() {
+            this.playerElement.oncontextmenu = null;
             this.model.off('change:provider', this.updateHtml);
             document.removeEventListener('mousedown', this.hideMenuCallback);
             this.hideMenuCallback = null;

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -381,6 +381,9 @@ define([
             _model.on('change:state', _stateHandler);
             _model.on('change:duration', _setLiveMode, this);
 
+            _model.on('change:flashBlocked', _onChangeFlashBlocked);
+            _onChangeFlashBlocked(_model, _model.get('flashBlocked'));
+
             _model.mediaController.on(events.JWPLAYER_MEDIA_ERROR, _errorHandler);
             _api.onPlaylistComplete(_playlistCompleteHandler);
             _api.onPlaylistItem(_playlistItemHandler);
@@ -485,6 +488,20 @@ define([
 
         function forward(evt) {
             _this.trigger(evt.type, evt);
+        }
+
+        function _onChangeFlashBlocked(model, isBlocked) {
+            if (isBlocked) {
+                utils.addClass(_playerElement, 'jw-flag-flash-blocked');
+                if (_rightClickMenu) {
+                    _rightClickMenu.destroy();
+                }
+            } else {
+                utils.removeClass(_playerElement,'jw-flag-flash-blocked');
+                if (_rightClickMenu) {
+                    _rightClickMenu.setup(_model, _playerElement, _playerElement);
+                }
+            }
         }
 
         var _onChangeControls = function(model, bool) {


### PR DESCRIPTION
Detect when Flash plugin is blocked. Hide UI and disable right click when in this state so that the user can see that the plugin is blocked and can right click to allow the Flash plugin to run.

Fixes #681 / JW7-1505