### PR TITLE
JW7-1539 Make audio object smaller than 5px by 5px

### DIFF
--- a/src/css/flags/audioplayer.less
+++ b/src/css/flags/audioplayer.less
@@ -3,6 +3,12 @@
 
     .jw-media {
         visibility: hidden;
+
+        // small object tag prevents chrome Power Save throttle
+        object {
+            width: 1px;
+            height: 1px;
+        }
     }
 
     .jw-controlbar {


### PR DESCRIPTION
Making the object tag smaller than 5px by 5px prevents Power Save throttle.
We do not want to power save in audio mode, because we cannot start the playback.

Asked @dannyfinks for a test case in squash.
Tested that this works in harness test page.

Tested with 0px by 0px, but it throttles.