### PR TITLE
Position captions above the control bar

### DIFF
--- a/src/css/flags/ads.less
+++ b/src/css/flags/ads.less
@@ -34,7 +34,7 @@
     }
 
     .jw-logo,
-    .jw-captions {
+    .jw-captions, video::-webkit-media-text-track-container {
         display: none;
     }
 }

--- a/src/css/flags/media-audio.less
+++ b/src/css/flags/media-audio.less
@@ -10,7 +10,9 @@
     }
     // This has higher specificity to overwrite caption position when user inactive in playing state
     &.jw-flag-user-inactive.jw-state-playing {
-        .jw-plugin, .jw-captions {
+        .jw-plugin,
+        .jw-captions,
+        video::-webkit-media-text-track-container {
             bottom: 3em;
         }
     }

--- a/src/css/flags/touch.less
+++ b/src/css/flags/touch.less
@@ -5,7 +5,7 @@
         font-size: 1.5em;
     }
 
-    .jw-captions {
+    .jw-captions, video::-webkit-media-text-track-container {
         // control bar is (1.5*2.5 = 3.75)em for mobile, so bottom should be 0.5 above that
         bottom: 4.25em;
     }

--- a/src/css/flags/user-inactive.less
+++ b/src/css/flags/user-inactive.less
@@ -9,7 +9,9 @@
             display: none;
         }
 
-        .jw-plugin, .jw-captions {
+        .jw-plugin,
+        .jw-captions,
+        video::-webkit-media-text-track-container {
             bottom: 0.5em;
         }
     }

--- a/src/css/imports/captions.less
+++ b/src/css/imports/captions.less
@@ -1,3 +1,5 @@
+@import "vars";
+
 .jw-captions {
     position: absolute;
     display: none;
@@ -36,4 +38,17 @@
     text-decoration: none;
     line-height: 1.3em;
     padding: 0.1em 0.8em;
+}
+
+.jwplayer {
+    video::-webkit-media-text-track-container {
+        bottom: @controlbar-height * 0.75;
+
+    }
+    &.jw-flag-compact-player {
+        video::-webkit-media-text-track-container {
+            bottom: @controlbar-height * 1.25;
+
+        }
+    }
 }


### PR DESCRIPTION
### Changes proposed in this pull request:
Position natively rendered WebVTT cues above the control bar for all player sizes.

Fixes #
JW7-2288