### PR TITLE
Bugfix/update tracks after exit fullscreen ios

### DIFF
--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -39,6 +39,10 @@ define([
             this.setCaptionsList(captionsMenu);
             _selectDefaultIndex();
         }, this);
+        // Notified by provider if track changed while in fullscreen mode
+        _model.mediaController.on('subtitlesTrackChangedInFullScreen', function(e) {
+            _setCurrentIndex(e.index);
+        }, this);
 
         // Append data to subtitle tracks
         _model.mediaController.on('subtitlesTrackData', function(e) {
@@ -232,12 +236,15 @@ define([
             }
 
             // set the index without the side effect of storing the Off label in _selectCaptions
-            if(_tracks.length > 0) {
-                _model.setVideoSubtitleTrack(captionsMenuIndex);
-            } else {
-                _model.set('captionsIndex', captionsMenuIndex);
-            }
+            _setCurrentIndex(captionsMenuIndex);
+        }
 
+        function _setCurrentIndex (index) {
+            if(_tracks.length > 0) {
+                _model.setVideoSubtitleTrack(index);
+            } else {
+                _model.set('captionsIndex', index);
+            }
         }
 
         this.getCurrentIndex = function() {

--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -39,10 +39,6 @@ define([
             this.setCaptionsList(captionsMenu);
             _selectDefaultIndex();
         }, this);
-        // Notified by provider if track changed while in fullscreen mode
-        _model.mediaController.on('subtitlesTrackChangedInFullScreen', function(e) {
-            _setCurrentIndex(e.index);
-        }, this);
 
         // Append data to subtitle tracks
         _model.mediaController.on('subtitlesTrackData', function(e) {

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -152,6 +152,9 @@ define([
                 case events.JWPLAYER_AUDIO_TRACK_CHANGED:
                     this.setCurrentAudioTrack(data.currentTrack, data.tracks);
                     break;
+                case 'subtitlesTrackChanged':
+                    this.setVideoSubtitleTrack(data.currentTrack);
+                    break;
 
                 case 'visualQuality':
                     var visualQuality = _.extend({}, data);

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -669,6 +669,8 @@ define([
             _sendFullscreen(e);
             if (utils.isIOS()) {
                 _videotag.controls = false;
+                _updateSelectedAudioTrack();
+                _updateSelectedTextTrack();
             }
         }
 
@@ -677,6 +679,43 @@ define([
                 target: e.target,
                 jwstate: _fullscreenState
             });
+        }
+
+        function _updateSelectedAudioTrack () {
+            if(_videotag.audioTracks) {
+                var _selectedAudioTrackIndex = -1;
+                for (var i = 0; i < _videotag.audioTracks.length; i++) {
+                    if (_videotag.audioTracks[i].enabled) {
+                        _selectedAudioTrackIndex = i;
+                        break;
+                    }
+                }
+                _setCurrentAudioTrack(_selectedAudioTrackIndex);
+            }
+        }
+        function _updateSelectedTextTrack() {
+            if(_videotag.textTracks) {
+                var _selectedTextTrack = null;
+                var _selectedTextTrackIndex = -1, i = 0;
+                for (i; i < _videotag.textTracks.length; i++) {
+                    if (_videotag.textTracks[i].mode === 'showing') {
+                        _selectedTextTrack = _videotag.textTracks[i];
+                        break;
+                    }
+                }
+                if(_selectedTextTrack) {
+                    for (i = 0; i < _textTracks.length; i++) {
+                        if (_textTracks[i].label === _selectedTextTrack.label) {
+                            _selectedTextTrackIndex = i;
+                            break;
+                        }
+                    }
+                }
+                if (_selectedTextTrackIndex !== _currentTextTrackIndex) {
+                    //update track index in the captions controller, offsetting by 1 to account for 'Off'
+                    _this.trigger('subtitlesTrackChangedInFullScreen', { index: _selectedTextTrackIndex + 1 });
+                }
+            }
         }
 
         this.checkComplete = function() {
@@ -874,7 +913,7 @@ define([
 
         function _setCurrentAudioTrack(index) {
             if (_videotag && _videotag.audioTracks && _audioTracks &&
-                index > -1 && index < _videotag.audioTracks.length) {
+                index > -1 && index < _videotag.audioTracks.length && index !== _currentAudioTrackIndex) {
                 _videotag.audioTracks[_currentAudioTrackIndex].enabled = false;
                 _currentAudioTrackIndex = index;
                 _videotag.audioTracks[_currentAudioTrackIndex].enabled = true;
@@ -893,6 +932,8 @@ define([
 
         //model expects setSubtitlesTrack when changing subtitle track
         this.setSubtitlesTrack = _setSubtitlesTrack;
+
+        this.getSubtitlesTrack = _getSubtitlesTrack;
 
         function _setTextTracks(tracks) {
             //filter for tracks where kind = 'subtitles'
@@ -928,6 +969,10 @@ define([
             } else {
                 _currentTextTrackIndex = -1;
             }
+        }
+
+        function _getSubtitlesTrack() {
+            return _currentTextTrackIndex;
         }
     }
 

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -166,14 +166,8 @@ define([
 
         // Enable tracks support for HLS videos
         function _onLoadedData() {
-            if(_videotag.audioTracks) {
-                _setAudioTracks(_videotag.audioTracks);
-                _videotag.audioTracks.onchange = _audioTrackChangeHandler;
-            }
-            if(_videotag.textTracks) {
-                _setTextTracks(_videotag.textTracks);
-                _videotag.textTracks.onchange = _textTrackChangeHandler;
-            }
+            _setAudioTracks(_videotag.audioTracks);
+            _setTextTracks(_videotag.textTracks);
         }
         function _clickHandler(evt) {
             _this.trigger('click', evt);
@@ -892,7 +886,11 @@ define([
         this.getCurrentAudioTrack = _getCurrentAudioTrack;
 
         function _setAudioTracks(tracks) {
-            if(tracks && tracks.length > 0) {
+            _audioTracks = null;
+            if (!tracks) {
+                return;
+            }
+            if (tracks.length) {
                 for (var i = 0; i < tracks.length; i++) {
                     if (tracks[i].enabled) {
                         _currentAudioTrackIndex = i;
@@ -910,6 +908,9 @@ define([
                     };
                     return _track;
                 });
+            }
+            tracks.onchange = _audioTrackChangeHandler;
+            if (_audioTracks) {
                 _this.trigger('audioTracks', { currentTrack: _currentAudioTrackIndex, tracks: _audioTracks });
             }
         }
@@ -939,8 +940,12 @@ define([
         this.getSubtitlesTrack = _getSubtitlesTrack;
 
         function _setTextTracks(tracks) {
+            _textTracks = null; 
+            if(!tracks) {
+                return;
+            }
             //filter for 'subtitles' tracks
-            if(tracks && tracks.length > 0) {
+            if (tracks.length) {
                 _textTracks = _.filter(tracks, function(track) {
                     return track.kind === 'subtitles';
                 });
@@ -948,6 +953,9 @@ define([
                 _.each(_textTracks, function(track) {
                     track.mode = 'disabled';
                 });
+            }
+            tracks.onchange = _textTrackChangeHandler;
+            if (_textTracks && _textTracks.length) {
                 _this.trigger('subtitlesTracks', { tracks: _textTracks });
             }
         }

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -166,10 +166,14 @@ define([
 
         // Enable tracks support for HLS videos
         function _onLoadedData() {
-            _setAudioTracks(_videotag.audioTracks);
-            _setTextTracks(_videotag.textTracks);
-            _videotag.audioTracks.onchange = _audioTrackChangeHandler;
-            _videotag.textTracks.onchange = _textTrackChangeHandler;
+            if(_videotag.audioTracks) {
+                _setAudioTracks(_videotag.audioTracks);
+                _videotag.audioTracks.onchange = _audioTrackChangeHandler;
+            }
+            if(_videotag.textTracks) {
+                _setTextTracks(_videotag.textTracks);
+                _videotag.textTracks.onchange = _textTrackChangeHandler;
+            }
         }
         function _clickHandler(evt) {
             _this.trigger('click', evt);
@@ -500,10 +504,10 @@ define([
 
         this.destroy = function() {
              _removeListeners(_mediaEvents, _videotag);
-            if(_videotag.audioTracks) {
+            if (_videotag.audioTracks) {
                 _videotag.audioTracks.onchange = null;
             }
-            if(_videotag.textTracks) {
+            if (_videotag.textTracks) {
                 _videotag.textTracks.onchange = null;
             }
             this.remove();


### PR DESCRIPTION
Updated the provider to listen for audio/text track change events. This keeps the model in sync when videos are in full screen mode on iOS devices where the native player controls are not available.

JW7-1884