### PR TITLE
video.load() must be forced in Safari and iOS

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -448,7 +448,7 @@ define([
 
         function _forceVideoLoad() {
             // These browsers will not replay videos without reloading them
-            return (_isMobile || _isSafari) && _videotag.ended;
+            return _isMobile || _isSafari;
         }
 
         function _completeLoad(startTime, duration, item) {


### PR DESCRIPTION
### Changes proposed in this pull request:

When a video tag's preload attribute is set to "none", `video.load()` must be called on the video tag after the src is changed in Safari and iOS or the new video will not play. 

Fixes #1071
JW7-2103