### PR TITLE
Do not hide control bar when playing audio

### DIFF
--- a/src/css/flags/media-audio.less
+++ b/src/css/flags/media-audio.less
@@ -1,7 +1,12 @@
-// This has higher specificity to overwrite jw-flag-user-inactive
 .jwplayer.jw-flag-media-audio {
     .jw-controlbar {
         display: table;
+    }
+    // This has higher specificity to overwrite jw-flag-user-inactive in pause state
+    &.jw-flag-user-inactive {
+        .jw-controlbar {
+            display: table;
+        }
     }
 }
 .jw-flag-media-audio {


### PR DESCRIPTION
After we bumped up inactive specificity for google ima control bar,
it had higher specificity than the audio flag.
Adding specific inactive flag to audio to not hide the control bar.
JW7-1969