### PR TITLE
Listen to mediaModel events sooner

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -93,6 +93,7 @@ define([
                 _.defer(_completeHandler);
             });
             _model.mediaController.on(events.JWPLAYER_MEDIA_ERROR, this.triggerError, this);
+            _model.mediaController.on('all', _this.trigger.bind(_this));
 
             // If we attempt to load flash, assume it is blocked if we don't hear back within a second
             _model.on('change:flashBlocked', function(model, isBlocked) {
@@ -186,7 +187,6 @@ define([
                     });
                 });
 
-                _model.mediaController.on('all', _this.trigger.bind(_this));
                 _view.on('all', _this.trigger.bind(_this));
 
                 this.showView(_view.element());


### PR DESCRIPTION
mediaModel events that came before playerReady were thrown out.
Listening on setup so that we listen to those events.
JW7-2446