### PR TITLE
Change oldProvider state when instream destorys

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -260,6 +260,9 @@ define([
                         item.starttime = _oldpos;
                         _model.loadVideo(item);
 
+                        // we need this because oldProvder and mediaModel has different states,
+                        // so change in mediaModel's state does not change provider state if newState === providerState
+                        _oldProvider.setState(_model.mediaModel.get('state'));
                         _oldProvider.play();
                         break;
                     case 'instream-postroll':


### PR DESCRIPTION
When instream is created, we change model's mediaModel state.
When the ad errors out, the instream destroys and tries to start the video.
Since the mediaModel's state is buffering, it changes the state to playing, but the provider's state is still playing.
This causes the mediaModel's state to stay in buffering, causing buffer icon to display on mobile devices.
JW7-1739