### PR TITLE
Use metadata source for determining embedded 608 captions position

### DIFF
--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -90,14 +90,31 @@ define([
                     var captionsMenu = _captionsMenu();
                     this.setCaptionsList(captionsMenu);
                 }
-                var time = e.position || _model.get('position');
-                var cueId = '' + Math.round(time * 10) + '_' + metadata.text;
+
+                var time, cueId;
+
+                if (metadata.useDTS) {
+                    // There may not be any 608 captions when the track is first created
+                    // Need to set the source so position is determined from metadata
+                    if(!track.source) {
+                        track.source = metadata.source || 'mpegts';
+                    }
+                    time = metadata.begin;
+                    cueId = metadata.begin + '_' + metadata.text;
+                } else {
+                    time = e.position || _model.get('position');
+                    cueId = '' + Math.round(time * 10) + '_' + metadata.text;
+                }
+
                 var cue = _metaCuesByTextTime[cueId];
                 if (!cue) {
                     cue = {
                         begin: time,
                         text: metadata.text
                     };
+                    if(metadata.end) {
+                        cue.end = metadata.end;
+                    }
                     _metaCuesByTextTime[cueId] = cue;
                     track.data.push(cue);
                 }


### PR DESCRIPTION
This addresses captions rendering issues caused by the model's static position for Live DVR streams. 
`metadata[source]` will be used to determine the alignment position for Live DVR streams with a negative duration. 
JW7-1984