### PR TITLE
Hide captions when displaying ads

### DIFF
--- a/src/css/flags/ads.less
+++ b/src/css/flags/ads.less
@@ -1,7 +1,12 @@
 .jwplayer.jw-flag-ads {
 
     .jw-preview,
-    .jw-dock {
+    .jw-dock,
+    .jw-logo,
+    .jw-captions.jw-captions-enabled {
+        display: none;
+    }
+    video::-webkit-media-text-track-container {
         display: none;
     }
 
@@ -30,15 +35,6 @@
         }
         .jw-icon-tooltip.jw-icon-volume {
             display : none;
-        }
-    }
-
-    .jw-logo, video::-webkit-media-text-track-container {
-        display: none;
-    }
-    .jw-captions {
-        &.jw-captions-enabled {
-            display: none;
         }
     }
 }

--- a/src/css/flags/ads.less
+++ b/src/css/flags/ads.less
@@ -33,9 +33,13 @@
         }
     }
 
-    .jw-logo,
-    .jw-captions, video::-webkit-media-text-track-container {
+    .jw-logo, video::-webkit-media-text-track-container {
         display: none;
+    }
+    .jw-captions {
+        &.jw-captions-enabled {
+            display: none;
+        }
     }
 }
 

--- a/src/css/flags/media-audio.less
+++ b/src/css/flags/media-audio.less
@@ -11,7 +11,9 @@
     // This has higher specificity to overwrite caption position when user inactive in playing state
     &.jw-flag-user-inactive.jw-state-playing {
         .jw-plugin,
-        .jw-captions,
+        .jw-captions {
+            bottom: 3em;
+        }
         video::-webkit-media-text-track-container {
             bottom: 3em;
         }

--- a/src/css/flags/touch.less
+++ b/src/css/flags/touch.less
@@ -5,8 +5,11 @@
         font-size: 1.5em;
     }
 
-    .jw-captions, video::-webkit-media-text-track-container {
+    .jw-captions {
         // control bar is (1.5*2.5 = 3.75)em for mobile, so bottom should be 0.5 above that
+        bottom: 4.25em;
+    }
+    video::-webkit-media-text-track-container {
         bottom: 4.25em;
     }
 

--- a/src/css/flags/user-inactive.less
+++ b/src/css/flags/user-inactive.less
@@ -10,7 +10,9 @@
         }
 
         .jw-plugin,
-        .jw-captions,
+        .jw-captions {
+            bottom: 0.5em;
+        }
         video::-webkit-media-text-track-container {
             bottom: 0.5em;
         }


### PR DESCRIPTION
### Changes proposed in this pull request:
The `jw-captions` class hides captions by default. We need to target `jw-captions-enabled` in order to hide captions during ad playback. 
Fixes #
JW7-2456