### PR TITLE
JW7-1502 Remove check preload none in init

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -424,7 +424,7 @@ define([
         };
 
         this.init = function(item) {
-            if (!_attached || item.preload === 'none') {
+            if (!_attached) {
                 return;
             }
 


### PR DESCRIPTION
Confirmed that we do not need this, because setting preload='none' will make the video tag to not preload.