### PR TITLE
Change caption position for audio inactive

### DIFF
--- a/src/css/flags/media-audio.less
+++ b/src/css/flags/media-audio.less
@@ -7,6 +7,9 @@
         .jw-controlbar {
             display: table;
         }
+        .jw-captions {
+            bottom: 3em;
+        }
     }
 }
 .jw-flag-media-audio {


### PR DESCRIPTION
When audio mode, we always show the control bar.
When inactive, we change the bottom of the captions to be lower since we do not have control bar for non-audio.
This applied to audio player too, resulting the captions to be displayed below the control bar.

JW7-2098