### PR TITLE
Fix mixed providers loading issue

### DIFF
--- a/src/js/providers/providers.js
+++ b/src/js/providers/providers.js
@@ -100,7 +100,7 @@ define([
                     var item = playlist[i];
                     var supported = provider.supports(item.sources[0], args);
                     if (supported) {
-                        playlist.splice(i);
+                        playlist.splice(i, 1);
                     }
                     loadProvider = loadProvider || supported;
                 }


### PR DESCRIPTION
When loading required providers, we spliced everything after the supported index.
We should only splice the item that is currently being looked at in the playlist.
JW7-2334