### PR TITLE
Expect exceptions to be caught in IE with DOM parser

### DIFF
--- a/src/js/utils/parser.js
+++ b/src/js/utils/parser.js
@@ -1,8 +1,7 @@
 define([
     'utils/underscore',
-    'utils/validator',
-    'utils/trycatch'
-], function(_, validator, trycatch) {
+    'utils/validator'
+], function(_, validator) {
     var parser = {};
 
     /** Gets an absolute file path based on a relative filepath * */
@@ -63,9 +62,9 @@ define([
     /** Takes an XML string and returns an XML object **/
     parser.parseXML = function (input) {
         var parsedXML = null;
-        trycatch.tryCatch(function() {
+        try {
             // Parse XML in FF/Chrome/Safari/Opera
-            if (window.DOMParser) {
+            if ('DOMParser' in window) {
                 parsedXML = (new window.DOMParser()).parseFromString(input, 'text/xml');
                 // In Firefox the XML doc may contain the parsererror, other browsers it's further down
                 if (containsParserErrors(parsedXML.childNodes) ||
@@ -78,7 +77,7 @@ define([
                 parsedXML.async = 'false';
                 parsedXML.loadXML(input);
             }
-        });
+        } catch(e) {/* Expected when content is not XML */}
 
         return parsedXML;
     };


### PR DESCRIPTION
Since parseXML is used to check if content is XML, it's expected to fail when the input is not. Exceptions thrown in `trycatch.tryCatch` are fatal in the debug player, so this method should use a regular try catch block.

JW7-2088 JW7-2091