### PR TITLE
Style focused elements using hover colors

### DIFF
--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -88,12 +88,19 @@
         .jw-button-color {
             color: @inactive-color;
             .hover(@hover-color);
+            &:focus {
+                outline: none;
+                color: @hover-color;
+            }
         }
 
         .jw-toggle {
             color: @hover-color;
             &.jw-off {
                 color: @inactive-color;
+            }
+            &:focus {
+                outline: none;
             }
         }
         

--- a/src/css/skins/seven.less
+++ b/src/css/skins/seven.less
@@ -79,12 +79,19 @@
     .jw-button-color {
         color: @inactive-color;
         .hover(@hover-color);
+        &:focus {
+            outline: none;
+            color: @hover-color;
+        }
     }
 
     .jw-toggle {
         color: @hover-color;
         &.jw-off {
             color: @inactive-color;
+        }
+        &:focus {
+            outline: none;
         }
     }
 


### PR DESCRIPTION
Remove the browser's focus ring on focused buttons and instead style elements the same as when they are being hovered over.

This is done so that the new aria label and tab indexing feature does not introduce new unexpected styling on websites using the player.

JW7-2628

=================
Other things to improve player behavior with tabbing (TODO / new tech-debt introduces by tabbing buttons):
1. When a button is tab focused in the control bar, the control bar should not hide
2. Change the behavior of space and enter keys when buttons are focused to click or toggle the focused button rather than always toggle playback