### PR TITLE
Hide controller during full slot ads on mobile

### DIFF
--- a/src/css/flags/ads.less
+++ b/src/css/flags/ads.less
@@ -60,7 +60,13 @@
     }
 }
 
-.jwplayer.jw-flag-ads-vpaid {
+.jwplayer.jw-flag-ads.jw-flag-touch {
+    .jw-controlbar {
+        display: table;
+    }
+}
+
+.jwplayer.jw-flag-ads-vpaid, .jwplayer.jw-flag-touch.jw-flag-ads-vpaid {
     .jw-controlbar {
         display: none;
     }
@@ -72,8 +78,3 @@
     }
 }
 
-.jwplayer.jw-flag-ads.jw-flag-touch {
-    .jw-controlbar {
-        display: table;
-    }
-}


### PR DESCRIPTION
Changed priority of CSS so that we can get the controlbar to hide on mobile during full slot ads.

JW7-2752