### PR TITLE
Fix embedded stylings blocking video

### DIFF
--- a/src/css/imports/captions.less
+++ b/src/css/imports/captions.less
@@ -50,6 +50,11 @@
     // Override vtt.js font-size so text resizes as the player size changes
     font-size: inherit;
     line-height: 1.3em;
+    background: rgba(0, 0, 0, 0);
+}
+
+.jw-text-track-container {
+    background: rgba(0, 0, 0, 0);
 }
 
 .jwplayer {

--- a/src/css/imports/captions.less
+++ b/src/css/imports/captions.less
@@ -50,11 +50,11 @@
     // Override vtt.js font-size so text resizes as the player size changes
     font-size: inherit;
     line-height: 1.3em;
-    background: rgba(0, 0, 0, 0);
+    background: transparent;
 }
 
 .jw-text-track-container {
-    background: rgba(0, 0, 0, 0);
+    background: transparent;
 }
 
 .jwplayer {


### PR DESCRIPTION
Need to make the background transparent for caption elements to ensure
they are not overwritten by embedded stylings

JW7-2779