### PR TITLE
Sideloaded tracks in Chrome

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -599,6 +599,7 @@ define([
             _visualQuality.reason = '';
             _setVideotagSource(_levels[_currentQuality]);
             this.setupSideloadedTracks(item.tracks);
+            _itemTracks = this.itemTracks;
         };
 
         this.load = function(item) {


### PR DESCRIPTION
### Changes proposed in this pull request:
Addressed bugs caused by enabling native rendering of sideloaded captions in Chrome:
- Selecting default index
- Sideloading tracks after a midroll ad
- Handling embedded tracks on playlist item changes

Fixes #
JW7-2597, JW7-2599, JW7-2600, JW7-2603