### PR TITLE
Fix disappearing volume control on "six" skin

### DIFF
--- a/src/css/skins/six.less
+++ b/src/css/skins/six.less
@@ -51,7 +51,8 @@
         background-size: @def-background-size;
 
         .jw-overlay {
-            bottom: 2.25em;
+            bottom: 2em;
+            padding-bottom: .25em;
         }
     }
 


### PR DESCRIPTION
On "six" skin: fix disappearing volume control when moving cursor from the volume icon to the volume control.