### PR TITLE
Fix youtube player control not showing on activity

### DIFF
--- a/src/js/view/clickhandler.js
+++ b/src/js/view/clickhandler.js
@@ -5,21 +5,24 @@ define([
     'utils/underscore'
 ], function(UI, events, Events, _) {
 
-    var ClickHandler = function(_model, _ele) {
+    var ClickHandler = function(_model, _ele, options) {
         var _display,
             _alternateClickHandler,
             _alternateDoubleClickHandler;
 
+        var _options = {enableDoubleTap: true, useMove: true};
         _.extend(this, Events);
 
         _display = _ele;
 
         this.element = function() { return _display; };
 
-        var userInteract = new UI(_display, {enableDoubleTap: true, useMove: true});
+        var userInteract = new UI(_display, _.extend(_options, options));
         userInteract.on('click tap', _clickHandler);
         userInteract.on('doubleClick doubleTap', _doubleClickHandler);
         userInteract.on('move', function(){ _this.trigger('move'); });
+        userInteract.on('over', function(){ _this.trigger('over'); });
+        userInteract.on('out', function(){ _this.trigger('out'); });
 
         this.clickHandler = _clickHandler;
 

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -522,7 +522,7 @@ define([
             var overlaysElement = _playerElement.getElementsByClassName('jw-overlays')[0];
             overlaysElement.addEventListener('mousemove', _userActivity);
 
-            _displayClickHandler = new ClickHandler(_model, _videoLayer);
+            _displayClickHandler = new ClickHandler(_model, _videoLayer, {useHover: true});
             _displayClickHandler.on('click', function() {
                 forward({type : events.JWPLAYER_DISPLAY_CLICK});
                 if(_model.get('controls')) {
@@ -535,6 +535,8 @@ define([
             });
             _displayClickHandler.on('doubleClick', _doubleClickFullscreen);
             _displayClickHandler.on('move', _userActivity);
+            _displayClickHandler.on('over', _userActivity);
+            _displayClickHandler.on('out', _userActivity);
             
             var displayIcon = new DisplayIcon(_model);
             //toggle playback


### PR DESCRIPTION
Youtube player does not receive mousemove event, because the child element is stealing the event.
We cannot make mousemove work, but we can add mouse over/out event so that control shows up when mouse moves in/out of the player.
JW7-924