### PR TITLE
Fix RTMP streams starting over after midrolls

### DIFF
--- a/src/flash/com/longtailvideo/jwplayer/media/RTMPMediaProvider.as
+++ b/src/flash/com/longtailvideo/jwplayer/media/RTMPMediaProvider.as
@@ -209,6 +209,7 @@ public class RTMPMediaProvider extends MediaProvider {
             // Resume VOD and restart live stream
             if (isVOD(_item.duration)) {
                 _stream.resume();
+                setState(PlayerState.PLAYING);
             } else {
                 _stream.play(_levels[_level].id);
                 setState(PlayerState.BUFFERING);

--- a/src/flash/com/longtailvideo/jwplayer/media/RTMPMediaProvider.as
+++ b/src/flash/com/longtailvideo/jwplayer/media/RTMPMediaProvider.as
@@ -205,7 +205,10 @@ public class RTMPMediaProvider extends MediaProvider {
             return;
         }
         _video.attachNetStream(_stream);
+        clearInterval(_interval);
+        _interval = setInterval(positionInterval, 100);
         if (_isPaused) {
+            _isPaused = false;
             // Resume VOD and restart live stream
             if (isVOD(_item.duration)) {
                 _stream.resume();
@@ -218,9 +221,6 @@ public class RTMPMediaProvider extends MediaProvider {
             // Start stream.
             _stream.play(_levels[_level].id);
         }
-        _isPaused = false;
-        clearInterval(_interval);
-        _interval = setInterval(positionInterval, 100);
     }
 
     /** Resize the Video and possible StageVideo. **/


### PR DESCRIPTION
In RTMP play method, we resume the video if the video is paused, but never set the state to playing.
Controller's play function is called a few times after a midroll, and checks for the state before calling provider's play function.
Since the state is not updated, controller called the play function, resulting the stream to start playing again from the beginning.

JW7-1877