### PR TITLE
Fixed captions positions on mobile devices

### DIFF
--- a/src/css/flags/media-audio.less
+++ b/src/css/flags/media-audio.less
@@ -1,3 +1,5 @@
+@import "../imports/vars";
+
 .jwplayer.jw-flag-media-audio {
     .jw-controlbar {
         display: table;
@@ -15,7 +17,7 @@
             bottom: 3em;
         }
         video::-webkit-media-text-track-container {
-            bottom: 3em;
+            max-height: calc(97% - 6.25 * (@controlbar-height));
         }
     }
 }

--- a/src/css/flags/touch.less
+++ b/src/css/flags/touch.less
@@ -10,7 +10,9 @@
         bottom: 4.25em;
     }
     video::-webkit-media-text-track-container {
-        bottom: 4.25em;
+        // need to compensate for the control bar being 3.75em on mobile
+        // 97% - 6.25 * 4.25em
+        max-height: 70%;
     }
 
     .jw-icon-tooltip.jw-open-drawer {

--- a/src/css/imports/captions.less
+++ b/src/css/imports/captions.less
@@ -46,13 +46,13 @@
     }
     video::-webkit-media-text-track-container {
         // With 16 lines of captions, 1em ~= 6.25% of height
-        max-height: calc(100% - 6.25 * (@controlbar-height));
+        max-height: calc(97% - 6.25 * (@controlbar-height));
         line-height: 1.3em;
     }
 
     &.jw-flag-compact-player {
         video::-webkit-media-text-track-container {
-            max-height: calc(100% - 7.5 * (@controlbar-height));
+            max-height: calc(97% - 7.5 * (@controlbar-height));
         }
     }
 }


### PR DESCRIPTION
### Changes proposed in this pull request:
Fixed captions position on mobile devices. Also adjusted the height of the captions container so it's ~0.5em above the control bar. This ensures that captions with line set to 'auto' display above the control bar.

Fixes #
JW7-2123