### PR TITLE
Hide display icon on mobile while the user is scrubbing

### DIFF
--- a/src/css/flags/touch.less
+++ b/src/css/flags/touch.less
@@ -26,4 +26,10 @@
     &.jw-state-paused .jw-display-icon-container {
         display: table;
     }
+
+    &.jw-state-paused.jw-flag-dragging {
+        .jw-display-icon-container {
+            display: none;
+        }
+    }
 }


### PR DESCRIPTION
JW7-1763 - Hide display icon on mobile while the user is scrubbing.  The player is technically paused in this state so the play icon was appearing in the center of the player.