### PR TITLE
Dont include withCredentials if its undefined everywhere, JW7-2629

### DIFF
--- a/src/js/playlist/playlist.js
+++ b/src/js/playlist/playlist.js
@@ -67,7 +67,13 @@ define([
                 originalSource.preload = originalSource.preload || preload;
             }
 
-            originalSource.withCredentials = _fallbackIfUndefined(originalSource.withCredentials, withCredentials);
+            // withCredentials is assigned in ascending priority order, source > playlist > model
+            // a false value that is a higher priority than true must result in a false withCredentials value
+            // we don't want undefined if all levels have withCredentials as undefined
+            var cascadedWithCredentials = _fallbackIfUndefined(originalSource.withCredentials, withCredentials);
+            if (!_.isUndefined(cascadedWithCredentials)) {
+                originalSource.withCredentials = cascadedWithCredentials;
+            }
 
             return Source(originalSource);
         }));

--- a/test/unit/playlist-filtering-test.js
+++ b/test/unit/playlist-filtering-test.js
@@ -144,4 +144,23 @@ define([
         assert.equal(pl[1].allSources[0].withCredentials, false);
         assert.equal(pl[2].allSources[0].withCredentials, true);
     });
+
+
+    test('it does not put withCredentials on the playlist if undefined', function (assert) {
+        assert.expect(2);
+
+        var undefinedCredentialsPlaylist = [
+            {
+                sources: [
+                    {
+                        file: 'foo.mp4'
+                    }
+                ]
+            }
+        ];
+
+        var pl = playlist.filterPlaylist(undefinedCredentialsPlaylist, new Providers(), undefined, undefined, undefined, undefined, undefined);
+        assert.equal(pl.length, 1);
+        assert.equal(pl[0].allSources[0].withCredentials, undefined);
+    });
 });


### PR DESCRIPTION
- Don't include withCredentials in the playlist object if it's undefined in all configuration levels

JW7-2629

