### PR TITLE
Replace html breaks with line breaks

### DIFF
--- a/src/js/parsers/captions/srt.js
+++ b/src/js/parsers/captions/srt.js
@@ -50,7 +50,7 @@ define([
                 entry.begin = _seconds(line.substr(0, index));
                 entry.end   = _seconds(line.substr(index + 5));
                 // Remaining lines contain the text
-                entry.text = array.slice(idx + 1).join('<br/>');
+                entry.text = array.slice(idx + 1).join('\r\n');
             }
         }
         return entry;


### PR DESCRIPTION
### Changes proposed in this pull request:
Multi-line captions need to be separated by line breaks, not html line break tags, so they can be rendered correctly.

Fixes #
JW7-2686