### PR TITLE
Improvements to visual quality detection

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -227,18 +227,19 @@ define([
         }
 
         function _checkVisualQuality() {
-            if (_visualQuality.level.width !== _videotag.videoWidth ||
-                _visualQuality.level.height !== _videotag.videoHeight) {
-                _visualQuality.level.width = _videotag.videoWidth;
-                _visualQuality.level.height = _videotag.videoHeight;
-                if (!_visualQuality.level.width || !_visualQuality.level.height) {
+            var level = _visualQuality.level;
+            if (level.width !== _videotag.videoWidth ||
+                level.height !== _videotag.videoHeight) {
+                level.width = _videotag.videoWidth;
+                level.height = _videotag.videoHeight;
+                if (!level.width || !level.height) {
                     return;
                 }
                 _visualQuality.reason = _visualQuality.reason || 'auto';
                 _visualQuality.mode = _levels[_currentQuality].type === 'hls' ? 'auto' : 'manual';
                 _visualQuality.bitrate = 0;
-                _visualQuality.level.index = _currentQuality;
-                _visualQuality.level.label = _levels[_currentQuality].label;
+                level.index = _currentQuality;
+                level.label = _levels[_currentQuality].label;
                 _this.trigger('visualQuality', _visualQuality);
             }
         }
@@ -606,6 +607,7 @@ define([
             _source = _levels[_currentQuality];
             _position = item.starttime || 0;
             _duration = item.duration || 0;
+            _visualQuality.reason = '';
             _setVideotagSource(item);
         };
 

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -233,11 +233,16 @@ define([
                 if (!_visualQuality.width || !_visualQuality.height) {
                     return;
                 }
+                var reason = _visualQuality.reason || 'auto';
+                delete _visualQuality.reason;
                 var visualQuality = {
                     level: _.extend({}, _visualQuality),
-                    reason: '',
-                    mode: 'auto'
+                    reason: reason,
+                    mode: _levels[_currentQuality].type === 'hls' ? 'auto' : 'manual',
+                    bitrate: 0
                 };
+                visualQuality.level.index = _currentQuality;
+                visualQuality.level.label = _levels[_currentQuality].label;
                 _this.trigger('visualQuality', visualQuality);
             }
         }
@@ -416,6 +421,9 @@ define([
                     }
                 }
             }
+            _visualQuality = {
+                reason: 'initial choice'
+            };
             return currentQuality;
         }
 
@@ -477,13 +485,11 @@ define([
             _currentAudioTrackIndex = -1;
             _currentTextTrackIndex = -1;
             _activeCuePosition = -1;
-            _visualQuality = {
-                index: 0,
-                label: '',
-                width: 0,
-                height: 0,
-                bitrate: 0
-            };
+            if(!_visualQuality.reason) {
+                _visualQuality = {
+                    reason: 'initial choice'
+                };
+            }
             _canSeek = false;
             _bufferFull = false;
             _isAndroidHLS = _useAndroidHLS(_source);
@@ -1002,6 +1008,9 @@ define([
             if (quality >= 0) {
                 if (_levels && _levels.length > quality) {
                     _currentQuality = quality;
+                    _visualQuality = {
+                        reason:  'manual'
+                    };
                     this.trigger(events.JWPLAYER_MEDIA_LEVEL_CHANGED, {
                         currentQuality: quality,
                         levels: _getPublicLevels(_levels)

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -227,23 +227,19 @@ define([
         }
 
         function _checkVisualQuality() {
-            if (_visualQuality.width !== _videotag.videoWidth || _visualQuality.height !== _videotag.videoHeight) {
-                _visualQuality.width = _videotag.videoWidth;
-                _visualQuality.height = _videotag.videoHeight;
-                if (!_visualQuality.width || !_visualQuality.height) {
+            if (_visualQuality.level.width !== _videotag.videoWidth ||
+                _visualQuality.level.height !== _videotag.videoHeight) {
+                _visualQuality.level.width = _videotag.videoWidth;
+                _visualQuality.level.height = _videotag.videoHeight;
+                if (!_visualQuality.level.width || !_visualQuality.level.height) {
                     return;
                 }
-                var reason = _visualQuality.reason || 'auto';
-                delete _visualQuality.reason;
-                var visualQuality = {
-                    level: _.extend({}, _visualQuality),
-                    reason: reason,
-                    mode: _levels[_currentQuality].type === 'hls' ? 'auto' : 'manual',
-                    bitrate: 0
-                };
-                visualQuality.level.index = _currentQuality;
-                visualQuality.level.label = _levels[_currentQuality].label;
-                _this.trigger('visualQuality', visualQuality);
+                _visualQuality.reason = _visualQuality.reason || 'auto';
+                _visualQuality.mode = _levels[_currentQuality].type === 'hls' ? 'auto' : 'manual';
+                _visualQuality.bitrate = 0;
+                _visualQuality.level.index = _currentQuality;
+                _visualQuality.level.label = _levels[_currentQuality].label;
+                _this.trigger('visualQuality', _visualQuality);
             }
         }
 
@@ -421,8 +417,10 @@ define([
                     }
                 }
             }
-            _visualQuality = {
-                reason: 'initial choice'
+            _visualQuality.reason = 'initial choice';
+            _visualQuality.level = {
+                width: 0,
+                height: 0
             };
             return currentQuality;
         }
@@ -486,8 +484,10 @@ define([
             _currentTextTrackIndex = -1;
             _activeCuePosition = -1;
             if(!_visualQuality.reason) {
-                _visualQuality = {
-                    reason: 'initial choice'
+                _visualQuality.reason = 'initial choice';
+                _visualQuality.level = {
+                    width: 0,
+                    height: 0
                 };
             }
             _canSeek = false;
@@ -1008,8 +1008,10 @@ define([
             if (quality >= 0) {
                 if (_levels && _levels.length > quality) {
                     _currentQuality = quality;
-                    _visualQuality = {
-                        reason:  'manual'
+                    _visualQuality.reason = 'manual';
+                    _visualQuality.level = {
+                        width: 0,
+                        height: 0
                     };
                     this.trigger(events.JWPLAYER_MEDIA_LEVEL_CHANGED, {
                         currentQuality: quality,

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -147,7 +147,7 @@ define([
             _currentTextTrackIndex = -1,
             _currentAudioTrackIndex = -1,
             _activeCuePosition = -1,
-            _visualQuality = {};
+            _visualQuality = { level: {} };
 
         // Find video tag, or create it if it doesn't exist.  View may not be built yet.
         var element = document.getElementById(_playerId);


### PR DESCRIPTION
`visualQuality.reason` is set to `'initial choice'` when the videoTag's source has changed or when the provider picks an initial quality. It's `'auto'` for HLS streams and `'manual'` otherwise.


JW7-1977