### PR TITLE
Clear timeout when request is aborted

### DIFF
--- a/src/js/utils/ajax.js
+++ b/src/js/utils/ajax.js
@@ -83,6 +83,9 @@ define([
                 _abortAjax(xhr);
                 options.onerror('Timeout', url, xhr);
             }, options.timeout);
+            xhr.onabort = function() {
+                clearTimeout(options.timeoutId);
+            };
         }
 
         try {


### PR DESCRIPTION
When `utils.ajax` requests are configured with a timeout and and aborted before they complete, the error event still fires on timeout. This change clears the timeout on abort.

Steps to repro:
```js
xhr = utils.ajax('http://google.com', e => console.log('ok') , e => console.log('error'), {
    timeout: 1000
});
xhr.abort();

// "error" is logged after one second
```