### PR TITLE
Remove persisted properties from default config

### DIFF
--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -16,8 +16,6 @@ define([
         castAvailable: false,
         skin: 'seven',
         stretching: 'uniform',
-        mute: false,
-        volume: 90,
         width: 480,
         height: 270
         //qualityLabel: '480p',     // specify a default quality

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -37,7 +37,10 @@ define([
             var storage = new Storage();
             storage.track(PERSIST_ITEMS, this);
 
-            _.extend(this.attributes, storage.getAllItems(), config, {
+            _.extend(this.attributes, {
+                mute: false,
+                volume: 90
+            }, storage.getAllItems(), config, {
                 // always start on first playlist item
                 item : 0,
                 // Initial state, upon setup


### PR DESCRIPTION
Default settings for persisted properties must be set in the model

 Having them in the config was overriding the persisted values.

Fixes #1077 JW7-2545

Note: Persisted values should override jwplayer.defaults, but since 7.0 the order was changed when persisted storage was moved into the model. That will be addressed later.