### PR TITLE
Improved handling of Flash throttle events JW7-1603

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -88,11 +88,17 @@ define([
 
             // If we attempt to load flash, assume it is blocked if we don't hear back within a second
             _model.on('change:flashBlocked', function(model, isBlocked) {
-                if (isBlocked) {
-                    this.trigger(events.JWPLAYER_ERROR, {
-                        message: 'Flash plugin failed to load'
-                    });
+                if (!isBlocked) {
+                    this._model.set('errorEvent', undefined);
+                    return;
                 }
+
+                var throttled = !!model.get('flashThrottle');
+                var errorEvent  = {
+                    message: throttled ? 'Click to run Flash' : 'Flash plugin failed to load'
+                };
+                this.trigger(events.JWPLAYER_ERROR, errorEvent);
+                this._model.set('errorEvent', errorEvent);
             }, this);
 
             function initMediaModel() {

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -72,6 +72,12 @@ define([
 
         function _videoEventHandler(type, data) {
             switch (type) {
+                case 'flashThrottle':
+                    var throttled = (data.state !== 'resume');
+                    this.set('flashThrottle', throttled);
+                    this.set('flashBlocked', throttled);
+                    break;
+
                 case 'flashBlocked':
                     this.set('flashBlocked', true);
                     return;
@@ -199,6 +205,11 @@ define([
             }
 
             this.set('provider', _currentProvider.getName());
+
+            if (_currentProvider.getName().name.indexOf('flash') === -1) {
+                this.set('flashThrottle', undefined);
+                this.set('flashBlocked', false);
+            }
 
             _provider = _currentProvider;
             _provider.volume(_this.get('volume'));

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -373,8 +373,6 @@ define([
 
             _model.on('change:errorEvent', _errorHandler);
 
-            _model.on('change:flashBlocked', _flashBlockedHandler);
-
             _model.on('change:controls', _onChangeControls);
             _onChangeControls(_model, _model.get('controls'));
             _model.on('change:state', _stateHandler);
@@ -897,14 +895,6 @@ define([
                 _title.updateText(evt.name, evt.message);
             } else {
                 _title.updateText(evt.message, '');
-            }
-        }
-
-        function _flashBlockedHandler(model, isBlocked) {
-            if (isBlocked) {
-                _title.updateText('Flash plugin is blocked', '');
-            } else {
-                _title.playlistItem(model, model.get('playlistItem'));
             }
         }
 


### PR DESCRIPTION
Flash throttled state now displays "Click to run Flash" instead of the same error as a blocked plugin ("Flash plugin failed to load").

Flash will not send a throttled event where `event.state` is `"throttled"` or `"paused"` in audio players or players larger than 400x300. Events where `event.state` is `"resume"` are always sent to reset any previous throttled state. Flash will not send throttled events after the first time event with a position != 0. At this point we assume playback has begun and throttling can be ignored.

Throttle events are now forwarded to the API should developers want to listen to them. These events are useful in out tests as well to observe offscreen player behavior.