### PR TITLE
Add travis yaml for running tests with travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: node_js
+node_js:
+  - 5
+  - 4
+
+before_install:
+  - npm install -g npm
+  - npm config set loglevel warn
+
+before_script:
+  - bower install
+  - webpack --only test
+  - npm install -g grunt-cli
+
+script:
+  - grunt karma:local 


### PR DESCRIPTION
This adds a travis config for running tests. It will currently only run karma tests locally since we can't run browserstack through public travis. 

