### PR TITLE
Fixed: Volume and mute are reset by built in defaults

### DIFF
--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -37,8 +37,9 @@ define([
         return val;
     }
 
-    var config = function(options) {
-        var allOptions = _.extend({}, (window.jwplayer || {}).defaults, options);
+    var config = function(options, storage) {
+        var persisted = storage && storage.getAllItems();
+        var allOptions = _.extend({}, (window.jwplayer || {}).defaults, persisted, options);
 
         _deserialize(allOptions);
 

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -5,6 +5,7 @@ define([
     'controller/Setup',
     'controller/captions',
     'controller/model',
+    'controller/storage',
     'playlist/playlist',
     'playlist/loader',
     'utils/helpers',
@@ -15,8 +16,8 @@ define([
     'events/states',
     'events/events',
     'view/error'
-], function(Config, InstreamAdapter, _, Setup, Captions,
-            Model, Playlist, PlaylistLoader, utils, View, Providers, Events, changeStateEvent, states, events, error) {
+], function(Config, InstreamAdapter, _, Setup, Captions, Model, Storage,
+            Playlist, PlaylistLoader, utils, View, Providers, Events, changeStateEvent, states, events, error) {
 
     function _queueCommand(command) {
         return function(){
@@ -78,9 +79,10 @@ define([
 
             var _video = function() { return _model.getVideo(); };
 
-            var config = new Config(options);
+            var storage = new Storage();
+            var config = new Config(options, storage);
 
-            _model = this._model.setup(config);
+            _model = this._model.setup(config, storage);
             _view  = this._view  = new View(_api, _model);
             _captions = new Captions(_api, _model);
             _setup = new Setup(_api, _model, _view, _setPlaylist);

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -1,22 +1,13 @@
 define([
     'utils/helpers',
     'providers/providers',
-    'controller/storage',
     'controller/qoe',
     'utils/underscore',
     'utils/backbone.events',
     'utils/simplemodel',
     'events/events',
     'events/states'
-], function(utils, Providers, Storage, QOE, _, Events, SimpleModel, events, states) {
-
-
-    var PERSIST_ITEMS = [
-        'volume',
-        'mute',
-        'captionLabel',
-        'qualityLabel'
-    ];
+], function(utils, Providers, QOE, _, Events, SimpleModel, events, states) {
 
     // Represents the state of the player
     var Model = function() {
@@ -33,11 +24,17 @@ define([
 
         this.set('mediaModel', this.mediaModel);
 
-        this.setup = function(config) {
-            var storage = new Storage();
-            storage.track(PERSIST_ITEMS, this);
+        this.setup = function(config, storage) {
+            if (storage) {
+                storage.track([
+                    'volume',
+                    'mute',
+                    'captionLabel',
+                    'qualityLabel'
+                ], this);
+            }
 
-            _.extend(this.attributes, storage.getAllItems(), config, {
+            _.extend(this.attributes, config, {
                 // always start on first playlist item
                 item : 0,
                 // Initial state, upon setup

--- a/test/unit/api-config-test.js
+++ b/test/unit/api-config-test.js
@@ -1,7 +1,7 @@
 define([
     'test/underscore',
     'api/config'
-], function (_, config) {
+], function (_, Config) {
     /* jshint qunit: true */
 
     QUnit.module('API config');
@@ -19,7 +19,7 @@ define([
     }
 
     function testConfig(assert, obj) {
-        var x = config(obj);
+        var x = new Config(obj);
 
 
         var attrs = ['width', 'height', 'base'];


### PR DESCRIPTION
**Issue:** volume and mute are reset by built in defaults #1077

**Solution:** Prioritize persisted properties above jwplayer.defaults and under setup config.

This insures that volume and mute can be persisted without being overridden by library defaults including the config module `Defaults` or `jwplayer.defaults`.

Persisted properties extend configuration options and are only overridden by setup options.

Fixes #1077 JW7-2545