### PR TITLE
Check for source type before checking extension

### DIFF
--- a/src/js/playlist/source.js
+++ b/src/js/playlist/source.js
@@ -35,8 +35,10 @@ define([
         } else if (mimetypeRegEx.test(_source.type)) {
             // if type is given as a mimetype
             _source.type = _source.type.replace(mimetypeRegEx, '$1');
-        } else {
-            // get type from extension if type is not yet determined
+        }
+
+        // get type from extension if type is not yet determined
+        if (!_source.type) {
             var extension = strings.extension(_source.file);
             _source.type = extension;
         }

--- a/src/js/playlist/source.js
+++ b/src/js/playlist/source.js
@@ -35,12 +35,8 @@ define([
         } else if (mimetypeRegEx.test(_source.type)) {
             // if type is given as a mimetype
             _source.type = _source.type.replace(mimetypeRegEx, '$1');
-        }
-
-        // get type from extension if type is not yet determined
-        if (!_source.type) {
-            var extension = strings.extension(_source.file);
-            _source.type = extension;
+        } else if (!_source.type) {
+            _source.type = strings.extension(_source.file);
         }
 
         if (!_source.type) {


### PR DESCRIPTION
When determining the source type, checking for source type was missing,
making the source type to be overwritten by the extension.
JW7-1941