### PR TITLE
Update duration before triggering meta event

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -207,7 +207,6 @@ define([
             if (_isAndroidHLS && (_videotag.duration === Infinity) && (_videotag.currentTime === 0)) {
                 return;
             }
-
             _updateDuration();
             _setPosition(_videotag.currentTime);
             // buffer ranges change during playback, not just on file progress
@@ -251,13 +250,14 @@ define([
                 }
             }
             _duration = duration;
-            if (_delayedSeek && duration) {
+            if (_delayedSeek && duration && duration !== Infinity) {
                 _this.seek(_delayedSeek);
             }
         }
 
         function _sendMetaEvent() {
-            var duration = _videotag.duration;
+            _updateDuration();
+            var duration = _duration;
             if (_isAndroidHLS && duration === Infinity) {
                 duration = 0;
             }
@@ -266,10 +266,6 @@ define([
                 height: _videotag.videoHeight,
                 width: _videotag.videoWidth
             });
-            // Do not update duration on androidHLS before time event
-            if (!_isAndroidHLS) {
-                _updateDuration();
-            }
         }
 
         function _canPlayHandler() {

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -238,8 +238,8 @@ define([
             }
             _position = currentTime;
         }
-
-        function _updateDuration() {
+        
+        function _getDuration() {
             var duration = _videotag.duration;
             var end = _getSeekableEnd();
             if (duration === Infinity && end) {
@@ -249,15 +249,18 @@ define([
                     duration = -seekableDuration;
                 }
             }
-            _duration = duration;
-            if (_delayedSeek && duration && duration !== Infinity) {
+            return duration;
+        }
+        
+        function _updateDuration() {
+            _duration = _getDuration();
+            if (_delayedSeek && _duration && _duration !== Infinity) {
                 _this.seek(_delayedSeek);
             }
         }
 
         function _sendMetaEvent() {
-            _updateDuration();
-            var duration = _duration;
+            var duration = _getDuration();
             if (_isAndroidHLS && duration === Infinity) {
                 duration = 0;
             }

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -180,7 +180,7 @@ define([
                 return;
             }
 
-            _updateDuration();
+            _updateDuration(_getDuration());
             _setBuffered(_getBuffer(), _position, _duration);
         }
 
@@ -207,7 +207,7 @@ define([
             if (_isAndroidHLS && (_videotag.duration === Infinity) && (_videotag.currentTime === 0)) {
                 return;
             }
-            _updateDuration();
+            _updateDuration(_getDuration());
             _setPosition(_videotag.currentTime);
             // buffer ranges change during playback, not just on file progress
             _setBuffered(_getBuffer(), _position, _duration);
@@ -252,9 +252,9 @@ define([
             return duration;
         }
         
-        function _updateDuration() {
-            _duration = _getDuration();
-            if (_delayedSeek && _duration && _duration !== Infinity) {
+        function _updateDuration(duration) {
+            _duration = duration;
+            if (_delayedSeek && duration && duration !== Infinity) {
                 _this.seek(_delayedSeek);
             }
         }
@@ -269,6 +269,7 @@ define([
                 height: _videotag.videoHeight,
                 width: _videotag.videoWidth
             });
+            _updateDuration(duration);
         }
 
         function _canPlayHandler() {


### PR DESCRIPTION
By updating the duration before triggering the `meta` event, duration will be displayed correctly on desktop and iOS. Android devices will show 'Live Broadcast' because duration isn't available for DVR streams.

JW7-1560