### PR TITLE
Fix control bar hiding issues for audio playback

### DIFF
--- a/src/css/flags/ads.less
+++ b/src/css/flags/ads.less
@@ -40,6 +40,12 @@
 }
 
 .jwplayer.jw-flag-ads-googleima {
+    &.jw-flag-user-inactive.jw-state-playing {
+        .jw-controlbar {
+            display: none;
+        }
+    }
+
     .jw-controlbar {
         display: table;
         bottom: 0;

--- a/src/css/flags/user-inactive.less
+++ b/src/css/flags/user-inactive.less
@@ -1,4 +1,4 @@
-.jwplayer.jw-flag-user-inactive {
+.jw-flag-user-inactive {
     &.jw-state-playing {
         .jw-controlbar,
         .jw-dock {


### PR DESCRIPTION
This happened after we bumped up inactive flag's specificity to fix googleIMA controlbar not disappearing issue.
Bumping the inactive flag's specificity down again, and making a css specific to googleIMA controlbar.
JW7-1969