### PR TITLE
Ensure captionsTrack has data when using captionsrenderer.

### DIFF
--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -358,8 +358,11 @@ define([
 
         this.setVideoSubtitleTrack = function(trackIndex, tracks) {
             this.set('captionsIndex', trackIndex);
-            // tracks could have changed even if the index hasn't
-            if(trackIndex && tracks && trackIndex < tracks.length) {
+            /*
+             * Tracks could have changed even if the index hasn't.
+             * Need to ensure track has data for captionsrenderer.
+             */
+            if(trackIndex && tracks && trackIndex < tracks.length && tracks[trackIndex-1].data) {
                 this.set('captionsTrack', tracks[trackIndex-1]);
             }
 


### PR DESCRIPTION
This ensures that the model only tries to set the `captionsTrack` when the track has captions data. 

JW7-1918
