### PR TITLE
JW7-1562 Fix postroll replaying single playlist item

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -83,8 +83,6 @@ define([
             // Make sure the original player's provider stops broadcasting events (pseudo-lock...)
             _oldProvider.detachMedia();
 
-            _model.mediaModel.set('state', states.BUFFERING);
-
             if (_controller.checkBeforePlay() || (_oldpos === 0 && !_oldProvider.checkComplete())) {
                 // make sure video restarts after preroll
                 _oldpos = 0;
@@ -100,6 +98,8 @@ define([
             if (currState === states.PLAYING || currState === states.BUFFERING) {
                 _oldProvider.pause();
             }
+
+            _model.mediaModel.set('state', states.BUFFERING);
 
             // Show instream state instead of normal player state
             _view.setupInstream(_instream._adModel);


### PR DESCRIPTION
Changing mediaModel's state to buffering also changes model's state. Then, on the next lines, when we check the type of ads (pre/mid/post roll), we are not getting model state === complete on postrolls, so they are being treated as midrolls.