### PR TITLE
JW7-842 Treat preload metadata as auto in flash provider

### DIFF
--- a/src/flash/com/longtailvideo/jwplayer/media/VideoMediaProvider.as
+++ b/src/flash/com/longtailvideo/jwplayer/media/VideoMediaProvider.as
@@ -90,11 +90,8 @@ public class VideoMediaProvider extends MediaProvider {
 
     override public function init(itm:PlaylistItem):void {
         setupVideo(itm);
-        // start loading the content only if preload is 'auto'
-        if (itm.preload === "auto") {
-            loadQuality();
-            _stream.pause();
-        }
+        loadQuality();
+        _stream.pause();
     }
 
     /** Load new media file; only requested once per item. **/
@@ -103,9 +100,7 @@ public class VideoMediaProvider extends MediaProvider {
         if (_item !== itm) {
             setupVideo(itm);
             loadQuality();
-        } else if (itm.preload === "metadata") {
-            loadQuality();
-        } else {
+        } else if (itm.preload !== "none") {
             play();
         }
 


### PR DESCRIPTION
We decided to preload as if it was auto whenever  preload is not none, because we can't just download metadata without start playing the video in flash.