### PR TITLE
Remove JW Player style tab focus

### DIFF
--- a/src/css/imports/jwplayerelement.less
+++ b/src/css/imports/jwplayerelement.less
@@ -38,7 +38,7 @@
         display: none;
     }
 
-    &:focus, .jw-swf {
+    &.jw-no-focus, .jw-swf {
         outline: none;
     }
 
@@ -151,10 +151,6 @@
 
 .jw-icon-playback {
     .jw-icon-play;
-}
-
-.jw-tab-focus:focus {
-    outline: solid 2px #0b7ef4;
 }
 
 // Allow pointer events through to the provider

--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -14,14 +14,6 @@ define([
 ], function(events, states,
             Events, utils, Timer, trycatch, _, Controller, actionsInit, mutatorsInit, legacyInit, version) {
 
-    function addFocusBorder(container) {
-        utils.addClass(container, 'jw-tab-focus');
-    }
-
-    function removeFocusBorder(container) {
-        utils.removeClass(container, 'jw-tab-focus');
-    }
-
     var Api = function (container, globalRemovePlayer) {
         var _this = this,
             _controller,
@@ -68,13 +60,7 @@ define([
             _controller.on(events.JWPLAYER_MEDIA_META, function (data) {
                 _.extend(_itemMeta, data.metadata);
             });
-            _controller.on(events.JWPLAYER_VIEW_TAB_FOCUS, function (data) {
-                if (data.hasFocus === true) {
-                    addFocusBorder(this.getContainer());
-                } else {
-                    removeFocusBorder(this.getContainer());
-                }
-            });
+
             // capture the ready event and add setup time to it
             _controller.on(events.JWPLAYER_READY, function(event) {
                 _playerReady = true;

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -60,8 +60,7 @@ define([
             _exitFullscreen,
             _elementSupportsFullscreen = false,
 
-            // Used to differentiate tab focus events from click events, because when
-            //  it is a click, the mouseDown event will occur immediately prior
+            // Used to differentiate tab focus events from click events
             _focusFromClick = false,
 
             _this = _.extend(this, Events);
@@ -174,36 +173,25 @@ define([
             }
         }
 
+        function handleBlur() {
+            _focusFromClick = false;
+            utils.removeClass(_playerElement, 'jw-no-focus');
+        }
+
         function handleMouseDown() {
             _focusFromClick = true;
-
-            // After a click it no longer has 'tab-focus'
-            _this.trigger(events.JWPLAYER_VIEW_TAB_FOCUS, {
-                hasFocus: false
-            });
+            utils.addClass(_playerElement, 'jw-no-focus');
         }
 
         function handleFocus() {
-            var wasTabEvent = !_focusFromClick;
-            _focusFromClick = false;
-
-            if (wasTabEvent) {
-                _this.trigger(events.JWPLAYER_VIEW_TAB_FOCUS, {
-                    hasFocus: true
-                });
+            if (!_focusFromClick) {
+                handleBlur();
             }
 
             // On tab-focus, show the control bar for a few seconds
             if (!_instreamMode) {
                 _userActivity();
             }
-        }
-
-        function handleBlur() {
-            _focusFromClick = false;
-            _this.trigger(events.JWPLAYER_VIEW_TAB_FOCUS, {
-                hasFocus: false
-            });
         }
 
         function _responsiveListener() {
@@ -601,8 +589,6 @@ define([
 
             _controlsLayer.appendChild(_controlbar.element());
 
-            _playerElement.onfocusin = handleFocus;
-            _playerElement.onfocusout = handleBlur;
             _playerElement.addEventListener('focus', handleFocus);
             _playerElement.addEventListener('blur', handleBlur);
             _playerElement.addEventListener('keydown', handleKeydown);


### PR DESCRIPTION
We want to remove JW Player style tab focus, and just use browser's style.
We also want to prevent focus by interaction (mouse click), and only focus with tab.
JW7-1793