### PR TITLE
Fix issues with captions not showing after midroll

### DIFF
--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -437,8 +437,14 @@ define(['../utils/underscore',
     }
 
     function _tracksAlreadySideloaded(tracks) {
+        // Determine if the currently chosen track is removed and disabled
+        var textTracks = this._textTracks;
+        var inuse = true;
+        if (this._renderNatively && textTracks && textTracks.length) {
+            inuse = textTracks[0].inuse;
+        }
         // Determine if the tracks are the same and the embedded + sideloaded count = # of tracks in the controlbar
-        return tracks === this.itemTracks && this._textTracks && this._textTracks.length >= tracks.length;
+        return tracks === this.itemTracks && textTracks && textTracks.length >= tracks.length && inuse;
     }
 
     function _clearSideloadedTextTracks() {


### PR DESCRIPTION
After midroll, we disable the text tracks when natively rendered.
We should have a check saying if the tracks inuse is false, we reload the tracks.
JW7-2652