### PR TITLE
Seeking to "Live" in DVR mode will seek to end minus 25 seconds

### DIFF
--- a/src/js/utils/constants.js
+++ b/src/js/utils/constants.js
@@ -2,6 +2,7 @@ define([], function() {
     return {
         repo : 'http://ssl.p.jwpcdn.com/player/v/',
         SkinsIncluded : ['seven'],
-        SkinsLoadable : ['beelden', 'bekle', 'five', 'glow', 'roundster', 'six', 'stormtrooper', 'vapor']
+        SkinsLoadable : ['beelden', 'bekle', 'five', 'glow', 'roundster', 'six', 'stormtrooper', 'vapor'],
+        dvrSeekLimit : -25
     };
 });

--- a/src/js/utils/parser.js
+++ b/src/js/utils/parser.js
@@ -142,9 +142,9 @@ define([
      * Determine the adaptive type
      */
     parser.adaptiveType = function(duration) {
-        if (duration !== -1) {
+        if (duration !== 0) {
             var MIN_DVR_DURATION = -120;
-            if(duration <= MIN_DVR_DURATION) {
+            if (duration <= MIN_DVR_DURATION) {
                 return 'DVR';
             }
             if (duration < 0 || duration === Infinity) {

--- a/src/js/view/components/slider.js
+++ b/src/js/view/components/slider.js
@@ -72,8 +72,10 @@ define([
                 }
             }
 
-            this.render(percentage);
-            this.update(percentage);
+            var updatedPercent = this.limit(percentage);
+            this.render(updatedPercent);
+            this.update(updatedPercent);
+
 
             return false;
         },
@@ -82,6 +84,10 @@ define([
             this.dragMove(evt);
         },
 
+        limit : function(percentage) {
+            // modules that extend Slider can set limits on the percentage (TimeSlider)
+            return percentage;
+        },
         update : function(percentage) {
             this.trigger('update', { percentage : percentage });
         },

--- a/src/js/view/controlbar.js
+++ b/src/js/view/controlbar.js
@@ -2,6 +2,7 @@ define([
     'utils/helpers',
     'utils/underscore',
     'utils/backbone.events',
+    'utils/constants',
     'utils/ui',
     'view/components/slider',
     'view/components/timeslider',
@@ -9,7 +10,7 @@ define([
     'view/components/playlist',
     'view/components/volumetooltip',
     'view/components/drawer'
-], function(utils, _, Events, UI, Slider, TimeSlider, Menu, Playlist, VolumeTooltip, Drawer) {
+], function(utils, _, Events, Constants, UI, Slider, TimeSlider, Menu, Playlist, VolumeTooltip, Drawer) {
 
     function button(icon, apiAction) {
         var element = document.createElement('div');
@@ -256,9 +257,9 @@ define([
 
             new UI(this.elements.duration).on('click tap', function(){
                 if (utils.adaptiveType(this._model.get('duration')) === 'DVR') {
-                    // -0.1 places the playhead at the most recent time.
-                    // this._api.seek(0) puts the user at the oldest DVR segment available.
-                    this._api.seek(-0.1);
+                    // Seek to "Live" position within live buffer, but not before current position
+                    var currentPosition = this._model.get('position');
+                    this._api.seek(Math.max(Constants.dvrSeekLimit, currentPosition));
                 }
             }, this);
 

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -2,6 +2,7 @@ define([
     'utils/helpers',
     'events/events',
     'utils/backbone.events',
+    'utils/constants',
     'events/states',
     'view/captionsrenderer',
     'view/clickhandler',
@@ -14,7 +15,7 @@ define([
     'view/title',
     'utils/underscore',
     'handlebars-loader!templates/player.html'
-], function(utils, events, Events, states,
+], function(utils, events, Events, Constants, states,
             CaptionsRenderer, ClickHandler, DisplayIcon, Dock, Logo,
             Controlbar, Preview, RightClick, Title, _, playerTemplate) {
 
@@ -96,7 +97,14 @@ define([
         _elementSupportsFullscreen = _requestFullscreen && _exitFullscreen;
 
         function adjustSeek(amount) {
-            var newSeek = utils.between(_model.get('position') + amount, 0, _model.get('duration'));
+            var min = 0;
+            var max = _model.get('duration');
+            var position = _model.get('position');
+            if (utils.adaptiveType(max) === 'DVR') {
+                min = max;
+                max = Math.max(position, Constants.dvrSeekLimit);
+            }
+            var newSeek = utils.between(position + amount, min, max);
             _api.seek(newSeek);
         }
 

--- a/test/unit/parser-test.js
+++ b/test/unit/parser-test.js
@@ -102,8 +102,8 @@ define([
     });
 
     test('parser.adaptiveType', function(assert) {
-        var type = parser.adaptiveType(-1);
-        assert.equal(type, 'VOD', 'adaptiveType with -1');
+        var type = parser.adaptiveType(0);
+        assert.equal(type, 'VOD', 'adaptiveType with 0');
 
         type = parser.adaptiveType(10);
         assert.equal(type, 'VOD', 'adaptiveType with 10');
@@ -113,6 +113,9 @@ define([
 
         type = parser.adaptiveType(-20);
         assert.equal(type, 'LIVE', 'adaptiveType with -20');
+
+        type = parser.adaptiveType(-1);
+        assert.equal(type, 'LIVE', 'adaptiveType with -1');
 
         type = parser.adaptiveType(Infinity);
         assert.equal(type, 'LIVE', 'adaptiveType with Infinity');


### PR DESCRIPTION
The last 25 seconds of a DVR stream in the time slider will show the "Live" tooltip. Clicking in that range or on the "Live" button to the right of the slider will seek to -25 seconds (the same time the stream would start playing at). The player will only seek forward in this case; If the position is closer to 0, the player will not seek back to -25 but continue playing in the "Live" range. The slider has been updates so that it will not render on mouse up at the position clicked if the DVR time is changed by the slider to meet these rules.

JW7-1744

Also applied changes to keyboard seeking, fixing DVR seeking with keyboard.
JW7-950