### PR TITLE
Download fonts as font file instead of base64 data

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -205,11 +205,11 @@ module.exports = function(grunt) {
                         },
                         {
                             test: /\.woff(\?v=\d+\.\d+\.\d+)?$/,
-                            loader: 'url?limit=10000&mimetype=application/font-woff'
+                            loader: 'file-loader?name=[name].[ext]'
                         },
                         {
                             test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/,
-                            loader: 'url?limit=10000&mimetype=application/octet-stream'
+                            loader: 'file-loader?name=[name].[ext]'
                         }
                     ]
                 }

--- a/src/css/icon-fonts.less
+++ b/src/css/icon-fonts.less
@@ -1,0 +1,9 @@
+/*** When not base64 encoded, fallbacks will work so that we won't load both fonts if we don't have to ***/
+/*** TTF is used for support for some older version of Android Stock (4.3 and less) ***/
+@font-face {
+    font-family: 'jw-icons';
+    src: url('../../assets/fonts/jw-icons.woff') format('woff'),
+        url('../../assets/fonts/jw-icons.ttf') format('truetype');
+    font-weight: normal;
+    font-style: normal;
+}

--- a/src/css/icon-fonts.less
+++ b/src/css/icon-fonts.less
@@ -1,9 +1,0 @@
-/*** When not base64 encoded, fallbacks will work so that we won't load both fonts if we don't have to ***/
-/*** TTF is used for support for some older version of Android Stock (4.3 and less) ***/
-@font-face {
-    font-family: 'jw-icons';
-    src: url('../../assets/fonts/jw-icons.woff') format('woff'),
-        url('../../assets/fonts/jw-icons.ttf') format('truetype');
-    font-weight: normal;
-    font-style: normal;
-}

--- a/src/css/imports/icons.less
+++ b/src/css/imports/icons.less
@@ -1,13 +1,5 @@
 @import "mixins";
 
-@font-face {
-    font-family: 'jw-icons';
-    src: url('../../../assets/fonts/jw-icons.woff') format('woff'),
-         url('../../../assets/fonts/jw-icons.ttf') format('truetype');
-    font-weight: normal;
-    font-style: normal;
-}
-
 .jw-icon-inline,
 .jw-icon-tooltip,
 .jw-icon-display,

--- a/src/css/imports/icons.less
+++ b/src/css/imports/icons.less
@@ -1,5 +1,15 @@
 @import "mixins";
 
+/*** When not base64 encoded, fallbacks will work so that we won't load both fonts if we don't have to ***/
+/*** TTF is used for support for some older version of Android Stock (4.3 and less) ***/
+@font-face {
+    font-family: 'jw-icons';
+    src: url('../../../assets/fonts/jw-icons.woff') format('woff'),
+    url('../../../assets/fonts/jw-icons.ttf') format('truetype');
+    font-weight: normal;
+    font-style: normal;
+}
+
 .jw-icon-inline,
 .jw-icon-tooltip,
 .jw-icon-display,

--- a/src/js/jwplayer.js
+++ b/src/js/jwplayer.js
@@ -1,7 +1,6 @@
 define([
     'api/global-api',
-    'utils/helpers',
-    '../css/jwplayer.less'
+    'utils/helpers'
 ], function (GlobalApi, utils) {
     /*global __webpack_public_path__:true*/
     __webpack_public_path__ = utils.loadFrom();

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -14,7 +14,8 @@ define([
     'view/rightclick',
     'view/title',
     'utils/underscore',
-    'templates/player.html'
+    'templates/player.html',
+    'css/jwplayer.less'
 ], function(utils, events, Events, Constants, states,
             CaptionsRenderer, ClickHandler, DisplayIcon, Dock, Logo,
             Controlbar, Preview, RightClick, Title, _, playerTemplate) {
@@ -65,6 +66,12 @@ define([
             _focusFromClick = false,
 
             _this = _.extend(this, Events);
+
+        // Include the separate chunk that contains the @font-face definition.  Check webpackJsonjwplayer so we don't
+        // run this in phantomjs because it breaks despite it working in browser and including files like we want it to.
+        if (window.webpackJsonpjwplayer) {
+            require('css/icon-fonts.less');
+        }
 
         this.model = _model;
         this.api = _api;

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -14,8 +14,7 @@ define([
     'view/rightclick',
     'view/title',
     'utils/underscore',
-    'templates/player.html',
-    'css/jwplayer.less'
+    'templates/player.html'
 ], function(utils, events, Events, Constants, states,
             CaptionsRenderer, ClickHandler, DisplayIcon, Dock, Logo,
             Controlbar, Preview, RightClick, Title, _, playerTemplate) {
@@ -70,7 +69,7 @@ define([
         // Include the separate chunk that contains the @font-face definition.  Check webpackJsonjwplayer so we don't
         // run this in phantomjs because it breaks despite it working in browser and including files like we want it to.
         if (window.webpackJsonpjwplayer) {
-            require('css/icon-fonts.less');
+            require('css/jwplayer.less');
         }
 
         this.model = _model;

--- a/test/config.js
+++ b/test/config.js
@@ -102,7 +102,7 @@
                 'templates/slider.html': 'handlebars-loader!templates/slider.html',
                 'templates/menu.html': 'handlebars-loader!templates/menu.html',
                 'templates/playlist.html': 'handlebars-loader!templates/playlist.html',
-                '../css/jwplayer.less': 'less!css/jwplayer',
+                'css/jwplayer.less': 'less!css/jwplayer',
                 'utils/video': mock + '/video.js'
             }
         },


### PR DESCRIPTION
Fonts are no longer loaded as base64 strings.  Instead, basic JWPlayer are added as a dependency for view.js while @font-face definitions are required separately so we can load woff or ttf files after we know where to load them from.  Require is used so webpack creates a single package that loads the fonts when appropriate.  Adds a check for window.webpackJsonpjwplayer to see if we're running it in phantomjs because it causes errors despite it working like we want it to.

JW7-2448