### PR TITLE
Update unit tests for QUnit 2.x upgrade

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -26,7 +26,6 @@
       //"jwplayer",
       "require",
       "define",
-      "module",
       "__DEBUG__",
       "__REPO__",
       "__SELF_HOSTED__",

--- a/bower.json
+++ b/bower.json
@@ -6,8 +6,6 @@
     "players@jwplayer.com"
   ],
   "devDependencies": {
-    "requirejs": "~2.1.15",
-    "qunit": "~1.18.0",
     "requirejs-text": "~2.0.14",
     "handlebars": "~4.0.5",
     "requirejs-handlebars": "~0.1.1",

--- a/test/index.html
+++ b/test/index.html
@@ -16,8 +16,8 @@
     </style>
 
     <!-- Load local QUnit. -->
-    <link rel="stylesheet" href="../bower_components/qunit/qunit/qunit.css" media="screen">
-    <script src="../bower_components/qunit/qunit/qunit.js"></script>
+    <link rel="stylesheet" href="../node_modules/qunitjs/qunit/qunit.css" media="screen">
+    <script src="../node_modules/qunitjs/qunit/qunit.js"></script>
 
     <script>
         var __DEBUG__ = true;
@@ -25,7 +25,7 @@
     </script>
 
     <!-- load requirejs library and run config.js -->
-    <script data-main="config" src="../bower_components/requirejs/require.js"></script>
+    <script data-main="config" src="../node_modules/requirejs/require.js"></script>
 </head>
 
 <body>

--- a/test/karma/browserstack-launchers.js
+++ b/test/karma/browserstack-launchers.js
@@ -1,3 +1,5 @@
+/* jshint node: true */
+
 module.exports = {
 
     // To view a list of currently available configurations run this command :

--- a/test/unit/ajax-test.js
+++ b/test/unit/ajax-test.js
@@ -4,7 +4,8 @@ define([
 ], function (_, utils) {
     /* jshint qunit: true */
 
-    module('utils.ajax');
+    QUnit.module('utils.ajax');
+    var test = QUnit.test.bind(QUnit);
 
     function validXHR(xhr) {
         if ('XDomainRequest' in window && xhr instanceof window.XDomainRequest) {

--- a/test/unit/api-config-test.js
+++ b/test/unit/api-config-test.js
@@ -3,7 +3,9 @@ define([
     'api/config'
 ], function (_, config) {
     /* jshint qunit: true */
-    module('API config');
+
+    QUnit.module('API config');
+    var test = QUnit.test.bind(QUnit);
 
     function validWidth(val) {
 

--- a/test/unit/api-test.js
+++ b/test/unit/api-test.js
@@ -28,7 +28,8 @@ define([
     var vid = document.createElement('video');
     var BROWSER_SUPPORTS_VIDEO = (!!vid.load);
 
-    module('Api');
+    QUnit.module('Api');
+    var test = QUnit.test.bind(QUnit);
 
     test('extends Events', function(assert) {
         var api = createApi('player');

--- a/test/unit/browser-test.js
+++ b/test/unit/browser-test.js
@@ -3,7 +3,8 @@ define([
 ], function (browser) {
     /* jshint qunit: true */
 
-    module('browser');
+    QUnit.module('browser');
+    var test = QUnit.test.bind(QUnit);
 
     test('browser checks', function(assert) {
         assert.equal(typeof browser.isFF(), 'boolean');

--- a/test/unit/constants-test.js
+++ b/test/unit/constants-test.js
@@ -3,9 +3,9 @@ define([
 ], function (constants) {
     /* jshint qunit: true */
 
-    module('constants');
+    QUnit.module('constants');
 
-    test('constants', function(assert) {
+    QUnit.test('constants', function(assert) {
         assert.equal(typeof constants.repo, 'string', 'constants.repo is a string');
 
         for (var i = 0; i < constants.SkinsIncluded.length; i++) {

--- a/test/unit/css-test.js
+++ b/test/unit/css-test.js
@@ -3,7 +3,8 @@ define([
 ], function (css) {
     /* jshint qunit: true */
 
-    module('css');
+    QUnit.module('css');
+    var test = QUnit.test.bind(QUnit);
 
     test('css.css and css.clearCss', function(assert) {
         var count = document.getElementsByTagName('style').length;

--- a/test/unit/dom-test.js
+++ b/test/unit/dom-test.js
@@ -3,7 +3,8 @@ define([
 ], function (dom) {
     /* jshint qunit: true */
 
-    module('dom');
+    QUnit.module('dom');
+    var test = QUnit.test.bind(QUnit);
 
     test('dom.addClass', function (assert) {
         var element = document.createElement('div');

--- a/test/unit/dxfp-test.js
+++ b/test/unit/dxfp-test.js
@@ -4,9 +4,9 @@ define([
 ], function (dfxp) {
     /* jshint qunit: true, maxlen: 1000 */
 
-    module('dfxp');
+    QUnit.module('dfxp');
 
-    test('exceptions', function(assert) {
+    QUnit.test('exceptions', function(assert) {
         assert.equal(typeof dfxp, 'function', 'dfxp is a function');
 
         assert.throws(function() {

--- a/test/unit/embed-swf-test.js
+++ b/test/unit/embed-swf-test.js
@@ -4,7 +4,8 @@ define([
 ], function ($, EmbedSwf) {
     /* jshint qunit: true */
 
-    module('Embed SWF Util');
+    QUnit.module('Embed SWF Util');
+    var test = QUnit.test.bind(QUnit);
 
     test('embeds a swf', function(assert) {
         var parent = $('<div id="container"></div>')[0];

--- a/test/unit/extendable-test.js
+++ b/test/unit/extendable-test.js
@@ -3,9 +3,9 @@ define([
 ], function (extendable) {
     /* jshint qunit: true */
 
-    module('extendable');
+    QUnit.module('extendable');
 
-    test('extendable.extend', function(assert) {
+    QUnit.test('extendable.extend', function(assert) {
         extendable();
 
         var static = {'test': 'staticTest'};

--- a/test/unit/fetch-test.js
+++ b/test/unit/fetch-test.js
@@ -5,7 +5,8 @@ define([
     /* jshint qunit: true */
     /* global Promise */
 
-    module('utils.fetch');
+    QUnit.module('utils.fetch');
+    var test = QUnit.test.bind(QUnit);
 
     function errorHandler(assert, done) {
         return function(error) {

--- a/test/unit/helpers-test.js
+++ b/test/unit/helpers-test.js
@@ -3,7 +3,8 @@ define([
 ], function (utils) {
     /* jshint qunit: true */
 
-    module('helpers');
+    QUnit.module('helpers');
+    var test = QUnit.test.bind(QUnit);
 
     test('helpers foreach test', function(assert) {
         var aData = {'hello': 'hi'};

--- a/test/unit/jwplayer-selectplayer-test.js
+++ b/test/unit/jwplayer-selectplayer-test.js
@@ -5,7 +5,8 @@ define([
 ], function (_, $, jwplayer) {
     /* jshint qunit: true */
 
-    module('jwplayer function');
+    QUnit.module('jwplayer function');
+    var test = QUnit.test.bind(QUnit);
 
     var append = function(html) {
         var $element = $(html);

--- a/test/unit/model-qoe-test.js
+++ b/test/unit/model-qoe-test.js
@@ -7,7 +7,8 @@ define([
 ], function (_, Model, SimpleModel, events, states) {
     /* jshint qunit: true */
 
-    module('Model QoE');
+    QUnit.module('Model QoE');
+    var test = QUnit.test.bind(QUnit);
 
     // mock MediaModel
     var MediaModel = function() {

--- a/test/unit/parser-test.js
+++ b/test/unit/parser-test.js
@@ -3,7 +3,8 @@ define([
 ], function (parser) {
     /* jshint qunit: true */
 
-    module('parser');
+    QUnit.module('parser');
+    var test = QUnit.test.bind(QUnit);
 
     var testerGenerator = function (assert, method) {
         return function (left, right, message) {

--- a/test/unit/playerutils-test.js
+++ b/test/unit/playerutils-test.js
@@ -4,9 +4,9 @@ define([
 ], function (playerutils, version) {
     /* jshint qunit: true */
 
-    module('playerutils');
+    QUnit.module('playerutils');
 
-    test('playerutils.versionCheck', function(assert) {
+    QUnit.test('playerutils.versionCheck', function(assert) {
         var versionCheck = playerutils.versionCheck('0.5');
         assert.ok(versionCheck, 'playerutils.versionCheck with valid version');
 

--- a/test/unit/playlist-filtering-test.js
+++ b/test/unit/playlist-filtering-test.js
@@ -45,7 +45,8 @@ define([
         assert.ok(sourcesMatch(filtered), title + sourceName + ' has only matching sources');
     }
 
-    module('playlist.filterSources');
+    QUnit.module('playlist.filterSources');
+    var test = QUnit.test.bind(QUnit);
 
     test('flash primary', function(assert) {
         testSource(assert, 'flv_mp4', 'flv', true);
@@ -68,7 +69,7 @@ define([
     });
 
 
-    module('playlist.filterPlaylist');
+    QUnit.module('playlist.filterPlaylist');
 
     test('filterPlaylist', function(assert) {
         var pl;

--- a/test/unit/playlist-item-test.js
+++ b/test/unit/playlist-item-test.js
@@ -4,7 +4,8 @@ define([
 ], function (_, item) {
     /* jshint qunit: true */
 
-    module('playlist item');
+    QUnit.module('playlist item');
+    var test = QUnit.test.bind(QUnit);
 
     // http://support.jwplayer.com/customer/portal/articles/1413113-configuration-options-reference
     function testItem(assert, config) {

--- a/test/unit/playlist-loader-test.js
+++ b/test/unit/playlist-loader-test.js
@@ -5,7 +5,8 @@ define([
 ], function (_, PlaylistLoader, events) {
     /* jshint qunit: true */
 
-    module('loader');
+    QUnit.module('loader');
+    var test = QUnit.test.bind(QUnit);
 
     test('Test JSON feed', function (assert) {
         var done = assert.async();

--- a/test/unit/playlist-test.js
+++ b/test/unit/playlist-test.js
@@ -12,7 +12,8 @@ define([
         return _.isObject(item) && _.isArray(item.sources) && _.isArray(item.tracks);
     }
 
-    module('playlist');
+    QUnit.module('playlist');
+    var test = QUnit.test.bind(QUnit);
 
     test('Test initialized successfully', function(assert) {
         assert.expect(3);

--- a/test/unit/provider-test.js
+++ b/test/unit/provider-test.js
@@ -82,7 +82,8 @@ define([
         return o;
     }
 
-    module('provider primary priority');
+    QUnit.module('provider primary priority');
+    var test = QUnit.test.bind(QUnit);
 
     test('no primary defined', function (assert) {
         var providerList = new Providers().providers;
@@ -127,7 +128,7 @@ define([
         assert.ok(keys.flash > keys.youtube, 'Flash has lower priority than youtube');
 	});
 
-	module('provider.choose tests');
+    QUnit.module('provider.choose');
 
 	// HTML5 Primary
 	test('html5 primary', function (assert) {

--- a/test/unit/scriptloader-test.js
+++ b/test/unit/scriptloader-test.js
@@ -4,7 +4,8 @@ define([
 ], function (scriptloader, parser) {
     /* jshint qunit: true */
 
-    module('scriptloader');
+    QUnit.module('scriptloader');
+    var test = QUnit.test.bind(QUnit);
 
     var STATUS = {
         NEW: 0,

--- a/test/unit/setup-test.js
+++ b/test/unit/setup-test.js
@@ -5,7 +5,8 @@ define([
 ], function (_, Api, events) {
     /* jshint qunit:true */
 
-    module('Setup');
+    QUnit.module('Setup');
+    var test = QUnit.test.bind(QUnit);
 
     test('fails when playlist is not an array', function(assert) {
 

--- a/test/unit/simplemodel-test.js
+++ b/test/unit/simplemodel-test.js
@@ -4,10 +4,9 @@ define([
 ], function (simpleModel, _) {
     /* jshint qunit: true */
 
-    module('simpleModel');
+    QUnit.module('simpleModel');
 
-
-    test('simplemodel', function(assert) {
+    QUnit.test('simplemodel', function(assert) {
         var model = _.extend({}, simpleModel);
         assert.notOk(model.get('noExisting'), 'get with no attributes');
 

--- a/test/unit/storage-test.js
+++ b/test/unit/storage-test.js
@@ -6,14 +6,13 @@ define([
     /* jshint qunit: true */
 
 
-    module('Storage');
+    QUnit.module('Storage');
 
     function mockModel() {
         _.extend(this, SimpleModel);
-
     }
 
-    test('provides persistent storage', function(assert) {
+    QUnit.test('provides persistent storage', function(assert) {
         var PERSIST = [
             'volume',
             'mute'

--- a/test/unit/strings-test.js
+++ b/test/unit/strings-test.js
@@ -1,9 +1,10 @@
 define([
     'utils/strings'
 ], function (strings) {
-    /* jshint qunit: true */
+    /* jshint qunit: true, maxlen: 1000 */
 
-    module('strings');
+    QUnit.module('strings');
+    var test = QUnit.test.bind(QUnit);
 
     test('strings.pad', function(assert) {
         var str = strings.pad('test', 7, '1');
@@ -30,7 +31,7 @@ define([
         assert.equal(ext,'jpg', 'extension correctly received');
 
         // akamai url's
-        ext = strings.extension('https://akamaihd.net/i/2013/01/20131114_56c3456df2b9b_vg01/,480_270_500,.mp4.csmil/master.m3u8?hdnea=st=145747587700~exp=645456~acl=/*~hmac=34523452345sdfggdfssd345345')
+        ext = strings.extension('https://akamaihd.net/i/2013/01/20131114_56c3456df2b9b_vg01/,480_270_500,.mp4.csmil/master.m3u8?hdnea=st=145747587700~exp=645456~acl=/*~hmac=34523452345sdfggdfssd345345');
         assert.equal(ext, 'm3u8', 'Akamai Tokenized Url\'s');
 
         ext = strings.extension('https://domain.net/master.m3u8?dot=.');

--- a/test/unit/timer-test.js
+++ b/test/unit/timer-test.js
@@ -3,8 +3,8 @@ define([
 ], function (timer) {
     /* jshint qunit: true */
 
-    module('timer');
-
+    QUnit.module('timer');
+    var test = QUnit.test.bind(QUnit);
 
     test('timer start/end test', function(assert) {
         var time = new timer();

--- a/test/unit/trycatch-test.js
+++ b/test/unit/trycatch-test.js
@@ -3,7 +3,8 @@ define([
 ], function (trycatch) {
     /* jshint qunit: true */
 
-    module('trycatch');
+    QUnit.module('trycatch');
+    var test = QUnit.test.bind(QUnit);
 
     test('defines', function(assert) {
         assert.expect(2);

--- a/test/unit/utils-defs-test.js
+++ b/test/unit/utils-defs-test.js
@@ -3,7 +3,7 @@ define([
 ], function (utils) {
     /* jshint qunit: true */
 
-    test('defines util functions ', function (assert) {
+    QUnit.test('defines util functions ', function (assert) {
         assert.expect(55);
 
         // functions in helpers

--- a/test/unit/utils-test.js
+++ b/test/unit/utils-test.js
@@ -3,7 +3,9 @@ define([
     'utils/helpers'
 ], function ( _, utils) {
     /* jshint qunit: true */
-    module('utils');
+
+    QUnit.module('utils');
+    var test = QUnit.test.bind(QUnit);
 
     test('utils.log', function(assert) {
         assert.expect(2);

--- a/test/unit/validator-test.js
+++ b/test/unit/validator-test.js
@@ -4,7 +4,8 @@ define([
 ], function (_, validator) {
     /* jshint qunit: true */
 
-    module('validator');
+    QUnit.module('validator');
+    var test = QUnit.test.bind(QUnit);
 
     var testerGenerator = function (assert, method) {
         return function (left, right, message) {


### PR DESCRIPTION
QUnit 2.x no longer exposes `module` and `test` global variables. Use `QUnit` global and it's methods instead.

Removed bower packages used in index page since npm modules are already available.