### PR TITLE
Display captions within resized container

### DIFF
--- a/src/js/polyfills/vtt.js
+++ b/src/js/polyfills/vtt.js
@@ -1000,7 +1000,9 @@
   // Runs the processing model over the cues and regions passed to it.
   // @param overlay A block level element (usually a div) that the computed cues
   //                and regions will be placed into.
-  WebVTT.processCues = function(window, cues, overlay) {
+  // @param updateBoxPosition added on 6/29/2016 by Evol Greaves: evol@jwplayer.com.
+  // This ensures that cues are displayed within the overlay whenever its size changes
+  WebVTT.processCues = function(window, cues, overlay, updateBoxPosition) {
     if (!window || !cues || !overlay) {
       return null;
     }
@@ -1034,7 +1036,7 @@
     }
 
     // We don't need to recompute the cues' display states. Just reuse them.
-    if (!shouldCompute(cues)) {
+    if (!shouldCompute(cues) && !updateBoxPosition) {
       for (var i = 0; i < cues.length; i++) {
         paddedOverlay.appendChild(cues[i].displayState);
       }

--- a/src/js/view/captionsrenderer.js
+++ b/src/js/view/captionsrenderer.js
@@ -69,7 +69,6 @@ define([
         };
 
         this.resize = function () {
-            renderCues();
             var width = _display.clientWidth,
                 scale = Math.pow(width / 400, 0.6);
             if (scale) {
@@ -78,14 +77,15 @@ define([
                     fontSize: Math.round(size) + 'px'
                 });
             }
-
+            renderCues(true);
         };
 
         this.renderCues = renderCues;
 
-        function renderCues() {
+        function renderCues(updateBoxPosition) {
+            updateBoxPosition = !!updateBoxPosition;
             if(_VTTRenderer) {
-                _VTTRenderer.WebVTT.processCues(window, _currentCues, _display);
+                _VTTRenderer.WebVTT.processCues(window, _currentCues, _display, updateBoxPosition);
             }
         }
 

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -847,14 +847,14 @@ define([
             clearTimeout(_controlsTimeout);
             _controlbar.hideComponents();
             utils.addClass(_playerElement, 'jw-flag-user-inactive');
-            _captionsRenderer.renderCues();
+            _captionsRenderer.renderCues(true);
         }
 
         function _userActivity() {
             if(!_showing){
                 utils.removeClass(_playerElement, 'jw-flag-user-inactive');
                 _controlbar.checkCompactMode(_videoLayer.clientWidth);
-                _captionsRenderer.renderCues();
+                _captionsRenderer.renderCues(true);
             }
 
             _showing = true;


### PR DESCRIPTION
### Changes proposed in this pull request:
This ensures that cues are repositioned when the controlbar toggles between active/inactive states.

Fixes # 
JW7-2443