### PR TITLE
allow pre-processing of captions via a configuration setting

### DIFF
--- a/src/js/view/captionsrenderer.js
+++ b/src/js/view/captionsrenderer.js
@@ -19,9 +19,7 @@ define([
         edgeStyle: null,
         windowColor: '#FFF',
         windowOpacity: 0,
-        captionParser: function (input) {
-            return input;
-        }
+        preprocessor: _.identity
     };
 
     /** Component that renders the actual captions on screen. **/
@@ -140,7 +138,7 @@ define([
                 _render('');
             } else if (found !== _current) {
                 _current = found;
-                _render( _options.captionParser(data[_current].text) );
+                _render( _options.preprocessor(data[_current].text) );
             }
         }
 

--- a/src/js/view/captionsrenderer.js
+++ b/src/js/view/captionsrenderer.js
@@ -18,7 +18,10 @@ define([
         // otherwise it's 'none'
         edgeStyle: null,
         windowColor: '#FFF',
-        windowOpacity: 0
+        windowOpacity: 0,
+        captionParser: function (input) {
+            return input;
+        }
     };
 
     /** Component that renders the actual captions on screen. **/
@@ -137,7 +140,7 @@ define([
                 _render('');
             } else if (found !== _current) {
                 _current = found;
-                _render(data[_current].text);
+                _render( _options.captionParser(data[_current].text) );
             }
         }
 

--- a/test/manual/index.html
+++ b/test/manual/index.html
@@ -79,7 +79,10 @@
                 file: 'not a playable option',
                 title: 'Filtered Out of Playlist'
             }
-        ]
+        ],
+        captions: {
+            captionParser: function(rawText){ return rawText.replace(/e/g,'E') }
+        }
     };
 
     var jwp = jwplayer('video-container').setup(config);

--- a/test/manual/index.html
+++ b/test/manual/index.html
@@ -81,7 +81,7 @@
             }
         ],
         captions: {
-            captionParser: function(rawText){ return rawText.replace(/e/g,'E') }
+            preprocessor: function(rawText){ return rawText.replace(/e/g,'E') }
         }
     };
 


### PR DESCRIPTION
This is a feature request to allow preprocessing of caption lines. I have encountered a situation where characters within caption lines have become corrupted (unrelated to JW Player) and need to be replaced on the client side.

Adding a ```captions.captionParser``` configuration option seems to be a very clean solution, and opens other possibilities including displaying related content based on the content of a live broadcast.