### PR TITLE
Catch SecurityException thrown by localStorage access with cookies blocked

### DIFF
--- a/src/js/controller/storage.js
+++ b/src/js/controller/storage.js
@@ -4,9 +4,13 @@ define([
 ], function(_, utils) {
 
     var jwplayer = window.jwplayer;
-    var storage = window.localStorage || {
-            removeItem: utils.noop
-        };
+    var storage = {
+        removeItem: utils.noop
+    };
+
+    try {
+        storage = window.localStorage;
+    } catch(e) {/* ignore */}
 
     function jwPrefix(str) {
         return 'jwplayer.' + str;


### PR DESCRIPTION
When cookies and local storage are disabled in the browser, access to window.localStorage throws an exception. This change catches that so that the player does not fail to setup and run under these circumstances. Instead, and object in memory will hold these settings for lifespan of the page/document as was the case when localStorage is unavailable.
JW7-1849