### PR TITLE
Listen to video tag for paused state and don't set state while detached

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -414,7 +414,6 @@ define([
                 return;
             }
             _videotag.removeAttribute('src');
-            // TODO: empty element
             if (!_isIE) {
                 _videotag.load();
             }


### PR DESCRIPTION
This is in response to a question on stackoverflow http://stackoverflow.com/questions/33089838/detect-pause-and-done-buttons-click-on-iphone-for-jwplayer7

The player state should change to paused if the video tag is paused without jw api interaction. The provider state should remain unchanged when the provider is not attached.

Clearing the stalled timer and maintaining canSeek state is moved up before exiting when not attached.

Fixes #834
JW7-1605