### PR TITLE
Set preview image in the background on complete and idle

### DIFF
--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -19,12 +19,22 @@ define([
         return dimension + (dimension.toString().indexOf('%') > 0 ? '' : 'px');
     };
 
+    var classNameArray = function(element) {
+        return _.isString(element.className) ? element.className.split(' ') : [];
+    };
+
+    var setClassName = function(element, className) {
+        className = strings.trim(className);
+        if (element.className !== className) {
+            element.className = className;
+        }
+    };
 
     dom.classList = function (element) {
         if (element.classList) {
             return element.classList;
         }
-        return element.className.split(' ');
+        return classNameArray(element);
     };
 
     dom.hasClass = jqueryfuncs.hasClass;
@@ -32,7 +42,7 @@ define([
     dom.addClass = function (element, classes) {
         // TODO:: use _.union on the two arrays
 
-        var originalClasses = _.isString(element.className) ? element.className.split(' ') : [];
+        var originalClasses = classNameArray(element);
         var addClasses = _.isArray(classes) ? classes : classes.split(' ');
 
         _.each(addClasses, function (c) {
@@ -41,14 +51,24 @@ define([
             }
         });
 
-        element.className = strings.trim(originalClasses.join(' '));
+        setClassName(element, originalClasses.join(' '));
     };
 
     dom.removeClass = function (element, c) {
-        var originalClasses = _.isString(element.className) ? element.className.split(' ') : [];
+        var originalClasses = classNameArray(element);
         var removeClasses = _.isArray(c) ? c : c.split(' ');
 
-        element.className = strings.trim(_.difference(originalClasses, removeClasses).join(' '));
+        setClassName(element, _.difference(originalClasses, removeClasses).join(' '));
+    };
+
+    dom.replaceClass = function (element, pattern, replaceWith) {
+        var classes = (element.className || '');
+        if (pattern.test(classes)) {
+            classes = classes.replace(pattern, replaceWith);
+        } else if (replaceWith) {
+            classes += ' ' + replaceWith;
+        }
+        setClassName(element, classes);
     };
 
     dom.toggleClass = function (element, c, toggleTo) {

--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -34,6 +34,7 @@ define([
         if (element.classList) {
             return element.classList;
         }
+        /* ie9 does not support classList http://caniuse.com/#search=classList */
         return classNameArray(element);
     };
 

--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -121,31 +121,19 @@ define([
         if (!element || !document.body.contains(element)) {
             return bounds;
         }
-        if (element.getBoundingClientRect) {
-            var rect = element.getBoundingClientRect(element),
-                scrollOffsetY = window.pageYOffset,
-                scrollOffsetX = window.pageXOffset;
-            if (!rect.width && !rect.height && !rect.left && !rect.top) {
-                //element is not visible / no layout
-                return bounds;
-            }
-            bounds.left = rect.left + scrollOffsetX;
-            bounds.right = rect.right + scrollOffsetX;
-            bounds.top = rect.top + scrollOffsetY;
-            bounds.bottom = rect.bottom + scrollOffsetY;
-            bounds.width = rect.right - rect.left;
-            bounds.height = rect.bottom - rect.top;
-        } else {
-            /*jshint -W084 */ // For the while loop assignment
-            bounds.width = element.offsetWidth | 0;
-            bounds.height = element.offsetHeight | 0;
-            do {
-                bounds.left += element.offsetLeft | 0;
-                bounds.top += element.offsetTop | 0;
-            } while (element = element.offsetParent);
-            bounds.right = bounds.left + bounds.width;
-            bounds.bottom = bounds.top + bounds.height;
+        var rect = element.getBoundingClientRect(element),
+            scrollOffsetY = window.pageYOffset,
+            scrollOffsetX = window.pageXOffset;
+        if (!rect.width && !rect.height && !rect.left && !rect.top) {
+            //element is not visible / no layout
+            return bounds;
         }
+        bounds.left = rect.left + scrollOffsetX;
+        bounds.right = rect.right + scrollOffsetX;
+        bounds.top = rect.top + scrollOffsetY;
+        bounds.bottom = rect.bottom + scrollOffsetY;
+        bounds.width = rect.right - rect.left;
+        bounds.height = rect.bottom - rect.top;
         return bounds;
     };
 

--- a/src/js/view/preview.js
+++ b/src/js/view/preview.js
@@ -6,49 +6,47 @@ define([
     var Preview = function(_model) {
         this.model = _model;
 
-        this.model.on('change:playlistItem', onPlaylistItem, this);
-        this.model.on('change:mediaModel', onMediaModel, this);
-        this.model.on('change:state', onChangeState, this);
+        _model.on('change:playlistItem', onPlaylistItem, this);
+        _model.on('change:mediaModel', onMediaModel, this);
     };
 
-    function onChangeState(model, state) {
-        var endOfPlaylist = (this.model.get('item') === (this.model.get('playlist').length - 1));
-        if ((state === 'complete') && (!model.get('repeat')) && endOfPlaylist) {
-            this.loadImage(model, model.get('playlistItem').image);
-        }
-    }
-
-    function onMediaModel() {
-        this.model.mediaModel.off('change:mediaType', onMediaType);
-        this.model.mediaModel.on('change:mediaType', onMediaType, this);
-    }
-
-    function onMediaType(mediaModel, mediaType) {
-        if (mediaType === 'audio') {
-            this.loadImage(this.model, this.model.get('playlistItem').image);
-        }
+    function onMediaModel(model, mediaModel) {
+        mediaModel.off('change:mediaType', null, this);
+        mediaModel.on('change:mediaType', function(mediaModel, mediaType) {
+            if (mediaType === 'audio') {
+                this.setImage(model.get('playlistItem').image);
+            }
+        }, this);
     }
 
     function onPlaylistItem(model, playlistItem) {
-        var loadImage = (this.model.get('state') === 'idle') && (this.model.get('item') === 0) &&
-            (!this.model.get('autostart') || utils.isMobile());
+        var delayPosterLoad = (model.get('autostart') && !utils.isMobile()) ||
+            (model.get('item') > 0);
 
-        if (loadImage) {
-            this.loadImage(model, playlistItem.image);
-        } else {
-            this.loadImage(model, null);
+        if (delayPosterLoad) {
+            this.setImage(null);
+            model.off('change:state', null, this);
+            model.on('change:state', function(model, state) {
+                if (state === 'complete' || state === 'idle') {
+                    this.setImage(playlistItem.image);
+                }
+            }, this);
+            return;
         }
+
+        this.setImage(playlistItem.image);
     }
 
     _.extend(Preview.prototype, {
         setup: function(element) {
             this.el = element;
-
-            if (this.model.get('playlistItem')) {
-                this.loadImage(this.model, this.model.get('playlistItem'));
+            var playlistItem = this.model.get('playlistItem');
+            if (playlistItem) {
+                this.setImage(playlistItem.image);
             }
         },
-        loadImage: function(model, img) {
+        setImage: function(img) {
+            this.model.off('change:state', null, this);
             var backgroundImage = '';
             if (_.isString(img)) {
                 backgroundImage = 'url("' + img + '")';

--- a/test/unit/dom-test.js
+++ b/test/unit/dom-test.js
@@ -41,6 +41,27 @@ define([
         assert.equal(element.className, '', 'Removed lass class from element');
     });
 
+
+    test('dom.replaceClass', function (assert) {
+        var element = document.createElement('div');
+
+        dom.replaceClass(element, /class0/, 'class1');
+        assert.equal(element.className, 'class1', 'Adds class to element when pattern is not matched');
+
+        element.className = 'class0';
+        dom.replaceClass(element, /class0/, 'class2');
+        assert.equal(element.className, 'class2', 'Replaces class when pattern matches only class');
+
+
+        element.className = 'class1 class2 class3';
+        dom.replaceClass(element, /class3/, 'class4');
+        assert.equal(element.className, 'class1 class2 class4', 'Replaces classes when pattern matches any class');
+
+        element.className = 'class1 class2 classB';
+        dom.replaceClass(element, /class\d/g, '');
+        assert.equal(element.className, 'classB', 'Replaces classes when pattern matches any class');
+    });
+
     test('dom.createElement', function(assert) {
         var element = dom.createElement('<div id=\'testid\'></div>');
 
@@ -126,21 +147,21 @@ define([
     test('bounds test', function(assert) {
         var element = document.createElement('div');
         var emptyBound = {left: 0, right: 0, width: 0, height: 0 , top: 0, bottom: 0};
-        var bound = dom.bounds(element);
-
-        assert.ok(_checkEqualBound(bound, emptyBound), 'bounds should be empty bounds');
 
         // check null bounds does not break
-        dom.bounds(null);
+        assert.propEqual(dom.bounds(null), emptyBound, 'bounds should be empty when element is not defined');
 
-        function _checkEqualBound(bound, checkBound) {
-            return bound.left === checkBound.left &&
-                    bound.right === checkBound.right &&
-                    bound.width === checkBound.width &&
-                    bound.height === checkBound.height &&
-                    bound.top === checkBound.top &&
-                    bound.bottom === checkBound.bottom;
-        }
+
+        assert.propEqual(dom.bounds(element), emptyBound, 'bounds should be empty when element is not in DOM');
+
+        element.style.display = 'none';
+        window.document.body.appendChild(element);
+        assert.propEqual(dom.bounds(element), emptyBound, 'bounds should be empty when element has no layout');
+
+        element.style.display = 'block';
+        element.style.width = '400px';
+        element.style.height = '400px';
+        assert.notPropEqual(dom.bounds(element), emptyBound, 'bounds should not be empty when element has layout');
     });
 
 });


### PR DESCRIPTION
Changes to preview.js make sure that we load preview images when the player is in a complete or idle state, or when playing audio. Loading is deferred for playlist items that auto start and the preview div backgroundImage is cleared to prevent unnecessary loading.

Additional changes to dom.js and view.js were made to reduce the number of changes to className on the main player element. state and skin classnames are replaced rather than removed and added, and className is not set when the desired value is equal to it's current value. Idle and complete state class changes are also deferred 100ms to avoid unnecessary style changes between playlist items. This is important because these states cause the preview div holding the poster to be displayed which could result in the background image being loaded. Chrome will load images event with display none, but the changes made to preview.js prevent that from happening.

#1056 JW7-2064 JW7-1904