### PR TITLE
JW7-1342 Fix ad skip button and overlay ads on small player

### DIFF
--- a/src/css/flags/touch.less
+++ b/src/css/flags/touch.less
@@ -1,7 +1,7 @@
 @import "../imports/icons";
 
 .jw-flag-touch {
-    .jw-controlbar {
+    .jw-controlbar, .jw-skip, .jw-plugin {
         font-size: 1.5em;
     }
 

--- a/src/css/imports/jwplayerelement.less
+++ b/src/css/imports/jwplayerelement.less
@@ -116,6 +116,7 @@
 
 .jw-plugin {
     position: absolute;
+    bottom: 2.5em;
 }
 
 .jw-cast-screen {


### PR DESCRIPTION
Skip button on small players was not aligned correctly, because we are setting style "bottom" with "3em".
On small devices, the font-size of controlbar is increased, but not the skip button, resulting "3em" of skip button to be smaller than "2.5em" of controlbar (since em is a scale based on the font size of current element).