### PR TITLE
IE 11/Edge able to toggle UI by tapping on the video

### DIFF
--- a/src/js/events/events.js
+++ b/src/js/events/events.js
@@ -8,6 +8,7 @@ define([], function() {
         TAP: 'tap',
         DOUBLE_TAP: 'doubleTap',
         OVER: 'over',
+        MOVE: 'move',
         OUT: 'out'
     };
 

--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -88,11 +88,17 @@ define([
                 elem.addEventListener('pointerover', overHandler);
                 elem.addEventListener('pointerout', outHandler);
             }
+            if(options.useMove){
+                elem.addEventListener('pointermove', moveHandler);
+            }
         } else if(_useMouseEvents){
             elem.addEventListener('mousedown', interactStartHandler);
             if(options.useHover) {
                 elem.addEventListener('mouseover', overHandler);
                 elem.addEventListener('mouseout', outHandler);
+            }
+            if(options.useMove) {
+                elem.addEventListener('mousemove', moveHandler);
             }
         }
 
@@ -103,6 +109,12 @@ define([
         function overHandler(evt){
             if (_useMouseEvents || (_usePointerEvents && evt.pointerType !== 'touch')) {
                 triggerEvent(events.touchEvents.OVER, evt);
+            }
+        }
+
+        function moveHandler(evt){
+            if (_useMouseEvents || (_usePointerEvents && evt.pointerType !== 'touch')) {
+                triggerEvent(events.touchEvents.MOVE, evt);
             }
         }
 
@@ -127,8 +139,8 @@ define([
                             elem.setPointerCapture(_pointerId);
                         }
                         elem.addEventListener('pointermove', interactDragHandler);
-                        elem.addEventListener('pointerup', interactEndHandler);
                         elem.addEventListener('pointercancel', interactEndHandler);
+                        elem.addEventListener('pointerup', interactEndHandler);
                     }
                 } else if(_useMouseEvents){
                     document.addEventListener('mousemove', interactDragHandler);
@@ -142,8 +154,8 @@ define([
                 }
 
                 _touchListenerTarget.addEventListener('touchmove', interactDragHandler);
-                _touchListenerTarget.addEventListener('touchend', interactEndHandler);
                 _touchListenerTarget.addEventListener('touchcancel', interactEndHandler);
+                _touchListenerTarget.addEventListener('touchend', interactEndHandler);
             }
         }
 
@@ -193,7 +205,8 @@ define([
             if (_hasMoved) {
                 triggerEvent(touchEvents.DRAG_END, evt);
             } else {
-                if(!options.directSelect || evt.target === elem) {
+                // Skip if we're not directly selecting the target and if its a cancel
+                if((!options.directSelect || evt.target === elem) && evt.type.indexOf('cancel') === -1) {
                     if (_usePointerEvents && evt instanceof window.PointerEvent) {
                         if (evt.pointerType === 'touch') {
                             triggerEvent(touchEvents.TAP, evt);
@@ -249,13 +262,19 @@ define([
                 if (options.preventScrolling) {
                     elem.releasePointerCapture(_pointerId);
                 }
+                elem.removeEventListener('pointerover', overHandler);
                 elem.removeEventListener('pointerdown', interactStartHandler);
                 elem.removeEventListener('pointermove', interactDragHandler);
+                elem.removeEventListener('pointermove', moveHandler);
                 elem.removeEventListener('pointercancel', interactEndHandler);
+                elem.removeEventListener('pointerout', outHandler);
                 elem.removeEventListener('pointerup', interactEndHandler);
             }
 
             elem.removeEventListener('click', interactEndHandler);
+            elem.removeEventListener('mouseover', overHandler);
+            elem.removeEventListener('mousemove', moveHandler);
+            elem.removeEventListener('mouseout', outHandler);
             document.removeEventListener('mousemove', interactDragHandler);
             document.removeEventListener('mouseup', interactEndHandler);
         };

--- a/src/js/view/clickhandler.js
+++ b/src/js/view/clickhandler.js
@@ -16,9 +16,10 @@ define([
 
         this.element = function() { return _display; };
 
-        var userInteract = new UI(_display, {enableDoubleTap: true});
+        var userInteract = new UI(_display, {enableDoubleTap: true, useMove: true});
         userInteract.on('click tap', _clickHandler);
         userInteract.on('doubleClick doubleTap', _doubleClickHandler);
+        userInteract.on('move', function(){ _this.trigger('move'); });
 
         this.clickHandler = _clickHandler;
 

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -399,10 +399,6 @@ define([
             _stateHandler(_model, states.IDLE);
             _model.on('change:fullscreen', _fullscreen);
 
-            if (!_isMobile) {
-                _displayClickHandler.element().addEventListener('mouseout', _userActivity, false);
-                _displayClickHandler.element().addEventListener('mousemove', _userActivity, false);
-            }
             _componentFadeListeners(_controlbar);
             _componentFadeListeners(_logo);
 
@@ -539,6 +535,7 @@ define([
                 _touchHandler();
             });
             _displayClickHandler.on('doubleClick', _doubleClickFullscreen);
+            _displayClickHandler.on('move', _userActivity);
             
             var displayIcon = new DisplayIcon(_model);
             //toggle playback
@@ -1026,10 +1023,6 @@ define([
                 _model.off('change:state', _castDisplay.statusDelegate);
                 _castDisplay.destroy();
                 _castDisplay = null;
-            }
-            if (_controlsLayer) {
-                _displayClickHandler.element().removeEventListener('mousemove', _userActivity);
-                _displayClickHandler.element().removeEventListener('mouseout', _userActivity);
             }
             if (_instreamMode) {
                 this.destroyInstream();


### PR DESCRIPTION
Update the UI class to handle "move" events and allows it to differentiate touch cancels (when the user taps the video and to scroll the page) from clicks.  This lets the user tap to show the player UI and drag on the video to scroll the page when interacting on a pointer events device.
removeEventListeners match the addEventListeners correctly.

Fixes JW7-1801

These changes open up the chance for refactors in other classes (cue points, view controlbar hover handling, and time slider interaction) via UI but will hold off on this so that we can test this separately.