### PR TITLE
Hide controls when showing overlay

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jwplayer",
-  "version": "7.3.0-beta.1",
+  "version": "7.3.0-beta.2",
   "description": "The JW Player is free for non-commerical use. To buy a license for commercial use, please visit \r http://www.jwplayer.com/pricing/",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jwplayer",
-  "version": "7.3.0-beta.2",
+  "version": "7.3.0-beta.1",
   "description": "The JW Player is free for non-commerical use. To buy a license for commercial use, please visit \r http://www.jwplayer.com/pricing/",
   "repository": {
     "type": "git",

--- a/src/css/flags/overlay.less
+++ b/src/css/flags/overlay.less
@@ -5,4 +5,9 @@
     .jw-controls-right .jw-logo {
         display: none;
     }
+    &-sharing, &-related {
+        .jw-controls {
+            display: none
+        }
+    }
 }


### PR DESCRIPTION
Hide `controls` via CSS when `sharing` or `related` overlays are showing. This circumvents the need to override the `controls` config value. JW7-1510