### PR TITLE
Don't send mediaType for Android HLS until visualQuality check

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -330,7 +330,9 @@ define([
             }
 
             _canSeek = true;
-            _setMediaType();
+            if (!_isAndroidHLS) {
+                _setMediaType();
+            }
             _sendBufferFull();
         }
 


### PR DESCRIPTION
Android doesn't get videoHeight for HLS until playback begins so don't send the mediaType event until the first visualQuality check when dimensions are sure to change.

JW7-2375