### PR TITLE
Fix XML Parser in Firefox

### DIFF
--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -23,9 +23,8 @@ define([
     dom.classList = function (element) {
         if (element.classList) {
             return element.classList;
-        } else {
-            return element.className.split(' ');
         }
+        return element.className.split(' ');
     };
 
     dom.hasClass = jqueryfuncs.hasClass;

--- a/src/js/utils/parser.js
+++ b/src/js/utils/parser.js
@@ -54,6 +54,12 @@ define([
         return '';
     });
 
+    function containsParserErrors(childNodes) {
+        return _.some(childNodes, function(node) {
+            return node.nodeName === 'parsererror';
+        });
+    }
+
     /** Takes an XML string and returns an XML object **/
     parser.parseXML = function (input) {
         var parsedXML = null;
@@ -61,9 +67,9 @@ define([
             // Parse XML in FF/Chrome/Safari/Opera
             if (window.DOMParser) {
                 parsedXML = (new window.DOMParser()).parseFromString(input, 'text/xml');
-                var childNodes = parsedXML.childNodes;
-                if (childNodes && childNodes.length && childNodes[0].firstChild &&
-                    childNodes[0].firstChild.nodeName === 'parsererror') {
+                // In Firefox the XML doc may contain the parsererror, other browsers it's further down
+                if (containsParserErrors(parsedXML.childNodes) ||
+                    (parsedXML.childNodes && containsParserErrors(parsedXML.childNodes[0].childNodes))) {
                     parsedXML = null;
                 }
             } else {


### PR DESCRIPTION
In Firefox the XML doc's second child contains the parsererror, rather than the firstchild's firstchild which was the only node we checked before. Now we look for errors in the doc's children and the firstchild's children before returning null.