### PR TITLE
Update buffer on time, not just duration and file progress

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -187,6 +187,8 @@ define([
 
             _setDuration(_videotag.duration);
             _setPosition(_videotag.currentTime);
+            // buffer ranges change during playback, not just on file progress
+            _setBuffered(_getBuffer(), _position, _duration);
 
             // send time events when playing
             if (_this.state === states.PLAYING) {


### PR DESCRIPTION
Browsers don't need to send a progress event when buffer ranges change. progress events are defined as file loading events. Media buffers can be filled and emptied as playback occurs and is not tied directly to file progress.

JW7-1534