### PR TITLE
Only set crossorigin attribute on video tag when side loading tracks

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -164,7 +164,6 @@ define([
         // Enable AirPlay
         _videotag.setAttribute('x-webkit-airplay', 'allow');
         _videotag.setAttribute('webkit-playsinline', '');
-        _videotag.setAttribute('crossorigin', 'anonymous');
 
         // Enable tracks support for HLS videos
         function _onLoadedData() {
@@ -477,6 +476,8 @@ define([
             if (!tracks) {
                 return;
             }
+            // CORS applies to track loading and requires the crossorigin attribute
+            _videotag.setAttribute('crossorigin', 'anonymous');
             for (var i = 0; i < tracks.length; i++) {
                 // only add .vtt tracks
                 if(tracks[i].file.indexOf('.vtt') === -1) {


### PR DESCRIPTION
When the crossorigin attribute is set in Chrome and Firefox, the video tag enforces CORS on video file equests. CORS is not enforced by default on video files, only on child text tracks linking to vtt files.

In Firefox when trying to load a video from a server without CORS headers with the attribute set, the console log states that the server hosting the video does not specify a cross-origin policy. There is no error logged in Chrome. For this reason we're only setting the attribute when loading text tracks. In 7.3 this will be limited to iOS where the crossorigin does not affect video.

JW7-1828
Fixes JW7-1922