### PR TITLE
Change oldProvider state when instream destroys

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -260,6 +260,11 @@ define([
                         item.starttime = _oldpos;
                         _model.loadVideo(item);
 
+                        // On error, mediaModel has buffering states in mobile, but oldProvider's state is playing.
+                        // So, changing mediaModel's state to playing does not change provider state unless we do this
+                        if (utils.isMobile() && (_model.mediaModel.get('state') === states.BUFFERING)) {
+                            _oldProvider.setState(states.BUFFERING);
+                        }
                         _oldProvider.play();
                         break;
                     case 'instream-postroll':


### PR DESCRIPTION
When instream is created, we change model's mediaModel state.
When the ad errors out, the instream destroys and tries to start the video.
Since the mediaModel's state is buffering, it changes the state to playing, but the provider's state is still playing.
This causes the mediaModel's state to stay in buffering, causing buffer icon to display on mobile devices.
JW7-1739