### PR TITLE
Default preload setting matches browser or behaves as "none"

### DIFF
--- a/src/flash/com/longtailvideo/jwplayer/media/VideoMediaProvider.as
+++ b/src/flash/com/longtailvideo/jwplayer/media/VideoMediaProvider.as
@@ -88,9 +88,11 @@ public class VideoMediaProvider extends MediaProvider {
     }
 
     override public function init(itm:PlaylistItem):void {
-        setupVideo(itm);
-        loadQuality();
-        _stream.pause();
+        if (itm.preload === "auto") {
+            setupVideo(itm);
+            loadQuality();
+            _stream.pause();
+        }
     }
 
     /** Load new media file; only requested once per item. **/
@@ -99,7 +101,7 @@ public class VideoMediaProvider extends MediaProvider {
         if (_item !== itm || _complete) {
             setupVideo(itm);
             loadQuality();
-        } else if (itm.preload !== "none") {
+        } else if (itm.preload === "auto") {
             play();
         }
 

--- a/src/flash/com/longtailvideo/jwplayer/player/SwfEventRouter.as
+++ b/src/flash/com/longtailvideo/jwplayer/player/SwfEventRouter.as
@@ -84,7 +84,7 @@ function(id, name, json) {
                 return swf.trigger(name);
             }
         }
-        console.log('Unhandled event from "' + id +'":', name, json);
+        // console.log('Unhandled event from "' + id +'":', name, json);
     }, 0);
 }]]></script>;
 

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -14,7 +14,6 @@ define([
         displaydescription: true,
         mobilecontrols: false,
         repeat: false,
-        preload: 'metadata',
         castAvailable: false,
         skin: 'seven',
         stretching: stretchUtils.UNIFORM,

--- a/src/js/providers/flash.js
+++ b/src/js/providers/flash.js
@@ -104,8 +104,8 @@ define([
 
         _.extend(this, Events, {
                 init: function(item) {
-                    // if preload is none or autostart is true, do nothing
-                    if (item.preload === 'none' || _playerConfig.autostart) {
+                    // if not preloading or autostart is true, do nothing
+                    if (!item.preload || item.preload === 'none' || _playerConfig.autostart) {
                         return;
                     } else {
                         _item = item;

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -414,8 +414,9 @@ define([
             _bufferFull = false;
             _isAndroidHLS = _useAndroidHLS(_source);
             _videotag.src = _source.file;
-            // set preload from the source, or default to metadata
-            _videotag.setAttribute('preload', _source.preload || 'metadata');
+            if (_source.preload) {
+                _videotag.setAttribute('preload', _source.preload);
+            }
         }
 
         this.stop = function() {


### PR DESCRIPTION
Revert the default preload behavior to match earlier players and do set video tag preload attribute unless a preload option is passed to setup.

Also disable "metadata" preload for Flash mp4 since we can only support "auto" in VideoMediaProvider. 