### PR TITLE
Render player view template in idle state so we don't see controlbar during setup

### DIFF
--- a/src/templates/player.html
+++ b/src/templates/player.html
@@ -1,4 +1,4 @@
-<div id="{{id}}" class="jwplayer jw-reset" tabindex="0">
+<div id="{{id}}" class="jwplayer jw-reset jw-state-idle" tabindex="0">
     <div class="jw-aspect jw-reset"></div>
     <div class="jw-media jw-reset"></div>
     <div class="jw-preview jw-reset"></div>


### PR DESCRIPTION
The controlbar can be seen for a very brief period while setting up the player. This adds the idle state class to the template so that initial rendering of the player matches it's initial state. 