### PR TITLE
Don't set state to paused after exiting fullscreen

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -148,7 +148,6 @@ define([
 
         _setupListeners(_mediaEvents, _videotag);
 
-
         // Workaround for a Safari bug where video disappears on switch to fullscreen
         if (!_isIOS7) {
             _videotag.controls = true;
@@ -583,11 +582,6 @@ define([
             _sendFullscreen(e);
             if (utils.isIOS()) {
                 _videotag.controls = false;
-                // iOS may pause the video after exiting fullscreen
-                //  when using the "Done" button
-                if (_videotag.paused) {
-                    _this.setState(states.PAUSED);
-                }
             }
         }
 


### PR DESCRIPTION
This removes some hacky code which is no longer needed
since we are now listening to the video tags pause events.

JW7-1687