### PR TITLE
JW7-1671 Do not call complete function when flash video completes

### DIFF
--- a/src/flash/com/longtailvideo/jwplayer/media/VideoMediaProvider.as
+++ b/src/flash/com/longtailvideo/jwplayer/media/VideoMediaProvider.as
@@ -364,7 +364,8 @@ public class VideoMediaProvider extends MediaProvider {
     protected function statusHandler(evt:NetStatusEvent):void {
         switch (evt.info.code) {
             case "NetStream.Play.Stop":
-                complete();
+                sendMediaEvent(MediaEvent.JWPLAYER_MEDIA_COMPLETE);
+                clearInterval(_interval);
                 break;
             case "NetStream.Play.StreamNotFound":
                 error('Error loading media: File not found');


### PR DESCRIPTION
complete function dispatched an event that calls stop function.
The stop function in VideoMediaProvider resets _buffered and _keyframes variables,
causing the player to think that it is not buffered enough to play when we try to replay.