### PR TITLE
Update the instream provider's state when an ad is skipped

### DIFF
--- a/src/js/controller/instream-html5.js
+++ b/src/js/controller/instream-html5.js
@@ -145,10 +145,6 @@ define([
                 provider.mute(_model.get('mute'));
 
                 _adModel.on('change:state', changeStateEvent, _this);
-            } else if(provider.state === 'playing') {
-                // state is still 'playing' after an ad is skipped. Need to update it here
-                // so the model gets the new play event when the next ad in an ad pod plays
-                provider.setState('loading');
             }
         }
 

--- a/src/js/controller/instream-html5.js
+++ b/src/js/controller/instream-html5.js
@@ -145,6 +145,10 @@ define([
                 provider.mute(_model.get('mute'));
 
                 _adModel.on('change:state', changeStateEvent, _this);
+            } else if(provider.state === 'playing') {
+                // state is still 'playing' after an ad is skipped. Need to update it here
+                // so the model gets the new play event when the next ad in an ad pod plays
+                provider.setState('loading');
             }
         }
 

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -305,7 +305,7 @@ define([
 
         function _playingHandler() {
             _this.setState(states.PLAYING);
-            if(!_videotag.attributes.__hasplayed) {
+            if(!_videotag.hasAttribute('__hasplayed')) {
                 _videotag.setAttribute('__hasplayed','');
             }
             _this.trigger(events.JWPLAYER_PROVIDER_FIRST_FRAME, {});
@@ -543,7 +543,6 @@ define([
                 _videotag.pause();
             }
             _currentQuality = -1;
-            _videotag.removeAttribute('__hasplayed');
             this.setState(states.IDLE);
         };
 
@@ -588,7 +587,7 @@ define([
             if(item.sources.length && item.sources[0].type !== 'hls') {
                 this.sendMediaType(item.sources);
             }
-            if (!_isMobile || _videotag.attributes.__hasplayed) {
+            if (!_isMobile || _videotag.hasAttribute('__hasplayed')) {
                 // don't change state on mobile before user initiates playback
                 _this.setState(states.LOADING);
             }

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -305,6 +305,9 @@ define([
 
         function _playingHandler() {
             _this.setState(states.PLAYING);
+            if(!_videotag.attributes.__hasplayed) {
+                _videotag.setAttribute('__hasplayed','');
+            }
             _this.trigger(events.JWPLAYER_PROVIDER_FIRST_FRAME, {});
         }
 
@@ -540,6 +543,7 @@ define([
                 _videotag.pause();
             }
             _currentQuality = -1;
+            _videotag.removeAttribute('__hasplayed');
             this.setState(states.IDLE);
         };
 
@@ -584,9 +588,8 @@ define([
             if(item.sources.length && item.sources[0].type !== 'hls') {
                 this.sendMediaType(item.sources);
             }
-
-            if (!_isMobile) {
-                // don't change state on mobile because a touch event may be required to start playback
+            if (!_isMobile || _videotag.attributes.__hasplayed) {
+                // don't change state on mobile before user initiates playback
                 _this.setState(states.LOADING);
             }
             _completeLoad(item.starttime || 0, item.duration || 0);

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -305,8 +305,8 @@ define([
 
         function _playingHandler() {
             _this.setState(states.PLAYING);
-            if(!_videotag.hasAttribute('__hasplayed')) {
-                _videotag.setAttribute('__hasplayed','');
+            if(!_videotag.hasAttribute('hasplayed')) {
+                _videotag.setAttribute('hasplayed','');
             }
             _this.trigger(events.JWPLAYER_PROVIDER_FIRST_FRAME, {});
         }
@@ -587,7 +587,7 @@ define([
             if(item.sources.length && item.sources[0].type !== 'hls') {
                 this.sendMediaType(item.sources);
             }
-            if (!_isMobile || _videotag.hasAttribute('__hasplayed')) {
+            if (!_isMobile || _videotag.hasAttribute('hasplayed')) {
                 // don't change state on mobile before user initiates playback
                 _this.setState(states.LOADING);
             }


### PR DESCRIPTION
The html5 provider's load function handles setting the player's state to `loading` before a video plays. This is gated to non-mobile devices because user interaction is sometimes needed to play a video on mobile.

In the case of an ad pod on a mobile device - where each ad needs to autoplay - a skip event leaves the provider in a `playing` state which never gets changed before the next ad starts playing. This results in the model being stuck in a `buffering` state until the provider's state is changed when a subsequent ad completes or we switch back to the playlist item's provider.

Setting the state to `loading` in the instream provider ensures the model gets updated.

JW7-1843