### PR TITLE
Remove height metrics for compact ui captions

### DIFF
--- a/src/css/imports/captions.less
+++ b/src/css/imports/captions.less
@@ -60,10 +60,4 @@
         max-height: calc(97% - 6.25 * (@controlbar-height));
         line-height: 1.3em;
     }
-
-    &.jw-flag-compact-player {
-        video::-webkit-media-text-track-container {
-            max-height: calc(97% - 7.5 * (@controlbar-height));
-        }
-    }
 }


### PR DESCRIPTION
The metrics for compact ui captions caused the captions to be half hidden behind the control bar.
Since there is a ticket to remove compact ui for later, it does not hurt to remove the css specific to compact mode.
JW7-2685