### PR TITLE
Increase audioplayer specifity for controlbar

### DIFF
--- a/src/css/flags/audioplayer.less
+++ b/src/css/flags/audioplayer.less
@@ -1,4 +1,4 @@
-.jw-flag-audio-player {
+.jwplayer.jw-flag-audio-player {
     background-color: transparent;
 
     .jw-media {
@@ -11,25 +11,23 @@
         }
     }
 
-    &.jw-state-paused,
-    &.jw-state-complete {
-        .jw-display-icon-container{
-            display: none;
-        }
+
+    .jw-preview, // overrides 'block' from .jw-state-idle
+    .jw-display-icon-container { // overrides 'block' from .jw-flag-touch.jw-state-paused
+        display: none;
     }
 
     .jw-controlbar {
-        display: table;  // This overwrites 'none' from jw-states-idle
+        display: table;  // This overrides 'none' from jw-state-idle
+        height: auto;
+        left: 0;
         bottom: 0;
         margin: 0;
         width: 100%;
         min-width: 100%;
         opacity: 1;
 
-        .jw-icon-fullscreen {
-            display: none;
-        }
-
+        .jw-icon-fullscreen,
         .jw-icon-tooltip {
             display: none;
         }
@@ -42,28 +40,9 @@
             display : none;
         }
     }
-}
-// This has higher specificity to overwrite jw-flag-user-inactive
-.jwplayer.jw-flag-audio-player {
-    .jw-controlbar {
-        display: table;
-        left: 0;
-    }
     &.jw-flag-user-inactive {
         .jw-controlbar {
-            display: table;
+            display: table; // overrides 'none' from jw-flag-user-inactive
         }
     }
-}
-// This has higher specificity to overwrite skins setting height
-.jwplayer.jw-flag-audio-player .jw-controlbar {
-    height: auto;
-}
-// This has higher specificity to overwrite jw-state-idle
-.jwplayer.jw-flag-audio-player .jw-preview {
-    display: none;
-}
-// This has higher specificity to overwrite .jw-flag-touch.jw-state-paused
-.jwplayer.jw-flag-audio-player .jw-display-icon-container {
-    display: none;
 }

--- a/src/css/flags/audioplayer.less
+++ b/src/css/flags/audioplayer.less
@@ -44,9 +44,16 @@
     }
 }
 // This has higher specificity to overwrite jw-flag-user-inactive
-.jwplayer.jw-flag-audio-player .jw-controlbar {
-    display: table;
-    left: 0;
+.jwplayer.jw-flag-audio-player {
+    .jw-controlbar {
+        display: table;
+        left: 0;
+    }
+    &.jw-flag-user-inactive {
+        .jw-controlbar {
+            display: table;
+        }
+    }
 }
 // This has higher specificity to overwrite skins setting height
 .jwplayer.jw-flag-audio-player .jw-controlbar {


### PR DESCRIPTION
Increase specificity of `jw-flag-audio-player`, giving it parity with `jw-flag-media-audio`. "controlbar only" mode now has the same specificity as "audio only". This addresses the regression caused by bumping up the specificity of `jw-flag-user-inactive` to hide the controlbar for Google IMA. 

Removed:
```
   &.jw-state-paused,
   &.jw-state-complete {
       .jw-display-icon-container{
           display: none;
       }
   }
```

This is now addressed by:

```
    .jw-display-icon-container { // overrides 'block' from .jw-flag-touch.jw-state-paused
        display: none;
    }
```

The above is specific enough to ensure the display icon container is hidden at all times when just the control bar should be displayed.

JW7-2019