### PR TITLE
Hiding cursor only when the player state is playing and user is inactive

### DIFF
--- a/src/css/flags/user-inactive.less
+++ b/src/css/flags/user-inactive.less
@@ -13,6 +13,10 @@
         .jw-captions {
             bottom: 0.5em;
         }
+        .jw-media {
+            cursor: none;
+            -webkit-cursor-visibility: auto-hide;
+        }
         video::-webkit-media-text-track-container {
             bottom: 0.5em;
         }
@@ -22,10 +26,5 @@
         .jw-controlbar {
             display: none;
         }
-    }
-
-    .jw-media {
-        cursor: none;
-        -webkit-cursor-visibility: auto-hide;
     }
 }


### PR DESCRIPTION
The Cursor will hide in HTML5 mode only
–– The cursor will autohide with the control bar when the player state is playing
–– The cursor will be displayed when the player state is buffering, paused or complete.

Fixes #
JW7-1601
