### PR TITLE
Fix other menus from becoming a toggle

### DIFF
--- a/src/js/view/components/menu.js
+++ b/src/js/view/components/menu.js
@@ -29,7 +29,7 @@ define([
             var isMenu = list.length > 2 || (list.length === 2 && options && options.toggle === false);
             var isToggle = !isMenu && list.length === 2;
             // Make caption menu always a toggle to show active color
-            utils.toggleClass(this.el, 'jw-toggle', isToggle || options.isToggle);
+            utils.toggleClass(this.el, 'jw-toggle', isToggle || !!options.isToggle);
             utils.toggleClass(this.el, 'jw-button-color', !isToggle);
             this.isActive = isMenu || isToggle;
 


### PR DESCRIPTION
Only cc menu should be active when not off, but there was a bug in toggleClass.
ToggleClass function sets the class when the provided flag is undefined.
JW7-1017