### PR TITLE
Display VTT natively when not using the Flash Provider

### DIFF
--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -14,6 +14,9 @@ define([
         // Listen for captions menu index changes from the view
         _model.on('change:captionsIndex', _captionsIndexHandler, this);
 
+        // Listen for item ready to determine which provider is in use
+        _model.on('itemReady', _itemReadyHandler, this);
+
         // Listen for provider subtitle tracks
         //   ignoring provider "subtitlesTrackChanged" since index should be managed here
         _model.mediaController.on('subtitlesTracks', _subtitlesTracksHandler, this);
@@ -138,8 +141,6 @@ define([
             _tracksById = {};
             _metaCuesByTextTime = {};
             _unknownCount = 0;
-
-            _model.on('itemReady', _itemReadyHandler, this);
         }
 
         function _itemReadyHandler(item) {

--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -139,14 +139,13 @@ define([
             _metaCuesByTextTime = {};
             _unknownCount = 0;
 
-            // meta event listener may have been turned off in subtitlesTracks event
-            _model.mediaController.off('meta', _metaHandler);
-            _model.mediaController.off('subtitlesTracks', _subtitlesTracksHandler);
-
             _model.on('itemReady', _itemReadyHandler, this);
         }
 
         function _itemReadyHandler(item) {
+            _model.mediaController.off('meta', _metaHandler);
+            _model.mediaController.off('subtitlesTracks', _subtitlesTracksHandler);
+
             if (_model.get('provider').name === 'flash') {
                 var tracks = item.tracks,
                     track, kind, i;
@@ -165,7 +164,7 @@ define([
             }
 
             // only listen for other captions if there are no side loaded captions
-            if (_tracks.length === 0) {
+            if (!_tracks.length) {
                 _model.mediaController.on('meta', _metaHandler, this);
                 _model.mediaController.on('subtitlesTracks', _subtitlesTracksHandler, this);
             }

--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -135,7 +135,7 @@ define([
         }
 
         /** Listen to playlist item updates. **/
-        function _itemHandler(item) {
+        function _itemHandler(model, item) {
             _item = item;
             _tracks = [];
             _tracksById = {};

--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -147,7 +147,7 @@ define([
             _model.mediaController.off('meta', _metaHandler);
             _model.mediaController.off('subtitlesTracks', _subtitlesTracksHandler);
 
-            if (_model.get('provider').name === 'flash') {
+            if (_model.get('provider').name !== 'html5') {
                 var tracks = item.tracks,
                     track, kind, i;
                 for (i = 0; i < tracks.length; i++) {

--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -132,7 +132,7 @@ define([
         }
 
         /** Listen to playlist item updates. **/
-        function _itemHandler(model, item) {
+        function _itemHandler(item) {
             _item = item;
             _tracks = [];
             _tracksById = {};
@@ -143,7 +143,11 @@ define([
             _model.mediaController.off('meta', _metaHandler);
             _model.mediaController.off('subtitlesTracks', _subtitlesTracksHandler);
 
-            if (!utils.isIOS()) {
+            _model.on('itemReady', _itemReadyHandler, this);
+        }
+
+        function _itemReadyHandler(item) {
+            if (_model.get('provider').name === 'flash') {
                 var tracks = item.tracks,
                     track, kind, i;
                 for (i = 0; i < tracks.length; i++) {

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -501,7 +501,7 @@ define([
             }
 
             // if playlist item contains .vtt tracks, load them
-            if (utils.isIOS() && item) {
+            if (item) {
                 _setupSideloadedTracks(item.tracks);
             }
         }

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -480,10 +480,6 @@ define([
         }
 
         function _setVideotagSource(item) {
-            if(!item) {
-                return;
-            }
-
             _textTracks = null;
             _audioTracks = null;
             _currentAudioTrackIndex = -1;

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -480,6 +480,10 @@ define([
         }
 
         function _setVideotagSource(item) {
+            if(!item) {
+                return;
+            }
+
             _textTracks = null;
             _audioTracks = null;
             _currentAudioTrackIndex = -1;
@@ -500,10 +504,7 @@ define([
                 _videotag.setAttribute('preload', _source.preload);
             }
 
-            // if playlist item contains .vtt tracks, load them
-            if (item) {
-                _setupSideloadedTracks(item.tracks);
-            }
+            _setupSideloadedTracks(item.tracks);
         }
 
         function _clearVideotagSource() {


### PR DESCRIPTION
`captions.js` must wait on the `itemReady` event to determine which provider is being used. When not using flash, we want the browser to handle VTT display.

JW7-1651