### PR TITLE
Feature/withcredentials

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -430,7 +430,7 @@ define([
             function _setPlaylist(p) {
                 var playlist = Playlist(p);
                 playlist = Playlist.filterPlaylist(playlist, _model.getProviders(), _model.get('androidhls'),
-                    _model.get('drm'), _model.get('preload'), _model.get('feedid'));
+                    _model.get('drm'), _model.get('preload'), _model.get('feedid'), _model.get('withCredentials'));
 
                 _model.set('playlist', playlist);
 

--- a/src/js/playlist/playlist.js
+++ b/src/js/playlist/playlist.js
@@ -13,13 +13,13 @@ define([
     };
 
     /** Go through the playlist and choose a single playable type to play; remove sources of a different type **/
-    Playlist.filterPlaylist = function(playlist, providers, androidhls, configDrm, preload, feedid) {
+    Playlist.filterPlaylist = function(playlist, providers, androidhls, configDrm, preload, feedid, withCredentials) {
         var list = [];
 
         _.each(playlist, function(item) {
             item = _.extend({}, item);
             item.allSources = _formatSources(item.sources, androidhls,
-                item.drm || configDrm, item.preload || preload);
+                item.drm || configDrm, item.preload || preload, item.withCredentials || withCredentials);
             item.sources = _filterSources(item.allSources, providers);
 
             if (!item.sources.length) {
@@ -45,7 +45,7 @@ define([
         return list;
     };
 
-    var _formatSources = function(sources, androidhls, itemDrm, preload) {
+    var _formatSources = function(sources, androidhls, itemDrm, preload, withCredentials) {
         return _.compact(_.map(sources, function(originalSource) {
             if (! _.isObject(originalSource)) {
                 return;
@@ -62,13 +62,14 @@ define([
                 originalSource.preload = originalSource.preload || preload;
             }
 
+            originalSource.withCredentials = originalSource.withCredentials || withCredentials;
+
             return Source(originalSource);
         }));
     };
 
     // A playlist item may have multiple different sources, but we want to stick with one.
     var _filterSources = function(sources, providers) {
-
         // legacy plugin support
         if (!providers || !providers.choose) {
             providers = new Providers({primary : providers ? 'flash' : null});

--- a/test/unit/playlist-filtering-test.js
+++ b/test/unit/playlist-filtering-test.js
@@ -100,4 +100,48 @@ define([
     });
 
 
+    test('it prioritizes withCredentials in the order of source, playlist, then global', function (assert) {
+        assert.expect(4);
+        var withCredentialsPlaylist = [
+            {
+                // Uses source
+                withCredentials: false,
+                sources: [
+                    {
+                        file: 'foo.mp4',
+                        withCredentials: true
+                    }
+                ]
+            },
+            {
+                // Uses playlist
+                withCredentials: true,
+                sources: [
+                    {
+                        file: 'foo.mp4'
+                    }
+                ]
+            },
+            {
+                // Uses global (providers)
+                sources: [
+                    {
+                        file: 'foo.mp4'
+                    }
+                ]
+            }
+        ];
+
+        var providersConfig = {
+            primary: 'html5'
+        };
+        
+        var pl = playlist.filterPlaylist(withCredentialsPlaylist, new Providers(providersConfig), undefined, undefined, undefined, undefined, false);
+        console.log(pl);
+
+        assert.equal(pl.length, 3);
+        assert.equal(pl[0].allSources[0].withCredentials, true);
+        assert.equal(pl[1].allSources[0].withCredentials, true);
+        assert.equal(pl[2].allSources[0].withCredentials, false);
+    });
 });


### PR DESCRIPTION
- Add `withCredentials` boolean flag, settable in source, playlist, or provider (top level) config

Some fetch requests need to be sent with credentials. This item allows users to set whether or not their requests should respond to set-cookie headers and pass them along with requests. 

The lowest set `withCredentials` wins out, i.e. source overrides playlist which overrides top level. Also added a test.

JW7-2499 and JW7-2582
