### PR TITLE
Fix mobile qoe set up time adding preroll time

### DIFF
--- a/src/js/controller/qoe.js
+++ b/src/js/controller/qoe.js
@@ -43,7 +43,7 @@ define([
             model._qoeItem.tick(events.JWPLAYER_MEDIA_PLAY_ATTEMPT);
         };
 
-        model.mediaController.once(events.JWPLAYER_MEDIA_PLAY_ATTEMPT, model._onPlayAttempt);
+        model.mediaController.on(events.JWPLAYER_MEDIA_PLAY_ATTEMPT, model._onPlayAttempt);
         model.mediaController.once(events.JWPLAYER_PROVIDER_FIRST_FRAME, model._triggerFirstFrame);
         model.mediaController.on(events.JWPLAYER_MEDIA_TIME, model._onTime);
     }


### PR DESCRIPTION
PlayAttempt happens before and after a preroll on mobile.
qoe had once event handler for playAttempt, resulting the second playAttempt event to be ignored.
Since set up time tracks time between playAttempt and firstFrame, we want to change the event handler to 'on'.
JW7-1011