### PR TITLE
Support HLS ID3 metadata in Edge

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -775,6 +775,37 @@ define([
                 TAL: 'album'
             };
             var id3Data = _.reduce(activeCues, function(data, cue) {
+                if (!('value' in cue)) {
+                    // Cue is not in Safari's key/data format
+                    if ('data' in cue && cue.data instanceof ArrayBuffer) {
+                        // EdgeHTML 13.10586 cue point format - contains raw data in an ArrayBuffer.
+                        
+                        var oldCue = cue;
+                        var array = new Uint8Array(oldCue.data);
+                        
+                        cue = { value: { key: '', data: '' } };
+                        
+                        var i = 10;
+                        while (i < 14 && i < array.length) {
+                            if (array[i] === 0) {
+                                break;
+                            }
+                            cue.value.key += String.fromCharCode(array[i]);
+                            i++;
+                        }
+                        
+                        i = 20;
+                        while (i < array.length) {
+                            if (array[i] === 0) {
+                                break;
+                            }
+                            if (array[i] >= 32) {
+                                cue.value.data += String.fromCharCode(array[i]);
+                            }
+                            i++;
+                        }
+                    }
+                }
                 // These friendly names mapping provides compatibility with our Flash implementation prior to 7.3
                 if(friendlyNames.hasOwnProperty(cue.value.key)) {
                     data[friendlyNames[cue.value.key]] = cue.value.data;

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -795,7 +795,7 @@ define([
             };
             var utf8ArrayToStr = function (array, startingIndex) {
                 // Based on code by Masanao Izumo <iz@onicos.co.jp>
-				// posted at http://www.onicos.com/staff/iz/amuse/javascript/expert/utf.txt
+                // posted at http://www.onicos.com/staff/iz/amuse/javascript/expert/utf.txt
                 
                 var out, i, len, c;
                 var char2, char3;


### PR DESCRIPTION
Since at least EdgeHTML 13.10586, Edge reads ID3 metadata from HLS streams, but the format exposed to JavaScript is different from that which Safari uses. This commit adds code to detect Edge's format and convert it to match Safari's before doing further processing.

The "if (array[i] >= 32)" statement is there because the data field of my cue points always starts with a 0x03 character. I think this signals a UTF-8 encoding for the text stream. I can't currently generate metadata in other encodings so I can't test this at the moment.

Edge will also sometimes expose more than one active cue point to JavaScript. This commit does not address that, so if two cue points are active with the same data field, JW Player may not use the more recent of the two.