### PR TITLE
OSX Firefox Flash fix for click handling on the video/poster image/flash ad

### DIFF
--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -28,6 +28,7 @@ define([
     browser.isIPod = _browserCheck(/iP(hone|od)/i);
     browser.isIPad = _browserCheck(/iPad/i);
     browser.isSafari602 = _browserCheck(/Macintosh.*Mac OS X 10_8.*6\.0\.\d* Safari/i);
+    browser.isOSX = _browserCheck(/Mac OS X/i);
     browser.isEdge = _browserCheck(/\sedge\/\d+/i);
 
     var _isIETrident = browser.isIETrident = function(browserVersion) {

--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -88,7 +88,14 @@ define([
                 elem.addEventListener('pointerout', outHandler);
             }
         } else if(_useMouseEvents){
-            elem.addEventListener('mousedown', interactStartHandler);
+            // This is a special case handler for OSX Firefox in Flash where it will not dispatch regular UI clicks
+            if(options.enableFlashClick){
+                elem.addEventListener('click', function(evt){
+                    triggerEvent('flash_click', evt);
+                });
+            } else {
+                elem.addEventListener('mousedown', interactStartHandler);
+            }
             if(options.useHover) {
                 elem.addEventListener('mouseover', overHandler);
                 elem.addEventListener('mouseout', outHandler);

--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -135,7 +135,7 @@ define([
 
                     // Handle clicks in OSX Firefox over Flash 'object'
                     if (_isOSXFirefox && evt.target.nodeName.toLowerCase() === 'object') {
-                        elem.addEventListener('click', interactFlashClickHandler);
+                        elem.addEventListener('click', interactEndHandler);
                     } else {
                         document.addEventListener('mouseup', interactEndHandler);
                     }
@@ -169,10 +169,6 @@ define([
             if (options.preventScrolling) {
                 preventDefault(evt);
             }
-        }
-
-        function interactFlashClickHandler(evt) {
-            triggerEvent('flash_click', evt);
         }
 
         function interactEndHandler(evt) {
@@ -259,7 +255,7 @@ define([
                 elem.removeEventListener('pointerup', interactEndHandler);
             }
 
-            elem.removeEventListener('click', interactFlashClickHandler);
+            elem.removeEventListener('click', interactEndHandler);
             document.removeEventListener('mousemove', interactDragHandler);
             document.removeEventListener('mouseup', interactEndHandler);
         };

--- a/src/js/view/clickhandler.js
+++ b/src/js/view/clickhandler.js
@@ -2,13 +2,15 @@ define([
     'utils/ui',
     'events/events',
     'utils/backbone.events',
-    'utils/underscore'
-], function(UI, events, Events, _) {
+    'utils/underscore',
+    'utils/helpers'
+], function(UI, events, Events, _, utils) {
 
     var ClickHandler = function(_model, _ele) {
         var _display,
             _alternateClickHandler,
-            _alternateDoubleClickHandler;
+            _alternateDoubleClickHandler,
+            _isOSXFirefox = utils.isFF() && utils.isOSX();
 
         _.extend(this, Events);
 
@@ -16,9 +18,10 @@ define([
 
         this.element = function() { return _display; };
 
-        var userInteract = new UI(_display, {enableDoubleTap: true});
+        var userInteract = new UI(_display, {enableDoubleTap: true, enableFlashClick: _isOSXFirefox});
         userInteract.on('click tap', _clickHandler);
         userInteract.on('doubleClick doubleTap', _doubleClickHandler);
+        userInteract.on('flash_click', _flashClickHandler);
 
         this.clickHandler = _clickHandler;
 
@@ -55,6 +58,14 @@ define([
             _alternateClickHandler = null;
             _alternateDoubleClickHandler = null;
         };
+
+        function _flashClickHandler(evt) {
+            if(evt.type === 'flash_click' && _isOSXFirefox && _model.getVideo() &&
+                _model.getVideo().getName().name.indexOf('flash') > -1) {
+                var newEvent = _.extend(evt, {type:events.touchEvents.CLICK});
+                _clickHandler(newEvent);
+            }
+        }
     };
 
 

--- a/src/js/view/clickhandler.js
+++ b/src/js/view/clickhandler.js
@@ -19,7 +19,6 @@ define([
         var userInteract = new UI(_display, {enableDoubleTap: true});
         userInteract.on('click tap', _clickHandler);
         userInteract.on('doubleClick doubleTap', _doubleClickHandler);
-        userInteract.on('flash_click', _flashClickHandler);
 
         this.clickHandler = _clickHandler;
 
@@ -56,13 +55,6 @@ define([
             _alternateClickHandler = null;
             _alternateDoubleClickHandler = null;
         };
-
-        function _flashClickHandler(evt) {
-            var newEvent = _.extend(evt, {
-                type: events.touchEvents.CLICK
-            });
-            _clickHandler(newEvent);
-        }
     };
 
 

--- a/src/js/view/clickhandler.js
+++ b/src/js/view/clickhandler.js
@@ -2,15 +2,13 @@ define([
     'utils/ui',
     'events/events',
     'utils/backbone.events',
-    'utils/underscore',
-    'utils/helpers'
-], function(UI, events, Events, _, utils) {
+    'utils/underscore'
+], function(UI, events, Events, _) {
 
     var ClickHandler = function(_model, _ele) {
         var _display,
             _alternateClickHandler,
-            _alternateDoubleClickHandler,
-            _isOSXFirefox = utils.isFF() && utils.isOSX();
+            _alternateDoubleClickHandler;
 
         _.extend(this, Events);
 
@@ -18,7 +16,7 @@ define([
 
         this.element = function() { return _display; };
 
-        var userInteract = new UI(_display, {enableDoubleTap: true, enableFlashClick: _isOSXFirefox});
+        var userInteract = new UI(_display, {enableDoubleTap: true});
         userInteract.on('click tap', _clickHandler);
         userInteract.on('doubleClick doubleTap', _doubleClickHandler);
         userInteract.on('flash_click', _flashClickHandler);
@@ -60,11 +58,10 @@ define([
         };
 
         function _flashClickHandler(evt) {
-            if(evt.type === 'flash_click' && _isOSXFirefox && _model.getVideo() &&
-                _model.getVideo().getName().name.indexOf('flash') > -1) {
-                var newEvent = _.extend(evt, {type:events.touchEvents.CLICK});
-                _clickHandler(newEvent);
-            }
+            var newEvent = _.extend(evt, {
+                type: events.touchEvents.CLICK
+            });
+            _clickHandler(newEvent);
         }
     };
 

--- a/src/js/view/rightclick.js
+++ b/src/js/view/rightclick.js
@@ -109,8 +109,9 @@ define([
 
             this.layer.appendChild(this.el);
 
-            this.playerUI = new UI(this.playerElement).on('click tap', this.hideMenu, this);
-            this.documentUI = new UI(document).on('click tap', this.hideMenu, this);
+            this.hideMenuHandler = this.hideMenu.bind(this);
+            this.addOffListener(this.playerElement);
+            this.addOffListener(document);
 
             // Update the menu if the provider changes
             this.model.on('change:provider', this.updateHtml, this);
@@ -131,12 +132,25 @@ define([
             _playerElement.oncontextmenu = this.rightClick.bind(this);
         },
 
+        addOffListener : function(element) {
+            element.addEventListener('mousedown', this.hideMenuHandler);
+            element.addEventListener('touchstart', this.hideMenuHandler);
+            element.addEventListener('pointerdown', this.hideMenuHandler);
+        },
+
+        removeOffListener : function(element) {
+            element.removeEventListener('mousedown', this.hideMenuHandler);
+            element.removeEventListener('touchstart', this.hideMenuHandler);
+            element.removeEventListener('pointerdown', this.hideMenuHandler);
+        },
+
         destroy : function() {
             if(this.el) {
                 this.hideMenu();
                 this.elementUI.off();
-                this.playerUI.off();
-                this.documentUI.off();
+                this.removeOffListener(this.playerElement);
+                this.removeOffListener(document);
+                this.hideMenuHandler = null;
                 this.el = null;
             }
 


### PR DESCRIPTION
This enables a workaround for detecting clicks on a flash object in OS X Firefox.  This adds a special, regular click listener to the UI object for the clickHander when using OS X Firefox.  Clicks weren't working in the bug because OS X FF wasn't handling mouse up listeners when a flash object was clicked, thus making it impossible for the UI to detect clicks.  OS X FF however will dispatch a regular click event from a flash object, so if we listen for that in those circumstances we can handle ad clicks correctly on the platform.  This strategy previously didn't work because the nonlinear ads existing within the flash object would have disrupted this strategy.  This also enables the user to click on the poster image to start playing a video on OS X FF.