### PR TITLE
Render WebVTT natively in iOS, Chrome & Safari

### DIFF
--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -152,12 +152,14 @@ define([
                 track, kind, isVTT, i;
             var isHTML5 = _model.get('provider').name === 'html5';
 
+            var canRenderNatively = utils.isChrome() || utils.isIOS() || utils.isSafari();
+
             for (i = 0; i < tracks.length; i++) {
                 track = tracks[i];
                 isVTT = track.file && (/\.(?:web)?vtt(?:\?.*)?$/i.test(track.file));
 
                 //let the browser handle rendering sideloaded VTT tracks in the HTML5 provider
-                if(isHTML5 && isVTT && !_isSDK) {
+                if(isHTML5 && isVTT && !_isSDK && canRenderNatively) {
                     continue;
                 }
 

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -551,7 +551,8 @@ define([
         }
 
         function _setupSideloadedTracks(tracks) {
-            if (_isSDK) {
+            var canRenderNatively = utils.isChrome() || utils.isIOS() || utils.isSafari();
+            if (_isSDK || !canRenderNatively) {
                 return;
             }
             if (tracks !== _itemTracks) {


### PR DESCRIPTION
### Changes proposed in this pull request:
Gated support for native WebVTT rendering to iOS, Safari and Chrome.

Fixes # 
JW7-2156