### PR TITLE
Fix vapor controlbar padding

### DIFF
--- a/src/css/skins/vapor.less
+++ b/src/css/skins/vapor.less
@@ -158,6 +158,9 @@
         .jw-controlbar {
             background: @inactive-color;
         }
+      .jw-controlbar-center-group {
+        padding-bottom: 0;
+      }
     }
 
   .jw-icon-inline,


### PR DESCRIPTION
- Set `padding-bottom: 0` for vapor since the controlbar is always 100% height
JW7-2738

