### PR TITLE
Volume and mute commands shouldn't be queued

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -59,10 +59,6 @@ define([
         playlistItem : _queueCommand('item'),
         setCurrentCaptions : _queueCommand('setCurrentCaptions'),
         setCurrentQuality : _queueCommand('setCurrentQuality'),
-
-        setVolume : _queueCommand('setVolume'),
-        setMute : _queueCommand('setMute'),
-
         setFullscreen : _queueCommand('setFullscreen'),
 
         setup : function(options, _api) {
@@ -192,8 +188,8 @@ define([
                 // Reset mediaType so that we get a change mediaType event
                 _model.mediaModel.set('mediaType', null);
 
-                _model.mediaController.on('all', _this.trigger.bind(_this));
-                _view.on('all', _this.trigger.bind(_this));
+                _model.mediaController.on('all', _this.trigger, _this);
+                _view.on('all', _this.trigger, _this);
 
                 this.showView(_view.element());
 
@@ -639,6 +635,7 @@ define([
             this._item = _item;
             this._setCurrentCaptions = _setCurrentCaptions;
             this._setCurrentQuality = _setCurrentQuality;
+            this._setFullscreen = _setFullscreen;
 
             this.detachMedia = _detachMedia;
             this.attachMedia = _attachMedia;
@@ -652,11 +649,10 @@ define([
             this.getVisualQuality = _getVisualQuality;
             this.getConfig = _getConfig;
             this.getState = _getState;
-            this._setFullscreen = _setFullscreen;
 
             // Model passthroughs
-            this._setVolume = _model.setVolume;
-            this._setMute = _model.setMute;
+            this.setVolume = _model.setVolume.bind(_model);
+            this.setMute = _model.setMute.bind(_model);
             this.getProvider = function(){ return _model.get('provider'); };
             this.getWidth = function() { return _model.get('containerWidth'); };
             this.getHeight = function() { return _model.get('containerHeight'); };

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -295,28 +295,28 @@ define([
             _currentProvider = null;
         };
 
-        this.setVolume = function(vol) {
-            vol = Math.round(vol);
-            _this.set('volume', vol);
+        this.setVolume = function(volume) {
+            volume = Math.round(volume);
+            this.set('volume', volume);
             if (_provider) {
-                _provider.volume(vol);
+                _provider.volume(volume);
             }
-            var muted = (vol === 0);
-            if (muted !== _this.get('mute')) {
-                _this.setMute(muted);
+            var mute = (volume === 0);
+            if (mute !== this.get('mute')) {
+                this.setMute(mute);
             }
         };
 
-        this.setMute = function(state) {
-            if (!utils.exists(state)) {
-                state = !_this.get('mute');
+        this.setMute = function(mute) {
+            if (!utils.exists(mute)) {
+                mute = !this.get('mute');
             }
-            _this.set('mute', state);
+            this.set('mute', mute);
             if (_provider) {
-                _provider.mute(state);
+                _provider.mute(mute);
             }
-            if (!state) {
-                var volume = Math.max(10, _this.get('volume'));
+            if (!mute) {
+                var volume = Math.max(10, this.get('volume'));
                 this.setVolume(volume);
             }
         };


### PR DESCRIPTION
Volume and mute can be set on the model when a provider is not available, so there is no need to queue these commands. Volume is set on providers when they are setup.

Cleaned up use of bind in controller, as well as `this` references and param names in model for set volume and mute.