### PR TITLE
Fix cors issues with redirect tracks

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -583,8 +583,10 @@ define([
                     continue;
                 }
                 if (!crossoriginAnonymous) {
-                    // CORS applies to track loading and requires the crossorigin attribute
-                    _videotag.setAttribute('crossorigin', 'anonymous');
+                    // CORS applies to track loading and requires the crossorigin attribute in IOS
+                    if (utils.isIOS()) {
+                        _videotag.setAttribute('crossorigin', 'anonymous');
+                    }
                     crossoriginAnonymous = true;
                 }
                 var track = document.createElement('track');


### PR DESCRIPTION
There is a timing issue with setting cors attribute and redirect and tracks.
Since cors attribute was added for iOS tracks to work correctly, adding a gate to only set cors attribute if on iOS.
The line was added in this commit: https://github.com/jwplayer/jwplayer/commit/094576e3c16956764b448a812dd53579dbb8e0bb
JW7-2460