### PR TITLE
Prevent double encoding of html entities in playlist items

### DIFF
--- a/src/js/view/components/playlist.js
+++ b/src/js/view/components/playlist.js
@@ -46,7 +46,7 @@ define([
                 return {
                     active : (idx === selectedIndex),
                     label : (idx+1)+ '.',
-                    title : item.title
+                    title : utils.createElement(item.title).textContent
                 };
             });
             return PlaylistTemplate(newList);


### PR DESCRIPTION
### Changes proposed in this pull request:

Prevent html entities in playlist item titles from being double-encoded by handlebars.