### PR TITLE
Decouple control bar on buffering state

### DIFF
--- a/src/css/flags/user-inactive.less
+++ b/src/css/flags/user-inactive.less
@@ -1,14 +1,22 @@
-.jw-flag-user-inactive.jw-state-playing {
-      .jw-controlbar,
-      .jw-dock {
-          display : none;
-      }
+.jw-flag-user-inactive {
+    &.jw-state-playing {
+        .jw-controlbar,
+        .jw-dock {
+            display: none;
+        }
 
-      .jw-logo.jw-hide {
-          display : none;
-      }
+        .jw-logo.jw-hide {
+            display: none;
+        }
 
-      .jw-plugin, .jw-captions{
-          bottom: 0.5em;
-      }
+        .jw-plugin, .jw-captions {
+            bottom: 0.5em;
+        }
+    }
+
+    &.jw-state-buffering {
+        .jw-controlbar {
+            display: none;
+        }
+    }
 }


### PR DESCRIPTION
On buffering state, we want to handle the icon separately from the control bar,
so that control bar is not shown when buffering.
JW7-1362