### PR TITLE
Updates for Google IMA to act as a provider and use player UI

### DIFF
--- a/src/css/flags/ads.less
+++ b/src/css/flags/ads.less
@@ -39,6 +39,18 @@
     }
 }
 
+.jwplayer.jw-flag-ads-googleima {
+    .jw-controlbar {
+        display: table;
+    }
+}
+
+.jwplayer.jw-flag-ads-vpaid {
+    .jw-controlbar {
+        display: none;
+    }
+}
+
 .jwplayer.jw-flag-ads-hide-controls {
     .jw-controls {
         display : none !important;

--- a/src/css/flags/audioplayer.less
+++ b/src/css/flags/audioplayer.less
@@ -11,6 +11,13 @@
         }
     }
 
+    &.jw-state-paused,
+    &.jw-state-complete {
+        .jw-display-icon-container{
+            display: none;
+        }
+    }
+
     .jw-controlbar {
         display: table;  // This overwrites 'none' from jw-states-idle
         bottom: 0;

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -193,6 +193,12 @@ define([
             }
         };
 
+        this.applyProviderListeners = function(provider){
+            _instream.applyProviderListeners(provider);
+
+            this.addClickHandler();
+        };
+
         this.play = function() {
             _instream.instreamPlay();
         };

--- a/src/js/controller/instream-flash.js
+++ b/src/js/controller/instream-flash.js
@@ -68,6 +68,7 @@ define([
             }, this);
 
             this.swf.triggerFlash('instream:init');
+            this.applyProviderListeners = function(){};
         },
 
         instreamDestroy: function() {

--- a/src/js/controller/instream-html5.js
+++ b/src/js/controller/instream-html5.js
@@ -56,6 +56,23 @@ define([
             _adModel.loadVideo(item);
         };
 
+        _this.applyProviderListeners = function(provider){
+            // check provider after item change
+            _checkProvider(provider);
+
+            // Match the main player's controls state
+            provider.off(events.JWPLAYER_ERROR);
+            provider.on(events.JWPLAYER_ERROR, function(data) {
+                this.trigger(events.JWPLAYER_ERROR, data);
+            }, _this);
+            _model.on('change:volume', function(data, value) {
+                _currentProvider.volume(value);
+            }, _this);
+            _model.on('change:mute', function(data, value) {
+                _currentProvider.mute(value);
+            }, _this);
+        };
+
         /** Stop the instream playback and revert the main player back to its original state **/
         this.instreamDestroy = function() {
             if (!_adModel) {
@@ -69,7 +86,9 @@ define([
             if (_currentProvider) {
                 _currentProvider.detachMedia();
                 _currentProvider.off();
-                _currentProvider.destroy();
+                if(_adModel.getVideo()){
+                    _currentProvider.destroy();
+                }
             }
 
             // Return the view to its normal state
@@ -101,8 +120,8 @@ define([
          ****** Private methods ******
          *****************************/
 
-        function _checkProvider() {
-            var provider = _adModel.getVideo();
+        function _checkProvider(pseduoProvider) {
+            var provider = pseduoProvider || _adModel.getVideo();
 
             if (_currentProvider !== provider) {
                 _currentProvider = provider;


### PR DESCRIPTION
Allows the instream adaptor to be assigned a provider, which is expected to output all appropriate playback information. Google IMA uses this to communicate with the player.
Styles added to support google IMA playback.

JW7-1530

Related to the PR at: https://github.com/jwplayer/jwplayer-ads-googima/pull/97