### PR TITLE
Fix replay not working for flash provider JW7-842

### DIFF
--- a/src/flash/com/longtailvideo/jwplayer/media/VideoMediaProvider.as
+++ b/src/flash/com/longtailvideo/jwplayer/media/VideoMediaProvider.as
@@ -370,6 +370,7 @@ public class VideoMediaProvider extends MediaProvider {
         switch (evt.info.code) {
             case "NetStream.Play.Stop":
                 complete();
+                _item = null;
                 break;
             case "NetStream.Play.StreamNotFound":
                 error('Error loading media: File not found');


### PR DESCRIPTION
After "NetStream.Play.Complete" is called, playing the same stream does not work. It only works in repeat, because repeat actually resumes the play before the complete event is fired. Therefore, for replay, we need to reload the video. Setting _item to null will reload the video on load, because we do a comparison between the passed in item and _item before executing video load.