### PR TITLE
Put the preview image behind the element that contains captions

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -867,7 +867,8 @@ define([
                 // Put the preview element before the media element in order to display browser captions
                 _playerElement.insertBefore(_preview.el, _videoLayer);
             } else {
-                _playerElement.insertBefore(_preview.el, _title.element());
+                // Put the preview element before the captions element to display captions with the captions renderer
+                _playerElement.insertBefore(_preview.el, _captionsRenderer.element());
             }
         }
 


### PR DESCRIPTION
### Changes proposed in this pull request:
Put the preview element immediately behind the element that contains captions.

Fixes #
JW7-2428