### PR TITLE
Match m3u8 type for azure playlist urls too

### DIFF
--- a/src/flash/com/longtailvideo/jwplayer/utils/Strings.as
+++ b/src/flash/com/longtailvideo/jwplayer/utils/Strings.as
@@ -253,7 +253,7 @@ public class Strings {
      */
 
     private static function getAzureFileFormat(path:String):String {
-        if (path.indexOf('(format=m3u8-') > -1) {
+        if ((/[\(,]format=m3u8-/i).test(path)) {
             return 'm3u8';
         } else {
             return '';

--- a/src/js/utils/strings.js
+++ b/src/js/utils/strings.js
@@ -40,7 +40,7 @@ define([
      * This does not return the file extension, instead it returns a media type extension
      */
     function getAzureFileFormat(path) {
-        if (path.indexOf('(format=m3u8-') > -1) {
+        if ((/[\(,]format=m3u8-/i).test(path)) {
             return 'm3u8';
         } else {
             return false;

--- a/test/unit/strings-test.js
+++ b/test/unit/strings-test.js
@@ -17,8 +17,11 @@ define([
         var ext = strings.extension('invalid');
         assert.equal(ext, undefined, 'invalid path extension returns undefined');
 
-        ext = strings.extension('(format=m3u8-');
-        assert.equal(ext, 'm3u8', 'azureFile extension');
+        ext = strings.extension('Manifest(format=m3u8-aapl-v3)"');
+        assert.equal(ext, 'm3u8', 'Azure file extension master');
+
+        ext = strings.extension('/Manifest(video,format=m3u8-aapl-v3,audiotrack=audio)');
+        assert.equal(ext, 'm3u8', 'Azure file extension playlist');
 
         ext = strings.extension(null);
         assert.equal(ext, '', 'no path extension');


### PR DESCRIPTION
We match the m3u8 format in azure master manifests to infer a type of HLS, but the rendition playlist have additional info that we were not matching.

This fixes that so that we can play single quality rendition playlist urls as well.

JW7-2136