### PR TITLE
Bugfix for URL's with no protocol

### DIFF
--- a/src/js/providers/flash.js
+++ b/src/js/providers/flash.js
@@ -13,7 +13,10 @@ define([
     }
 
     function flashThrottleTarget(config) {
-        var sameHost = ((new URL(config.flashplayer).host) === window.location.host);
+        var a = document.createElement('a');
+        a.href = config.flashplayer;
+
+        var sameHost = (a.hostname === window.location.host);
 
         return utils.isChrome() && !sameHost;
     }


### PR DESCRIPTION
The URL method breaks if there isn't http or https in it.