### PR TITLE
Move karma config to root

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -29,8 +29,6 @@ module.exports = function(grunt) {
 
     var packageInfo = grunt.file.readJSON('package.json');
     var buildVersion = getBuildVersion(packageInfo);
-    // both flashVersion and swfTarget are needed to force flex to build using the right version
-    var flashVersion = 11.2;
 
     // For task testing
     // grunt.loadTasks('../grunt-flash-compiler/tasks');
@@ -225,28 +223,12 @@ module.exports = function(grunt) {
 
         karma: {
             options: {
-                configFile: './test/karma/karma.conf.js',
-                port: env.KARMA_PORT || 9876,
-                coverageReporter: {
-                    type : 'html',
-                    dir: 'reports/coverage'
-                },
+                configFile: './karma.conf.js',
                 junitReporter: {
                     suite: '<%= grunt.task.current.target %>',
                     outputDir: 'reports/junit'
                 },
-                customLaunchers: require( './test/karma/browserstack-launchers' ),
-                browserStack: {
-                    username:  process.env.BS_USERNAME,
-                    accessKey: process.env.BS_AUTHKEY,
-                    name: 'Unit Tests',
-                    project: 'jwplayer',
-                    build: '' + (env.JOB_NAME     || 'local' ) +' '+
-                                (env.BUILD_NUMBER || env.USER) +' '+
-                                (env.GIT_BRANCH   || ''      ) +' '+
-                                buildVersion.split('+')[0],
-                    timeout: 600 // 10 min
-                }
+                concurrency: 1
             },
             phantomjs : {
                 browsers: ['PhantomJS']

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,11 +1,20 @@
+/* jshint node: true */
 module.exports = function( config ) {
-    /* jshint node: true */
-
+    var env = process.env;
     var isJenkins = !!process.env.JENKINS_HOME;
+    var serverPort = process.env.KARMA_PORT || 9876;
+    var testReporters = [
+        'progress',
+        'coverage'
+    ];
+    if (isJenkins) {
+        testReporters.push('junit');
+    }
+    var packageInfo = JSON.parse(require('fs').readFileSync('package.json', 'utf8'));
 
     config.set({
 
-        basePath: '../../',
+        basePath: '.',
 
         plugins: [
             'karma-coverage',
@@ -19,11 +28,8 @@ module.exports = function( config ) {
             'karma-browserstack-launcher'
         ],
         frameworks: ['requirejs', 'qunit'],
-        reporters: [
-            'dots',
-            'coverage'
-        ],
-        port: 9876, // web server port
+        reporters: testReporters,
+        port: serverPort, // web server port
         colors: !isJenkins, // colors in the output (reporters and logs)
         autoWatch: false, // watch file and execute tests whenever any file changes
         singleRun: true, // if true, Karma captures browsers, runs the tests and exits
@@ -40,11 +46,32 @@ module.exports = function( config ) {
         // config.LOG_DEBUG
         logLevel: config.LOG_INFO,
 
+        browsers: [
+            'PhantomJS',
+            'Chrome',
+            //'Safari', // experiencing issues with safari-launcher@1.0.0 and Safari 9.1.1
+            'Firefox'
+        ],
+
+        customLaunchers: require( './test/karma/browserstack-launchers' ),
+
+        browserStack: {
+            username:  env.BS_USERNAME,
+            accessKey: env.BS_AUTHKEY,
+            name: 'Unit Tests',
+            project: 'jwplayer',
+            build: '' + (env.JOB_NAME     || 'local' ) +' '+
+            (env.BUILD_NUMBER || env.USER) +' '+
+            (env.GIT_BRANCH   || ''      ) +' '+
+            packageInfo.version,
+            timeout: 300 // 5 minutes
+        },
+
         // to avoid DISCONNECTED messages when connecting to BrowserStack
-        browserDisconnectTimeout : 5*60*1000, // default 2000
+        browserDisconnectTimeout : 20 * 1000, // default 2000
         browserDisconnectTolerance : 1, // default 0
-        browserNoActivityTimeout : 7*60*1000, //default 10000
-        captureTimeout : 8*60*1000, //default 60000
+        browserNoActivityTimeout : 100 * 1000, //default 10000
+        captureTimeout : 120 * 1000, //default 60000
 
         files : [
             //3rd Party Code
@@ -74,11 +101,13 @@ module.exports = function( config ) {
             // source files, that you want to generate coverage for
             'src/js/*.js': ['coverage'],
             'src/js/!(polyfill)/*.js': ['coverage']
-        }
-    });
+        },
+        coverageReporter: {
+            type: 'html',
+            dir: 'reports/coverage'
+        },
 
-    // Jenkins JUnit report
-    if (isJenkins) {
-        config.reporters.push( 'junit' );
-    }
+        // number of browsers to run at once
+        concurrency: Infinity
+    });
 };

--- a/package.json
+++ b/package.json
@@ -24,20 +24,20 @@
     "grunt-contrib-uglify": "^1.0.1",
     "grunt-contrib-watch": "^1.0.0",
     "grunt-flash-compiler": "~0.2.1",
-    "grunt-karma": "^0.12.2",
+    "grunt-karma": "^2.0.0",
     "grunt-recess": "^1.0.1",
     "handlebars": "^4.0.5",
     "handlebars-loader": "^1.2.0",
     "karma": "^0.13.22",
-    "karma-browserstack-launcher": "^0.1.11",
-    "karma-chrome-launcher": "^0.2.3",
-    "karma-coverage": "^0.5.5",
-    "karma-firefox-launcher": "^0.1.7",
-    "karma-junit-reporter": "^0.4.2",
+    "karma-browserstack-launcher": "^1.0.1",
+    "karma-chrome-launcher": "^1.0.1",
+    "karma-coverage": "^1.0.0",
+    "karma-firefox-launcher": "^1.0.0",
+    "karma-junit-reporter": "^1.0.0",
     "karma-phantomjs-launcher": "^1.0.0",
-    "karma-qunit": "^0.1.9",
-    "karma-requirejs": "^0.2.6",
-    "karma-safari-launcher": "^0.1.1",
+    "karma-qunit": "^1.0.0",
+    "karma-requirejs": "^1.0.0",
+    "karma-safari-launcher": "^1.0.0",
     "less": "^2.6.1",
     "less-loader": "^2.2.3",
     "load-grunt-tasks": "^3.5.0",
@@ -46,7 +46,7 @@
     "node-libs-browser": "^1.0.0",
     "parallel-webpack": "^1.4.0",
     "phantomjs-prebuilt": "2.1.7",
-    "qunitjs": "^1.23.0",
+    "qunitjs": "^1.23.1",
     "raw-loader": "^0.5.1",
     "requirejs": "^2.2.0",
     "simple-style-loader": "0.3.0",
@@ -55,7 +55,8 @@
     "webpack": "^1.13.0"
   },
   "scripts": {
-    "postinstall": "bower install"
+    "postinstall": "bower install",
+    "test": "karma start"
   },
   "engines": {
     "node": ">=4.3.1"

--- a/test/unit/api-config-test.js
+++ b/test/unit/api-config-test.js
@@ -134,24 +134,24 @@ define([
 
         apiConfig = testConfig(assert, {});
         if (window.__SELF_HOSTED__) {
-            assert.ok(/.+\//.test(apiConfig.base),
-                'Config sets base to the jwplayer script location in self-hosted builds');
+            assert.ok(/.*\//.test(apiConfig.base),
+                'config.base is set to the jwplayer script location in self-hosted builds: '+apiConfig.base);
         } else {
-            assert.ok(/.+\//.test(apiConfig.base),
-                'Config sets base to the repo');
+            assert.ok(/.*\//.test(apiConfig.base),
+                'config.base is set to the repo locations: '+apiConfig.base);
         }
 
         apiConfig = testConfig(assert, {
             base: '.'
         });
-        assert.ok(/.+\//.test(apiConfig.base),
-            'Config replaces a base of "." with the jwplayer script location');
+        assert.ok(/.*\//.test(apiConfig.base),
+            'config.base of "." is replaced with the jwplayer script locations: '+apiConfig.base);
 
         apiConfig = testConfig(assert, {
             base: CUSTOM_BASE
         });
         assert.equal(apiConfig.base, CUSTOM_BASE,
-            'Config does not replace base when a custom value other than "." is specified');
+            'config.base is not replaced when a custom value other than "." is specified');
     });
 
     test('flattens skin object', function(assert) {

--- a/test/unit/api-test.js
+++ b/test/unit/api-test.js
@@ -329,6 +329,25 @@ define([
         });
     });
 
+    test('queues commands called after setup before ready', function(assert) {
+        var done = assert.async();
+
+        var api = createApi('player');
+
+        var config = _.extend(configSmall, {});
+
+        api.setup(config)
+            .play()
+            .pause()
+            .on('ready', function() {
+                assert.ok(true, 'ready event fired after setup');
+                done();
+            }).on('setupError', function() {
+                assert.ok(false, 'FAIL');
+                done();
+            });
+    });
+
     function createApi(id, globalRemoveCallback) {
         var container = createContainer(id);
         return new Api(container, globalRemoveCallback || _.noop);

--- a/test/unit/setup-test.js
+++ b/test/unit/setup-test.js
@@ -95,7 +95,7 @@ define([
 
     test('succeeds when model.playlist.sources is valid', function(assert) {
         var model = {
-            playlist: [{sources:[{file:'file.mp4'}]}]
+            playlist: [{sources:[{file:'http://playertest.longtailvideo.com/mp4.mp4'}]}]
         };
 
         testSetup(model, function() {
@@ -131,7 +131,7 @@ define([
 
     test('modifies config', function(assert) {
         var options = {
-            file: 'file.mp4',
+            file: 'http://playertest.longtailvideo.com/mp4.mp4',
             aspectratio: '4:3',
             width: '100%'
         };


### PR DESCRIPTION
 This allows for standalone use of karma without grunt using `karma start`. This is defined as the default test command in package.json ad can also be triggered with `npm test`.

You'll need to make sure you install karma-cli globally first:

```
npm install karma-cli -g
```

then you can run `npm test` or `karma start`.