### PR TITLE
Hide preview for autostart on desktop

### DIFF
--- a/src/css/states/idle.less
+++ b/src/css/states/idle.less
@@ -3,6 +3,9 @@
 .jw-state-idle {
     .jw-preview {
         display: block;
+        &.jw-autostart {
+            display: none;
+        }
     }
 
     .jw-icon-display {

--- a/src/js/view/preview.js
+++ b/src/js/view/preview.js
@@ -1,6 +1,7 @@
 define([
-    'utils/underscore'
-], function(_) {
+    'utils/underscore',
+    'utils/helpers'
+], function(_, util) {
 
     var Preview = function(_model) {
         this.model = _model;
@@ -18,6 +19,10 @@ define([
         },
         loadImage: function(model, playlistItem) {
             var img = playlistItem.image;
+
+            // hide the preview in idle state if autostart is true and not mobile to prevent preview flashing
+            var hidePreview = model.get('autostart') && !util.isMobile();
+            util.toggleClass(this.el, 'jw-autostart', hidePreview);
 
             if (_.isString(img)) {
                 this.el.style.backgroundImage = 'url("' + img + '")';


### PR DESCRIPTION
We want to prevent preview image from flashing just before the playback begins when autostart is true.
We still want to show preview image when on complete state, so we are only hiding if the state is idle with autostart true.
JW7-1904