### PR TITLE
Youtube ID util should not rely on try catch

### DIFF
--- a/src/js/utils/validator.js
+++ b/src/js/utils/validator.js
@@ -1,7 +1,6 @@
 define([
-    'utils/underscore',
-    'utils/trycatch'
-], function(_, trycatch) {
+    'utils/underscore'
+], function(_) {
     var validator = {};
 
     /**
@@ -56,16 +55,12 @@ define([
      *  - YE7VzlLtp-4
      **/
     validator.youTubeID = function (path) {
-        var status = trycatch.tryCatch(function() {
-            // Left as a dense regular expression for brevity.
-            return (/v[=\/]([^?&]*)|youtu\.be\/([^?]*)|^([\w-]*)$/i).exec(path).slice(1).join('').replace('?', '');
-        });
-
-        if (status instanceof trycatch.Error) {
+        // Left as a dense regular expression for brevity.
+        var matches = (/v[=\/]([^?&]*)|youtu\.be\/([^?]*)|^([\w-]*)$/i).exec(path);
+        if (!matches) {
             return '';
         }
-
-        return status;
+        return matches.slice(1).join('').replace('?', '');
     };
 
 


### PR DESCRIPTION
When debugging (jwplayer.debug = true) this breaks. There's no reason we should ever rely on try catch when exceptions can easily be avoided.