### PR TITLE
Setup sideloaded tracks after preroll or midroll

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -551,7 +551,8 @@ define([
             if (_isSDK || !canRenderNatively) {
                 return;
             }
-            if (tracks !== _itemTracks) {
+            // Add tracks if we're playing the item for the first time or resuming playback after a midroll
+            if (tracks !== _itemTracks || tracks.length && !_videotag.textTracks.length) {
                 disableTextTrack();
                 dom.emptyElement(_videotag);
                 _itemTracks = tracks;


### PR DESCRIPTION
### Changes proposed in this pull request:
Sideloaded tracks are removed from the videotag when playing an ad. This ensures that they're re-added when playback resumes after a preroll or midroll ad.
Fixes #
JW7-2418