### PR TITLE
Run unit tests on latest versions of Chrome, Firefox and Edge

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -347,10 +347,13 @@ module.exports = function(grunt) {
             },
             // browserstack_all: { browsers: Object.keys( require( './test/qunit/karma/browserstack-launchers' ) ) },
             browserstack : {
-                browsers: ['chrome_45']
+                browsers: ['chrome']
             },
             browserstack_firefox : {
-                browsers: ['firefox_41']
+                browsers: ['firefox']
+            },
+            browserstack_edge : {
+                browsers: ['edge']
             },
             browserstack_ie11 : {
                 browsers: ['ie11_windows']

--- a/test/karma/browserstack-launchers.js
+++ b/test/karma/browserstack-launchers.js
@@ -25,13 +25,6 @@ module.exports = {
         os: 'OS X',
         os_version: 'Mavericks'
     },
-    firefox_34: {
-        base: 'BrowserStack',
-        browser: 'firefox',
-        browser_version: '34.0',
-        os: 'OS X',
-        os_version: 'Yosemite'
-    },
     firefox_35: {
         base: 'BrowserStack',
         browser: 'firefox',
@@ -43,6 +36,12 @@ module.exports = {
         base: 'BrowserStack',
         browser: 'firefox',
         browser_version: '41.0',
+        os: 'OS X',
+        os_version: 'Yosemite'
+    },
+    firefox: {
+        base: 'BrowserStack',
+        browser: 'firefox',
         os: 'OS X',
         os_version: 'Yosemite'
     },
@@ -62,17 +61,16 @@ module.exports = {
         os: 'OS X',
         os_version: 'Yosemite'
     },
-    chrome_44: {
-        base: 'BrowserStack',
-        browser: 'chrome',
-        browser_version: '44.0',
-        os: 'OS X',
-        os_version: 'Yosemite'
-    },
     chrome_45: {
         base: 'BrowserStack',
         browser: 'chrome',
         browser_version: '45.0',
+        os: 'OS X',
+        os_version: 'Yosemite'
+    },
+    chrome: {
+        base: 'BrowserStack',
+        browser: 'chrome',
         os: 'OS X',
         os_version: 'Yosemite'
     },
@@ -105,6 +103,12 @@ module.exports = {
         browser_version: '11.0',
         os: 'Windows',
         os_version: '7'
+    },
+    edge: {
+        base: 'BrowserStack',
+        browser: 'edge',
+        os: 'Windows',
+        os_version: '10'
     },
 
     // Opera


### PR DESCRIPTION
Removing version from BrowserStack browser config runs tests on the latest version.