### PR TITLE
Wait to call resize until the player is on the page

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -410,12 +410,12 @@ define([
             }
 
             // This setTimeout allows the player to actually get embedded into the player
-            setTimeout(function() {
+            _api.on(events.JWPLAYER_READY, function() {
                 // Initialize values for containerWidth and containerHeight
                 _responsiveListener();
 
                 _resize(_model.get('width'), _model.get('height'));
-            }, 0);
+            });
         };
 
         function _onCastActive(model, val) {


### PR DESCRIPTION
When we call resize too soon, it will not propagate the event
through the player to the plugins.

JW7-1491