### PR TITLE
Turn off captions when media is detached

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -933,6 +933,7 @@ define([
          */
         this.detachMedia = function() {
             clearTimeout(_playbackTimeout);
+            disableTextTrack();
             _attached = false;
             return _videotag;
         };
@@ -1254,6 +1255,12 @@ define([
                     mediaType = 'audio';
                 }
                 _this.trigger('mediaType', {mediaType: mediaType});
+            }
+        }
+
+        function disableTextTrack() {
+            if(_textTracks && _textTracks[_currentTextTrackIndex]) {
+                _textTracks[_currentTextTrackIndex].mode = 'disabled';
             }
         }
     }


### PR DESCRIPTION
Disable current textTrack when detaching media while preserving `_currentTextTrackIndex`. 

Note: In fullscreen mode on iOS devices, after a mid-roll is complete and media playback resumes, captions that were previously showing will not display. This seems to be an iOS specific issue that can be mitigated by exiting fullscreen and selecting the captions track from the control bar, then resuming playback. In desktop browsers, captions behavior will be as it was before a mid-roll ad is played.

JW7-2089