### PR TITLE
Fix for changing default caption label

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -738,6 +738,11 @@ define([
                         currentQuality: quality,
                         levels: _getPublicLevels(_levels)
                     });
+
+                    // The playerConfig is not updated automatically, because it is a clone
+                    // from when the provider was first initialized
+                    _playerConfig.qualityLabel = _levels[quality].label;
+
                     var time = _videotag.currentTime || 0;
                     var duration = _videotag.duration || 0;
                     if (duration <= 0) {


### PR DESCRIPTION
We saw an error where new defaults were not working when
changing the item but keeping the same provider. This is a quirk
of how providers use the players config by cloning an instance
of the model when the provider is instantiated.

This quirk would be eliminated by passing in a getter method
to providers which gets the current state of the provider, instead
of passing in a simple object.

JW7-1719