### PR TITLE
Chromecast responsive styling and aspectratio config cloning

### DIFF
--- a/src/css/imports/cast.less
+++ b/src/css/imports/cast.less
@@ -9,9 +9,21 @@
 
 .jwplayer.jw-flag-casting .jw-display-icon-container {
     border-radius: 0;
-    top: 8em;
-    padding: 2em 5em;
     border: 1px solid white;
+
+    position: absolute;
+    top: auto;
+    left: 0.5em;
+    right: 0.5em;
+    bottom: 50%;
+
+    margin-bottom: -12.5%;
+    height: 50%;
+    width: 50%;
+    padding: 0;
+
+    background-repeat: no-repeat;
+    background-position: center;
 
     .jw-icon {
         font-size: 3em;
@@ -33,10 +45,10 @@
 
 .jw-cast-label {
     position: absolute;
-    left: 10px;
-    right: 10px;
-    bottom: 50%;
-    margin-bottom: 100px;
+    left: 0.5em;
+    right: 0.5em;
+    bottom: 75%;
+    margin-bottom: 1.5em;
     text-align: center;
 }
 

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -105,6 +105,9 @@ define([
         if (typeof ar !== 'string' || !utils.exists(ar)) {
             return 0;
         }
+        if (/^\d*\.?\d+%$/.test(ar)) {
+            return ar;
+        }
         var index = ar.indexOf(':');
         if (index === -1) {
             return 0;

--- a/test/unit/api-config-test.js
+++ b/test/unit/api-config-test.js
@@ -82,9 +82,21 @@ define([
             width:'10%',
             aspectratio : '4:3'
         });
-
         // 4:3 is 75% because of 3/4
         assert.equal(x.aspectratio, '75%', 'integer aspect ratio');
+
+        x = testConfig(assert, {
+            width : '100%',
+            aspectratio : '58.25%'
+        });
+        assert.strictEqual(x.aspectratio, '58.25%', 'percentage aspect ratio is passed through');
+
+        x = testConfig(assert, {
+            width : '100%',
+            aspectratio : '75%'
+        });
+        assert.strictEqual(x.aspectratio, '75%', 'percentage aspect ratio is passed through');
+
 
         x = testConfig(assert, {
             width : '200',


### PR DESCRIPTION
These changes are part of the fix for #971. The casting configuration is handled in the commercial project. These fixes will go into 7.3. Since we change the `aspectratio` setup option into a percentage ("16:9" becomes "56.25%") this allows percentages be passed in the config and to be cloned for creating the casting view.

The casting display icon and label positioning and scaling have been updated to scale and center in the player to work at all sizes down to 300x200.

JW7-1916