### PR TITLE
Cleanup beforeunload

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -185,8 +185,11 @@ define([
 
                 // prevent video error in display on window close
                 window.addEventListener('beforeunload', function() {
-                    if (!_isCasting()) { // don't call stop while casting
-                        _stop(true);
+                    if (_setup) {
+                        _setup.destroy();
+                    }
+                    if (_model) {
+                        _model.destroy();
                     }
                 });
 
@@ -566,14 +569,6 @@ define([
                     }
                 }
                 return null;
-            }
-
-            function _isCasting() {
-                var provider = _model.getVideo();
-                if (provider) {
-                    return provider.isCaster;
-                }
-                return false;
             }
 
             function _attachMedia() {

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -225,6 +225,7 @@ define([
         };
 
         this.destroy = function() {
+            this.off();
             if (_provider) {
                 _provider.off(null, null, this);
                 _provider.destroy();


### PR DESCRIPTION
We stop video playback on window beforeunload to prevent an html5 video error from showing up in the console when a page with the player is refreshed. There are still a lot of event listeners attached in the player's model and provider. These events cause repaints and reflows in the page. Cleaning this up should improve page refresh performance.

JW7-1920

Before
![screen shot 2015-12-29 at 2 35 42 pm](https://cloud.githubusercontent.com/assets/333258/12040855/590ce4fe-ae3a-11e5-8023-89401050a8e3.png)

After
![screen shot 2015-12-29 at 2 38 22 pm](https://cloud.githubusercontent.com/assets/333258/12040856/590d2874-ae3a-11e5-80d3-a862dccc9721.png)
