### PR TITLE
Persist only user changes to captions track

### DIFF
--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -127,7 +127,6 @@ define([
                     }
                 }
             }
-
             var captionsMenu = _captionsMenu();
             this.setCaptionsList(captionsMenu);
             _selectDefaultIndex();
@@ -233,7 +232,7 @@ define([
 
         function _setCurrentIndex (index) {
             if(_tracks.length) {
-                _model.setVideoSubtitleTrack(index);
+                _model.setVideoSubtitleTrack(index, _tracks);
             } else {
                 _model.set('captionsIndex', index);
             }

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -539,7 +539,7 @@ define([
 
             function _setCurrentCaptions(index) {
                 // update provider subtitle track
-                _model.setVideoSubtitleTrack(index);
+                _model.persistVideoSubtitleTrack(index);
 
                 _this.trigger(events.JWPLAYER_CAPTIONS_CHANGED, {
                     tracks: _getCaptionsList(),

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -358,14 +358,19 @@ define([
         this.setVideoSubtitleTrack = function(trackIndex, tracks) {
             this.set('captionsIndex', trackIndex);
             // tracks could have changed even if the index hasn't
-            if(trackIndex && tracks) {
+            if(trackIndex && tracks && trackIndex < tracks.length) {
                 this.set('captionsTrack', tracks[trackIndex-1]);
             }
-            this.persistCaptionsTrack();
 
             if (_provider && _provider.setSubtitlesTrack) {
                 _provider.setSubtitlesTrack(trackIndex);
             }
+
+        };
+
+        this.persistVideoSubtitleTrack = function(trackIndex) {
+            this.setVideoSubtitleTrack(trackIndex);
+            this.persistCaptionsTrack();
         };
     };
 


### PR DESCRIPTION
Ensures that ```captionsLabel``` is persisted only from user selection.