### PR TITLE
Only do the pointer-events hack for flash provider

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -555,11 +555,19 @@ define([
 
             // make displayIcon clickthrough on chrome for flash to avoid power safe throttle
             if (utils.isChrome()) {
-                var resetPointerEvents = function() {
-                    document.removeEventListener('mouseup', resetPointerEvents);
-                    displayIcon.el.style.pointerEvents = 'auto';
-                };
                 displayIcon.el.addEventListener('mousedown', function() {
+                    var provider = _model.getVideo();
+                    var isFlash = (provider && provider.getName().name.indexOf('flash') === 0);
+
+                    if (!isFlash) {
+                        return;
+                    }
+
+                    var resetPointerEvents = function() {
+                        document.removeEventListener('mouseup', resetPointerEvents);
+                        displayIcon.el.style.pointerEvents = 'auto';
+                    };
+
                     this.style.pointerEvents = 'none';
                     document.addEventListener('mouseup', resetPointerEvents);
                 });


### PR DESCRIPTION
We currently have a work-around which disables and re-enables
pointerEvents on the play button on mousedown and mouseup.
This allows a click to touch a swf which is behind the play button
allowing chrome to know it was a true click and not throttle playback.

Since this work-around is only for Chrome-Flash there is no reason to
use it for Chrome-non-flash.

JW7-1759