### PR TITLE
Modify check for trackIndex range so nth track is included

### DIFF
--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -362,7 +362,7 @@ define([
              * Tracks could have changed even if the index hasn't.
              * Need to ensure track has data for captionsrenderer.
              */
-            if(trackIndex && tracks && trackIndex < tracks.length && tracks[trackIndex-1].data) {
+            if(trackIndex && tracks && trackIndex <= tracks.length && tracks[trackIndex-1].data) {
                 this.set('captionsTrack', tracks[trackIndex-1]);
             }
 


### PR DESCRIPTION
For the nth track, `trackIndex === tracks.length` because Off's trackIndex is 0.
JW7-1960