### PR TITLE
Use external webpack config

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,8 @@
 /* jshint node: true */
 
+var path = require('path');
 var webpack = require('webpack');
+var parallelWebpack = require('parallel-webpack');
 var env = process.env;
 
 function getBuildVersion(packageInfo) {
@@ -29,9 +31,6 @@ module.exports = function(grunt) {
     var buildVersion = getBuildVersion(packageInfo);
     // both flashVersion and swfTarget are needed to force flex to build using the right version
     var flashVersion = 11.2;
-
-    var webpackCompilers = {};
-    var autoprefixBrowsers = encodeURIComponent('> 1%');
 
     // For task testing
     // grunt.loadTasks('../grunt-flash-compiler/tasks');
@@ -175,96 +174,6 @@ module.exports = function(grunt) {
                 }
             }
         },
-
-        webpack : {
-            options: {
-                entry: {
-                    jwplayer : ['./src/js/jwplayer.js']
-                },
-                stats: {
-                    timings: true
-                },
-                resolve: {
-                    modulesDirectories: [
-                        'src/js/',
-                        'src'
-                    ]
-                },
-                devtool: 'cheap-source-map',
-                //devtool: 'cheap-eval-source-map',
-                module: {
-                    loaders: [
-                        {
-                            test: /\.less$/,
-                            loaders: [
-                                // custom style-loader in src/js/view/ removes source maps with base64 url
-                                // TODO: optimize by using jwplayer utils.css() (may require updates to util)
-                                'simple-style-loader',
-                                'css',
-                                'autoprefixer?browsers=' + autoprefixBrowsers,
-                                'less?compress'
-                            ]
-                        },
-                        {
-                            test: /\.html$/,
-                            loader: 'handlebars-loader'
-                        },
-                        {
-                            test: /\.woff(\?v=\d+\.\d+\.\d+)?$/,
-                            loader: 'file-loader?name=[name].[ext]'
-                        },
-                        {
-                            test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/,
-                            loader: 'file-loader?name=[name].[ext]'
-                        }
-                    ]
-                }
-            },
-            debug : {
-                options: {
-                    debug: true,
-                    output: {
-                        path: 'bin-debug/',
-                        filename: '[name].js',
-                        chunkFilename:'[name].js',
-                        sourceMapFilename : '[name].[hash].map',
-                        library: 'jwplayer',
-                        libraryTarget: 'umd',
-                        pathinfo: true
-                    },
-                    plugins: [
-                        new webpack.DefinePlugin({
-                            __SELF_HOSTED__ : true,
-                            __REPO__ : '\'\'',
-                            __DEBUG__ : true,
-                            __BUILD_VERSION__: '\'' + buildVersion + '\'',
-                            __FLASH_VERSION__: flashVersion
-                        })
-                    ]
-                }
-            },
-            release : {
-                options: {
-                    output: {
-                        path: 'bin-release/',
-                        filename: '[name].js',
-                        chunkFilename: '[name].js',
-                        sourceMapFilename : '[name].[hash].map',
-                        library: 'jwplayer',
-                        libraryTarget: 'umd'
-                    },
-                    plugins: [
-                        new webpack.DefinePlugin({
-                            __SELF_HOSTED__ : true,
-                            __REPO__ : '\'\'',
-                            __DEBUG__ : false,
-                            __BUILD_VERSION__: '\'' + buildVersion + '\'',
-                            __FLASH_VERSION__: flashVersion
-                        })
-                    ]
-                }
-            }
-        },
         uglify: {
             options: {
                 // screwIE8: true,
@@ -385,33 +294,29 @@ module.exports = function(grunt) {
         }
     });
 
