### PR TITLE
Fix reloading same playlist item for flash

### DIFF
--- a/src/flash/com/longtailvideo/jwplayer/media/VideoMediaProvider.as
+++ b/src/flash/com/longtailvideo/jwplayer/media/VideoMediaProvider.as
@@ -179,6 +179,7 @@ public class VideoMediaProvider extends MediaProvider {
         _buffered = 0;
         _starttime = 0;
         _offset = {time: 0, byte: 0};
+        _complete = true;
         super.stop();
     }
 


### PR DESCRIPTION
When stop is called, we need to reload the item even if it is the same as the stored item.

JW7-1821