### PR TITLE
Filter for supported track kinds

### DIFF
--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -301,7 +301,7 @@ define(['../utils/underscore',
     function textTrackChangeHandler() {
         var textTracks = this.video.textTracks;
         var inUseTracks = _.filter(textTracks, function (track)  {
-            return track.inuse || !track._id;
+            return (track.inuse || !track._id) && _kindSupported(track.kind);
         });
         if (!this._textTracks || inUseTracks.length > this._textTracks.length) {
             // If the video element has more tracks than we have internally..
@@ -335,7 +335,7 @@ define(['../utils/underscore',
         for (var i = 0; i < tracks.length; i++) {
             var itemTrack = tracks[i];
             // only add valid and supported kinds https://developer.mozilla.org/en-US/docs/Web/HTML/Element/track
-            if (itemTrack.kind && !(/subtitles|captions/i).test(itemTrack.kind)) {
+            if (itemTrack.kind && !_kindSupported(itemTrack.kind)) {
                 continue;
             }
             var track = _createTrack.call(this, itemTrack);
@@ -383,6 +383,10 @@ define(['../utils/underscore',
 
     function _nativeRenderingSupported(providerName) {
         return providerName.indexOf('flash') === -1 && (utils.isChrome() || utils.isIOS() || utils.isSafari());
+    }
+
+    function _kindSupported(kind) {
+        return (/subtitles|captions/i).test(kind);
     }
 
     function _initTextTracks() {

--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -66,7 +66,7 @@ define(['../utils/underscore',
                     track.oncuechange = _cueChangeHandler.bind(this);
                     this._tracksById[track._id] = track;
                 }
-                else if (track.kind === 'subtitles' || track.kind === 'captions') {
+                else if (_kindSupported(track.kind)) {
                     var mode = track.mode,
                         cue;
 
@@ -386,7 +386,7 @@ define(['../utils/underscore',
     }
 
     function _kindSupported(kind) {
-        return (/subtitles|captions/i).test(kind);
+        return kind === 'subtitles' || kind === 'captions';
     }
 
     function _initTextTracks() {


### PR DESCRIPTION
### Changes proposed in this pull request:

Metadata tracks are not included in the subtitlesTracks list. This ensures that we filter for only subtitles and captions tracks when comparing the counts of what's already included in the menu and track changes coming from the video tag.

Fixes #
JW7-2730