### PR TITLE
Set crossorigin attribute on videotag for tracks to load correctly in iOS

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -164,6 +164,7 @@ define([
         // Enable AirPlay
         _videotag.setAttribute('x-webkit-airplay', 'allow');
         _videotag.setAttribute('webkit-playsinline', '');
+        _videotag.setAttribute('crossorigin', 'anonymous');
 
         // Enable tracks support for HLS videos
         function _onLoadedData() {


### PR DESCRIPTION
JW7-1828