### PR TITLE
Non-native captions rendering in audio mode

### DIFF
--- a/src/css/flags/media-audio.less
+++ b/src/css/flags/media-audio.less
@@ -12,10 +12,14 @@
     }
     // This has higher specificity to overwrite caption position when user inactive in playing state
     &.jw-flag-user-inactive.jw-state-playing {
-        .jw-plugin,
-        .jw-captions {
+        .jw-plugin {
             bottom: 3em;
         }
+
+        .jw-captions {
+            max-height: calc(97% - 6.25 * (@controlbar-height));
+        }
+        // Separate shadow dom style to prevent side effects in browsers where the element doesn't exist
         video::-webkit-media-text-track-container {
             max-height: calc(97% - 6.25 * (@controlbar-height));
         }


### PR DESCRIPTION
### Changes proposed in this pull request:
Ensure non-natively rendered captions are always above the control bar when the player is in audio mode.

Fixes #
JW7-2771