### PR TITLE
Send playReason with playAttempt event

### DIFF
--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -316,7 +316,7 @@ define([
         this.loadVideo = function(item) {
 
             this.mediaModel.set('playAttempt', true);
-            this.mediaController.trigger(events.JWPLAYER_MEDIA_PLAY_ATTEMPT);
+            this.mediaController.trigger(events.JWPLAYER_MEDIA_PLAY_ATTEMPT, {'playReason': this.get('playReason')});
 
             if (!item) {
                 var idx = this.get('item');

--- a/src/js/events/change-state-event.js
+++ b/src/js/events/change-state-event.js
@@ -25,7 +25,7 @@ define([
                 oldstate: oldstate,
                 reason: model.mediaModel.get('state')
             };
-            // add reason for play of the event type is play
+            // add reason for play if the event type is play
             if (eventType === 'play') {
                 evt.playReason = model.get('playReason');
             }


### PR DESCRIPTION
Instead of sending playReason with play event, we send it with playAttempt event, so that we know the playReason faster.
JW7-1860