### PR TITLE
Revert the workaround for 302 redirect caption

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -562,9 +562,11 @@ define([
             if (_isSDK || !canRenderNatively) {
                 return;
             }
-            if (tracks && tracks.length) {
+            // Add tracks if we're playing the item for the first time or resuming playback after a midroll
+            if (tracks !== _itemTracks || (tracks.length && !_videotag.textTracks.length)) {
                 disableTextTrack();
                 dom.emptyElement(_videotag);
+                _itemTracks = tracks;
                 _addTracksToVideoTag(tracks);
             }
         }
@@ -650,6 +652,7 @@ define([
             if (!_attached) {
                 return;
             }
+            _itemTracks = null;
             _levels = item.sources;
             _currentQuality = _pickInitialQuality(item.sources);
             // the loadeddata event determines the mediaType for HLS sources
@@ -659,7 +662,6 @@ define([
 
             _position = item.starttime || 0;
             _duration = item.duration || 0;
-            _itemTracks = item.tracks;
             _visualQuality.reason = '';
             _setVideotagSource(_levels[_currentQuality]);
             _setupSideloadedTracks(item.tracks);
@@ -679,7 +681,6 @@ define([
                 // don't change state on mobile before user initiates playback
                 _this.setState(states.LOADING);
             }
-            _itemTracks = item.tracks;
             _completeLoad(item.starttime || 0, item.duration || 0);
         };
 

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -585,11 +585,12 @@ define([
                 if (!(/subtitles|captions|descriptions|chapters|metadata/i).test(itemTrack.kind)) {
                     continue;
                 }
-                var requiresCorsAttribute = !_videotag.hasAttribute('crossorigin') && utils.crossdomain(itemTrack.file);
-                if (requiresCorsAttribute && !crossoriginAnonymous) {
+                if (!crossoriginAnonymous) {
                     // CORS applies to track loading and requires the crossorigin attribute
-                    _videotag.setAttribute('crossorigin', 'anonymous');
-                    crossoriginAnonymous = true;
+                    if (!_videotag.hasAttribute('crossorigin') && utils.crossdomain(itemTrack.file)) {
+                        _videotag.setAttribute('crossorigin', 'anonymous');
+                        crossoriginAnonymous = true;
+                    }
                 }
                 var track = document.createElement('track');
                 track.src     = itemTrack.file;

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -206,7 +206,6 @@ define([
                 return;
             }
             _videotag.setAttribute('jw-loaded', 'started');
-            _setupSideloadedTracks(_itemTracks);
         }
 
         function _clickHandler(evt) {
@@ -479,6 +478,7 @@ define([
             if (sourceChanged || loadedSrc === 'none' || loadedSrc === 'started') {
                 _duration = duration;
                 _setVideotagSource(_levels[_currentQuality]);
+                _setupSideloadedTracks(_itemTracks);
                 _videotag.load();
             } else {
                 // Load event is from the same video as before
@@ -563,6 +563,7 @@ define([
                 return;
             }
             if (tracks && tracks.length) {
+                disableTextTrack();
                 dom.emptyElement(_videotag);
                 _addTracksToVideoTag(tracks);
             }
@@ -573,6 +574,7 @@ define([
             if (!tracks) {
                 return;
             }
+            var crossoriginAnonymous = false;
             for (var i = 0; i < tracks.length; i++) {
                 var itemTrack = tracks[i];
                 // only add .vtt or .webvtt files
@@ -584,9 +586,10 @@ define([
                     continue;
                 }
                 var requiresCorsAttribute = !_videotag.hasAttribute('crossorigin') && utils.crossdomain(itemTrack.file);
-                if (requiresCorsAttribute) {
+                if (requiresCorsAttribute && !crossoriginAnonymous) {
                     // CORS applies to track loading and requires the crossorigin attribute
                     _videotag.setAttribute('crossorigin', 'anonymous');
+                    crossoriginAnonymous = true;
                 }
                 var track = document.createElement('track');
                 track.src     = itemTrack.file;
@@ -658,6 +661,7 @@ define([
             _itemTracks = item.tracks;
             _visualQuality.reason = '';
             _setVideotagSource(_levels[_currentQuality]);
+            _setupSideloadedTracks(item.tracks);
         };
 
         this.load = function(item) {
@@ -1195,7 +1199,7 @@ define([
         }
 
         function disableTextTrack() {
-            if(_textTracks && _textTracks[_currentTextTrackIndex]) {
+            if (_textTracks && _textTracks[_currentTextTrackIndex]) {
                 _textTracks[_currentTextTrackIndex].mode = 'disabled';
             }
         }


### PR DESCRIPTION
Reverting the workaround for 302 redirect with captions proposed in https://github.com/jwplayer/jwplayer/pull/1172, since this is a problem with the video.
Keeping some of the good changes.
JW7-2460