### PR TITLE
Use VTTCue polyfill in IE/Edge

### DIFF
--- a/src/js/controller/setup-steps.js
+++ b/src/js/controller/setup-steps.js
@@ -101,9 +101,9 @@ define([
     }
 
     function _loadVTTCuePolyfill(resolve) {
-        if (!window.VTTCue && !window.TextTrackCue) {
+        if (!window.VTTCue) {
             require.ensure(['polyfills/vttcue'], function(require) {
-                window.VTTCue = require('polyfills/vttcue');
+                require('polyfills/vttcue');
                 resolve();
             }, 'polyfills.vttcue');
         } else {

--- a/src/js/polyfills/vttcue.js
+++ b/src/js/polyfills/vttcue.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-(function(root) {
+(function() {
 
   var autoKeyword = "auto";
   var directionSetting = {
@@ -304,5 +304,5 @@
     return WebVTT.convertCueToDOMTree(window, this.text);
   };
 
-  return VTTCue;
+  window.VTTCue = VTTCue;
 }(this));

--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -498,8 +498,8 @@ define(['../utils/underscore',
     }
 
     function _convertToVTTCues(cues) {
-        // VTTCue is available natively or polyfilled everywhere except IE/Edge, which has TextTrackCue
-        var VTTCue = window.VTTCue || window.TextTrackCue;
+        // VTTCue is available natively or polyfilled where necessary
+        var VTTCue = window.VTTCue;
         var vttCues = _.map(cues, function (cue) {
             return new VTTCue(cue.begin, cue.end, cue.text);
         });


### PR DESCRIPTION
### Changes proposed in this pull request:
TextTrackCue is supported in IE10+ and Edge. However, TextTrackCue does not have properties necessary for positioning captions (eg. `line`). Polyfilling VTTCue in IE/Edge addresses these shortcomings.
Fixes #
JW7-2678, JW7-2679, JW7-2681