### PR TITLE
Include play reason with beforePlay event

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -295,7 +295,7 @@ define([
                 }
                 if (!_preplay) {
                     _preplay = true;
-                    _this.trigger(events.JWPLAYER_MEDIA_BEFOREPLAY, {});
+                    _this.trigger(events.JWPLAYER_MEDIA_BEFOREPLAY, {'playReason': _model.get('playReason')});
                     _preplay = false;
                     if (_interruptPlay) {
                         _interruptPlay = false;


### PR DESCRIPTION
Instead of firing play reason with playAttempt, fire it with beforePlay event to know the reason faster.
JW7-1860