-    grunt.registerMultiTask('webpack', 'Spawn a webpack compiler', function() {
+    grunt.registerTask('webpack-watch', 'Spawn a webpack watch task', function() {
         var done = this.async();
-        var target = this.target;
-        var compiler = webpackCompilers[target];
-        if (!compiler) {
-            compiler = webpackCompilers[target] = webpack( this.options() );
-        }
-        compiler.run(function(err, stats) {
-            var fail = false;
+        parallelWebpack.run(path.resolve('./webpack.config.js'), {
+            watch: true
+        }).then(done).catch(function(err) {
+            grunt.log.error(err.toString());
+            done(false);
+        });
+    });
+
+    grunt.registerTask('webpack', 'Run webpack compiler', function() {
+        var done = this.async();
+        parallelWebpack.run(path.resolve('./webpack.config.js'), {}).then(function(err, res) {
             if (err) {
-                fail = true;
-                grunt.log.writeln(err.toString());
-            } else {
-                // Fail build when errors are found
-                if (stats.compilation.errors.length) {
-                    fail = true;
-                }
-                grunt.log.writeln(stats.toString({
-                    chunks: false
-                }));
+                grunt.log.error(err.toString());
             }
-            if (fail) {
-                webpackCompilers[target] = null;
-                done(false);
-                return;
+            if (res) {
+                grunt.log.writeln(res.toString());
             }
             done();
+        }).catch(function(err) {
+            grunt.log.error(err.toString());
+            done(false);
         });
     });
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "load-grunt-tasks": "^3.5.0",
     "loader-utils": "^0.2.14",
     "node-libs-browser": "^1.0.0",
+    "parallel-webpack": "^1.4.0",
     "phantomjs-prebuilt": "2.1.7",
     "qunitjs": "^1.23.0",
     "raw-loader": "^0.5.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,154 @@
+/* jshint node: true */
+var webpack = require('webpack');
+var env = process.env;
+var _ = require('lodash');
+var argv = require('minimist')(process.argv.slice(2));
+
+var packageInfo = require('./package.json');
+var flashVersion = 11.2;
+
+function getBuildVersion(packageInfo) {
+    // Build Version: {major.minor.revision}
+    var metadata = '';
+    if (env.BUILD_NUMBER) {
+        var branch = env.GIT_BRANCH;
+        metadata = 'opensource';
+        if (branch) {
+            metadata += '_' + branch.replace(/^origin\//, '').replace(/[^0-9A-Za-z-]/g, '-');
+        }
+        metadata += '.' + env.BUILD_NUMBER;
+    } else {
+        var now = new Date();
+        now.setTime(now.getTime()-now.getTimezoneOffset()*60000);
+        metadata = 'local.' + now.toISOString().replace(/[\.\-:T]/g, '-').replace(/Z|\.\d/g, '');
+    }
+    return packageInfo.version +'+'+ metadata;
+}
+
+var compileConstants =
+{
+    __SELF_HOSTED__: true,
+    __REPO__ : '\'\'',
+    __DEBUG__ : false,
+    __BUILD_VERSION__: '\'' + getBuildVersion(packageInfo) + '\'',
+    __FLASH_VERSION__: flashVersion
+};
+
+var uglifyJsOptions = {
+    screwIE8: true,
+    stats: true,
+    compress: {
+        warnings: false
+    },
+    mangle: {
+        toplevel: true,
+        eval: true,
+        except: ['export', 'require']
+    }
+};
+
+var multiConfig = _.compact(_.map([
+    {
+        name: 'debug',
+        output: {
+            path: 'bin-debug/',
+            filename: '[name].js',
+            chunkFilename:'[name].js',
+            sourceMapFilename : '[name].[hash].map',
+            library: 'jwplayer',
+            libraryTarget: 'umd',
+            pathinfo: true
+        },
+        debug: true,
+        devtool: 'source-map',
+        plugins: [
+            new webpack.DefinePlugin(_.defaults({
+                __DEBUG__ : true
+            }, compileConstants))
+        ]
+    },
+    {
+        name: 'release',
+        output: {
+            path: 'bin-release/',
+            filename: '[name].js',
+            chunkFilename: '[name].js',
+            sourceMapFilename : '[name].[hash].map',
+            library: 'jwplayer',
+            libraryTarget: 'umd'
+        },
+        watch: false,
+        progress: false,
+        plugins: [
+            new webpack.DefinePlugin(compileConstants),
+            new webpack.optimize.OccurrenceOrderPlugin(),
+            new webpack.optimize.UglifyJsPlugin(uglifyJsOptions)
+        ]
+    }
+], function(configuration) {
+    // Use `webpack --only {CONFIG_NAME}` to filter out multiple configurations
+    //  ex: `webpack --only debug` will only return and build the debug config
+    if (argv.only) {
+        if (configuration.name !== argv.only) {
+            return;
+        }
+    }
+
+    return _.defaultsDeep(configuration, {
+        entry: {
+            // the array notation is required due to bug in webpack :
+            //    https://github.com/webpack/webpack/issues/300
+            jwplayer: ['./src/js/jwplayer.js']
+        },
+        output: {
+            // This would allow loading of modules from our CDN
+            //crossOriginLoading: 'anonymous'
+        },
+        umdNamedDefine: true,
+        stats: {
+            timings: true
+        },
+        devtool: 'cheap-source-map',
+        resolve: {
+            modulesDirectories: [
+                'src/js/',
+                'src'
+            ]
+        },
+        module: {
+            loaders: [
+                {
+                    test: /\.less$/,
+                    loaders: [
+                        'simple-style-loader',
+                        'css',
+                        'autoprefixer?browsers=' + encodeURIComponent('> 1%'),
+                        'less?compress'
+                    ]
+                },
+                {
+                    test: /\.html$/,
+                    loader: 'handlebars-loader'
+                },
+                {
+                    test: /\.woff(\?v=\d+\.\d+\.\d+)?$/,
+                    loader: 'file-loader?name=[name].[ext]'
+                },
+                {
+                    test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/,
+                    loader: 'file-loader?name=[name].[ext]'
+                }
+            ]
+        }
+    });
+}));
+
+// When only returning one config, return the object.
+// This provides flat webpack output can be opened in the analyze tool.
+// Example: `webpack --only debug -j > output.json`
+//  and open output.json at http://webpack.github.io/analyse/
+if (multiConfig.length === 1) {
+    multiConfig = multiConfig[0];
+}
+
+module.exports = multiConfig;


### PR DESCRIPTION
#### webpack

There are two webpack targets for compiling JavaScript: debug and release

1. debug - unminified player for development
1. release - minified player

#### webpack CLI
Use webpack for rapid js development. Don't forget to run tests with grunt before committing. 

First install webpack and webpack-dev-server globally for cli access:
`npm install webpack webpack-dev-server -g`

- Build all configurations with `webpack`
- Run `webpack --watch` (or `webpack -w`) for faster compilation when source files change
- Use the `--only` flag with debug or release to only build a single configuration:
`webpack --only debug`


#### Grunt

The default `grunt` task builds all player components.

`grunt webpack` builds all webpack targets in parallel. `grunt webpack-watch` is also available but not as fast as using `webpack -w`.

#### Examples
1. Watch for JS changes and compile bin-debug/ files
  ```
  webpack --only debug -w
  ```

1. Serve and watch with webpack-dev-server
  ```
  webpack-dev-server --only debug -w --output-public-path /bin-debug/
  ## It would be nice if webpack-dev-server used the output path
  ## defined in webpack.config.js. Ideas?
  ```

1. Analyze the dependency graph (outputs json which can be viewed at http://webpack.github.io/analyse/):
  ```
  rm -f webpack.graph.json && webpack --only release -j > webpack.graph.json
  ```

For more options add `--help` or see https://webpack.github.io/docs/cli.html.