### PR TITLE
Handle AJAX status errors

### DIFF
--- a/src/js/utils/ajax.js
+++ b/src/js/utils/ajax.js
@@ -132,11 +132,17 @@ define([
             var xhr = e.currentTarget || options.xhr;
             if (xhr.readyState === 4) {
                 clearTimeout(options.timeoutId);
+                if (xhr.status >= 400) {
+                    var message;
+                    if (xhr.status === 404) {
+                        message = 'File not found';
+                    } else {
+                        message = '' + xhr.status + '(' + xhr.statusText + ')';
+                    }
+                    return options.onerror(message, options.url, xhr);
+                }
                 if (xhr.status === 200) {
                     return _ajaxComplete(options)(e);
-                }
-                if (xhr.status === 404) {
-                    return options.onerror('File not found', options.url, xhr);
                 }
             }
         };


### PR DESCRIPTION
This change aborts and errors xhr requests on statuses of 400 or over. Handles 403 that could result in ad requests hanging.

JW7-1958