### PR TITLE
Hide controlbar for google IMA when inactive

### DIFF
--- a/src/css/flags/user-inactive.less
+++ b/src/css/flags/user-inactive.less
@@ -1,4 +1,4 @@
-.jw-flag-user-inactive {
+.jwplayer.jw-flag-user-inactive {
     &.jw-state-playing {
         .jw-controlbar,
         .jw-dock {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -519,6 +519,8 @@ define([
         }
 
         function _setupControls() {
+            var overlaysElement = _playerElement.getElementsByClassName('jw-overlays')[0];
+            overlaysElement.addEventListener('mousemove', _userActivity);
 
             _displayClickHandler = new ClickHandler(_model, _videoLayer);
             _displayClickHandler.on('click', function() {


### PR DESCRIPTION
Inactive flag had a lower specificity than google ima.
Bumping up specificity by adding .jwplayer for inactive flag.
Added mousemove event listener to overlays to show controlbar on user activity.
JW7-1952