### PR TITLE
Added a config variable to preserve autostart setting in model.setup(…

### DIFF
--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -53,7 +53,8 @@ define([
             });
 
             // Mobile doesn't support autostart
-            if (utils.isMobile()) {
+            // This check should be replaced with something that detects whether the current system requires a user interaction to start playback
+            if (utils.isMobile() && !config.mobileSdk) {
                 this.set('autostart', false);
             }
 

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -53,7 +53,8 @@ define([
             });
 
             // Mobile doesn't support autostart
-            // This check should be replaced with something that detects whether the current system requires a user interaction to start playback
+            // This check should be replaced with something that detects whether the current system
+            // requires a user interaction to start playback
             if (utils.isMobile() && !config.mobileSdk) {
                 this.set('autostart', false);
             }


### PR DESCRIPTION
…) when running in a mobile SDK