### PR TITLE
Handle string logo margins

### DIFF
--- a/src/js/view/title.js
+++ b/src/js/view/title.js
@@ -44,7 +44,9 @@ define([
             var dockButtons = model.get('dock');
             var logo = model.get('logo');
             if (logo) {
-                var padding = model.get('logoWidth') + (isNaN(1*logo.margin) ? 0 : logo.margin);
+                // Only use Numeric or pixel ("Npx") margin values
+                var margin = 1*(''+logo.margin).replace('px', '');
+                var padding = model.get('logoWidth') + (isNaN(margin) ? 0 : margin);
                 if (logo.position ===  'top-left') {
                     titleStyle.paddingLeft = padding;
                 } else if (logo.position ===  'top-right') {


### PR DESCRIPTION
When the logo margin in config was a string, and not a CSS value ("10" for example), the value was being concatenated instead of added to the padding that pushes the title over.

This fix handles numbers and strings, and adds pixel margins to the padding.

JW7-1959