### PR TITLE
JW7-1671 Reload flash video on replay

### DIFF
--- a/src/flash/com/longtailvideo/jwplayer/media/VideoMediaProvider.as
+++ b/src/flash/com/longtailvideo/jwplayer/media/VideoMediaProvider.as
@@ -364,7 +364,8 @@ public class VideoMediaProvider extends MediaProvider {
     protected function statusHandler(evt:NetStatusEvent):void {
         switch (evt.info.code) {
             case "NetStream.Play.Stop":
-                complete();
+                sendMediaEvent(MediaEvent.JWPLAYER_MEDIA_COMPLETE);
+                clearInterval(_interval);
                 break;
             case "NetStream.Play.StreamNotFound":
                 error('Error loading media: File not found');

--- a/src/flash/com/longtailvideo/jwplayer/media/VideoMediaProvider.as
+++ b/src/flash/com/longtailvideo/jwplayer/media/VideoMediaProvider.as
@@ -323,6 +323,11 @@ public class VideoMediaProvider extends MediaProvider {
         if (_item.type == 'mp4') {
             prm = _offset.time;
         }
+        
+        // set complete to false before _stream.play is called
+        _complete = false;
+        _buffered = 0;
+        
         //  need to call stream.play even when preloading, because this is how stream starts to load the content
         if (!_startparam || _offset.time == 0) {
             _stream.play(url);
@@ -331,17 +336,13 @@ public class VideoMediaProvider extends MediaProvider {
         } else {
             _stream.play(url + '?' + _startparam + '=' + prm);
         }
-        _buffered = 0;
-
+        
         sendBufferEvent(0);
 
         // TODO: do this on enter frame like HLS
         clearInterval(_interval);
         this.seeking = true;
         _interval = setInterval(positionHandler, 100);
-
-        // set complete to false because a new stream starts
-        _complete = false;
     }
 
     /** Return the seek offset based upon a position. **/

--- a/src/flash/com/longtailvideo/jwplayer/media/VideoMediaProvider.as
+++ b/src/flash/com/longtailvideo/jwplayer/media/VideoMediaProvider.as
@@ -50,7 +50,7 @@ public class VideoMediaProvider extends MediaProvider {
     /** Is buffering due to load/seek or underflow? **/
     private var seeking:Boolean;
 
-    private var _forceReload:Boolean;
+    private var _complete:Boolean;
 
     /** Set the current quality level. **/
     override public function set currentQuality(quality:Number):void {
@@ -99,10 +99,9 @@ public class VideoMediaProvider extends MediaProvider {
     /** Load new media file; only requested once per item. **/
     override public function load(itm:PlaylistItem):void {
         setState(PlayerState.LOADING);
-        if (_item !== itm || _forceReload) {
+        if (_item !== itm || _complete) {
             setupVideo(itm);
             loadQuality();
-            _forceReload = false;
         } else if (itm.preload !== "none") {
             play();
         }
@@ -340,6 +339,9 @@ public class VideoMediaProvider extends MediaProvider {
         clearInterval(_interval);
         this.seeking = true;
         _interval = setInterval(positionHandler, 100);
+
+        // set complete to false because a new stream starts
+        _complete = false;
     }
 
     /** Return the seek offset based upon a position. **/
@@ -368,7 +370,7 @@ public class VideoMediaProvider extends MediaProvider {
         switch (evt.info.code) {
             case "NetStream.Play.Stop":
                 complete();
-                _forceReload = true;
+                _complete = true;
                 break;
             case "NetStream.Play.StreamNotFound":
                 error('Error loading media: File not found');

--- a/src/flash/com/longtailvideo/jwplayer/media/VideoMediaProvider.as
+++ b/src/flash/com/longtailvideo/jwplayer/media/VideoMediaProvider.as
@@ -50,6 +50,8 @@ public class VideoMediaProvider extends MediaProvider {
     /** Is buffering due to load/seek or underflow? **/
     private var seeking:Boolean;
 
+    private var _forceReload:Boolean;
+
     /** Set the current quality level. **/
     override public function set currentQuality(quality:Number):void {
         if (!_item) return;
@@ -97,9 +99,10 @@ public class VideoMediaProvider extends MediaProvider {
     /** Load new media file; only requested once per item. **/
     override public function load(itm:PlaylistItem):void {
         setState(PlayerState.LOADING);
-        if (_item !== itm) {
+        if (_item !== itm || _forceReload) {
             setupVideo(itm);
             loadQuality();
+            _forceReload = false;
         } else if (itm.preload !== "none") {
             play();
         }
@@ -364,8 +367,8 @@ public class VideoMediaProvider extends MediaProvider {
     protected function statusHandler(evt:NetStatusEvent):void {
         switch (evt.info.code) {
             case "NetStream.Play.Stop":
-                sendMediaEvent(MediaEvent.JWPLAYER_MEDIA_COMPLETE);
-                clearInterval(_interval);
+                complete();
+                _forceReload = true;
                 break;
             case "NetStream.Play.StreamNotFound":
                 error('Error loading media: File not found');


### PR DESCRIPTION
Flash video does not reload on replay because it has the same item.
When complete function is called after playback, it calls stop function.
Could not figure out why, but after stop function, it is not possible to resume the netstream.
Forcing the stream to reset fixes the issue.

Tried to set _item to null when complete is called, but that results a flash error.