### PR TITLE
When testing provider priority, use relative comparisons

### DIFF
--- a/test/unit/provider-test.js
+++ b/test/unit/provider-test.js
@@ -73,6 +73,15 @@ define([
         };
     }
 
+    function getKeyIndexes(arr) {
+        var o = {};
+        for (var i= 0; i < arr.length; i++) {
+            var name = getName(arr[i]);
+            o[name] = i;
+        }
+        return o;
+    }
+
     module('provider primary priority');
 
     test('no primary defined', function (assert) {
@@ -80,18 +89,21 @@ define([
         assert.expect(4);
 
 		assert.ok(providerList.length >= 3, 'There are at least 3 providers listed');
-		assert.equal(getName(providerList[1]), 'html5', 'HTML5 is the number 1 provider');
-		assert.equal(getName(providerList[2]), 'flash', 'Flash is the number 2 provider');
-		assert.equal(getName(providerList[0]), 'youtube', 'YouTube is the number 3 provider');
+
+        var keys = getKeyIndexes(providerList);
+		assert.ok(keys.html5 < keys.flash, 'HTML5 has higher priority than flash');
+        assert.ok(keys.html5 > keys.youtube, 'HTML5 has lower priority than youtube');
+        assert.ok(keys.flash > keys.youtube, 'Flash has lower priority than youtube');
     });
 
     test('html5 primary requested', function (assert) {
 		var providerList = new Providers({primary: 'html5'}).providers;
         assert.expect(3);
 
-        assert.equal(getName(providerList[1]), 'html5', 'HTML5 is the number 1 provider');
-        assert.equal(getName(providerList[2]), 'flash', 'Flash is the number 2 provider');
-        assert.equal(getName(providerList[0]), 'youtube', 'YouTube is the number 3 provider');
+        var keys = getKeyIndexes(providerList);
+        assert.ok(keys.html5 < keys.flash, 'HTML5 has higher priority than flash');
+        assert.ok(keys.html5 > keys.youtube, 'HTML5 has lower priority than youtube');
+        assert.ok(keys.flash > keys.youtube, 'Flash has lower priority than youtube');
     });
 
 
@@ -99,18 +111,20 @@ define([
 		var providerList = new Providers({primary: 'flash'}).providers;
         assert.expect(3);
 
-        assert.equal(getName(providerList[1]), 'flash', 'Flash is the number 1 provider');
-        assert.equal(getName(providerList[2]), 'html5', 'HTML5 is the number 2 provider');
-        assert.equal(getName(providerList[0]), 'youtube', 'YouTube is the number 3 provider');
+        var keys = getKeyIndexes(providerList);
+        assert.ok(keys.html5 > keys.flash, 'HTML5 has lower priority than flash');
+        assert.ok(keys.html5 > keys.youtube, 'HTML5 has lower priority than youtube');
+        assert.ok(keys.flash > keys.youtube, 'Flash has lower priority than youtube');
     });
 
 	test('invalid primary requested', function (assert) {
 		var providerList = new Providers({primary:'invalid primary value'}).providers;
         assert.expect(3);
 
-        assert.equal(getName(providerList[1]), 'html5', 'HTML5 is the number 1 provider');
-        assert.equal(getName(providerList[2]), 'flash', 'Flash is the number 2 provider');
-        assert.equal(getName(providerList[0]), 'youtube', 'YouTube is the number 3 provider');
+        var keys = getKeyIndexes(providerList);
+        assert.ok(keys.html5 < keys.flash, 'HTML5 has higher priority than flash');
+        assert.ok(keys.html5 > keys.youtube, 'HTML5 has lower priority than youtube');
+        assert.ok(keys.flash > keys.youtube, 'Flash has lower priority than youtube');
 	});
 
 	module('provider.choose tests');


### PR DESCRIPTION
The previous tests were checking that the exact index of the provider in the list
of providers was the expected value. This doesn't scale well when adding
new providers, so instead we will ensure that they are in the correct ordering
relative to eachother.