### PR TITLE
Handle Flash throttling as flash blocked

### DIFF
--- a/src/flash/com/longtailvideo/jwplayer/player/Player.as
+++ b/src/flash/com/longtailvideo/jwplayer/player/Player.as
@@ -13,10 +13,12 @@ import com.longtailvideo.jwplayer.view.View;
 import flash.display.Sprite;
 import flash.events.ErrorEvent;
 import flash.events.Event;
+import flash.events.ThrottleEvent;
+import flash.events.ThrottleType;
 import flash.geom.Rectangle;
 import flash.system.Security;
 
-[SWF(width="640", height="360", frameRate="60", backgroundColor="#000000")]
+[SWF(width="640", height="360", frameRate="30", backgroundColor="#000000")]
 
 public class Player extends Sprite implements IPlayer {
 
@@ -34,6 +36,8 @@ public class Player extends Sprite implements IPlayer {
 
         RootReference.init(this);
         this.addEventListener(Event.ADDED_TO_STAGE, stageReady);
+        this.addEventListener(ThrottleEvent.THROTTLE, flashThrottled);
+
         this.tabEnabled = false;
         this.tabChildren = false;
         this.focusRect = false;
@@ -55,6 +59,14 @@ public class Player extends Sprite implements IPlayer {
         this.removeEventListener(Event.ADDED_TO_STAGE, stageReady);
         RootReference.init(this);
         _view.setupView();
+    }
+
+    private function flashThrottled(e:ThrottleEvent):void {
+        // e.state can be ThrottleType.THROTTLE, ThrottleType.PAUSE, or ThrottleType.RESUME
+        // in Chrome we only get 'throttle' and 'resume' for offscreen and power-save throttling
+        SwfEventRouter.triggerJsEvent('throttle', {
+            state: e.state
+        });
     }
 
     public function get version():String {

--- a/src/js/providers/flash.js
+++ b/src/js/providers/flash.js
@@ -312,6 +312,14 @@ define([
                         utils.log('Error playing media: %o %s', event.code, event.message, event);
                         this.trigger(events.JWPLAYER_MEDIA_ERROR, event);
                     }, this);
+
+                    _swf.on('throttle', function(e) {
+                        if (e.state === 'resume') {
+                            this.trigger('flashUnblocked');
+                        } else {
+                            this.trigger('flashBlocked');
+                        }
+                    }, this);
                 },
                 remove: function() {
                     _currentQuality = -1;


### PR DESCRIPTION
Throttled event is fired when tab is backgrounded, as well as when Chrome puts the Flash plugin into 
"Power Save" mode. This shows the user that the player is in a psuedo-paused state and allows them to resume plugin playback* by right clicking and selecting "Run This Plugin" or by simply clicking.

*When clicking the player state will likely be toggled to pause and another click is required to start playing. We don't have a way to resolve this that would not interfere with players that were simply throttled by being backgrounded so we'll revisit this issue in 7.2.

