### PR TITLE
Use requestAnimationFrame for responsive sizing

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -231,21 +231,23 @@ define([
                 containerWidth = Math.round(bounds.width),
                 containerHeight = Math.round(bounds.height);
 
-            if (containerWidth && containerHeight) {
-                if (containerWidth !== _lastWidth || containerHeight !== _lastHeight) {
-                    _lastWidth = containerWidth;
-                    _lastHeight = containerHeight;
-                    clearTimeout(_resizeMediaTimeout);
-                    _resizeMediaTimeout = setTimeout(_resizeMedia, 50);
-
-                    _model.set('containerWidth', containerWidth);
-                    _model.set('containerHeight', containerHeight);
-                    _this.trigger(events.JWPLAYER_RESIZE, {
-                        width: containerWidth,
-                        height: containerHeight
-                    });
-                }
+            // If we have bad values for either dimension or the container is the same size as before, return early.
+            if ((!containerWidth || !containerHeight) ||
+                (containerWidth === _lastWidth && containerHeight === _lastHeight)) {
+                return;
             }
+
+            _lastWidth = containerWidth;
+            _lastHeight = containerHeight;
+            clearTimeout(_resizeMediaTimeout);
+            _resizeMediaTimeout = setTimeout(_resizeMedia, 50);
+
+            _model.set('containerWidth', containerWidth);
+            _model.set('containerHeight', containerHeight);
+            _this.trigger(events.JWPLAYER_RESIZE, {
+                width: containerWidth,
+                height: containerHeight
+            });
         }
 
         function _responsiveListener() {
@@ -256,12 +258,12 @@ define([
                 }
             } else {
                 if (window.requestAnimationFrame) {
-                    cancelAnimationFrame(_resizeContainerRequestId);
-                    _resizeContainerRequestId = requestAnimationFrame(_setContainerDimensions);
+                    window.cancelAnimationFrame(_resizeContainerRequestId);
+                    _resizeContainerRequestId = window.requestAnimationFrame(_setContainerDimensions);
                 } else {
-                    clearTimeout(_resizeContainerRequestId);
+                    window.clearTimeout(_resizeContainerRequestId);
                     // 60Hz framerate is approximately 17ms
-                    _resizeContainerRequestId = setTimeout(_setContainerDimensions, 17);
+                    _resizeContainerRequestId = window.setTimeout(_setContainerDimensions, 17);
                 }
             }
         }

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -52,6 +52,7 @@ define([
             _showing = false,
             _rightClickMenu,
             _resizeMediaTimeout = -1,
+            _resizeContainerRequestId = -1,
             _previewDisplayStateTimeout = -1,
             _currentState,
             _originalContainer,
@@ -225,17 +226,12 @@ define([
             }
         }
 
-        function _responsiveListener() {
+        function _setContainerDimensions() {
             var bounds = _bounds(_playerElement),
                 containerWidth = Math.round(bounds.width),
                 containerHeight = Math.round(bounds.height);
 
-            if (!document.body.contains(_playerElement)) {
-                window.removeEventListener('resize', _responsiveListener);
-                if (_isMobile) {
-                    window.removeEventListener('orientationchange', _responsiveListener);
-                }
-            } else if (containerWidth && containerHeight) {
+            if (containerWidth && containerHeight) {
                 if (containerWidth !== _lastWidth || containerHeight !== _lastHeight) {
                     _lastWidth = containerWidth;
                     _lastHeight = containerHeight;
@@ -250,7 +246,24 @@ define([
                     });
                 }
             }
-            return bounds;
+        }
+
+        function _responsiveListener() {
+            if (!document.body.contains(_playerElement)) {
+                window.removeEventListener('resize', _responsiveListener);
+                if (_isMobile) {
+                    window.removeEventListener('orientationchange', _responsiveListener);
+                }
+            } else {
+                if (window.requestAnimationFrame) {
+                    cancelAnimationFrame(_resizeContainerRequestId);
+                    _resizeContainerRequestId = requestAnimationFrame(_setContainerDimensions);
+                } else {
+                    clearTimeout(_resizeContainerRequestId);
+                    // 60Hz framerate is approximately 17ms
+                    _resizeContainerRequestId = setTimeout(_setContainerDimensions, 17);
+                }
+            }
         }
 
 


### PR DESCRIPTION
Updates the container dimensions for the player using requestAnimationFrame so as to only update it when the DOM has updated.  This helps correct issues where the resize event can propagate incorrect container sizes when entering or exiting fullscreen.

JW7-2740