### PR TITLE
[REVIEW] Parse frames correctly from time string

### DIFF
--- a/src/js/parsers/captions/dfxp.js
+++ b/src/js/parsers/captions/dfxp.js
@@ -10,6 +10,15 @@ define([
         validate(xmlDoc);
         var _captions = [];
         var paragraphs = xmlDoc.getElementsByTagName('p');
+        // Default frameRate is 30
+        var frameRate = 30;
+        var tt = xmlDoc.getElementsByTagName('tt');
+        if (tt && tt[0]) {
+            var parsedFrameRate = parseFloat(tt[0].getAttribute('ttp:frameRate'));
+            if (!isNaN(parsedFrameRate)) {
+                frameRate = parsedFrameRate;
+            }
+        }
         validate(paragraphs);
         if (!paragraphs.length) {
             paragraphs = xmlDoc.getElementsByTagName('tt:p');
@@ -28,13 +37,13 @@ define([
                 var end = p.getAttribute('end');
 
                 var entry = {
-                    begin: _seconds(begin),
+                    begin: _seconds(begin, frameRate),
                     text: text
                 };
                 if (end) {
-                    entry.end = _seconds(end);
+                    entry.end = _seconds(end, frameRate);
                 } else if (dur) {
-                    entry.end = entry.begin + _seconds(dur);
+                    entry.end = entry.begin + _seconds(dur, frameRate);
                 }
                 _captions.push(entry);
             }

--- a/src/js/utils/strings.js
+++ b/src/js/utils/strings.js
@@ -79,16 +79,17 @@ define([
     /**
      * Convert a time-representing string to a number.
      *
-     * @param {String}    The input string. Supported are 00:03:00.1 / 03:00.1 / 180.1s / 3.2m / 3.2h
+     * @param {String}    The input string. Supported are 00:03:00:29 / 00:03:00.1 / 03:00.1 / 180.1s / 3.2m / 3.2h
      * @return {Number}    The number of seconds.
      */
-    var seconds = function (str) {
+    var seconds = function (str, frameRate) {
         if (_.isNumber(str)) {
             return str;
         }
 
         str = str.replace(',', '.');
         var arr = str.split(':');
+        var arrLength = arr.length;
         var sec = 0;
         if (str.slice(-1) === 's') {
             sec = parseFloat(str);
@@ -96,11 +97,19 @@ define([
             sec = parseFloat(str) * 60;
         } else if (str.slice(-1) === 'h') {
             sec = parseFloat(str) * 3600;
-        } else if (arr.length > 1) {
-            sec = parseFloat(arr[arr.length - 1]);
-            sec += parseFloat(arr[arr.length - 2]) * 60;
-            if (arr.length === 3) {
-                sec += parseFloat(arr[arr.length - 3]) * 3600;
+        } else if (arrLength > 1) {
+            var secIndex = arrLength - 1;
+            if (arrLength === 4) {
+                // if frame is included in the string, calculate seconds by dividing by frameRate
+                if (frameRate) {
+                    sec = parseFloat(arr[secIndex]) / frameRate;
+                }
+                secIndex -= 1;
+            }
+            sec += parseFloat(arr[secIndex]);
+            sec += parseFloat(arr[secIndex - 1]) * 60;
+            if (arrLength >= 3) {
+                sec += parseFloat(arr[secIndex - 2]) * 3600;
             }
         } else {
             sec = parseFloat(str);

--- a/test/unit/strings-test.js
+++ b/test/unit/strings-test.js
@@ -62,6 +62,12 @@ define([
 
         sec = strings.seconds('01:01:01.111');
         assert.equal(sec, 3661.111, 'hours minute seconds milliseconds input returns seconds');
+
+        sec = strings.seconds('00:00:01:15');
+        assert.equal(sec, 1, 'hours minute seconds frames input without frameRate returns seconds without frames');
+
+        sec = strings.seconds('00:01:01:25', 50);
+        assert.equal(sec, 61.5, 'hours minute seconds frames input with frameRate returns seconds');
     });
 
     test('strings.hms', function(assert) {


### PR DESCRIPTION
We did not support time string with format hh:mm:ss:ff, where ff refers to frames.
Frames were treated as seconds, resulting captions with frames to have wrong start/end time.
Calculate the frames correctly when parsing.
JW7-2763