### PR TITLE
Save all sources before filtering in playlist

### DIFF
--- a/src/js/playlist/playlist.js
+++ b/src/js/playlist/playlist.js
@@ -18,8 +18,9 @@ define([
 
         _.each(playlist, function(item) {
             item = _.extend({}, item);
-            item.sources = _filterSources(item.sources, providers, androidhls,
+            item.allSources = _formatSources(item.sources, androidhls,
                 item.drm || configDrm, item.preload || preload);
+            item.sources = _filterSources(item.allSources, providers);
 
             if (!item.sources.length) {
                 return;
@@ -39,15 +40,8 @@ define([
         return list;
     };
 
-    // A playlist item may have multiple different sources, but we want to stick with one.
-    var _filterSources = function(sources, providers, androidhls, itemDrm, preload) {
-
-        // legacy plugin support
-        if (!providers || !providers.choose) {
-            providers = new Providers({primary : providers ? 'flash' : null});
-        }
-
-        sources = _.compact(_.map(sources, function(originalSource) {
+    var _formatSources = function(sources, androidhls, itemDrm, preload) {
+        return _.compact(_.map(sources, function(originalSource) {
             if (! _.isObject(originalSource)) {
                 return;
             }
@@ -65,6 +59,15 @@ define([
 
             return Source(originalSource);
         }));
+    };
+
+    // A playlist item may have multiple different sources, but we want to stick with one.
+    var _filterSources = function(sources, providers) {
+
+        // legacy plugin support
+        if (!providers || !providers.choose) {
+            providers = new Providers({primary : providers ? 'flash' : null});
+        }
 
         var bestType = _chooseType(sources, providers);
 


### PR DESCRIPTION
Since playlist item sources were being filtered out if the type is different from bestType,
we could not find castable hls source when dash was chosen as bestType.
Saving the sources before filtering will allow us to search for castable sources in chromecast controller.
JW7-1751