### PR TITLE
Map ID3 metadata for compatibility and ease of use

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -755,17 +755,15 @@ define([
                 TAL: 'album'
             };
             var id3Data = _.reduce(activeCues, function(data, cue) {
-                // These frienly name mapping provide compatibility with our Flash implementation
+                // These friendly names mapping provides compatibility with our Flash implementation prior to 7.3
                 if(friendlyNames.hasOwnProperty(cue.value.key)) {
                     data[friendlyNames[cue.value.key]] = cue.value.data;
                 }
-                /* Flatten the data by using the info value as the key if available
-                 * And provide a collection for keys with info values
-                 *   TLEN: 03:50
-                 *   artworkURL: http://domain.com/cover.jpg
-                 *   WXXX: {"artworkURL":"http://domain.com/cover.jpg"}
+                /* The meta event includes a metadata object with flattened cue key/data pairs
+                 * If a cue also includes an info field, then create a collection of info/data pairs for the cue key
+                 *   TLEN: 03:50                                        // key: "TLEN", data: "03:50"
+                 *   WXXX: {"artworkURL":"http://domain.com/cover.jpg"} // key: "WXXX", info: "artworkURL" ...
                  */
-                data[cue.value.info || cue.value.key] = cue.value.data;
                 if(cue.value.info) {
                     var collection = data[cue.value.key];
                     if (!_.isObject(collection)) {
@@ -773,6 +771,8 @@ define([
                         data[cue.value.key] = collection;
                     }
                     collection[cue.value.info] = cue.value.data;
+                } else {
+                    data[cue.value.key] = cue.value.data;
                 }
                 return data;
             }, {});

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -737,47 +737,50 @@ define([
             _setCurrentAudioTrack(_selectedAudioTrackIndex);
         }
 
-        function _cueChangeHandler (e) {
-            if(!e.currentTarget.activeCues.length || _activeCuePosition === e.currentTarget.activeCues[0].startTime) {
-                return;
-            }
+        function _cueChangeHandler(e) {
             _parseID3(e.currentTarget.activeCues);
         }
 
-        function _parseID3 (activeCues) {
+        function _parseID3(activeCues) {
+            if (!activeCues || !activeCues.length || _activeCuePosition === activeCues[0].startTime) {
+                return;
+            }
             var friendlyNames = {
-                TIT1: 'group',
                 TIT2: 'title',
                 TT2: 'title',
                 WXXX: 'url',
                 TPE1: 'artist',
                 TP1: 'artist',
                 TALB: 'album',
-                TAL: 'album',
-                TCOM: 'composer',
-                TFLT: 'filetype',
-                TLEN: 'length',
-                TIT3: 'subtitle'
+                TAL: 'album'
             };
             var id3Data = _.reduce(activeCues, function(data, cue) {
+                // These frienly name mapping provide compatibility with our Flash implementation
                 if(friendlyNames.hasOwnProperty(cue.value.key)) {
                     data[friendlyNames[cue.value.key]] = cue.value.data;
-                } else {
-                    data[cue.value.info || cue.value.key] = cue.value.data;
+                }
+                /* Flatten the data by using the info value as the key if available
+                 * And provide a collection for keys with info values
+                 *   TLEN: 03:50
+                 *   artworkURL: http://domain.com/cover.jpg
+                 *   WXXX: {"artworkURL":"http://domain.com/cover.jpg"}
+                 */
+                data[cue.value.info || cue.value.key] = cue.value.data;
+                if(cue.value.info) {
+                    var collection = data[cue.value.key];
+                    if (!_.isObject(collection)) {
+                        collection = {};
+                        data[cue.value.key] = collection;
+                    }
+                    collection[cue.value.info] = cue.value.data;
                 }
                 return data;
             }, {});
-            var metaData = {
-                position: _position,
-                metadata: {
-                    startTime: activeCues[0].startTime,
-                    type: 'metadata',
-                    provider: 'html5',
-                    data: id3Data
-                }
-            };
             _activeCuePosition = activeCues[0].startTime;
-            _this.trigger('meta', metaData);
+            _this.trigger('meta', {
+                metadataTime: _activeCuePosition,
+                metadata: id3Data
+            });
         }
 
         function _fullscreenEndHandler(e) {
@@ -1067,8 +1070,8 @@ define([
                 var i = 0, len = tracks.length;
                 for (i; i < len; i++) {
                     if (tracks[i].kind === 'metadata') {
-                        tracks[i].mode = 'showing';
                         tracks[i].oncuechange = _cueChangeHandler;
+                        tracks[i].mode = 'showing';
                     }
                     else if (tracks[i].kind === 'subtitles' || tracks[i].kind === 'captions') {
                         // set subtitles Off by default


### PR DESCRIPTION
These changes make the ID3 metadata available in a way that is consistent with JW Player 6 and our current Flash implementation*, while also exposing ID3 key/data pairs and key: info/data collections. Here's an example:

```
{
  metadata: {
    title: "Who Knew - From Kiis 102.7 Los Angeles",    // JW6 Friendly Name
    TIT2: "Who Knew - From Kiis 102.7 Los Angeles",     // ID3 Key
    PRIV: {                                             // ID3 Key collection
      "com.apple.streaming.transportStreamTimestamp":{}  // ID3 PRIV info : [ArrayBuffer]
    },
    url: song_spot=x,                                   // JW6 WXXX friendly name
    WXXX: {                                             // ID3 Key collection
      "URL": "song_spot=x"                               // ID3 WXXX info : String
    },
    artist: "Pink",                                     // JW6 Friendly Name
    TPE1: "Pink"                                        // ID3 Key
  }
}
```
* One breaking change is that Flash 7.1-7.2 output a single key/info pair for some ID3 "PRIV" fields. This was incorrect since the actual data was omitted and multiple PRIV fields would overwrite each other. This will be addressed in 7.3 so that our Flash HLSID3 parser matches this output.