### PR TITLE
Fix for mediaModel getting reset unexpectedly

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -120,7 +120,7 @@ define([
                     });
                 });
                 // For onItem callback
-                _model.on('change:playlistItem', function(model, playlistItem) {
+                _model.on('itemSet', function(model, playlistItem) {
                     _this.trigger(events.JWPLAYER_PLAYLIST_ITEM, {
                         index: model.get('item'),
                         item: playlistItem
@@ -396,6 +396,9 @@ define([
                 _model.set('item', index);
                 _model.set('playlistItem', playlist[index]);
                 _model.setActiveItem(playlist[index]);
+
+                // Listening for change:item won't suffice when loading the same index or file
+                _model.trigger('itemSet');
             }
 
             function _prev() {

--- a/src/js/controller/instream-html5.js
+++ b/src/js/controller/instream-html5.js
@@ -37,11 +37,11 @@ define([
 
         /** Load an instream item and initialize playback **/
         _this.load = function(item) {
-            // Make sure it chooses a provider
             _adModel.setPlaylist([item]);
 
             _adModel.set('item', 0);
             _adModel.set('playlistItem', item);
+            // Make sure it chooses a provider
             _adModel.setActiveItem(item);
 
             // check provider after item change

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -263,8 +263,6 @@ define([
             if (_currentProvider.init) {
                 _currentProvider.init(item);
             }
-
-            this.trigger('setItem');
         };
 
         this.resetProvider = function() {

--- a/src/js/view/captionsrenderer.js
+++ b/src/js/view/captionsrenderer.js
@@ -212,7 +212,7 @@ define([
             return _display;
         };
 
-        _model.on('change:item', function() {
+        _model.on('itemSet', function() {
             _timeEvent = null;
             _current = -1;
             _render('');

--- a/src/js/view/controlbar.js
+++ b/src/js/view/controlbar.js
@@ -186,15 +186,15 @@ define([
             }
             this.onVolume(this._model, this._model.get('volume'));
             this.onPlaylist(this._model, this._model.get('playlist'));
-            this.onPlaylistItem(this._model, this._model.get('playlistItem'));
+            this.onItemSet(this._model, this._model.get('playlistItem'));
             this.onCastAvailable(this._model, this._model.get('castAvailable'));
             this.onCaptionsList(this._model, this._model.get('captionsList'));
 
             // Listen for model changes
+            this._model.on('itemSet', this.onItemSet, this);
             this._model.on('change:volume', this.onVolume, this);
             this._model.on('change:mute', this.onMute, this);
             this._model.on('change:playlist', this.onPlaylist, this);
-            this._model.on('change:playlistItem', this.onPlaylistItem, this);
             this._model.on('change:castAvailable', this.onCastAvailable, this);
             this._model.on('change:duration', this.onDuration, this);
             this._model.on('change:position', this.onElapsed, this);
@@ -289,7 +289,7 @@ define([
                 this.elements.playlist.setup(playlist, model.get('item'));
             }
         },
-        onPlaylistItem : function(model/*, item*/) {
+        onItemSet : function() {
             this.elements.time.updateBuffer(0);
             this.elements.time.render(0);
             this.elements.duration.innerHTML = '00:00';
@@ -297,7 +297,7 @@ define([
             
             this.clearCompactMode();
 
-            var itemIdx = model.get('item');
+            var itemIdx = this._model.get('item');
             if(this.elements.playlist) {
                 this.elements.playlist.selectItem(itemIdx);
             }


### PR DESCRIPTION
This bug manifested as the HD menu not appearing because the controlbar
listens for a "change:levels" event from the mediaModel in order to populate.
It was, however, listening to the wrong instance of mediaModel, because we bound
the listener when we see a "change:playlistItem" event.

We assumed that every time we create a new mediaModel that we would also call
the "change:playlistItem" in order to rebind listeners. This is not true in some
situations, such as when the new item is the same as the old one.

The better solution is to use an event which specifically tells you when the item changes
which I call here "itemSet"

JW7-1563