### PR TITLE
Change text on flash blocked error

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -90,7 +90,7 @@ define([
             _model.on('change:flashBlocked', function(model, isBlocked) {
                 if (isBlocked) {
                     this.trigger(events.JWPLAYER_ERROR, {
-                        message: 'Flash plugin is blocked'
+                        message: 'Flash plugin failed to load'
                     });
                 }
             }, this);


### PR DESCRIPTION
Since flash may fail to load for reasons other than flash-blocking
(such as slow internet or missing .swf files on cdn), the text should
be more generic.