### PR TITLE
Logo disabled when an overlay is displayed

### DIFF
--- a/src/css/flags/overlay.less
+++ b/src/css/flags/overlay.less
@@ -2,4 +2,7 @@
     .jw-title {
         display: none;
     }
+    .jw-controls-right .jw-logo {
+        display: none;
+    }
 }

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -508,11 +508,7 @@ define([
                 _stateHandler(model, state);
             }
 
-            if (bool) {
-                utils.removeClass(_playerElement, 'jw-flag-controls-disabled');
-            } else {
-                utils.addClass(_playerElement, 'jw-flag-controls-disabled');
-            }
+            utils.toggleClass(_playerElement, 'jw-flag-controls-disabled', !bool);
         };
 
         function _doubleClickFullscreen() {


### PR DESCRIPTION
Logo disabled when an overlay is up.
Switched an add/remove class to toggle as well.

JW7-1816