### PR TITLE
Use 'Unknown CC' for embedded texttracks without a label

### DIFF
--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -198,7 +198,7 @@ define([
             for (var i = 0; i < _tracks.length; i++) {
                 list.push({
                     id: _tracks[i].id,
-                    label: _tracks[i].label
+                    label: _tracks[i].label || 'Unknown CC'
                 });
             }
             return list;

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -1077,7 +1077,8 @@ define([
                         tracks[i].oncuechange = _cueChangeHandler;
                         tracks[i].mode = 'showing';
                     }
-                    else if (tracks[i].kind === 'subtitles' || tracks[i].kind === 'captions') {
+                    else if ((tracks[i].kind === 'subtitles' || tracks[i].kind === 'captions') &&
+                        (tracks[i].label || tracks[i].language)) {
                         // set subtitles Off by default
                         tracks[i].mode = 'disabled';
                         if(!_textTracks) {

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -1077,8 +1077,7 @@ define([
                         tracks[i].oncuechange = _cueChangeHandler;
                         tracks[i].mode = 'showing';
                     }
-                    else if ((tracks[i].kind === 'subtitles' || tracks[i].kind === 'captions') &&
-                        (tracks[i].label || tracks[i].language)) {
+                    else if (tracks[i].kind === 'subtitles' || tracks[i].kind === 'captions') {
                         // set subtitles Off by default
                         tracks[i].mode = 'disabled';
                         if(!_textTracks) {


### PR DESCRIPTION
Embedded text tracks might not have a label or language. It's best to label these tracks as 'Unknown CC' to match native behavior in fullscreen mode on iOS and prevent user confusion. These tracks might not contain cues.

Note: In fullscreen mode on iOS devices, the `TextTrackList.onchange` event fires multiple times per user selection from the Audio & Subtitles menu. There seems to be an issue when toggling from 'Off' or 'Auto (Recommended)' to an 'Unknown CC' track - the 'Unknown CC' track is selected initially, then the `TextTrackList.onchange` event fires again, selecting another track from the menu. This seems to occur with bad textTracks (eg. the 'Unknown CC' track contains no cues). The native Audio & Subtitles menu does not update to reflect this until after exiting and reentering fullscreen mode. The player honors the browser's `TextTrackList.onchange` event, so the selected captions track in the player's control bar always reflects the `showing` track from the last time the event fired.

JW7-1929