### PR TITLE
Google IMA control fixes: don't overlap the skip button.  Hide play icon on touch

### DIFF
--- a/src/css/flags/ads.less
+++ b/src/css/flags/ads.less
@@ -42,6 +42,21 @@
 .jwplayer.jw-flag-ads-googleima {
     .jw-controlbar {
         display: table;
+        bottom: 0;
+    }
+
+    &.jw-flag-touch {
+        .jw-controlbar {
+            font-size: 1em;
+        }
+
+        &.jw-state-paused .jw-display-icon-container {
+            display: none;
+        }
+    }
+
+    &.jw-skin-seven .jw-controlbar {
+        font-size: 0.9em;
     }
 }
 


### PR DESCRIPTION
During Google IMA ads, the following happens:

controlbar is fixes to the bottom of the player (inset controlbar skins like roundster do not overlap the skip button)
the seven skin has its size slightly reduced to ensure it does not overlap the skip button
on touch devices, the control bar doesn't have an increased size so that it does not overlap the skip button
on touch devices, the play icon does not appear in the middle of the player when the ad is paused

JW7-1850 JW7-1851