### PR TITLE
Handle configs without playlists more concretely

### DIFF
--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -79,8 +79,18 @@ define([
 
         if (!config.playlist) {
             // This is a legacy fallback, assuming a playlist item has been flattened into the config
-            //  we clone it to avoid circular dependences
-            config.playlist = _.clone(config);
+            var obj = _.pick(config, [
+                'title',
+                'description',
+                'type',
+                'mediaid',
+                'image',
+                'file',
+                'sources',
+                'tracks'
+            ]);
+
+            config.playlist = [ obj ];
         }
 
         return config;

--- a/test/unit/api-config-test.js
+++ b/test/unit/api-config-test.js
@@ -73,7 +73,7 @@ define([
         x = testConfig(assert, {
             file:'abc.mp4'
         });
-        assert.equal(x.playlist.file, 'abc.mp4', 'Passing a file attr works');
+        assert.equal(x.playlist[0].file, 'abc.mp4', 'Passing a file attr works');
     });
 
     test('accepts aspectratio in percentage and W:H formats', function(assert) {


### PR DESCRIPTION
When we don't have a playlist we are supposed to infer a single playlist item
using the contents of the root-level config. However we don't need to use
*all* properties, only the ones relevant to a media item.