### PR TITLE
Remove dependency on player global swc Throttle class definitions

### DIFF
--- a/src/flash/com/longtailvideo/jwplayer/player/Player.as
+++ b/src/flash/com/longtailvideo/jwplayer/player/Player.as
@@ -13,8 +13,6 @@ import com.longtailvideo.jwplayer.view.View;
 import flash.display.Sprite;
 import flash.events.ErrorEvent;
 import flash.events.Event;
-import flash.events.ThrottleEvent;
-import flash.events.ThrottleType;
 import flash.geom.Rectangle;
 import flash.system.Security;
 
@@ -29,6 +27,9 @@ public class Player extends Sprite implements IPlayer {
     protected var _instream:InstreamPlayer;
 
     public function Player() {
+        // Send embedded event so we know flash isn't blocked
+        SwfEventRouter.triggerJsEvent('embedded');
+
         Security.allowDomain("*");
 
         // Send embedded event so we know flash isn't blocked
@@ -36,7 +37,7 @@ public class Player extends Sprite implements IPlayer {
 
         RootReference.init(this);
         this.addEventListener(Event.ADDED_TO_STAGE, stageReady);
-        this.addEventListener(ThrottleEvent.THROTTLE, flashThrottled);
+        this.addEventListener('throttle', flashThrottled);
 
         this.tabEnabled = false;
         this.tabChildren = false;
@@ -61,11 +62,12 @@ public class Player extends Sprite implements IPlayer {
         _view.setupView();
     }
 
-    private function flashThrottled(e:ThrottleEvent):void {
+    private function flashThrottled(e:Event):void {
         // e.state can be ThrottleType.THROTTLE, ThrottleType.PAUSE, or ThrottleType.RESUME
         // in Chrome we only get 'throttle' and 'resume' for offscreen and power-save throttling
+        var state:String = e['state'] as String;
         SwfEventRouter.triggerJsEvent('throttle', {
-            state: e.state
+            state: state
         });
     }
 


### PR DESCRIPTION
Not importing the Throttle classes will avoid errors we get when using mxmlc in grunt where the wrong playerglobal.swc is targeted (11 rather than 11.2).
