### PR TITLE
Move handlebars-loader rules into grunt

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -200,6 +200,10 @@ module.exports = function(grunt) {
                                     '!less?compress'
                         },
                         {
+                            test: /\.html$/,
+                            loader: 'handlebars-loader'
+                        },
+                        {
                             test: /\.woff(\?v=\d+\.\d+\.\d+)?$/,
                             loader: 'url?limit=10000&mimetype=application/font-woff'
                         },

--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "requirejs": "~2.1.15",
     "qunit": "~1.18.0",
     "requirejs-text": "~2.0.14",
-    "handlebars": "~3.0.0",
+    "handlebars": "~4.0.5",
     "requirejs-handlebars": "~0.1.1",
     "underscore": "~1.8.3",
     "require-less": "~0.1.5",

--- a/src/js/view/components/menu.js
+++ b/src/js/view/components/menu.js
@@ -3,7 +3,7 @@ define([
     'utils/helpers',
     'utils/underscore',
     'utils/ui',
-    'handlebars-loader!templates/menu.html'
+    'templates/menu.html'
 ], function(Tooltip, utils, _, UI, menuTemplate) {
     var Menu = Tooltip.extend({
         setup : function (list, selectedIndex, options) {

--- a/src/js/view/components/playlist.js
+++ b/src/js/view/components/playlist.js
@@ -3,7 +3,7 @@ define([
     'utils/underscore',
     'view/components/tooltip',
     'utils/ui',
-    'handlebars-loader!templates/playlist.html'
+    'templates/playlist.html'
 ], function(utils, _, Tooltip, UI, PlaylistTemplate) {
 
     var Playlist = Tooltip.extend({

--- a/src/js/view/components/slider.js
+++ b/src/js/view/components/slider.js
@@ -1,7 +1,7 @@
 define([
     'utils/extendable',
     'utils/ui',
-    'handlebars-loader!templates/slider.html',
+    'templates/slider.html',
     'utils/helpers'
 ], function(Extendable, UI, SliderTemplate, utils) {
 

--- a/src/js/view/displayicon.js
+++ b/src/js/view/displayicon.js
@@ -2,7 +2,7 @@ define([
     'utils/helpers',
     'utils/backbone.events',
     'utils/ui',
-    'handlebars-loader!templates/displayicon.html',
+    'templates/displayicon.html',
     'utils/underscore'
 ], function(utils, Events, UI, Template, _) {
 

--- a/src/js/view/dock.js
+++ b/src/js/view/dock.js
@@ -1,5 +1,5 @@
 define([
-    'handlebars-loader!templates/dock.html',
+    'templates/dock.html',
     'utils/helpers',
     'utils/underscore',
     'utils/ui'

--- a/src/js/view/error.js
+++ b/src/js/view/error.js
@@ -1,5 +1,5 @@
 define([
-    'handlebars-loader!templates/error.html'
+    'templates/error.html'
 ], function(error) {
 
     function make(id, skin, title, body) {

--- a/src/js/view/logo.js
+++ b/src/js/view/logo.js
@@ -4,7 +4,7 @@ define([
     'events/events',
     'utils/underscore',
     'utils/backbone.events',
-    'handlebars-loader!templates/logo.html'
+    'templates/logo.html'
 ], function(UI, utils, events, _, Events, logoTemplate) {
     var _styles = utils.style;
 

--- a/src/js/view/rightclick.js
+++ b/src/js/view/rightclick.js
@@ -1,6 +1,6 @@
 define([
     'utils/helpers',
-    'handlebars-loader!templates/rightclick.html',
+    'templates/rightclick.html',
     'utils/underscore',
     'utils/ui',
     'version'

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -14,7 +14,7 @@ define([
     'view/rightclick',
     'view/title',
     'utils/underscore',
-    'handlebars-loader!templates/player.html'
+    'templates/player.html'
 ], function(utils, events, Events, Constants, states,
             CaptionsRenderer, ClickHandler, DisplayIcon, Dock, Logo,
             Controlbar, Preview, RightClick, Title, _, playerTemplate) {

--- a/test/config.js
+++ b/test/config.js
@@ -93,6 +93,15 @@
         map: {
             // make sure the text plugin is used to load templates
             '*': {
+                'templates/displayicon.html': 'handlebars-loader!templates/displayicon.html',
+                'templates/dock.html': 'handlebars-loader!templates/dock.html',
+                'templates/logo.html': 'handlebars-loader!templates/logo.html',
+                'templates/player.html': 'handlebars-loader!templates/player.html',
+                'templates/error.html': 'handlebars-loader!templates/error.html',
+                'templates/rightclick.html': 'handlebars-loader!templates/rightclick.html',
+                'templates/slider.html': 'handlebars-loader!templates/slider.html',
+                'templates/menu.html': 'handlebars-loader!templates/menu.html',
+                'templates/playlist.html': 'handlebars-loader!templates/playlist.html',
                 '../css/jwplayer.less': 'less!css/jwplayer',
                 'utils/video': mock + '/video.js'
             }


### PR DESCRIPTION
Use handlebars-loader with webpack for all html files. The loader settings are moved into grunt so that we can add additional parameters in one place (`'handlebars-loader?debug'` for example).

Had to map all the template files in the unit tests :construction_worker:. It would be nice if there was a way to avoid having to map each file.
