### PR TITLE
JW7-1342 JW7-1158 Fix ad skip button and overlay ads on small player, and fix caption position

### DIFF
--- a/src/css/flags/touch.less
+++ b/src/css/flags/touch.less
@@ -1,8 +1,13 @@
 @import "../imports/icons";
 
 .jw-flag-touch {
-    .jw-controlbar {
+    .jw-controlbar, .jw-skip, .jw-plugin {
         font-size: 1.5em;
+    }
+
+    .jw-captions {
+        // control bar is (1.5*2.5 = 3.75)em for mobile, so bottom should be 0.5 above that
+        bottom: 4.25em;
     }
 
     .jw-icon-tooltip.jw-open-drawer {

--- a/src/css/flags/user-inactive.less
+++ b/src/css/flags/user-inactive.less
@@ -7,4 +7,8 @@
       .jw-logo.jw-hide {
           display : none;
       }
+
+      .jw-plugin, .jw-captions{
+          bottom: 0.5em;
+      }
 }

--- a/src/css/imports/captions.less
+++ b/src/css/imports/captions.less
@@ -7,7 +7,7 @@
     margin: 0 auto;
     width: 100%;
     left: 0;
-    bottom: 1.75em;
+    bottom: 3em;
     right: 0;
     max-width: 90%;
     text-align: center;

--- a/src/css/imports/jwplayerelement.less
+++ b/src/css/imports/jwplayerelement.less
@@ -116,6 +116,7 @@
 
 .jw-plugin {
     position: absolute;
+    bottom: 3em;
 }
 
 .jw-cast-screen {


### PR DESCRIPTION
Caption and overlay ads have been changed to always be 0.5em above the controlbar.
When inactive and controlbar is hidden, they move down to be 0.5em above the bottom of the player.
Skip button height does not change when controlbar is hidden.