### PR TITLE
Trigger mediaType event from provider to notify model of audio-only HLS streams

### DIFF
--- a/src/flash/com/longtailvideo/jwplayer/events/MediaEvent.as
+++ b/src/flash/com/longtailvideo/jwplayer/events/MediaEvent.as
@@ -31,12 +31,14 @@ public class MediaEvent extends PlayerEvent {
     // Total number of seconds in the currently loaded media
     public static const JWPLAYER_MEDIA_LEVELS:String = "levels";
     public static const JWPLAYER_MEDIA_LEVEL_CHANGED:String = "levelsChanged";
+    public static const JWPLAYER_MEDIA_TYPE:String = "mediaType";
 
     private var _currentQuality:Number;
     private var _bufferPercent:Number;
     private var _position:Number;
     private var _duration:Number;
     private var _volume:Number;
+    private var _mediaType:String;
 
     public var levels:Array = null;
     public var metadata:Object = null;
@@ -110,6 +112,14 @@ public class MediaEvent extends PlayerEvent {
         _volume = value;
     }
 
+    public function get mediaType():String {
+        return _mediaType;
+    }
+
+    public function set mediaType(value:String):void {
+        _mediaType = value;
+    }
+
     public override function clone():Event {
         // the class must be dynamic to make the properties enumerable
         return new MediaEvent(type, {
@@ -121,7 +131,8 @@ public class MediaEvent extends PlayerEvent {
             volume: _volume,
             mute: mute,
             levels: levels,
-            currentQuality: _currentQuality
+            currentQuality: _currentQuality,
+            mediaType: _mediaType
         });
     }
 
@@ -158,6 +169,9 @@ public class MediaEvent extends PlayerEvent {
                 break;
             case JWPLAYER_MEDIA_MUTE:
                 js.mute = mute;
+                break;
+            case JWPLAYER_MEDIA_TYPE:
+                js.mediaType = _mediaType;
                 break;
         }
 

--- a/src/js/providers/flash.js
+++ b/src/js/providers/flash.js
@@ -338,6 +338,10 @@ define([
                         this.trigger(events.JWPLAYER_MEDIA_ERROR, event);
                     }, this);
 
+                    _swf.on('adaptiveEventAudio', function() {
+                        this.trigger('mediaType', {mediaType: 'audio'});
+                    }, this);
+
                     if (flashThrottleTarget(_playerConfig)) {
                         _swf.on('throttle', function(e) {
                             clearTimeout(_flashBlockedTimeout);

--- a/src/js/providers/flash.js
+++ b/src/js/providers/flash.js
@@ -125,7 +125,10 @@ define([
                     _beforecompleted = false;
                     this.setState(states.LOADING);
                     _flashCommand('load', item);
-                    this.sendMediaType(item.sources);
+                    // HLS mediaType comes from the AdaptiveProvider
+                    if(item.sources.length && item.sources[0].type !== 'hls') {
+                        this.sendMediaType(item.sources);
+                    }
                 },
                 play: function() {
                     _flashCommand('play');
@@ -338,8 +341,8 @@ define([
                         this.trigger(events.JWPLAYER_MEDIA_ERROR, event);
                     }, this);
 
-                    _swf.on('adaptiveEventAudio', function() {
-                        this.trigger('mediaType', {mediaType: 'audio'});
+                    _swf.on('mediaType', function(e) {
+                        this.trigger('mediaType', {mediaType: e.mediaType});
                     }, this);
 
                     if (flashThrottleTarget(_playerConfig)) {

--- a/src/js/providers/flash.js
+++ b/src/js/providers/flash.js
@@ -247,7 +247,8 @@ define([
                         events.JWPLAYER_MEDIA_SEEKED,
                         'subtitlesTracks',
                         'subtitlesTrackChanged',
-                        'subtitlesTrackData'
+                        'subtitlesTrackData',
+                        'mediaType'
                     ];
 
                     var forwardEventsWithDataDuration = [
@@ -339,10 +340,6 @@ define([
                     _swf.on(events.JWPLAYER_ERROR, function(event) {
                         utils.log('Error playing media: %o %s', event.code, event.message, event);
                         this.trigger(events.JWPLAYER_MEDIA_ERROR, event);
-                    }, this);
-
-                    _swf.on('mediaType', function(e) {
-                        this.trigger('mediaType', {mediaType: e.mediaType});
                     }, this);
 
                     if (flashThrottleTarget(_playerConfig)) {

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -146,7 +146,8 @@ define([
             _audioTracks = null,
             _currentTextTrackIndex = -1,
             _currentAudioTrackIndex = -1,
-            _activeCuePosition = -1;
+            _activeCuePosition = -1,
+            _mediaType = 'video';
 
         // Find video tag, or create it if it doesn't exist.  View may not be built yet.
         var element = document.getElementById(_playerId);
@@ -168,9 +169,11 @@ define([
 
         // Enable tracks support for HLS videos
         function _onLoadedData() {
+            _setMediaType(_videotag.videoTracks);
             _setAudioTracks(_videotag.audioTracks);
             _setTextTracks(_videotag.textTracks);
         }
+
         function _clickHandler(evt) {
             _this.trigger('click', evt);
         }
@@ -450,6 +453,7 @@ define([
         function _setVideotagSource(item) {
             _textTracks = null;
             _audioTracks = null;
+            _mediaType = 'video';
             _currentAudioTrackIndex = -1;
             _currentTextTrackIndex = -1;
             _activeCuePosition = -1;
@@ -575,7 +579,10 @@ define([
             }
 
             _setLevels(item.sources);
-            this.sendMediaType(item.sources);
+
+            if(!item.sources.length || item.sources[0].type !== 'hls') {
+                this.sendMediaType(item.sources);
+            }
 
             if (!_isMobile) {
                 // don't change state on mobile because a touch event may be required to start playback
@@ -1064,6 +1071,8 @@ define([
 
         this.getSubtitlesTrack = _getSubtitlesTrack;
 
+        this.getMediaType = _getMediaType;
+
         function _setTextTracks(tracks) {
             _textTracks = null; 
             if(!tracks) {
@@ -1121,6 +1130,15 @@ define([
 
         function _getSubtitlesTrack() {
             return _currentTextTrackIndex;
+        }
+
+        function _setMediaType(videoTracks) {
+            _mediaType = videoTracks && videoTracks.length ? 'video' : 'audio';
+            _this.trigger('mediaType', {mediaType: _mediaType});
+        }
+
+        function _getMediaType() {
+            return _mediaType;
         }
     }
 

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -563,7 +563,10 @@ define([
 
             _levels = item.sources;
             _currentQuality = _pickInitialQuality(item.sources);
-            this.sendMediaType(item.sources);
+            // the loadeddata event determines the mediaType for HLS sources
+            if(item.sources.length && item.sources[0].type !== 'hls') {
+                this.sendMediaType(item.sources);
+            }
 
             _source = _levels[_currentQuality];
             _position = item.starttime || 0;

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -146,8 +146,7 @@ define([
             _audioTracks = null,
             _currentTextTrackIndex = -1,
             _currentAudioTrackIndex = -1,
-            _activeCuePosition = -1,
-            _mediaType = 'video';
+            _activeCuePosition = -1;
 
         // Find video tag, or create it if it doesn't exist.  View may not be built yet.
         var element = document.getElementById(_playerId);
@@ -453,7 +452,6 @@ define([
         function _setVideotagSource(item) {
             _textTracks = null;
             _audioTracks = null;
-            _mediaType = 'video';
             _currentAudioTrackIndex = -1;
             _currentTextTrackIndex = -1;
             _activeCuePosition = -1;
@@ -580,7 +578,7 @@ define([
 
             _setLevels(item.sources);
 
-            if(!item.sources.length || item.sources[0].type !== 'hls') {
+            if(item.sources.length && item.sources[0].type !== 'hls') {
                 this.sendMediaType(item.sources);
             }
 
@@ -1071,8 +1069,6 @@ define([
 
         this.getSubtitlesTrack = _getSubtitlesTrack;
 
-        this.getMediaType = _getMediaType;
-
         function _setTextTracks(tracks) {
             _textTracks = null; 
             if(!tracks) {
@@ -1133,12 +1129,8 @@ define([
         }
 
         function _setMediaType(videoTracks) {
-            _mediaType = videoTracks && videoTracks.length ? 'video' : 'audio';
-            _this.trigger('mediaType', {mediaType: _mediaType});
-        }
-
-        function _getMediaType() {
-            return _mediaType;
+            var mediaType = videoTracks && videoTracks.length ? 'video' : 'audio';
+            _this.trigger('mediaType', {mediaType: mediaType});
         }
     }
 


### PR DESCRIPTION
The `adaptiveEventAudio` event notifies the flash provider that an HLS stream is audio-only. For audio only streams, the preview image disappears briefly while buffering before playback begins.  

In the html5 provider, `_videotag.videoTracks.length` will be 0 when HLS streams are audio-only. The `mediaType` event notifies the model before the provider's `load` function is called, so it's no longer necessary to call `sendMediaType` on load for HLS streams.

JW7-1914