### PR TITLE
Fix toggle class css when off and focused

### DIFF
--- a/src/css/imports/controlbar.less
+++ b/src/css/imports/controlbar.less
@@ -113,7 +113,7 @@
 
 .jw-toggle {
     color: @toggle-active;
-    &.jw-off {
+    &.jw-off, &.jw-off:focus {
         color: @toggle-inactive;
     }
     &:focus {


### PR DESCRIPTION
When focused, the style of jw-off was overwritten.
Placing another specification so that jw-off style is not overwritten when focused.
JW7-2703