### PR TITLE
Change caption position for audio inactive

### DIFF
--- a/src/css/flags/media-audio.less
+++ b/src/css/flags/media-audio.less
@@ -8,6 +8,12 @@
             display: table;
         }
     }
+    // This has higher specificity to overwrite caption position when user inactive in playing state
+    &.jw-flag-user-inactive &.jw-state-playing {
+        .jw-plugin, .jw-captions {
+            bottom: 3em;
+        }
+    }
 }
 .jw-flag-media-audio {
     .jw-preview {


### PR DESCRIPTION
When audio mode, we always show the control bar.
When inactive, we change the bottom of the captions to be lower since we do not have control bar for non-audio.
This applied to audio player too, resulting the captions to be displayed below the controlbar.

JW7-2098