### PR TITLE
Properly set withCredentials on source

### DIFF
--- a/src/js/playlist/playlist.js
+++ b/src/js/playlist/playlist.js
@@ -18,8 +18,13 @@ define([
 
         _.each(playlist, function(item) {
             item = _.extend({}, item);
-            item.allSources = _formatSources(item.sources, androidhls,
-                item.drm || configDrm, item.preload || preload, item.withCredentials || withCredentials);
+
+            item.allSources = _formatSources(item.sources,
+                androidhls,
+                item.drm || configDrm,
+                item.preload || preload,
+                _fallbackIfUndefined(item.withCredentials, withCredentials));
+
             item.sources = _filterSources(item.allSources, providers);
 
             if (!item.sources.length) {
@@ -62,7 +67,7 @@ define([
                 originalSource.preload = originalSource.preload || preload;
             }
 
-            originalSource.withCredentials = originalSource.withCredentials || withCredentials;
+            originalSource.withCredentials = _fallbackIfUndefined(originalSource.withCredentials, withCredentials);
 
             return Source(originalSource);
         }));
@@ -91,6 +96,10 @@ define([
         }
 
         return null;
+    }
+
+    function _fallbackIfUndefined(value, fallback) {
+        return _.isUndefined(value) ? fallback : value;
     }
 
     return Playlist;

--- a/test/unit/playlist-filtering-test.js
+++ b/test/unit/playlist-filtering-test.js
@@ -105,17 +105,16 @@ define([
         var withCredentialsPlaylist = [
             {
                 // Uses source
-                withCredentials: false,
                 sources: [
                     {
                         file: 'foo.mp4',
-                        withCredentials: true
+                        withCredentials: false
                     }
                 ]
             },
             {
                 // Uses playlist
-                withCredentials: true,
+                withCredentials: false,
                 sources: [
                     {
                         file: 'foo.mp4'
@@ -123,7 +122,7 @@ define([
                 ]
             },
             {
-                // Uses global (providers)
+                // Uses model
                 sources: [
                     {
                         file: 'foo.mp4'
@@ -135,13 +134,14 @@ define([
         var providersConfig = {
             primary: 'html5'
         };
+
+        var withCredentialsOnModel = true;
         
-        var pl = playlist.filterPlaylist(withCredentialsPlaylist, new Providers(providersConfig), undefined, undefined, undefined, undefined, false);
-        console.log(pl);
+        var pl = playlist.filterPlaylist(withCredentialsPlaylist, new Providers(providersConfig), undefined, undefined, undefined, undefined, withCredentialsOnModel);
 
         assert.equal(pl.length, 3);
-        assert.equal(pl[0].allSources[0].withCredentials, true);
-        assert.equal(pl[1].allSources[0].withCredentials, true);
-        assert.equal(pl[2].allSources[0].withCredentials, false);
+        assert.equal(pl[0].allSources[0].withCredentials, false);
+        assert.equal(pl[1].allSources[0].withCredentials, false);
+        assert.equal(pl[2].allSources[0].withCredentials, true);
     });
 });


### PR DESCRIPTION
- Order of setting withCredentials on source goes in order of 1. source 2. playlist 3. model
- Only fallback if the flag on the current level is undefined


In the previous ticket, `withCredentials` was set to true if any of the three booleans were `true` - false cases at lower levels (i.e. souce) were being overwritten by `true` values higher up (`playlist`, `model`). This change makes it such that fallback is performed only if the current level is undefined.

Fixes #
JW7-2582

