### PR TITLE
HTML5 provider dispatches "visualQuality" event

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -146,7 +146,8 @@ define([
             _audioTracks = null,
             _currentTextTrackIndex = -1,
             _currentAudioTrackIndex = -1,
-            _activeCuePosition = -1;
+            _activeCuePosition = -1,
+            _visualQuality = {};
 
         // Find video tag, or create it if it doesn't exist.  View may not be built yet.
         var element = document.getElementById(_playerId);
@@ -220,6 +221,24 @@ define([
                     position: _position,
                     duration: _duration
                 });
+
+                _checkVisualQuality();
+            }
+        }
+
+        function _checkVisualQuality() {
+            if (_visualQuality.width !== _videotag.videoWidth || _visualQuality.height !== _videotag.videoHeight) {
+                _visualQuality.width = _videotag.videoWidth;
+                _visualQuality.height = _videotag.videoHeight;
+                if (!_visualQuality.width || !_visualQuality.height) {
+                    return;
+                }
+                var visualQuality = {
+                    level: _.extend({}, _visualQuality),
+                    reason: '',
+                    mode: 'auto'
+                };
+                _this.trigger('visualQuality', visualQuality);
             }
         }
 
@@ -458,6 +477,13 @@ define([
             _currentAudioTrackIndex = -1;
             _currentTextTrackIndex = -1;
             _activeCuePosition = -1;
+            _visualQuality = {
+                index: 0,
+                label: '',
+                width: 0,
+                height: 0,
+                bitrate: 0
+            };
             _canSeek = false;
             _bufferFull = false;
             _isAndroidHLS = _useAndroidHLS(_source);


### PR DESCRIPTION
The html5 provider now checks when video size changes while playing after each time event. If the width or height changes and neither is 0, then a "visualQuality" event is dispatched with the new dimensions. `index` and `bitrate` are always 0, and `label` is always an empty string, because their values cannot be determined.

By listening to "visualQuality" events one can track the native size of the current video, as well as when quality changes occur in adaptive playback of HLS streams in iOS and Safari. This also populates the value returned by `jwplayer().getVisualQuality()` any time video is being played with the HTML5 provider.

JW7-1977