### PR TITLE
Reset width and height to style when resizing

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -854,7 +854,9 @@ define([
                 return false;
             }
             var style = {
-                objectFit: ''
+                objectFit: '',
+                width: '',
+                height: ''
             };
             if (stretching === 'uniform') {
                 // snap video to edges when the difference in aspect ratio is less than 9%


### PR DESCRIPTION
Some VPAID ad resize with an incorrect width.
This is fine, but when we resize again after the VPAID ad, since there is no width/height associated with the style,
we resize with a wrong width/height.
Adding video width and height as empty strings to the style so that we reset and resize correctly.
This is a regression from the following commit:
https://github.com/jwplayer/jwplayer/commit/02799fca211597ba74cd78f03e9df6d042136973
JW7-2625