### PR TITLE
Add keyboard shortcut for captions

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -167,6 +167,14 @@ define([
                 case 40: // down-arrow
                     adjustVolume(-10);
                     break;
+                case 67: // c-key
+                    var captionsList = _api.getCaptionsList();
+                    var listLength = captionsList.length;
+                    if (listLength) {
+                        var nextIndex = (_api.getCurrentCaptions() + 1) % listLength;
+                        _api.setCurrentCaptions(nextIndex);
+                    }
+                    break;
                 case 77: // m-key
                     _api.setMute();
                     break;


### PR DESCRIPTION
Allow c key to choose the next caption track.
If there is only one caption for the playlist item, toggle the caption on/off.
JW7-1910