### PR TITLE
Allow an "Off" caption default to work

### DIFF
--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -216,6 +216,14 @@ define([
         function _selectDefaultIndex() {
             var captionsMenuIndex = 0;
             var label = _model.get('captionLabel');
+
+            // Because there is no explicit track for "Off"
+            //  it is the implied zeroth track
+            if (label === 'Off') {
+                _model.set('captionsIndex', 0);
+                return;
+            }
+
             for (var i = 0; i < _tracks.length; i++) {
                 var track = _tracks[i];
                 if (label && label === track.label) {


### PR DESCRIPTION
In the past this would not work because there are no tracks for "Off"
so when it checks the local storage/cookie value against tracks it would not
match.
This bug showed up only occasionally when there was a default track present, but
the local storage value was Off

JW7-1719