### PR TITLE
Don't listen for throttle events for same-host swfs

### DIFF
--- a/src/js/providers/flash.js
+++ b/src/js/providers/flash.js
@@ -12,6 +12,12 @@ define([
         return playerId + '_swf_' + (_providerId++);
     }
 
+    function flashThrottleTarget(config) {
+        var sameHost = ((new URL(config.flashplayer).host) === window.location.host);
+
+        return utils.isChrome() && !sameHost;
+    }
+
     function FlashProvider(_playerId, _playerConfig) {
         // private properties
         var _container;
@@ -213,9 +219,7 @@ define([
                         });
 
                         // setup flash player
-                        var config = _.extend({
-                            watchThrottle: utils.isChrome()
-                        }, _playerConfig);
+                        var config = _.extend({}, _playerConfig);
                         var result = _swf.triggerFlash('setup', config);
                         if (result === _swf) {
                         _swf.__ready = true;
@@ -331,8 +335,7 @@ define([
                         this.trigger(events.JWPLAYER_MEDIA_ERROR, event);
                     }, this);
 
-                    // We cannot rely on firefox to properly return results
-                    if (utils.isChrome()) {
+                    if (flashThrottleTarget(_playerConfig)) {
                         _swf.on('throttle', function(e) {
                             clearTimeout(_flashBlockedTimeout);
 


### PR DESCRIPTION
This will improve the experience for self-hosters and small players.
The issue is that scrolling the player out of view triggers the same
throttle event as actually having PPS occur. This causes us to avoid
that edge-case in more player setups.

JW7-1770