### PR TITLE
JW7-1707 - Set bottom margin to 0 to position ads in IE11/Edge

### DIFF
--- a/src/css/imports/jwplayerelement.less
+++ b/src/css/imports/jwplayerelement.less
@@ -127,7 +127,7 @@
         opacity: 0;
         cursor: pointer;
         position: absolute;
-        margin: auto;
+        margin: auto auto 0 auto;
         left: 0;
         right: 0;
         bottom: 0;


### PR DESCRIPTION
Set bottom margin to 0 to position ads in IE11/Edge