### PR TITLE
Don't throw if VTT file is valid but without captions

### DIFF
--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -170,7 +170,6 @@ define([
 
                 if (kind === 'captions' || kind === 'subtitles') {
                     if (track.file) {
-                        _addTrack(track);
                         _load(track);
                     } else if (track.data) {
                         _addTrack(track);
@@ -239,6 +238,9 @@ define([
             } else {
                 status = utils.tryCatch(function() {
                     track.data = srt(xhr.responseText);
+                    if (track.data) {
+                        _addTrack(track);
+                    }
                 });
             }
             if (status instanceof utils.Error) {

--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -170,7 +170,7 @@ define([
 
                 if (kind === 'captions' || kind === 'subtitles') {
                     if (track.file) {
-                        _load(track);
+                        _load.call(this, track);
                     } else if (track.data) {
                         _addTrack(track);
                     }
@@ -212,12 +212,13 @@ define([
         }
 
         function _load(track) {
+            var _this = this;
             utils.ajax(track.file, function(xhr) {
-                _xhrSuccess(xhr, track);
+                _xhrSuccess(xhr, track, _this);
             }, _errorHandler);
         }
 
-        function _xhrSuccess(xhr, track) {
+        function _xhrSuccess(xhr, track, _this) {
             var rss = xhr.responseXML ? xhr.responseXML.firstChild : null,
                 status;
 
@@ -237,9 +238,11 @@ define([
                 });
             } else {
                 status = utils.tryCatch(function() {
+                    // If no valid captions were found, an empty array is returned
                     track.data = srt(xhr.responseText);
-                    if (track.data) {
+                    if (track.data.length) {
                         _addTrack(track);
+                        _this.setCaptionsList(_captionsMenu());
                     }
                 });
             }

--- a/src/js/parsers/captions/srt.js
+++ b/src/js/parsers/captions/srt.js
@@ -15,6 +15,7 @@ define([
         if (list.length === 1) {
             list = data.split('\n\n');
         }
+
         for (var i = 0; i < list.length; i++) {
             if (list[i] === 'WEBVTT') {
                 continue;
@@ -25,9 +26,7 @@ define([
                 _captions.push(entry);
             }
         }
-        if (!_captions.length) {
-            throw new Error('Invalid SRT file');
-        }
+
         return _captions;
     };
 


### PR DESCRIPTION
- Don't throw if VTT is empty
- Don't add to captions menu if VTT is empty
- Download VTT before adding to list to prevent pre-emptive adding of empty track

See https://github.com/jwplayer/jwplayer/issues/1098

JW7-2440

