### PR TITLE
Do not clear image on mediaType event

### DIFF
--- a/src/js/view/preview.js
+++ b/src/js/view/preview.js
@@ -24,12 +24,8 @@ define([
     }
 
     function onMediaType(mediaModel, mediaType) {
-        var audio = (mediaType === 'audio');
-        if (audio) {
+        if (mediaType === 'audio') {
             this.loadImage(this.model, this.model.get('playlistItem').image);
-        } else {
-            // clear image
-            this.loadImage(this.model, null);
         }
     }
 


### PR DESCRIPTION
On mediaType, we cleared image if mediaType is not audio.
This resulted video preview images to clear out.
We do not need to clear image on mediaType, because it happens after onPlaylistItem, where the image gets updated/cleared out.
JW7-1904