### PR TITLE
Support HLS DVR on Safari/iOS, and handle android HLS duration

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -574,10 +574,10 @@ define([
                 return false;
             }
 
-            function _attachMedia(seekable) {
+            function _attachMedia() {
                 // Called after instream ends
                 var status = utils.tryCatch(function() {
-                    _model.getVideo().attachMedia(seekable);
+                    _model.getVideo().attachMedia();
                 });
 
                 if (status instanceof utils.Error) {

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -230,9 +230,8 @@ define([
                     duration = -seekableDuration;
                 }
             }
-            _canSeek = !!end;
             _duration = duration;
-            if (_delayedSeek > 0 && _duration > _delayedSeek) {
+            if (_delayedSeek && duration) {
                 _this.seek(_delayedSeek);
             }
         }

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -230,6 +230,7 @@ define([
                     duration = -seekableDuration;
                 }
             }
+            _canSeek = !!end;
             _duration = duration;
             if (_delayedSeek > 0 && _duration > _delayedSeek) {
                 _this.seek(_delayedSeek);
@@ -444,7 +445,6 @@ define([
                 while(index--) {
                     end = Math.max(end, _videotag.seeakble.end(index));
                 }
-                _canSeek = true;
             }
             return end;
         }
@@ -531,7 +531,9 @@ define([
                     offset: seekPos
                 });
             }
-
+            if (!_canSeek) {
+                _canSeek = !!_getSeekableEnd();
+            }
             if (_canSeek) {
                 _delayedSeek = 0;
                 // setting currentTime can throw an invalid DOM state exception if the video is not ready

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -95,7 +95,7 @@ define([
 
                 pause: _pauseHandler,
                 //ratechange: _generalHandler,
-                readystatechange: _readyStateHandler,
+                //readystatechange: _readyStateHandler,
                 seeked: _seekedHandler,
                 //seeking: _seekingHandler,
                 //stalled: _stalledHandler,
@@ -162,21 +162,13 @@ define([
             _this.trigger('click', evt);
         }
 
-        function _readyStateHandler() {
-            if (_videotag.readyState === 4) {
-                if (_delayedSeek > 0 && _duration > _delayedSeek) {
-                    _this.seek(_delayedSeek);
-                }
-            }
-        }
-
         function _durationChangeHandler() {
             if (!_attached) {
                 return;
             }
 
             _setBuffered(_getBuffer(), _position, _videotag.duration);
-            _setDuration(_videotag.duration);
+            _updateDuration();
         }
 
         function _progressHandler() {
@@ -199,7 +191,7 @@ define([
                 _playbackTimeout = setTimeout(_checkPlaybackStalled, STALL_DELAY);
             }
 
-            _setDuration(_videotag.duration);
+            _updateDuration();
             _setPosition(_videotag.currentTime);
             // buffer ranges change during playback, not just on file progress
             _setBuffered(_getBuffer(), _position, _duration);
@@ -228,7 +220,15 @@ define([
             _position = currentTime;
         }
 
-        function _setDuration(duration) {
+        function _updateDuration() {
+            var duration = _videotag.duration;
+            if (duration === Infinity && _videotag.seekable && _videotag.seekable.length) {
+                var seekableDuration =
+                    _videotag.seekable.end(_videotag.seekable.length - 1) - _videotag.seekable.start(0);
+                if (seekableDuration > 120) {
+                    duration = -seekableDuration;
+                }
+            }
             _duration = duration;
             if (_delayedSeek > 0 && _duration > _delayedSeek) {
                 _this.seek(_delayedSeek);
@@ -241,7 +241,7 @@ define([
                 height: _videotag.videoHeight,
                 width: _videotag.videoWidth
             });
-            _setDuration(_videotag.duration);
+            _updateDuration();
         }
 
         function _canPlayHandler() {


### PR DESCRIPTION
Checked that HLS DVR works in iOS and Safari.
Handling android HLS getting incorrect duration before time event.
JW7-1560 JW7-1789