### PR TITLE
Fix 'Live Broadcast' issue with item change

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -191,6 +191,10 @@ define([
             } else if (_this.state === states.PLAYING) {
                 _playbackTimeout = setTimeout(_checkPlaybackStalled, STALL_DELAY);
             }
+            // When video has not yet started playing for androidHLS, we cannot get the correct duration
+            if (_isAndroidHLS && (_videotag.duration === Infinity) && (_videotag.currentTime === 0)) {
+                return;
+            }
 
             _updateDuration();
             _setPosition(_videotag.currentTime);


### PR DESCRIPTION
Since we get timeupdate event with playlist item change, we update the duration for androidHLS on item change.
For hls, we still have duration as infinity, resulting 'Live Broadcast' message bug.
Making a fix so that if the videotag's currentTime is 0(not yet playing), we do not update the duration.
JW7-1789