### PR TITLE
Update player duration when item is changed

### DIFF
--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -264,6 +264,8 @@ define([
             this.mediaModel.off();
             this.mediaModel = new MediaModel();
             this.set('mediaModel', this.mediaModel);
+            this.set('position', item.starttime || 0);
+            this.set('duration', item.duration || 0);
 
             this.setProvider(item);
         };
@@ -332,16 +334,14 @@ define([
 
         // The model is also the mediaController for now
         this.loadVideo = function(item) {
-
-            this.mediaModel.set('playAttempt', true);
-            this.mediaController.trigger(events.JWPLAYER_MEDIA_PLAY_ATTEMPT, {'playReason': this.get('playReason')});
-
             if (!item) {
                 var idx = this.get('item');
                 item = this.get('playlist')[idx];
             }
             this.set('position', item.starttime || 0);
             this.set('duration', item.duration || 0);
+            this.mediaModel.set('playAttempt', true);
+            this.mediaController.trigger(events.JWPLAYER_MEDIA_PLAY_ATTEMPT, {'playReason': this.get('playReason')});
 
             _provider.load(item);
         };


### PR DESCRIPTION
Player position and duration should be updated when the active item is set and mediaModel is reset, before item ready and before initializing the item's provider.

JW7-2385