### PR TITLE
Bugfix for setting track index when no tracks exist

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -838,7 +838,6 @@ define([
             return { name : _name };
         };
 
-        this.getTextTracks = _getTextTracks;
 
         //model expects setSubtitlesTrack when changing subtitle track
         this.setSubtitlesTrack = _setSubtitlesTrack;
@@ -852,10 +851,6 @@ define([
                 });
                 _this.trigger('subtitlesTracks',{tracks: _textTracks});
             }
-        }
-
-        function _getTextTracks() {
-            return _textTracks;
         }
 
         function _setSubtitlesTrack(index) {

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -859,6 +859,9 @@ define([
         }
 
         function _setSubtitlesTrack(index) {
+            if(!_textTracks) {
+                return;
+            }
             //index off by 1 because of 'off' option
             if(_currentTextTrackIndex > -1 && _currentTextTrackIndex < _textTracks.length) {
                 _textTracks[_currentTextTrackIndex].mode = 'disabled';


### PR DESCRIPTION
This addresses the scenario where html5 is not the provider and doesn't need to know the current index. Also removed the unused getter since the model stores the textTracks. 

JW7-1873