### PR TITLE
JW7-1317 Fix android youtube being stuck on cued or unstarted

### DIFF
--- a/src/js/providers/youtube.js
+++ b/src/js/providers/youtube.js
@@ -247,6 +247,10 @@ define([
             switch (_youtubeState) {
 
                 case youtubeStates.UNSTARTED: // -1: //unstarted
+                    // play video on android to avoid being stuck in this state
+                    if (utils.isAndroid()) {
+                        _youtubePlayer.playVideo();
+                    }
                     return;
 
                 case youtubeStates.ENDED: // 0: //ended (idle after playback)
@@ -289,6 +293,10 @@ define([
 
                 case youtubeStates.CUED: // 5: //video cued (idle before playback)
                     _this.setState(states.IDLE);
+                    // play video on android to avoid being stuck in this state
+                    if (utils.isAndroid()) {
+                        _youtubePlayer.playVideo();
+                    }
                     return;
             }
         }


### PR DESCRIPTION
If we try to play the youtube video too quickly on Android, the youtube API sends us unstarted event, or cue it until we start playing. To fix this issue, we want to play the video when we get these states on Android.