### PR TITLE
Add focus outline style for IE11

### DIFF
--- a/src/css/imports/jwplayerelement.less
+++ b/src/css/imports/jwplayerelement.less
@@ -38,8 +38,12 @@
         display: none;
     }
 
-    &.jw-no-focus, .jw-swf {
+    &.jw-no-focus:focus, .jw-swf {
         outline: none;
+    }
+
+    &.jw-ie:focus {
+        outline: #585858 dotted 1px;
     }
 
     &:hover {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -69,6 +69,9 @@ define([
         this.api = _api;
 
         _playerElement = utils.createElement(playerTemplate({id: _model.get('id')}));
+        if (utils.isIE()) {
+            utils.addClass(_playerElement, 'jw-ie');
+        }
 
         var width = _model.get('width'),
             height = _model.get('height');


### PR DESCRIPTION
Since IE does not display focus outline, we add that for IE.
JW7-1793