### PR TITLE
Change cc menu to active color when not off

### DIFF
--- a/src/js/view/components/menu.js
+++ b/src/js/view/components/menu.js
@@ -7,7 +7,8 @@ define([
 ], function(Tooltip, utils, _, UI, menuTemplate) {
     var Menu = Tooltip.extend({
         setup : function (list, selectedIndex, options) {
-            if(!this.iconUI){
+            options = options || {};
+            if (!this.iconUI) {
                 this.iconUI = new UI(this.el, {'useHover': true, 'directSelect': true});
 
                 this.toggleValueListener= this.toggleValue.bind(this);
@@ -27,7 +28,8 @@ define([
 
             var isMenu = list.length > 2 || (list.length === 2 && options && options.toggle === false);
             var isToggle = !isMenu && list.length === 2;
-            utils.toggleClass(this.el, 'jw-toggle', isToggle);
+            // Make caption menu always a toggle to show active color
+            utils.toggleClass(this.el, 'jw-toggle', isToggle || options.isToggle);
             utils.toggleClass(this.el, 'jw-button-color', !isToggle);
             this.isActive = isMenu || isToggle;
 
@@ -53,7 +55,7 @@ define([
             this.trigger('toggleValue');
         },
         select: function (evt) {
-            if(evt.target.parentElement === this.content) {
+            if (evt.target.parentElement === this.content) {
                 var classes = utils.classList(evt.target);
                 // find the class with a name of the form 'jw-item-1'
                 var item = _.find(classes, function(c) { return c.indexOf('jw-item') === 0;});
@@ -64,18 +66,17 @@ define([
             }
         },
         selectItem : function(selectedIndex) {
-            if(this.content){
-                for(var i=0; i<this.content.children.length; i++ ){
+            if (this.content) {
+                for (var i = 0; i < this.content.children.length; i++) {
                     utils.toggleClass(this.content.children[i], 'jw-active-option', (selectedIndex === i));
                 }
-            } else {
-                utils.toggleClass(this.el, 'jw-off', (selectedIndex === 0));
             }
+            utils.toggleClass(this.el, 'jw-off', (selectedIndex === 0));
         },
         reset : function() {
             utils.addClass(this.el, 'jw-off');
             this.iconUI.off();
-            if(this.contentUI) {
+            if (this.contentUI) {
                 this.contentUI.off().destroy();
             }
             this.removeContent();

--- a/src/js/view/controlbar.js
+++ b/src/js/view/controlbar.js
@@ -280,7 +280,7 @@ define([
 
         onCaptionsList: function(model, tracks) {
             var index = model.get('captionsIndex');
-            this.elements.cc.setup(tracks, index);
+            this.elements.cc.setup(tracks, index, {isToggle: true});
             this.clearCompactMode();
         },
         onCaptionsIndex: function(model, index) {


### PR DESCRIPTION
When the cc menu has more than 1 caption, it did not change to active color when we selected something other than off.
Changing this behavior so that cc changes to active when something other than off is selected.
JW7-1017