### PR TITLE
JW7-1723 JW7-1710 - Adds a test to detect Edge

### DIFF
--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -28,7 +28,7 @@ define([
     browser.isIPod = _browserCheck(/iP(hone|od)/i);
     browser.isIPad = _browserCheck(/iPad/i);
     browser.isSafari602 = _browserCheck(/Macintosh.*Mac OS X 10_8.*6\.0\.\d* Safari/i);
-    browser.isEdge = _browserCheck(/edge/i);
+    browser.isEdge = _browserCheck(/\sedge\/\d+/i);
 
     var _isIETrident = browser.isIETrident = function(browserVersion) {
         if(browser.isEdge()){

--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -25,12 +25,15 @@ define([
     };
 
     browser.isFF = _browserCheck(/firefox/i);
-    browser.isChrome = _browserCheck(/chrome/i);
     browser.isIPod = _browserCheck(/iP(hone|od)/i);
     browser.isIPad = _browserCheck(/iPad/i);
     browser.isSafari602 = _browserCheck(/Macintosh.*Mac OS X 10_8.*6\.0\.\d* Safari/i);
+    browser.isEdge = _browserCheck(/edge/i);
 
     var _isIETrident = browser.isIETrident = function(browserVersion) {
+        if(browser.isEdge()){
+            return true;
+        }
         if (browserVersion) {
             browserVersion = parseFloat(browserVersion).toFixed(1);
             return _userAgentMatch(new RegExp('trident/.+rv:\\s*' + browserVersion, 'i'));
@@ -45,6 +48,10 @@ define([
             return _userAgentMatch(new RegExp('msie\\s*' + browserVersion, 'i'));
         }
         return _userAgentMatch(/msie/i);
+    };
+
+    browser.isChrome = function(){
+        return _browserCheck(/chrome/i) && !browser.isEdge();
     };
 
     browser.isIE = function(browserVersion) {

--- a/test/unit/utils-defs-test.js
+++ b/test/unit/utils-defs-test.js
@@ -4,7 +4,7 @@ define([
     /* jshint qunit: true */
 
     test('defines util functions ', function (assert) {
-        assert.expect(54);
+        assert.expect(55);
 
         // functions in helpers
         assert.equal(typeof utils.log, 'function', 'log function is defined');
@@ -32,6 +32,7 @@ define([
         assert.equal(typeof utils.isFlashSupported, 'function', 'isFlashSupported function is defined');
         assert.equal(typeof utils.isFF, 'function', 'isFF function is defined');
         assert.equal(typeof utils.isChrome, 'function', 'isChrome function is defined');
+        assert.equal(typeof utils.isEdge, 'function', 'isEdge function is defined');
         assert.equal(typeof utils.isIPod, 'function', 'isIPod function is defined');
         assert.equal(typeof utils.isIPad, 'function', 'isIPad function is defined');
         assert.equal(typeof utils.isSafari602, 'function', 'isSafari602 function is defined');


### PR DESCRIPTION
Adds a test that will detect IE Edge to fix other issues.  For Trident tests, Edge counts as a trident browser because they have the same sorts of issues.  isChrome is changed to test for chrome in the userAgent && !isEdge because Edge will represent itself as chrome.

This will have a PR paired with it in commercial that maintains DASH support on Edge