### PR TITLE
Fallback for displaying audio track titles in the control bar

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -903,7 +903,7 @@ define([
                 }
                 _audioTracks = _.map(tracks, function(track) {
                     var _track = {
-                        name: track.label,
+                        name: track.label || track.language,
                         language: track.language
                     };
                     return _track;


### PR DESCRIPTION
Displays ```language``` if the ```label``` property is not available in an audio track. 

Note: MS Edge does not currently support the ```label``` or ```kind``` properties.