### PR TITLE
Detect when fonts are loaded before displaying icons

### DIFF
--- a/src/css/imports/icons.less
+++ b/src/css/imports/icons.less
@@ -17,6 +17,12 @@
     .jw-icon;
 }
 
+.jw-font-load-detect {
+    position: absolute;
+    visibility: hidden;
+    display: inline-block;
+}
+
 /*** ICONS ***/
 .jw-icon-audio-tracks {
     &:before {
@@ -142,4 +148,3 @@
         content: "\e616";
     }
 }
-

--- a/src/css/imports/icons.less
+++ b/src/css/imports/icons.less
@@ -17,12 +17,6 @@
     .jw-icon;
 }
 
-.jw-font-load-detect {
-    position: absolute;
-    visibility: hidden;
-    display: inline-block;
-}
-
 /*** ICONS ***/
 .jw-icon-audio-tracks {
     &:before {

--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -20,6 +20,12 @@
     -o-font-feature-settings: "liga";
     font-feature-settings: "liga";
     -moz-osx-font-smoothing: grayscale;
+
+    visibility: hidden;
+
+    .jw-flag-icons-ready & {
+        visibility: visible;
+    }
 }
 
 .inset-controlbar() {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -66,16 +66,17 @@ define([
 
             _this = _.extend(this, Events);
 
-        // Include the separate chunk that contains the @font-face definition.  Check webpackJsonjwplayer so we don't
-        // run this in phantomjs because it breaks despite it working in browser and including files like we want it to.
-        if (window.webpackJsonpjwplayer) {
-            require('css/jwplayer.less');
-        }
-
         this.model = _model;
         this.api = _api;
 
         _playerElement = utils.createElement(playerTemplate({id: _model.get('id')}));
+
+        // Include the separate chunk that contains the @font-face definition.  Check webpackJsonjwplayer so we don't
+        // run this in phantomjs because it breaks despite it working in browser and including files like we want it to.
+        if (window.webpackJsonpjwplayer) {
+            _applyStyles();
+        }
+
         if (utils.isIE()) {
             utils.addClass(_playerElement, 'jw-ie');
         }
@@ -101,6 +102,36 @@ define([
             document.mozCancelFullScreen ||
             document.msExitFullscreen;
         _elementSupportsFullscreen = _requestFullscreen && _exitFullscreen;
+
+        function _applyStyles() {
+            var pollTarget = utils.createElement(
+                '<span class="jw-font-load-detect jw-reset">&#xe614&#xe614&#xe614</span>'
+            );
+            _playerElement.appendChild(pollTarget);
+
+            require('css/jwplayer.less');
+
+            var iconSize = 0;
+            var startTime = Date.now();
+
+            // Polls the width of the poll target to see when its size increases because its using the wider font glyphs
+            var fontRenderedPoll = function() {
+                var pollTargetWidth = pollTarget.offsetWidth;
+
+                if (!iconSize && pollTargetWidth) {
+                    iconSize = pollTargetWidth;
+                    utils.addClass(pollTarget, 'jw-icon-inline');
+                } else if (Date.now() - startTime > 5000 || (iconSize && iconSize !== pollTargetWidth)) {
+                    _playerElement.removeChild(pollTarget);
+                    utils.addClass(_playerElement, 'jw-flag-icons-ready');
+                    return;
+                }
+
+                setTimeout(fontRenderedPoll, 50);
+            };
+
+            setTimeout(fontRenderedPoll, 1);
+        }
 
         function adjustSeek(amount) {
             var min = 0;

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -108,6 +108,11 @@ define([
                 '<span class="jw-font-load-detect jw-reset">&#xe614&#xe614&#xe614</span>'
             );
             _playerElement.appendChild(pollTarget);
+            utils.css(pollTarget, {
+                position: 'absolute',
+                visibility: 'hidden',
+                display: 'inline-block'
+            });
 
             require('css/jwplayer.less');
 

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -105,14 +105,14 @@ define([
 
         function _applyStyles() {
             var pollTarget = utils.createElement(
-                '<span class="jw-font-load-detect jw-reset">&#xe614&#xe614&#xe614</span>'
+                '<span ' +
+                    'class="jw-font-load-detect jw-reset" ' +
+                    'style="position: absolute; visibility: hidden; display: inline-block"' +
+                '>' +
+                    '&#xe614&#xe614&#xe614' +
+                '</span>'
             );
             _playerElement.appendChild(pollTarget);
-            utils.css(pollTarget, {
-                position: 'absolute',
-                visibility: 'hidden',
-                display: 'inline-block'
-            });
 
             require('css/jwplayer.less');
 


### PR DESCRIPTION
Detect when fonts are loaded before displaying icons by polling the width of a span.  The span starts out with a basic width and will have its size increase ones the icon font is applied and wider glyphs are used instead of the default glyphs.  This may be a more appropriate way to determine if the UI is ready in the future to make sure we don't need to do many repaints before we display the UI.

JW7-2481