### PR TITLE
JW7-1531 Fix poster image not displayed during audio playback

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -876,10 +876,13 @@ define([
             if (_castDisplay) {
                 _castDisplay.setState(_model.get('state'));
             }
-            _model.mediaModel.on('change:mediaType', function(model, val) {
-                var isAudioFile = (val ==='audio');
-                utils.toggleClass(_playerElement, 'jw-flag-media-audio', isAudioFile);
-            });
+            _onMediaTypeChange(_model.mediaModel.get('mediaType'));
+            _model.mediaModel.on('change:mediaType', _onMediaTypeChange, this);
+        }
+
+        function _onMediaTypeChange(val) {
+            var isAudioFile = (val ==='audio');
+            utils.toggleClass(_playerElement, 'jw-flag-media-audio', isAudioFile);
         }
 
         function _setLiveMode(model, duration){


### PR DESCRIPTION
View is listening to the change in mediaType. init happens after than view load, so it does not call toggleClass for audio when we send mediaType on load.