### PR TITLE
Remove CDN from open jwplayer builds

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -28,6 +28,8 @@
       "define",
       "module",
       "__DEBUG__",
+      "__REPO__",
+      "__SELF_HOSTED__",
       "__BUILD_VERSION__",
       "__FLASH_VERSION__"
     ]

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -224,6 +224,8 @@ module.exports = function(grunt) {
                     },
                     plugins: [
                         new webpack.DefinePlugin({
+                            __SELF_HOSTED__ : true,
+                            __REPO__ : '\'\'',
                             __DEBUG__ : true,
                             __BUILD_VERSION__: '\'' + buildVersion + '\'',
                             __FLASH_VERSION__: flashVersion
@@ -243,6 +245,8 @@ module.exports = function(grunt) {
                     },
                     plugins: [
                         new webpack.DefinePlugin({
+                            __SELF_HOSTED__ : true,
+                            __REPO__ : '\'\'',
                             __DEBUG__ : false,
                             __BUILD_VERSION__: '\'' + buildVersion + '\'',
                             __FLASH_VERSION__: flashVersion

--- a/src/js/utils/constants.js
+++ b/src/js/utils/constants.js
@@ -1,6 +1,6 @@
 define([], function() {
     return {
-        repo : 'http://ssl.p.jwpcdn.com/player/v/',
+        repo : __REPO__,
         SkinsIncluded : ['seven'],
         SkinsLoadable : ['beelden', 'bekle', 'five', 'glow', 'roundster', 'six', 'stormtrooper', 'vapor'],
         dvrSeekLimit : -25

--- a/src/js/utils/playerutils.js
+++ b/src/js/utils/playerutils.js
@@ -9,6 +9,10 @@ define([
 
     /** Gets the repository location **/
     playerUtils.repo = _.memoize(function () {
+        if (__SELF_HOSTED__) {
+            return  parser.getScriptPath('jwplayer.js');
+        }
+
         var semver = version.split('+')[0];
         var repo = Constants.repo + semver + '/';
         if (validator.isHTTPS()) {
@@ -35,7 +39,10 @@ define([
 
 
     playerUtils.loadFrom = function () {
-        return (__DEBUG__ ? parser.getScriptPath('jwplayer.js') : playerUtils.repo());
+        if (__DEBUG__ || __SELF_HOSTED__) {
+            return parser.getScriptPath('jwplayer.js');
+        }
+        return playerUtils.repo();
     };
 
     return playerUtils;

--- a/test/config.js
+++ b/test/config.js
@@ -3,6 +3,8 @@
     // This allows us to test modules without loading full player
     window.__BUILD_VERSION__ = '7.3.0';
     window.__FLASH_VERSION__ = 11.2;
+    window.__REPO__ = '';
+    window.__SELF_HOSTED__ = true;
     window.__DEBUG__ = false;
 
     var base = '';
@@ -16,6 +18,11 @@
     }
     if (!('Promise' in window)) {
         deps.push('polyfills/promise');
+    }
+    if (!('console' in window) || !('log' in window.console) ) {
+        window.console = {
+            log: function() {}
+        };
     }
 
     var callback;

--- a/test/unit/api-config-test.js
+++ b/test/unit/api-config-test.js
@@ -126,23 +126,29 @@ define([
     });
 
     test('updates base to cdn or script location', function(assert) {
-        var CDN_URL = 'http://ssl.p.jwpcdn.com/player/v/'+ window.__BUILD_VERSION__ +'/';
-        var CUSTOM_BASE = 'http://ssl.p.jwpcdn.com/player/v/7.0.1-beta.1/';
+        var CUSTOM_BASE = 'http://mywebsite.com/jwplayer/';
+        var apiConfig;
 
-        var x = testConfig(assert, {});
-        assert.equal(x.base, CDN_URL,
-            'Config sets base to the CDN url when no base is specified');
 
-        x = testConfig(assert, {
+        apiConfig = testConfig(assert, {});
+        if (window.__SELF_HOSTED__) {
+            assert.ok(/.+\//.test(apiConfig.base),
+                'Config sets base to the jwplayer script location in self-hosted builds');
+        } else {
+            assert.ok(/.+\//.test(apiConfig.base),
+                'Config sets base to the repo');
+        }
+
+        apiConfig = testConfig(assert, {
             base: '.'
         });
-        assert.ok(/.+\//.test(x.base) && x.base !== CDN_URL,
-            'Config replaces a base of "." with the jwplayer script location (not the CDN path)');
+        assert.ok(/.+\//.test(apiConfig.base),
+            'Config replaces a base of "." with the jwplayer script location');
 
-        x = testConfig(assert, {
+        apiConfig = testConfig(assert, {
             base: CUSTOM_BASE
         });
-        assert.equal(x.base, CUSTOM_BASE,
+        assert.equal(apiConfig.base, CUSTOM_BASE,
             'Config does not replace base when a custom value other than "." is specified');
     });
 

--- a/test/unit/constants-test.js
+++ b/test/unit/constants-test.js
@@ -6,14 +6,16 @@ define([
     module('constants');
 
     test('constants', function(assert) {
-        assert.equal(typeof constants.repo, 'string');
+        assert.equal(typeof constants.repo, 'string', 'constants.repo is a string');
 
         for (var i = 0; i < constants.SkinsIncluded.length; i++) {
-            assert.equal(typeof constants.SkinsIncluded[i], 'string');
+            var skinIncluded = constants.SkinsIncluded[i];
+            assert.equal(typeof skinIncluded, 'string', 'Player configured to include "'+ skinIncluded +'" skin');
         }
 
         for (var j = 0; j < constants.SkinsLoadable.length; j++) {
-            assert.equal(typeof constants.SkinsLoadable[j], 'string');
+            var loadsSkin = constants.SkinsLoadable[j];
+            assert.equal(typeof loadsSkin, 'string', 'Player configured to load "'+ loadsSkin +'" skin');
         }
 
     });


### PR DESCRIPTION
Make builds of this repo self-hosted. The source no longer includes the path to our cdn which hosts commercial builds. `__REPO__` and `__SELF_HOSTED__` compile time constants have been added.