### PR TITLE
Fix for cues offset by a percentage

### DIFF
--- a/src/js/view/components/chapters.mixin.js
+++ b/src/js/view/components/chapters.mixin.js
@@ -17,10 +17,11 @@ define([
             if (this.time.toString().slice(-1) === '%') {
                 this.pct = this.time;
             } else {
-                this.pct = (this.time/duration) * 100;
+                var percentage = (this.time/duration) * 100;
+                this.pct = percentage + '%';
             }
 
-            this.el.style.left = this.pct + '%';
+            this.el.style.left = this.pct;
         }
     });
 


### PR DESCRIPTION
This bug affected cues with an offset of a percentage.
We were adding a % sign to the end of "x%" resulting in "x%%"

JW7-1730