### PR TITLE
1. Refactor setup steps

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -104,6 +104,9 @@ define([
             function _playerReady() {
                 _setup = null;
 
+                // Set up provider and allow preload
+                _model.setItem(_model.get('item'));
+
                 _model.on('change:state', changeStateEvent, this);
 
                 // For 'onCast' callback
@@ -628,6 +631,11 @@ define([
                     mode = ! _model.get('controls');
                 }
                 _model.set('controls', mode);
+
+                var provider = _model.getVideo();
+                if (provider) {
+                    provider.setControls(mode);
+                }
             };
 
             this.playerDestroy = function () {

--- a/src/js/controller/qoe.js
+++ b/src/js/controller/qoe.js
@@ -49,10 +49,11 @@ define([
     }
 
     function initModel(model) {
+        var oldMediaModel = null;
 
-        model.on('change:mediaModel', function(model, mediaModel, oldMediaModel) {
+        function onMediaModel(model, mediaModel) {
             // finish previous item
-            if (model._qoeItem) {
+            if (model._qoeItem && oldMediaModel) {
                 model._qoeItem.end(oldMediaModel.get('state'));
             }
             // reset item level qoe
@@ -62,11 +63,15 @@ define([
 
             trackFirstFrame(model);
 
-            mediaModel.on('change:state', function(mediaModel, newstate, oldstate) {
+            mediaModel.on('change:state', function (mediaModel, newstate, oldstate) {
                 model._qoeItem.end(oldstate);
                 model._qoeItem.start(newstate);
             });
-        });
+
+            oldMediaModel = model;
+        }
+
+        model.on('change:mediaModel', onMediaModel);
     }
 
     return {

--- a/src/js/controller/qoe.js
+++ b/src/js/controller/qoe.js
@@ -49,9 +49,8 @@ define([
     }
 
     function initModel(model) {
-        var oldMediaModel = null;
 
-        function onMediaModel(model, mediaModel) {
+        function onMediaModel(model, mediaModel, oldMediaModel) {
             // finish previous item
             if (model._qoeItem && oldMediaModel) {
                 model._qoeItem.end(oldMediaModel.get('state'));
@@ -67,8 +66,6 @@ define([
                 model._qoeItem.end(oldstate);
                 model._qoeItem.start(newstate);
             });
-
-            oldMediaModel = model;
         }
 
         model.on('change:mediaModel', onMediaModel);

--- a/src/js/controller/setup-steps.js
+++ b/src/js/controller/setup-steps.js
@@ -213,7 +213,6 @@ define([
     }
 
     function _setupComponents(resolve, _model, _api, _view) {
-        _model.setItem(0);
         _view.setup();
         resolve();
     }

--- a/src/js/view/components/timeslider.js
+++ b/src/js/view/components/timeslider.js
@@ -59,7 +59,9 @@ define([
         setup : function() {
             Slider.prototype.setup.apply(this, arguments);
 
-            this.onPlaylistItem(this._model, this._model.get('playlistItem'));
+            if (this._model.get('playlistItem')) {
+                this.onPlaylistItem(this._model, this._model.get('playlistItem'));
+            }
 
             this.elementRail.appendChild(this.timeTip.element());
 

--- a/src/js/view/preview.js
+++ b/src/js/view/preview.js
@@ -12,7 +12,9 @@ define([
         setup: function(element) {
             this.el = element;
 
-            this.loadImage(this.model, this.model.get('playlistItem'));
+            if (this.model.get('playlistItem')) {
+                this.loadImage(this.model, this.model.get('playlistItem'));
+            }
         },
         loadImage: function(model, playlistItem) {
             var img = playlistItem.image;

--- a/src/js/view/title.js
+++ b/src/js/view/title.js
@@ -4,6 +4,8 @@ define([
 
     var Title = function(_model) {
         this.model = _model;
+
+        this.model.on('change:playlistItem', this.playlistItem, this);
     };
 
     _.extend(Title.prototype, {
@@ -24,8 +26,9 @@ define([
             this.title = arr[0];
             this.description = arr[1];
 
-            this.model.on('change:playlistItem', this.playlistItem, this);
-            this.playlistItem(this.model, this.model.get('playlistItem'));
+            if (this.model.get('playlistItem')) {
+                this.playlistItem(this.model, this.model.get('playlistItem'));
+            }
         },
 
         playlistItem : function(model, item) {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -355,7 +355,7 @@ define([
             _userActivity();
 
             // adds video tag to video layer
-            _model.getVideo().setContainer(_videoLayer);
+            _model.set('mediaContainer', _videoLayer);
 
             // Native fullscreen (coming through from the provider)
             _model.mediaController.on('fullscreenchange', _fullscreenChangeHandler);
@@ -511,8 +511,6 @@ define([
             } else {
                 utils.addClass(_playerElement, 'jw-flag-controls-disabled');
             }
-
-            model.getVideo().setControls(bool);
         };
 
         function _doubleClickFullscreen() {


### PR DESCRIPTION
The primary goal of this is to remove model.setItem from setup-steps.js
This will make it easier to remove setItem from the model and move it into the controller.

This change means that you are no longer guaranteed to have a playlistItem when setting up the view,
so there is much more safety around setup methods in the view.