### PR TITLE
Only persist options when set by API

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,4 +1,3 @@
 src/js/utils/backbone.events.js
 src/js/utils/underscore.js
 src/js/polyfills/*.js
-src/js/__*/*.js

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -22,6 +22,8 @@ define([
         volume: 90,
         width: 480,
         height: 270
+        //qualityLabel: '480p',     // specify a default quality
+        //captionLabel: 'English',  // specify a default Caption
     };
 
     function _deserialize(options) {

--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -137,11 +137,12 @@ define([
         }
 
         function _captionsIndexHandler(model, captionsMenuIndex) {
-            if (captionsMenuIndex === 0) {
-                _setCaptionsTrack(model, null);
-                return;
+            var track = null;
+            if (captionsMenuIndex !== 0) {
+                track = _tracks[captionsMenuIndex-1];
             }
-            _setCaptionsTrack(model, _tracks[captionsMenuIndex-1]);
+
+            model.set('captionsTrack', track);
         }
 
         function _addTrack(track) {
@@ -198,17 +199,6 @@ define([
             _errorHandler(message);
         }
 
-        function _setCaptionsTrack(model, track) {
-            model.set('captionsTrack', track);
-
-            if (track) {
-                // update preference if an option was selected
-                model.set('captionLabel', track.label);
-            } else {
-                model.set('captionLabel', 'Off');
-            }
-        }
-
         function _captionsMenu() {
             var list = [{
                 id: 'off',
@@ -248,10 +238,6 @@ define([
 
         this.getCaptionsList = function() {
             return _model.get('captionsList');
-        };
-
-        this.setCurrentIndex = function(captionsMenuIndex) {
-            _api.setCurrentCaptions(captionsMenuIndex);
         };
 
         this.setCaptionsList = function(captionsMenu) {

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -163,7 +163,6 @@ define([
         };
 
         this.persistQualityLevel = function(quality, levels) {
-            // For storage
             var currentLevel = levels[quality] || {};
             var label = currentLevel.label;
             this.set('qualityLabel', label);

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -135,6 +135,7 @@ define([
                     break;
                 case events.JWPLAYER_MEDIA_LEVEL_CHANGED:
                     this.setQualityLevel(data.currentQuality, data.levels);
+                    this.persistQualityLevel(data.currentQuality, data.levels);
                     break;
                 case events.JWPLAYER_AUDIO_TRACKS:
                     this.setCurrentAudioTrack(data.currentTrack, data.tracks);
@@ -158,11 +159,14 @@ define([
             if (quality > -1 && levels.length > 1 && _provider.getName().name !== 'youtube') {
                 this.mediaModel.set('currentLevel', parseInt(quality));
 
-                // For storage
-                var currentLevel = levels[quality] || {};
-                var label = currentLevel.label;
-                this.set('qualityLabel', label);
             }
+        };
+
+        this.persistQualityLevel = function(quality, levels) {
+            // For storage
+            var currentLevel = levels[quality] || {};
+            var label = currentLevel.label;
+            this.set('qualityLabel', label);
         };
 
         this.setCurrentAudioTrack = function(currentTrack, tracks) {
@@ -317,12 +321,26 @@ define([
                 _provider.stop();
             }
         };
+
         this.playVideo = function() {
             _provider.play();
         };
 
+        this.persistCaptionsTrack = function() {
+            var track = this.get('captionsTrack');
+
+            if (track) {
+                // update preference if an option was selected
+                this.set('captionLabel', track.label);
+            } else {
+                this.set('captionLabel', 'Off');
+            }
+        };
+
+
         this.setVideoSubtitleTrack = function(trackIndex) {
             this.set('captionsIndex', trackIndex);
+            this.persistCaptionsTrack();
 
             if (_provider.setSubtitlesTrack) {
                 _provider.setSubtitlesTrack(trackIndex);


### PR DESCRIPTION
This relates directly to chosen quality level and chosen caption track.

Before this fix, every new playlist item would re-set the selected options
because storage works by simply persisting attributes within the model.

To makes this work, we more carefully update the attributes, only when
explicitly set by API instead of events from the provider.

JW7-1719