### PR TITLE
Mute set after volume to override volume if necessary

### DIFF
--- a/src/js/controller/instream-html5.js
+++ b/src/js/controller/instream-html5.js
@@ -141,8 +141,8 @@ define([
 
                 provider.on(events.JWPLAYER_PLAYER_STATE, stateHandler);
                 provider.attachMedia();
-                provider.mute(_model.get('mute'));
                 provider.volume(_model.get('volume'));
+                provider.mute(_model.get('mute'));
 
                 _adModel.on('change:state', changeStateEvent, _this);
             }


### PR DESCRIPTION
Changed the order so that mute is set after volume is set so that it correctly overrides audio values

JW7-1859