### PR TITLE
More VTT.js fixes

### DIFF
--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -53,7 +53,7 @@ define(['../utils/underscore',
                     track._id = createTrackId.call(this, track);
                     track.inuse = true;
                 }
-                if (!track.inuse || !this._tracksById || this._tracksById[track._id]) {
+                if (!track.inuse || this._tracksById[track._id]) {
                     continue;
                 }
                 // setup TextTrack

--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -396,6 +396,7 @@ define(['../utils/underscore',
             if (track) {
                 track.kind = itemTrack.kind;
                 track.label = itemTrack.label;
+                track.default = itemTrack.default;
                 track.language = itemTrack.language || '';
             } else {
                 track = this.video.addTextTrack(itemTrack.kind, itemTrack.label, itemTrack.language || '');


### PR DESCRIPTION
Default captions is not selecting the correct captions track. Captions track are inconsistent between playlist items.

http://player-develop-test-jenkins.longtailvideo.com/builds/lastSuccessfulBuild/archive/test/squash/bootstrap.html?primary=html5&edition=ads&feature=default_captions