### PR TITLE
getCurrentCaptions method missing in controller

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -651,6 +651,7 @@ define([
             this.setCurrentAudioTrack = _setCurrentAudioTrack;
             this.getCurrentAudioTrack = _getCurrentAudioTrack;
             this.getAudioTracks = _getAudioTracks;
+            this.getCurrentCaptions = _getCurrentCaptions;
             this.getCaptionsList = _getCaptionsList;
             this.getVisualQuality = _getVisualQuality;
             this.getConfig = _getConfig;


### PR DESCRIPTION
### Changes proposed in this pull request:

*- This adds back the getCurrentCaptions method that was removed accidentally*

