### PR TITLE
 Try/Catch on api.trigger instead of api.on

### DIFF
--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -44,28 +44,7 @@ define([
                 args = {};
             }
             args.type = type;
-            return Events.trigger.call(_this, type, args);
-        };
-
-        this.on = function(name, callback) {
-            if (!_.isFunction(callback)) {
-                if (_.isString(callback)) {
-                    throw new TypeError('eval callbacks depricated');
-                }
-                utils.log('Expected a function', name, callback);
-                return this;
-            }
-
-            var safeCallback = function() {
-                var status = trycatch.tryCatch(callback, this, arguments);
-
-                if (status instanceof trycatch.Error) {
-                    utils.log('There was an error calling back an event handler for "'+
-                        name+'". Error: '+ status.message);
-                }
-            };
-
-            return Events.on.call(_this, name, safeCallback);
+            return Events.triggerSafe.call(_this, type, args);
         };
 
         // Required by vast

--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -44,6 +44,9 @@ define([
                 args = {};
             }
             args.type = type;
+            if (window.jwplayer && window.jwplayer.debug) {
+                return Events.trigger.call(_this, type, args);
+            }
             return Events.triggerSafe.call(_this, type, args);
         };
 

--- a/src/js/utils/backbone.events.js
+++ b/src/js/utils/backbone.events.js
@@ -92,6 +92,18 @@ define([
             if (events) triggerEvents(events, args, this);
             if (allEvents) triggerEvents(allEvents, arguments, this);
             return this;
+        },
+        // This is a c/p of the above trigger method, swapping out triggerEvents for safeTriggerEvents
+        //  this will have worse performance but safely allows plugins to not wreck eachother
+        triggerSafe: function (name) {
+            if (!this._events) return this;
+            var args = slice.call(arguments, 1);
+            if (!eventsApi(this, 'trigger', name, args)) return this;
+            var events = this._events[name];
+            var allEvents = this._events.all;
+            if (events) safeTriggerEvents(events, args, this);
+            if (allEvents) safeTriggerEvents(allEvents, arguments, this);
+            return this;
         }
 
         /*
@@ -165,6 +177,16 @@ define([
             default:
                 while (++i < l) (ev = events[i]).callback.apply(ev.context || context, args);
                 return;
+        }
+    };
+
+    // This is a deconstruction of the above default while loop, with try/catch inserted
+    var safeTriggerEvents = function(events, args, context) {
+        var ev, i = -1, l = events.length;
+        while (++i < l) {
+            try {
+                (ev = events[i]).callback.apply(ev.context || context, args);
+            } catch(e) {}
         }
     };
 

--- a/test/data/api-methods.js
+++ b/test/data/api-methods.js
@@ -74,6 +74,7 @@ define({
     once: null,
     skipAd: null,
     trigger: null,
+    triggerSafe: null,
     onAdClick: null,
     onAdCompanions: null,
     onAdComplete: null,

--- a/test/unit/api-test.js
+++ b/test/unit/api-test.js
@@ -25,14 +25,48 @@ define([
         });
     });
 
-    test('deprecates eval callbacks', function(assert) {
+    test('api.trigger works', function(assert) {
         var api = createApi('player');
+        var check = false;
+        function update() {
+            check = true;
+        }
+        api.on('x', update);
+        api.trigger('x');
 
-        var addListenerWithStringCallback = function() {
-            api.on('play', 'function() {}');
-        };
+        assert.ok(check, 'api.trigger works');
+    });
 
-        assert.throws(addListenerWithStringCallback, TypeError, 'passing a string as a callback throws a TypeError');
+    test('api.off works', function(assert) {
+        var api = createApi('player');
+        var check = false;
+        function update() {
+            check = true;
+        }
+        api.on('x', update);
+        api.off('x', update);
+        api.trigger('x');
+
+        assert.equal(check, false, 'api.off works');
+    });
+
+    test('bad events don\'t break player', function(assert) {
+        var api = createApi('player');
+        var check = false;
+        function update() {
+            check = true;
+        }
+        function bad() {
+            throw TypeError('blah');
+        }
+
+        api.on('x', bad);
+        api.on('x', update);
+        api.on('x', bad);
+
+        api.trigger('x');
+
+        assert.ok(check, 'When events blow up, handler continues');
     });
 
     test('rendering mode is html5', function(assert) {

--- a/test/unit/api-test.js
+++ b/test/unit/api-test.js
@@ -51,6 +51,9 @@ define([
     });
 
     test('bad events don\'t break player', function(assert) {
+        window.jwplayer = window.jwplayer || {};
+        delete window.jwplayer.debug;
+
         var api = createApi('player');
         var check = false;
         function update() {
@@ -67,6 +70,25 @@ define([
         api.trigger('x');
 
         assert.ok(check, 'When events blow up, handler continues');
+    });
+
+    test('throws exceptions when debug is true', function(assert) {
+        window.jwplayer = window.jwplayer || {};
+        window.jwplayer.debug = true;
+
+        var api = createApi('player');
+
+        function bad() {
+            throw TypeError('blah');
+        }
+
+        api.on('x', bad);
+
+        assert.throws(function() {
+            api.trigger('x');
+        }, TypeError, 'exceptions are not caught when jwplayer.debug = true');
+
+        delete window.jwplayer.debug;
     });
 
     test('rendering mode is html5', function(assert) {


### PR DESCRIPTION
Our first approach to safely handling user callbacks was to wrap
the users code in a try/catch, and calling that our new safeCallback.
This solution does not work because when the user tries api.off('event', fn)
the fn no longer matches the function in api._events and so the off command doesn't
remove the bound event.

This fixes that by try/catching around when the callback is called in the trigger method.
A neat side-effect of this is that we don't need to overwrite the .on method at all, so
I went ahead and cleaned out some older debug code as well.

JW7-1764