### PR TITLE
Fix flash reload same item not working

### DIFF
--- a/src/flash/com/longtailvideo/jwplayer/media/VideoMediaProvider.as
+++ b/src/flash/com/longtailvideo/jwplayer/media/VideoMediaProvider.as
@@ -103,6 +103,8 @@ public class VideoMediaProvider extends MediaProvider {
             loadQuality();
         } else if (itm.preload === "auto") {
             play();
+        } else {
+            loadQuality();
         }
 
         // need to call this every time we load, but after setupVideo has been called


### PR DESCRIPTION
In load function for videoMediaProvider, the function did not do anything if the item was the same and preload is not equal to auto.
This resulted the provider to be stuck on buffering when reloading the same item.
Adding an else statement to prevent the provider from being stuck.

JW7-1821