### PR TITLE
Persist captions track before ad playback begins

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -740,6 +740,9 @@ define([
             this.createInstream = function() {
                 this.instreamDestroy();
                 this._instreamAdapter = new InstreamAdapter(this, _model, _view);
+                // Persist the current captions track so the index
+                // is  set correctly after ad playback ends
+                _model.persistCaptionsTrack();
                 return this._instreamAdapter;
             };
 


### PR DESCRIPTION
### Changes proposed in this pull request:
When a user selects a cc track while in fullscreen mode on an iOS device, the selection wasn't persisted. If playback gets interrupted by a midroll ad, captions would be turned off when playback resumes. 

This change persists the current track before ad playback begins so the index will be set correctly when playback resumes. 

Fixes #
JW7-2737