### PR TITLE
Stop encoding urls for preview images

### DIFF
--- a/src/js/view/preview.js
+++ b/src/js/view/preview.js
@@ -20,8 +20,6 @@ define([
             var img = playlistItem.image;
 
             if (_.isString(img)) {
-                // encode special characters into URL
-                img = encodeURI(img);
                 this.el.style.backgroundImage = 'url("' + img + '")';
             } else {
                 this.el.style.backgroundImage = '';


### PR DESCRIPTION
This was originally done to allow a publisher who passed in non-encoded urls
to still work (specifically, they were passing a url which has a double-quote character).

This causes a problem for other users who have already encoded the url, since double-encoding
breaks pathing. A better solution is to require users to pass in a well-formed url.

https://github.com/jwplayer/jwplayer/issues/919
JW7-883