### PR TITLE
Added basic fetch util

### DIFF
--- a/src/js/polyfills/promise.js
+++ b/src/js/polyfills/promise.js
@@ -180,6 +180,6 @@ define(['utils/underscore'], function(_) {
         asap = fn;
     };
 
-    window.Promise = Promise;
+    window.Promise || (window.Promise = Promise);
 
 });

--- a/src/js/utils/fetch.js
+++ b/src/js/utils/fetch.js
@@ -1,0 +1,78 @@
+define([
+    'utils/underscore',
+    'utils/ajax'
+], function(_, utilsAjax) {
+    /* global Promise */
+
+    var supportArrayBuffer = 'ArrayBuffer' in window;
+
+    function Request(input, options) {
+        options = options || {};
+        this.url = input;
+        this.credentials = options.credentials || 'omit';
+    }
+
+    function Response(xhr) {
+        this._xhr = xhr;
+        this.url = xhr.responseURL || '';
+        this.status = xhr.status;
+        this.statusText = xhr.statusText;
+        this.headers = {/* not implemented */};
+        this.ok = this.status >= 200 && this.status < 300;
+        this.type = 'default';
+        this.bodyUsed = false;
+    }
+
+    Response.prototype.text = function() {
+        return read(this, this._xhr.responseText);
+    };
+
+    Response.prototype.json = function() {
+        return this.text().then(JSON.parse);
+    };
+
+    Response.prototype.arrayBuffer = function() {
+        if (supportArrayBuffer && ArrayBuffer.prototype.isPrototypeOf(this._xhr.response)) {
+            return read(this, this._xhr.response);
+        }
+        throw new Error('could not read response as ArrayBuffer');
+    };
+
+    function read(response, returnValue) {
+        if (response.bodyUsed) {
+            return Promise.reject(new TypeError('Already read'));
+        }
+        response.bodyUsed = true;
+        return Promise.resolve(returnValue);
+    }
+
+    var fetch = window.fetch && window.fetch.bind(window);
+
+    return {
+        fetch: fetch || function(request, options) {
+
+            if (_.isString(request)) {
+                request = new Request(request, options);
+            }
+
+            return new Promise(function(resolve, reject) {
+                utilsAjax.ajax({
+                    url: request.url,
+                    mimeType: '',
+                    responseType: '',
+                    withCredentials: (request.credentials === 'include'),
+                    oncomplete: function(xhr) {
+                        resolve(new Response(xhr));
+                    },
+                    onerror: function(message, url, xhr) {
+                        if (xhr.readyState < 4) {
+                            reject(new TypeError(message));
+                        } else {
+                            resolve(new Response(xhr));
+                        }
+                    }
+                });
+            });
+        }
+    };
+});

--- a/test/config.js
+++ b/test/config.js
@@ -7,11 +7,17 @@
 
     var base = '';
     var deps = [
-        // Add polyfills for phantomjs 1.x and IE9
-        'bind-polyfill',
-        'polyfills/base64',
-        'polyfills/promise'
+        'bind-polyfill'
     ];
+
+    // Add polyfills for phantomjs 1.x and IE9
+    if (!('atob' in window)) {
+        deps.push('polyfills/base64');
+    }
+    if (!('Promise' in window)) {
+        deps.push('polyfills/promise');
+    }
+
     var callback;
 
     if (!window.__karma__) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -9,6 +9,7 @@ define([
     'unit/dom-test',
     'unit/dxfp-test',
     'unit/embed-swf-test',
+    'unit/fetch-test',
     'unit/extendable-test',
     'unit/helpers-test',
     'unit/jwplayer-selectplayer-test',

--- a/test/unit/fetch-test.js
+++ b/test/unit/fetch-test.js
@@ -1,0 +1,68 @@
+define([
+    'test/underscore',
+    'utils/fetch'
+], function (_, utils) {
+    /* jshint qunit: true */
+    /* global Promise */
+
+    module('utils.fetch');
+
+    function errorHandler(assert, done) {
+        return function(error) {
+            assert.ok(false, error);
+            done();
+        };
+    }
+
+    test('response.text()', function (assert) {
+        var done = assert.async();
+
+        var uri = require.toUrl('./data/playlist.json');
+
+        var promise = utils.fetch(uri)
+            .then(function(response) {
+                assert.ok(response.ok, 'fetch response is ok');
+                return response.text();
+            }).then(function(text) {
+                assert.ok(_.isString(text),
+                    'response.text() resolved with string content');
+                assert.ok(_.isArray(JSON.parse(text)),
+                    'content matches expected result');
+                done();
+            })
+            .catch(errorHandler(assert, done));
+
+        assert.ok(Promise.prototype.isPrototypeOf(promise),
+            'utils.fetch returns a Promise');
+    });
+
+    test('response.json()', function (assert) {
+        var done = assert.async();
+
+        var uri = require.toUrl('./data/playlist.json');
+
+        utils.fetch(uri)
+            .then(function(response) {
+                assert.ok(response.ok, 'fetch response is ok');
+                return response.json();
+            }).then(function(json){
+                assert.ok(_.isArray(json),
+                    'response.json() resolved with json content');
+                done();
+            })
+            .catch(errorHandler(assert, done));
+    });
+
+    test('error "File not found" (404)', function (assert) {
+        var done = assert.async();
+
+        utils.fetch('failUrl')
+            .then(function(response) {
+                assert.notOk(response.ok, 'fetch response is not ok');
+                assert.equal(response.status, 404, 'fetch resolves with 404 status');
+                done();
+            })
+            .catch(errorHandler(assert, done));
+    });
+
+});


### PR DESCRIPTION
Basic fetch util for using `GlobalFetch ` in Chrome and Firefox and falling back to xhr in browsers without fetch support. Response text() and json() are tested, as is a request resulting in a 404 response.

```
jwplayer().utils.fetch(uri)
    .then(function(response) {
        return response.json(); // or return response.text();
    .then(function(data) {
        /* handle parsed json data */
    .catch(function(error) {
        /* an error was thrown */
    });
```

We still need ArrayBuffer and chunk handling using readers. TODO:


* Response.headers to get Content-Length
* Response.body.getReader() or other WebService method for reading chunks on progress
  * Reader provides a result with a chunk `value` or `done` status, and a `cancel()` method [see demo](https://googlechrome.github.io/samples/fetch-api/fetch-response-stream.html):
```
        return reader.read().then(function (result) {
          if (result.done) {
            // all done
            return;
          }
          var chunk = result.value;  // Uint8Array
          return reader.cancel();
```

* ByteRange requests
* A wrapper that can perform delayed retries

[W3C spec](https://fetch.spec.whatwg.org/#fetch-api)