### PR TITLE
Don't fire pause event when at end of playback

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -272,9 +272,16 @@ define([
         }
 
         function _pauseHandler() {
+            // Sometimes the browser will fire "complete" and then a "pause" event
             if (_this.state === states.COMPLETE) {
                 return;
             }
+
+            // If "pause" fires before "complete", we still don't want to propagate it
+            if (_videotag.currentTime === _videotag.duration) {
+                return;
+            }
+
             _this.setState(states.PAUSED);
         }
 


### PR DESCRIPTION
This bug manifested due to our change to listen for video tag pause events.
Some browsers (including Chrome 46) will fire a "pause" event right before a "complete" event.
We cannot guarantee the order of the pause and complete events, so this should handle either
ordering of the two.

JW7-1689