### PR TITLE
Use trycatch util when executing player event callbacks

### DIFF
--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -4,6 +4,7 @@ define([
     'utils/backbone.events',
     'utils/helpers',
     'utils/timer',
+    'utils/trycatch',
     'utils/underscore',
     'controller/controller',
     'api/api-actions',
@@ -11,7 +12,7 @@ define([
     'api/callbacks-deprecate',
     'version'
 ], function(events, states,
-            Events, utils, Timer, _, Controller, actionsInit, mutatorsInit, legacyInit, version) {
+            Events, utils, Timer, trycatch, _, Controller, actionsInit, mutatorsInit, legacyInit, version) {
 
     function addFocusBorder(container) {
         utils.addClass(container, 'jw-tab-focus');
@@ -50,13 +51,16 @@ define([
             if (_.isString(callback)) {
                 throw new TypeError('eval callbacks depricated');
             }
+            if (!_.isFunction(callback)) {
+                return this;
+            }
 
             var safeCallback = function() {
-                try {
-                    callback.apply(this, arguments);
-                } catch(e) {
+                var status = trycatch.tryCatch(callback, this, arguments);
+
+                if (status instanceof trycatch.Error) {
                     utils.log('There was an error calling back an event handler for "'+
-                        name+'". Error: '+ e.message);
+                        name+'". Error: '+ status.message);
                 }
             };
 

--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -48,10 +48,11 @@ define([
         };
 
         this.on = function(name, callback) {
-            if (_.isString(callback)) {
-                throw new TypeError('eval callbacks depricated');
-            }
             if (!_.isFunction(callback)) {
+                if (_.isString(callback)) {
+                    throw new TypeError('eval callbacks depricated');
+                }
+                utils.log('Expected a function', name, callback);
                 return this;
             }
 

--- a/test/unit/api-test.js
+++ b/test/unit/api-test.js
@@ -103,7 +103,17 @@ define([
         var api = createApi('player');
 
         _.each(apiMethodsChainable, function(args, method) {
-            var result = api[method].apply(api, args);
+            var fn = api[method];
+            assert.ok(_.isFunction(fn), 'api.' + method + ' is defined');
+
+            var result;
+            try {
+                result = fn.apply(api, args);
+            } catch(e) {
+                var expectedMessage = method +' does not throw an error';
+                assert.equal(method +' threw an error', expectedMessage, expectedMessage +':'+ e.message);
+            }
+
             assert.strictEqual(result, api, 'api.' + method + ' returns an instance of itself');
         });
     });


### PR DESCRIPTION
This allows disabling of try catch on event handlers using `jwplayer.debug = true` which was the main goal of adding this util to the player.

The method also returns early if the callback is not a function or String.