### PR TITLE
Move preview div instead of media div

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -867,7 +867,7 @@ define([
                 // Put the preview element before the media element in order to display browser captions
                 _playerElement.insertBefore(_preview.el, _videoLayer);
             } else {
-                _playerElement.insertBefore(_videoLayer, _preview.el);
+                _playerElement.insertBefore(_preview.el, _title.element());
             }
         }
 


### PR DESCRIPTION
Moving the media div causes the HTML5Video element to be removed
and re-added to the DOM which can have side-effects.

JW7-2386