### PR TITLE
Do not update duration if not set with a time update

### DIFF
--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -129,9 +129,11 @@ define([
 
                 case events.JWPLAYER_MEDIA_TIME:
                     this.mediaModel.set('position', data.position);
-                    this.mediaModel.set('duration', data.duration);
                     this.set('position', data.position);
-                    this.set('duration', data.duration);
+                    if (_.isNumber(data.duration)) {
+                        this.mediaModel.set('duration', data.duration);
+                        this.set('duration', data.duration);
+                    }
                     break;
                 case events.JWPLAYER_PROVIDER_CHANGED:
                     this.set('provider', _provider.getName());


### PR DESCRIPTION
Ultimately, I want to separate the idea of providers sending time updates
from them updating the duration of the media file. This brings us a step further
by allowing the provider to not specify a duration with a JWPLAYER_MEDIA_TIME event,
without setting dur to NaN.