### PR TITLE
Only listen for changes to captions/subtitles tracks

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -756,7 +756,8 @@ define([
             var _selectedTextTrackIndex = -1, i = 0;
             _activeCuePosition = -1;
             for (i; i < _videotag.textTracks.length; i++) {
-                if (_videotag.textTracks[i].mode === 'showing') {
+                if ((_videotag.textTracks[i].kind === 'subtitles' || _videotag.textTracks[i].kind === 'captions')
+                    && _videotag.textTracks[i].mode === 'showing') {
                     _selectedTextTrack = _videotag.textTracks[i];
                     break;
                 }

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -752,19 +752,11 @@ define([
         }
 
         function _textTrackChangeHandler() {
-            var _selectedTextTrack = null;
             var _selectedTextTrackIndex = -1, i = 0;
-            _activeCuePosition = -1;
-            for (i; i < _videotag.textTracks.length; i++) {
-                if ((_videotag.textTracks[i].kind === 'subtitles' || _videotag.textTracks[i].kind === 'captions')
-                    && _videotag.textTracks[i].mode === 'showing') {
-                    _selectedTextTrack = _videotag.textTracks[i];
-                    break;
-                }
-            }
-            if(_selectedTextTrack && _textTracks) {
-                for (i = 0; i < _textTracks.length; i++) {
-                    if (_textTracks[i].label === _selectedTextTrack.label) {
+            // if a caption/subtitle track is showing, find its index
+            if(_textTracks) {
+                for (i; i < _textTracks.length; i++) {
+                    if (_textTracks[i].mode === 'showing') {
                         _selectedTextTrackIndex = i;
                         break;
                     }


### PR DESCRIPTION
Monitor changes to `subtitles` or `captions` textTracks. `metadata` textTracks are unaffected by user/api changes to the CC menu. There's also no need to reset the `_activeCuePosition` in `_textTrackChangeHandler ` since it pertains to `metadata` tracks only. 

JW7-2023