### PR TITLE
Positon captions container in aspectmode 

### DIFF
--- a/src/css/imports/captions.less
+++ b/src/css/imports/captions.less
@@ -1,8 +1,8 @@
 @import "vars";
 
 .jw-captions {
-    position: relative;
-    width: inherit;
+    position: absolute;
+    width: 100%;
     height: inherit;
     text-align: center;
     display: none;
@@ -16,6 +16,7 @@
     pointer-events: none;
     word-break: break-all;
     overflow: hidden;
+    top: 0;
 
     &.jw-captions-enabled {
         display: block;

--- a/src/js/view/captionsrenderer.js
+++ b/src/js/view/captionsrenderer.js
@@ -202,6 +202,12 @@ define([
             utils.empty(_display);
         };
 
+        this.setContainerHeight = function (height) {
+            _style(_display, {
+                height: height
+            });
+        };
+
         function setupCaptionStyles(playerId, windowStyle, textStyle) {
             // VTT.js DOM window styles
             cssUtils.css('#' + playerId + ' .jw-text-track-display', windowStyle, playerId);

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -564,7 +564,7 @@ define([
             _displayClickHandler.on('doubleClick', _doubleClickFullscreen);
             _displayClickHandler.on('move', _userActivity);
             _displayClickHandler.on('over', _userActivity);
-            
+
             var displayIcon = new DisplayIcon(_model);
             //toggle playback
             displayIcon.on('click', function() {
@@ -722,6 +722,11 @@ define([
             if (!utils.hasClass(_playerElement, 'jw-flag-aspect-mode')) {
                 playerStyle.height = height;
             }
+
+            if (_model.get('aspectratio')) {
+                _resizeAspectModeCaptions();
+            }
+
             _styles(_playerElement, playerStyle, true);
 
             _checkAudioMode(height);
@@ -794,6 +799,11 @@ define([
                 clearTimeout(_resizeMediaTimeout);
                 _resizeMediaTimeout = setTimeout(_resizeMedia, 250);
             }
+
+            if (_model.get('aspectratio')) {
+                _resizeAspectModeCaptions();
+            }
+
             _captionsRenderer.resize();
 
             _controlbar.checkCompactMode(width);
@@ -970,6 +980,11 @@ define([
                     _userActivity();
                     break;
             }
+        }
+
+        function _resizeAspectModeCaptions() {
+            var aspectRatioContainer = _playerElement.getElementsByClassName('jw-aspect')[0];
+            _captionsRenderer.setContainerHeight(aspectRatioContainer.offsetHeight);
         }
 
         this.setupInstream = function(instreamModel) {


### PR DESCRIPTION
- Manually set captions container height to player element's height

In non-aspect mode, the captions container height is set to a percentage of its parent element. In aspect mode the parent element is set to `auto`, indicating that it should be the height of its children. This results in the captions container having a height of 0. This PR sets the height in aspect mode to the player's height when 1) ready and 2) resizing.

Also sets the `.jw-captions` class to `position: absolute` and `top: 0` - this does not affect non-aspectmode positioning but allows aspectmode positioning to work correctly.

Fixes #
JW7-2745

