### PR TITLE
expose NetStream buffer events

### DIFF
--- a/src/flash/com/longtailvideo/jwplayer/media/RTMPMediaProvider.as
+++ b/src/flash/com/longtailvideo/jwplayer/media/RTMPMediaProvider.as
@@ -680,6 +680,12 @@ public class RTMPMediaProvider extends MediaProvider {
             case 'NetStream.Seek.Notify':
                 sendMediaEvent(MediaEvent.JWPLAYER_MEDIA_SEEKED);
                 break;
+            case 'NetStream.Buffer.Empty':
+                sendBufferEvent(0);
+                break;
+            case 'NetStream.Buffer.Full':
+                sendBufferEvent(100);
+                break;
         }
     }
 }

--- a/src/flash/com/longtailvideo/jwplayer/media/RTMPMediaProvider.as
+++ b/src/flash/com/longtailvideo/jwplayer/media/RTMPMediaProvider.as
@@ -684,7 +684,11 @@ public class RTMPMediaProvider extends MediaProvider {
                 sendBufferEvent(0);
                 break;
             case 'NetStream.Buffer.Full':
-                sendBufferEvent(100);
+                var bufferPercent:Number = 100;
+                if (_item.duration > 0) {
+                    bufferPercent = 100 * (_stream.time + _stream.bufferLength) / _item.duration;
+                }
+                sendBufferEvent(bufferPercent);
                 break;
         }
     }


### PR DESCRIPTION
### Changes proposed in this pull request:
Expose NetStream buffer events to the JS API to allow handling of stalled live streams

Fixes #929