### PR TITLE
Change state transition for instream item complete

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -128,10 +128,11 @@ define([
         }
 
         function _instreamItemComplete(e) {
-            // Allow 'play' state change to trigger next adPlay event in ad pods
-            _instream._adModel.set('state', 'complete');
 
             if (_array && _arrayIndex + 1 < _array.length) {
+                // We want a play event for the next item, so we ensure the state != playing
+                _instream._adModel.set('state', 'buffering');
+
                 // destroy skip button
                 _model.set('skipButton', false);
 


### PR DESCRIPTION
Changing the state to complete as we did before helps us ensure that we get
a play event for each item in a pod of instream items. However it has a side-effect
of causing a replay icon to flicker on screen.

To solve that we only do the "state" change hack when needed. We also use
buffering instead of complete so it will look correct to the user.

JW7-1517