### PR TITLE
Allow controlbar controls to responsively resize in audio mode

### DIFF
--- a/src/css/flags/audioplayer.less
+++ b/src/css/flags/audioplayer.less
@@ -11,21 +11,20 @@
         }
     }
 
-
     .jw-preview, // overrides 'block' from .jw-state-idle
     .jw-display-icon-container { // overrides 'block' from .jw-flag-touch.jw-state-paused
         display: none;
     }
 
     .jw-controlbar {
+        vertical-align: middle;
         display: table;  // This overrides 'none' from jw-state-idle
-        height: auto;
+        height: 100%;
         left: 0;
         bottom: 0;
         margin: 0;
         width: 100%;
         min-width: 100%;
-        opacity: 1;
 
         .jw-icon-fullscreen,
         .jw-icon-tooltip {
@@ -44,5 +43,15 @@
         .jw-controlbar {
             display: table; // overrides 'none' from jw-flag-user-inactive
         }
+    }
+
+    // Setting height/line-height to their defaults allows the controls to responsively resize
+    .jw-icon-inline {
+        height: auto;
+        line-height: normal;
+    }
+
+    .jw-group {
+        vertical-align: middle;
     }
 }

--- a/src/css/flags/audioplayer.less
+++ b/src/css/flags/audioplayer.less
@@ -54,4 +54,9 @@
     .jw-group {
         vertical-align: middle;
     }
+
+    // Small hack to keep the seekbar properly centered with the other elemenets when vertical-align: middle'd
+    .jw-controlbar-center-group {
+        padding-bottom: 2px;
+    }
 }

--- a/src/css/imports/vars.less
+++ b/src/css/imports/vars.less
@@ -2,7 +2,7 @@
 
 // (160,160,160)
 // Colors
-@active-color: rgba(255, 255, 255, 1) ;
+@active-color: rgba(255, 255, 255, 1);
 @inactive-color: rgba(255, 255, 255, .6);
 @background-color: rgba(33, 33, 33, 0.8);
 @accent-color: rgba(255, 255, 255, 1);


### PR DESCRIPTION
- Set `.jw-icon-inline` `height` and `line-height` to their initial values
- Remove extra space in `vars.less`

Fixes #
JW7-2738

