### PR TITLE
Fix grunt clean

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -364,14 +364,14 @@ module.exports = function(grunt) {
         },
 
         clean: {
+            options: {
+                force: true
+            },
             dist: {
-                files: [{
-                    dot: true,
-                    src: [
-                        'bin-debug',
-                        'bin-release'
-                    ]
-                }]
+                src: [
+                    'bin-debug/',
+                    'bin-release/'
+                ]
             }
         }
     });


### PR DESCRIPTION
`grunt clean` started failing recently with the error:

```
ERROR
Warning: Cannot delete files outside the current working directory. Use --force to continue.
```

Adding the `force` option to grunt-contrib-clean fixes this issue.
