### PR TITLE
Remove beforeunload listener

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -197,16 +197,6 @@ define([
 
                 this.showView(_view.element());
 
-                // prevent video error in display on window close
-                window.addEventListener('beforeunload', function() {
-                    if (_setup) {
-                        _setup.destroy();
-                    }
-                    if (_model) {
-                        _model.destroy();
-                    }
-                });
-
                 // Defer triggering of events until they can be registered
                 _.defer(_playerReadyNotify);
             }


### PR DESCRIPTION
- Remove `beforeunload` event listener

Navigating to a mailto link causes `beforeunload` to trigger, which results in the player remaining on the page in a broken state. This PR removes the event listener.

JW7-2268

