### PR TITLE
Remove HTMLElement nodes from Flash script args

### DIFF
--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -1,7 +1,6 @@
 define([
-    'utils/underscore',
-    'utils/trycatch'
-], function(_, trycatch) {
+    'utils/underscore'
+], function(_) {
     var browser = {};
 
     var _userAgentMatch = _.memoize(function (regex) {
@@ -130,18 +129,16 @@ define([
         }
 
         if (typeof window.ActiveXObject !== 'undefined') {
-            var status = trycatch.tryCatch(function() {
+            try {
                 flash = new window.ActiveXObject('ShockwaveFlash.ShockwaveFlash');
                 if (flash) {
                     return parseFloat(flash.GetVariable('$version').split(' ')[1].replace(/\s*,\s*/, '.'));
                 }
-            });
-
-            if (status instanceof trycatch.Error) {
+            } catch(e) {
                 return 0;
             }
 
-            return status;
+            return flash;
         }
         return 0;
     };

--- a/src/js/utils/embedswf.js
+++ b/src/js/utils/embedswf.js
@@ -90,6 +90,13 @@ define([
             var args = Array.prototype.slice.call(arguments, 1);
             var status = utils.tryCatch(function() {
                 if (args.length) {
+                    // remove any nodes from arguments
+                    // cyclical structures cannot be converted to JSON
+                    for (var i=args.length; i--;) {
+                        if (typeof args[i] === 'object') {
+                            _.each(args[i], deleteHTMLElement);
+                        }
+                    }
                     var json = JSON.stringify(args);
                     swfInstance.__externalCall(name, json);
                 } else {
@@ -117,6 +124,12 @@ define([
         if (swf && swf.parentNode) {
             swf.style.display = 'none';
             swf.parentNode.removeChild(swf);
+        }
+    }
+
+    function deleteHTMLElement(value, prop, object) {
+        if (value instanceof window.HTMLElement) {
+            delete object[prop];
         }
     }
 


### PR DESCRIPTION
Strips out HTMLElements in messages sent to Flash before attempting to convert them to JSON. The 'mediaContainer' element added to the model in 7.3 caused an exception when trying to pass the player config to Flash. This resolves the "JSON.stringify cannot serialize cyclic structures" error seen on older browsers (Chrome 37, Windows).

JW7-1878