### PR TITLE
Do not reregister providers

### DIFF
--- a/src/js/api/global-api.js
+++ b/src/js/api/global-api.js
@@ -72,6 +72,11 @@ define([
     function registerProvider(provider) {
         var name = provider.getName().name;
 
+        // Only register the provider if it isn't registered already.  This is an issue on pages with multiple embeds.
+        if (ProvidersLoaded[name]) {
+            return;
+        }
+
         // If there isn't a "supports" val for this guy
         if (! _.find(ProvidersSupported, _.matches({name : name}))) {
             if (!_.isFunction(provider.supports)) {


### PR DESCRIPTION
Do not reregister providers.  Reregistering providers causes issues when we check instanceof later in model.setActiveItem()

JW7-2246