### PR TITLE
Set model captions style after captionsrenderer setup

### DIFF
--- a/src/js/view/captionsrenderer.js
+++ b/src/js/view/captionsrenderer.js
@@ -191,14 +191,11 @@ define([
             _display.appendChild(_captionsWindow);
 
             this.populate(_model.get('captionsTrack'));
+            _model.set('captions', _options);
         };
 
         this.clear = function () {
             utils.empty(_display);
-        };
-
-        this.getStyles = function () {
-            return _options;
         };
 
         function setupShadowDOMStyles(playerId, windowStyle, textStyle) {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -1021,7 +1021,6 @@ define([
             _captionsRenderer.clear();
             _captionsRenderer.setup(_model.get('id'), captionsStyle);
             _captionsRenderer.resize();
-            _model.set('captions', _captionsRenderer.getStyles());
         };
 
         this.destroy = function() {


### PR DESCRIPTION
- Set captions style on the model within captionsrenderer setup

The original implementation of getCaptions required setCaptions to be set in order to return a defined object. This ticket sets the captions style on the model within the captionsrenderer setup so that the object will always be defined.

JW7-2022

