### PR TITLE
Reset visualQuality reason after event fires

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -241,6 +241,7 @@ define([
                 level.index = _currentQuality;
                 level.label = _levels[_currentQuality].label;
                 _this.trigger('visualQuality', _visualQuality);
+                _visualQuality.reason = '';
             }
         }
 


### PR DESCRIPTION
`_visualQuality.reason` needs to be reset after the `visualQuality` event fires so that the correct reason is attributed to adaptive quality changes in HLS streams.

JW7-1977