### PR TITLE
Sync HLS WebVTT with mpegts

### DIFF
--- a/src/flash/com/longtailvideo/jwplayer/events/SubtitlesTrackDataEvent.as
+++ b/src/flash/com/longtailvideo/jwplayer/events/SubtitlesTrackDataEvent.as
@@ -4,33 +4,39 @@ import flash.events.Event;
 public class SubtitlesTrackDataEvent extends PlayerEvent {
     public static const TYPE:String = "subtitlesTrackData";
 
-    public function SubtitlesTrackDataEvent(name:String, captions:Array) {
+    public function SubtitlesTrackDataEvent(name:String, captions:Array, source:String=null) {
         super(TYPE);
         _name = name;
         _captions = captions;
+        _source = source;
     }
 
     private var _name:String;
+    private var _captions:Array;
+    private var _source:String;
 
     public function get name():String {
         return _name;
     }
 
-    private var _captions:Array;
-
     public function get captions():Array {
         return _captions;
     }
 
+    public function get source():String {
+        return _source;
+    }
+
     public override function clone():Event {
-        return new SubtitlesTrackDataEvent(_name, _captions);
+        return new SubtitlesTrackDataEvent(_name, _captions, _source);
     }
 
     override public function toJsObject():Object {
         return {
             type: TYPE,
             name: name,
-            captions: captions
+            captions: captions,
+            source: source
         };
     }
 }

--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -48,6 +48,7 @@ define([
                 // Player expects that tracks were received in 'subtitlesTracks' event
                 return;
             }
+            track.source = e.source;
             var cues = e.captions || [];
             var sort = false;
             for (var i=0; i<cues.length; i++) {

--- a/src/js/utils/strings.js
+++ b/src/js/utils/strings.js
@@ -64,19 +64,6 @@ define([
     };
 
     /**
-     * Convert seconds to HH:MN:SS.sss
-     *
-     * @param seconds  The number of seconds
-     * @return        An HH:MN:SS.sss string
-     **/
-    var hms = function(seconds) {
-        var h = parseInt(seconds / 3600);
-        var m = parseInt(seconds / 60) % 60;
-        var s = seconds % 60;
-        return pad(h, 2) + ':' + pad(m, 2) + ':' + pad(s.toFixed(3), 6);
-    };
-
-    /**
      * Convert a time-representing string to a number.
      *
      * @param {String}    The input string. Supported are 00:03:00.1 / 03:00.1 / 180.1s / 3.2m / 3.2h
@@ -126,7 +113,6 @@ define([
         pad : pad,
         xmlAttribute : xmlAttribute,
         extension : extension,
-        hms: hms,
         seconds: seconds,
         suffix: suffix,
         prefix: prefix

--- a/src/js/utils/strings.js
+++ b/src/js/utils/strings.js
@@ -13,9 +13,8 @@ define([
      * @param {String} padder
      */
     var pad = function (str, length, padder) {
-        if (!padder) {
-            padder = '0';
-        }
+        str = '' + str;
+        padder = padder || '0';
         while (str.length < length) {
             str = padder + str;
         }
@@ -62,6 +61,19 @@ define([
         if (path.lastIndexOf('.') > -1) {
             return path.substr(path.lastIndexOf('.') + 1, path.length).toLowerCase();
         }
+    };
+
+    /**
+     * Convert seconds to HH:MN:SS.sss
+     *
+     * @param seconds  The number of seconds
+     * @return        An HH:MN:SS.sss string
+     **/
+    var hms = function(seconds) {
+        var h = parseInt(seconds / 3600);
+        var m = parseInt(seconds / 60) % 60;
+        var s = seconds % 60;
+        return pad(h, 2) + ':' + pad(m, 2) + ':' + pad(s.toFixed(3), 6);
     };
 
     /**
@@ -114,6 +126,7 @@ define([
         pad : pad,
         xmlAttribute : xmlAttribute,
         extension : extension,
+        hms: hms,
         seconds: seconds,
         suffix: suffix,
         prefix: prefix

--- a/src/js/view/captionsrenderer.js
+++ b/src/js/view/captionsrenderer.js
@@ -91,28 +91,41 @@ define([
             _select(_captionsTrack, _timeEvent);
         }
 
-        /** Select a caption for rendering. **/
-        function _select(track, timeEvent) {
-            if (!(track && track.data) || !timeEvent) {
-                return;
-            }
-            var data = track.data;
-            var pos = timeEvent.position;
-            // subtitles with "source" time must be synced with "metadata[source]"
+        function _getAlignmentPosition(track, timeEvent) {
             var source = track.source;
+            var metadata = timeEvent.metadata;
+
+            // subtitles with "source" time must be synced with "metadata[source]"
             if (source) {
-                if (timeEvent.metadata && _.isNumber(timeEvent.metadata[source])) {
-                    pos = timeEvent.metadata[source];
+                if (metadata && _.isNumber(metadata[source])) {
+                    return metadata[source];
                 } else {
                     return false;
                 }
             }
 
-            var found = -1;
+            // Default to syncing with current position
+            return timeEvent.position;
+        }
+
+        /** Select a caption for rendering. **/
+        function _select(track, timeEvent) {
+            if (!(track && track.data) || !timeEvent) {
+                return;
+            }
+
+            var pos = _getAlignmentPosition(track, timeEvent);
+            if (pos === false) {
+                return;
+            }
+
+            var data = track.data;
             if (_current >= 0 && _intersects(data, _current, pos)) {
                 // no change
                 return;
             }
+
+            var found = -1;
             for (var i = 0; i < data.length; i++) {
                 if (_intersects(data, i, pos)) {
                     found = i;


### PR DESCRIPTION
When subs include `useMPEGTS` and time events include `metadata.mpegts` use the mpeg timestamps to sync subtitles. If subs include `useMPEGTS` but `mpegts` is not present in the event (seek), then do not render captions.

Seek and change:item events also reset captions state so that captions can render correctly.

Also adds a new util `jwplayer.utils.hms(seconds)` which outputs time in hours minutes seconds `H:MM:SS.sss` format. Useful for outputting time in a readable format.

JW7-1322