### PR TITLE
Allow player to resume after detach during seek

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -627,6 +627,9 @@ define([
                 _canSeek = false;
             }
 
+            // If we were mid-seek when detached, we want to allow it to resume
+            this.seeking = false;
+
             // In case the video tag was modified while we shared it
             _videotag.loop = false;
 


### PR DESCRIPTION
When we switch to instream mode while the player is mid-seek
it was causing the state to get stuck in the "seeking" mode, which prevented
the provider from resuming when instream mode ended. Instead, it would wait to
play for the "seeked" event to occur, which it never does.

JW7-1665