### PR TITLE
Fix mp4 quality switch in Firefox

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -514,6 +514,10 @@ define([
                 }
             } else {
                 _delayedSeek = seekPos;
+                // Some browsers won't fire canplay event in a paused state (Firefox)
+                if (_videotag.paused) {
+                    _videotag.play();
+                }
             }
         };
 

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -14,6 +14,7 @@ define([
         _isMSIE = utils.isMSIE(),
         _isMobile = utils.isMobile(),
         _isSafari = utils.isSafari(),
+        _isFirefox = utils.isFF(),
         _isAndroid = utils.isAndroidNative(),
         _isIOS7 = utils.isIOS(7),
         _name = 'html5';
@@ -514,8 +515,9 @@ define([
                 }
             } else {
                 _delayedSeek = seekPos;
-                // Some browsers won't fire canplay event in a paused state (Firefox)
-                if (_videotag.paused) {
+                // Firefox isn't firing canplay event when in a paused state
+                // https://bugzilla.mozilla.org/show_bug.cgi?id=1194624
+                if (_isFirefox && _videotag.paused) {
                     _videotag.play();
                 }
             }


### PR DESCRIPTION
Firefox is stuck buffering when switching qualities because our provider requires a 'canplay' event to fire for delayed seek to work. This event does not fire after changing sources in Firefox because the video tag goes into a paused state and does not fire 'canplay' until play() is called.

The regression in 7.2 comes from removing `_canPlayHandler()` from within `_loadedMetadataHandler` https://github.com/jwplayer/jwplayer/commit/eb6a6251f13f91226c454631595e9ffeac934bca.

JW7-1813