### PR TITLE
Improve mediaType detection for HLS

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -1134,11 +1134,10 @@ define([
         }
 
         function _setMediaType(videoTracks, audioTracks) {
-            // set mediaType only for HLS in Safari since the model is notified
-            // of the mediaType earlier for other formats.
-            if(videoTracks && _levels[0].type === 'hls') {
-                // track count in iOS 8.4 is always 0, so this ensures we
-                // default to video if length === 0 for both audio & video
+            // Only send mediaType when:
+            // - format is HLS, since other types are handled earlier by default.js
+            // - # of audio or video tracks > 0 to avoid false positive in iOS 8.4
+            if(_levels[0].type === 'hls' && videoTracks && audioTracks && (videoTracks.length || audioTracks.length)) {
                 var mediaType = audioTracks.length && !videoTracks.length ? 'audio' : 'video';
                 _this.trigger('mediaType', {mediaType: mediaType});
             }

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -1134,11 +1134,14 @@ define([
         }
 
         function _setMediaType(videoTracks, audioTracks) {
-            // Only send mediaType when:
-            // - format is HLS, since other types are handled earlier by default.js
-            // - # of audio or video tracks > 0 to avoid false positive in iOS 8.4
-            if(_levels[0].type === 'hls' && videoTracks && audioTracks && (videoTracks.length || audioTracks.length)) {
-                var mediaType = audioTracks.length && !videoTracks.length ? 'audio' : 'video';
+            // Send mediaType when format is HLS. Other types are handled earlier by default.js.
+            if(_levels[0].type === 'hls' && videoTracks && audioTracks) {
+                var mediaType = 'video';
+                // In iOS 8.4, videoTracks and audioTracks length = 0.
+                // Only set mediaType to audio when we have audioTracks but no videoTracks
+                if(!videoTracks.length && audioTracks.length) {
+                    mediaType = 'audio';
+                }
                 _this.trigger('mediaType', {mediaType: mediaType});
             }
         }

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -168,7 +168,7 @@ define([
 
         // Enable tracks support for HLS videos
         function _onLoadedData() {
-            _setMediaType(_videotag.videoTracks);
+            _setMediaType(_videotag.videoTracks, _videotag.audioTracks);
             _setAudioTracks(_videotag.audioTracks);
             _setTextTracks(_videotag.textTracks);
         }
@@ -1133,11 +1133,13 @@ define([
             return _currentTextTrackIndex;
         }
 
-        function _setMediaType(videoTracks) {
+        function _setMediaType(videoTracks, audioTracks) {
             // set mediaType only for HLS in Safari since the model is notified
             // of the mediaType earlier for other formats.
             if(videoTracks && _levels[0].type === 'hls') {
-                var mediaType = videoTracks.length ? 'video' : 'audio';
+                // track count in iOS 8.4 is always 0, so this ensures we
+                // default to video if length === 0 for both audio & video
+                var mediaType = audioTracks.length && !videoTracks.length ? 'audio' : 'video';
                 _this.trigger('mediaType', {mediaType: mediaType});
             }
         }


### PR DESCRIPTION
In iOS 8.4, the lengths of `videoTracks` and `audioTracks` are 0 when `loadeddata` fires. This ensures that we only set `mediaType` to 'audio' when we have `audioTracks` and no `videoTracks` and default to 'video' otherwise. JW7-1989