### PR TITLE
Scale video in IE, Android Native, and iOS 8 with transforms

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -10,6 +10,7 @@ define([
 
     var clearTimeout = window.clearTimeout,
         STALL_DELAY = 256,
+        _isIE = utils.isIE(),
         _isMSIE = utils.isMSIE(),
         _isMobile = utils.isMobile(),
         _isSafari = utils.isSafari(),
@@ -807,24 +808,33 @@ define([
                 var videoAspectRatio = _videotag.videoWidth / _videotag.videoHeight;
                 if (Math.abs(playerAspectRatio - videoAspectRatio) < 0.09) {
                     style.objectFit = 'fill';
+                    stretching = 'exactfit';
                 }
             }
-            if (_isIOS7 || _isIOS8) {
-                // Prior to iOS 9, object-fit worked poorly. These additional styles to make it fit correctly.
-                style.maxHeight = '100%';
-                style.maxWidth =  '100%';
-                if (style.objectFit !== 'fill' && stretching !== 'fill' && stretching !== 'exactfit') {
-                    // margins will be used to center video in container
-                    style.width = 'auto';
-                    style.height = 'auto';
-                    if (stretching === 'uniform') {
-                        if (width / _videotag.videoWidth > height / _videotag.videoHeight) {
-                            style.height = '100%';
-                        } else {
-                            style.width = '100%';
-                        }
-                    }
+            // Prior to iOS 9, object-fit worked poorly
+            // object-fit is not implemented in IE or Android Browser in 4.4 and lower
+            // http://caniuse.com/#feat=object-fit
+            // feature detection may work for IE but not for browsers where object-fit works for images only
+            var fitVideoUsingTransforms = _isIE || _isAndroid || _isIOS7 || _isIOS8;
+            if (fitVideoUsingTransforms) {
+                // Use transforms to center and scale video in container
+                var x = - Math.floor(_videotag.videoWidth  / 2 + 1);
+                var y = - Math.floor(_videotag.videoHeight / 2 + 1);
+                var scaleX = Math.ceil(width  * 100 / _videotag.videoWidth)  / 100;
+                var scaleY = Math.ceil(height * 100 / _videotag.videoHeight) / 100;
+                if (stretching === 'none') {
+                    scaleX = scaleY = 1;
+                } else if (stretching === 'fill') {
+                    scaleX = scaleY = Math.max(scaleX, scaleY);
+                } else if (stretching === 'uniform') {
+                    scaleX = scaleY = Math.min(scaleX, scaleY);
                 }
+                style.width  = _videotag.videoWidth;
+                style.height = _videotag.videoHeight;
+                style.top = style.left = '50%';
+                style.margin  = 0;
+                cssUtils.transform(_videotag,
+                    'translate(' + x + 'px, ' + y + 'px) scale(' + scaleX.toFixed(2) + ', ' + scaleY.toFixed(2) + ')');
             }
             cssUtils.style(_videotag, style);
             return false;

--- a/src/js/utils/css.js
+++ b/src/js/utils/css.js
@@ -92,15 +92,13 @@ define([
     };
 
     var transform = function (element, value) {
-        var transform = 'transform',
-            style = {};
-        value = value || '';
-        style[transform] = value;
-        style['-webkit-' + transform] = value;
-        style['-ms-' + transform] = value;
-        style['-moz-' + transform] = value;
-        style['-o-' + transform] = value;
-        _style(element, style);
+        _style(element, {
+            transform: value,
+            webkitTransform: value,
+            msTransform: value,
+            mozTransform: value,
+            oTransform: value
+        });
     };
 
     var hexToRgba = function (hexColor, opacity) {

--- a/test/unit/css-test.js
+++ b/test/unit/css-test.js
@@ -80,16 +80,16 @@ define([
         css.transform(element, 'none');
 
         assert.equal(element.style.transform, 'none', 'css transform');
-        assert.equal(element.style.MsTransform, 'none', 'css transform ms');
-        assert.equal(element.style.MozTransform, 'none', 'css transform moz');
-        assert.equal(element.style.OTransform, 'none', 'css transform o');
+        assert.equal(element.style.msTransform, 'none', 'css transform ms');
+        assert.equal(element.style.mozTransform, 'none', 'css transform moz');
+        assert.equal(element.style.oTransform, 'none', 'css transform o');
 
         css.transform(element, '');
 
         assert.equal(element.style.transform, '', 'css transform');
-        assert.equal(element.style.MsTransform, '', 'css transform ms');
-        assert.equal(element.style.MozTransform, '', 'css transform moz');
-        assert.equal(element.style.OTransform, '', 'css transform o');
+        assert.equal(element.style.msTransform, '', 'css transform ms');
+        assert.equal(element.style.mozTransform, '', 'css transform moz');
+        assert.equal(element.style.oTransform, '', 'css transform o');
     });
 
     test('css.hexToRgba', function(assert) {


### PR DESCRIPTION
Added IE and Android Native to the scaling fix based on http://caniuse.com/#feat=object-fit

If needed, transforms will always be used to scale, removing the margins-only fix used in some cases. This fixes the glitches seen in IE and iOS, when css swapped out transforms for margins because of the player resizing or video aspect ratio changing.

The scale will now always be an exact fit or up to 1/100th of a pixel larger so that edges are always covered.

The css utility changes fix setting transforms in IE9.

JW7-1892