### PR TITLE
Side load captions once per item and don't clear after ads

### DIFF
--- a/src/js/providers/flash.js
+++ b/src/js/providers/flash.js
@@ -6,7 +6,7 @@ define([
     'utils/embedswf',
     'providers/default',
     'utils/backbone.events',
-    'providers/tracks-mixin',
+    'providers/tracks-mixin'
 ], function(utils, _, events, states, EmbedSwf, DefaultProvider, Events, Tracks) {
     var _providerId = 0;
     function getObjectId(playerId) {
@@ -468,7 +468,6 @@ define([
                     }
                     _container = null;
                     _item = null;
-                    this.clearTracks();
                     this.off();
                 }
         });

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -460,7 +460,7 @@ define([
             if (sourceChanged || loadedSrc === 'none' || loadedSrc === 'started') {
                 _duration = duration;
                 _setVideotagSource(_levels[_currentQuality]);
-                _this.setupSideloadedTracks(this._itemTracks);
+                _this.setupSideloadedTracks(_this._itemTracks);
                 _videotag.load();
             } else {
                 // Load event is from the same video as before

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -144,7 +144,6 @@ define([
             _audioTracks = null,
             _currentAudioTrackIndex = -1,
             _activeCuePosition = -1,
-            _itemTracks = null,
             _visualQuality = { level: {} };
 
         // Find video tag, or create it if it doesn't exist.  View may not be built yet.
@@ -154,7 +153,6 @@ define([
         _videotag.className = 'jw-video jw-reset';
 
         this.isSDK = _isSDK;
-        this.itemTracks = _itemTracks;
         this.video = _videotag;
 
         // prevent browser from showing second cast icon
@@ -462,7 +460,7 @@ define([
             if (sourceChanged || loadedSrc === 'none' || loadedSrc === 'started') {
                 _duration = duration;
                 _setVideotagSource(_levels[_currentQuality]);
-                _this.setupSideloadedTracks(_itemTracks);
+                _this.setupSideloadedTracks(this._itemTracks);
                 _videotag.load();
             } else {
                 // Load event is from the same video as before
@@ -531,8 +529,6 @@ define([
 
                 dom.emptyElement(_videotag);
                 _currentQuality = -1;
-                _itemTracks = null;
-                _this.clearTracks();
                 // Don't call load in iE9/10 and check for load in PhantomJS
                 if (!_isMSIE && 'load' in _videotag) {
                     _videotag.load();
@@ -566,6 +562,7 @@ define([
                 return;
             }
             _clearVideotagSource();
+            this.clearTracks();
             // IE may continue to play a video after changing source and loading a new media file.
             // https://connect.microsoft.com/IE/feedbackdetail/view/2000141/htmlmediaelement-autoplays-after-src-is-changed-and-load-is-called
             if(utils.isIETrident()) {
@@ -587,7 +584,6 @@ define([
             if (!_attached) {
                 return;
             }
-            _itemTracks = null;
             _levels = item.sources;
             _currentQuality = _pickInitialQuality(item.sources);
             // the loadeddata event determines the mediaType for HLS sources
@@ -600,7 +596,6 @@ define([
             _visualQuality.reason = '';
             _setVideotagSource(_levels[_currentQuality]);
             this.setupSideloadedTracks(item.tracks);
-            _itemTracks = this.itemTracks;
         };
 
         this.load = function(item) {

--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -117,14 +117,13 @@ define(['../utils/underscore',
             _cancelXhr(this._itemTracks);
         }
         this._itemTracks = itemTracks;
-
-        this._renderNatively = _nativeRenderingSupported(this.getName().name);
-        if (!itemTracks || !itemTracks.length) {
+        if (!itemTracks) {
             return;
         }
-
+        
         if (!alreadyLoaded) {
             // Add tracks if we're starting playback or resuming after a midroll
+            this._renderNatively = _nativeRenderingSupported(this.getName().name);
             if (this._renderNatively) {
                 this.disableTextTrack();
                 _clearSideloadedTextTracks.call(this);


### PR DESCRIPTION
Cleaned up new captions mixin.

Ensured sideloaded captions are only loaded once per playlist item and that loading is aborted if the item is skipped before loading completes.

Fixed leak that kept adding event listener which was never actually removed.

Removed code that cleared captions on provider destroy because it removed tracks on ad complete requiring captions to be loaded a again for the current playback item.

JW7-2826