### PR TITLE
Wrap text on words not letters and round down to the nearest half fon…

### DIFF
--- a/src/css/imports/captions.less
+++ b/src/css/imports/captions.less
@@ -11,10 +11,9 @@
     letter-spacing: normal;
     word-spacing: normal;
     text-transform: none;
-    text-indent: 0px;
+    text-indent: 0;
     text-decoration: none;
     pointer-events: none;
-    word-break: break-all;
     overflow: hidden;
     top: 0;
 
@@ -37,7 +36,8 @@
     display: inline-block;
     color: white;
     background-color: black;
-    word-wrap: break-word;
+    word-wrap: normal;
+    word-break: normal;
     white-space: pre-line;
     font-style: normal;
     font-weight: normal;

--- a/src/js/view/captionsrenderer.js
+++ b/src/js/view/captionsrenderer.js
@@ -74,7 +74,7 @@ define([
             if (scale) {
                 var size = _options.fontSize * scale;
                 _style(_display, {
-                    fontSize: Math.round(size) + 'px'
+                    fontSize: Math.floor(size*2)/2 + 'px'
                 });
             }
             renderCues(true);


### PR DESCRIPTION
If captions lines don't fit, wrap on words not on letters. Round to half font sizes to closer match native webvtt font sizing in Chrome.

JW7-2790