### PR TITLE
Don't display title for audio only players

### DIFF
--- a/src/css/flags/audioplayer.less
+++ b/src/css/flags/audioplayer.less
@@ -13,7 +13,8 @@
 
 
     .jw-preview, // overrides 'block' from .jw-state-idle
-    .jw-display-icon-container { // overrides 'block' from .jw-flag-touch.jw-state-paused
+    .jw-display-icon-container, // overrides 'block' from .jw-flag-touch.jw-state-paused
+    .jw-title { // overrides 'block' from .jw-state-idle
         display: none;
     }
 


### PR DESCRIPTION
Title and description are now hidden like some of the other components when the player is audio only. 

JW7-2717