### PR TITLE
Fix fullscreen flash stretch issues

### DIFF
--- a/src/flash/com/longtailvideo/jwplayer/view/View.as
+++ b/src/flash/com/longtailvideo/jwplayer/view/View.as
@@ -119,14 +119,7 @@ public class View extends Sprite {
 
     private function resizeMedia(width:Number, height:Number):void {
         if (_mediaLayer.numChildren > 0 && _model.media.display) {
-            var preserveAspect:Boolean = (_model.fullscreen && _model.stretching === Stretcher.EXACTFIT);
-            if (preserveAspect) {
-                _model.config.stretching = Stretcher.UNIFORM;
-                _model.media.resize(width, height);
-                _model.config.stretching = Stretcher.EXACTFIT;
-            } else {
-                _model.media.resize(width, height);
-            }
+            _model.media.resize(width, height);
         }
     }
 


### PR DESCRIPTION
In fullscreen mode exact fit, flash had a logic to change the stretch setting to uniform then resize.
Removing that logic so that stretching works as expected in fullscreen mode.
JW7-1890