### PR TITLE
Ensure video tag (or swf) is in view before ready event

### DIFF
--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -247,6 +247,17 @@ define([
             return _providers.choose(source).provider;
         };
 
+        this.setItemIndex = function(index) {
+            var playlist = this.get('playlist');
+
+            // If looping past the end, or before the beginning
+            index = parseInt(index, 10) || 0;
+            index = (index + playlist.length) % playlist.length;
+
+            this.set('item', index);
+            this.set('playlistItem', playlist[index]);
+            this.setActiveItem(playlist[index]);
+        };
 
         this.setActiveItem = function(item) {
             // Item is actually changing

--- a/src/js/controller/setup-steps.js
+++ b/src/js/controller/setup-steps.js
@@ -65,12 +65,18 @@ define([
                     'LOAD_SKIN'
                 ]
             },
+            SET_ITEM : {
+                method: _setPlaylistItem,
+                depends: [
+                    'INIT_PLUGINS',
+                    'FILTER_PLAYLIST'
+                ]
+            },
             SEND_READY : {
                 method: _sendReady,
                 depends: [
-                    'INIT_PLUGINS',
-                    'FILTER_PLAYLIST',
-                    'SETUP_VIEW'
+                    'SETUP_VIEW',
+                    'SET_ITEM'
                 ]
             }
         };
@@ -227,6 +233,11 @@ define([
     function _setupView(resolve, _model, _api, _view) {
         _view.setup();
         resolve();
+    }
+
+    function _setPlaylistItem(resolve, _model) {
+        _model.once('itemReady', resolve);
+        _model.setItemIndex(_model.get('item'));
     }
 
     function _sendReady(resolve) {


### PR DESCRIPTION
Waiting for the model's "itemReady" event ensures that the provider is loaded and the view has a video tag (or swf object) in the media element when "ready" is fired.

Fixes #1329 / JW7-2802