### PR TITLE
Remove small black area for poster image

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,29 +1,15 @@
 {
-    //"indent": 4,
     "maxlen": 120,
     "trailing": true,
     "eqeqeq": true,
     "browser": true,
-
-    // console, alert
     "devel": true,
-
-    // A function can only take max 3 arguments
     "maxparams": 99,
-
-    // Strings use single quotes instead of double
     "quotmark": "single",
-
-    // All conditionals and loops require curly brackets
     "curly": true,
-
-    // require correct variable declaration
     "undef": true,
     "unused": true,
-
-    // These variables are predefined
     "predef": [
-      //"jwplayer",
       "require",
       "define",
       "Promise",

--- a/.jshintrc
+++ b/.jshintrc
@@ -26,6 +26,7 @@
       //"jwplayer",
       "require",
       "define",
+      "Promise",
       "__DEBUG__",
       "__REPO__",
       "__SELF_HOSTED__",

--- a/src/js/view/preview.js
+++ b/src/js/view/preview.js
@@ -2,9 +2,9 @@ define([
     'utils/underscore',
     'utils/helpers'
 ], function(_, utils) {
-
     var Preview = function(_model) {
         this.model = _model;
+        this.aspectRatioPromise = Promise.resolve(0);
 
         _model.on('change:playlistItem', onPlaylistItem, this);
         _model.on('change:mediaModel', onMediaModel, this);
@@ -46,10 +46,25 @@ define([
             }
         },
         setImage: function(img) {
+            // Remove onload function from previous image
+            if (this.image) {
+                this.image.onload = null;
+            }
             this.model.off('change:state', null, this);
             var backgroundImage = '';
             if (_.isString(img)) {
                 backgroundImage = 'url("' + img + '")';
+
+                // Save the background image's width and height for resize check in view.js
+                this.image = new Image();
+                this.aspectRatioPromise = new Promise(function(resolve) {
+                    this.image.onload = function() {
+                        resolve(this.width / this.height);
+                    };
+                    this.image.src = img;
+                }.bind(this));
+            } else {
+                this.aspectRatioPromise = Promise.resolve(0);
             }
             utils.style(this.el, {
                 backgroundImage: backgroundImage

--- a/src/js/view/preview.js
+++ b/src/js/view/preview.js
@@ -81,7 +81,7 @@ define([
                         backgroundSize = 'cover';
                     }
                 }
-                utils.css.style(this.el, {
+                utils.style(this.el, {
                     backgroundSize: backgroundSize
                 });
             }

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -698,6 +698,20 @@ define([
 
             // pass width, height from jwResize if present
             _resizeMedia(width, height);
+
+            if (_this.model.get('stretching') === 'uniform' && _preview) {
+                var playerAspectRatio = _playerElement.clientWidth / _playerElement.clientHeight;
+                // snap image to edges when the difference in aspect ratio is less than 9%
+                var backgroundSize = null;
+                _preview.aspectRatioPromise.then(function(imageAspectRatio) {
+                    if (Math.abs(playerAspectRatio - imageAspectRatio) < 0.09) {
+                        backgroundSize = 'cover';
+                    }
+                    utils.css.style(_preview.el, {
+                        backgroundSize: backgroundSize
+                    });
+                });
+            }
         }
 
         function _checkAudioMode(height) {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -698,20 +698,6 @@ define([
 
             // pass width, height from jwResize if present
             _resizeMedia(width, height);
-
-            if (_this.model.get('stretching') === 'uniform' && _preview) {
-                var playerAspectRatio = _playerElement.clientWidth / _playerElement.clientHeight;
-                // snap image to edges when the difference in aspect ratio is less than 9%
-                var backgroundSize = null;
-                _preview.aspectRatioPromise.then(function(imageAspectRatio) {
-                    if (Math.abs(playerAspectRatio - imageAspectRatio) < 0.09) {
-                        backgroundSize = 'cover';
-                    }
-                    utils.css.style(_preview.el, {
-                        backgroundSize: backgroundSize
-                    });
-                });
-            }
         }
 
         function _checkAudioMode(height) {
@@ -756,6 +742,10 @@ define([
                     return;
                 }
                 height = _videoLayer.clientHeight;
+            }
+
+            if (_preview) {
+                _preview.resize(width, height, _model.get('stretching'));
             }
 
             //IE9 Fake Full Screen Fix


### PR DESCRIPTION
When the stretch is set to uniform, and the black area is small enough,
we want to stretch the poster image to remove the black area.
JW7-2507