### PR TITLE
Expose reason for a play event

### DIFF
--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -36,8 +36,13 @@ define([
         this._ = _;
         this.Events = Events;
         this.version = version;
+        this.playReason = 'unknown';
 
         this.trigger = function(type, args) {
+            if (type === 'play') {
+                args.playReason = _this.playReason;
+                _this.playReason = 'unknown';
+            }
             if (_.isObject(args)) {
                 args = _.extend({}, args);
             } else {
@@ -200,6 +205,9 @@ define([
         };
 
         this.play = function (state) {
+            if (this.playReason === 'unknown') {
+                this.playReason = 'external';
+            }
             if (state === true) {
                 _controller.play();
                 return _this;

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -212,6 +212,7 @@ define([
                 });
 
                 if (_model.get('autostart')) {
+                    _api.playReason = 'autostart';
                     _play();
                 }
 
@@ -450,6 +451,7 @@ define([
                 if (idx === _model.get('playlist').length - 1) {
                     // If it's the last item in the playlist
                     if (_model.get('repeat')) {
+                        _api.playReason = 'repeat';
                         _next();
                     } else {
                         _model.set('state', states.COMPLETE);
@@ -460,6 +462,8 @@ define([
 
                 // It wasn't the last item in the playlist,
                 //  so go to the next one
+                console.log('here');
+                _api.playReason = 'playlist';
                 _next();
             }
 

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -133,6 +133,7 @@ define([
                     break;
                 case 13: // enter
                 case 32: // space
+                    _api.playReason = 'interaction';
                     _api.play();
                     break;
                 case 37: // left-arrow, if not adMode
@@ -450,6 +451,7 @@ define([
                 _model.get('state') === states.COMPLETE ||
                 _model.get('state') === states.PAUSED) &&
                 _model.get('controls')) {
+                _api.playReason = 'interaction';
                 _api.play();
             }
 
@@ -465,6 +467,7 @@ define([
             if (!evt.link) {
                 //_togglePlay();
                 if (_model.get('controls')) {
+                    _api.playReason = 'interaction';
                     _api.play();
                 }
             } else {
@@ -527,6 +530,7 @@ define([
             _displayClickHandler.on('click', function() {
                 forward({type : events.JWPLAYER_DISPLAY_CLICK});
                 if(_model.get('controls')) {
+                    _api.playReason = 'interaction';
                     _api.play();
                 }
             });
@@ -541,6 +545,7 @@ define([
             //toggle playback
             displayIcon.on('click', function() {
                 forward({type : events.JWPLAYER_DISPLAY_CLICK});
+                _api.playReason = 'interaction';
                 _api.play();
             });
             displayIcon.on('tap', function() {

--- a/test/data/api-members.js
+++ b/test/data/api-members.js
@@ -3,6 +3,7 @@ define({
     version: '',
     _qoe: {},
     utils: {},
+    playReason: '',
     Events: {},
     _: function() {}
 });


### PR DESCRIPTION
We want to store a reason for a play event in API,
so that we can expose that in analytics.
0 - Unknown reason
1 - Interaction with JW Player UI
2 - Autostart from config
3 - Repeat
4 - External api
5 - Internal api (related)
6 - Internal api (playlist progression)
JW7-1645