### PR TITLE
Set global color classes so the related plugin can use active/inactive styling

### DIFF
--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -269,4 +269,34 @@
             min-width: @controlbar-height * 5/8;
         }
     }
+    // Set color classes in the skin so they can be reused in other parts of the player (i.e. the related overlay)
+    .set-global-color-classes() {
+        .jw-color-active {
+            color: @active-color;
+            stroke: @active-color;
+            border-color: @active-color;
+        }
+
+        .jw-color-active-hover {
+            &:hover {
+                color: @active-color;
+                stroke: @active-color;
+                border-color: @active-color;
+            }
+        }
+
+        .jw-color-inactive {
+            color: @inactive-color;
+            stroke: @inactive-color;
+            border-color: @inactive-color;
+        }
+
+        .jw-color-inactive-hover {
+            &:hover {
+                color: @inactive-color;
+                stroke: @inactive-color;
+                border-color: @inactive-color;
+            }
+        }
+    }
 }

--- a/src/css/skins/beelden.less
+++ b/src/css/skins/beelden.less
@@ -36,11 +36,12 @@
 
     @controlbar-height: 2em;
     #namespace > .controlbar-height();
-
     #namespace > .basic-skin-styles(); // Using the above local variables
-    .skin-element-padding();
+    #namespace > .set-global-color-classes();
 
+    .skin-element-padding();
     .inset-controlbar();
+
     .jw-controlbar,
     .jw-skip {
         box-shadow: inset 0px 7px 1px -5px rgba(128,128,128,1);

--- a/src/css/skins/bekle.less
+++ b/src/css/skins/bekle.less
@@ -31,11 +31,12 @@
     @volume-background: fade(#505863,90%);
 
     @controlbar-height: 2em;
+
     #namespace > .controlbar-height();
-
     #namespace > .basic-skin-styles(); // Using the above local variables
-    .skin-element-padding();
+    #namespace > .set-global-color-classes();
 
+    .skin-element-padding();
     .inset-controlbar();
     .jw-controlbar {
         border-radius: .3em;

--- a/src/css/skins/five.less
+++ b/src/css/skins/five.less
@@ -30,11 +30,12 @@
     @five-border-radius: 0;
 
     @controlbar-height: 2em;
+
     #namespace > .controlbar-height();
-
     #namespace > .basic-skin-styles(); // Using the above local variables
-    .skin-element-padding();
+    #namespace > .set-global-color-classes();
 
+    .skin-element-padding();
     /* Styles for play button container on idle */
     .jw-display-icon-container {
         border-radius: @five-border-radius;

--- a/src/css/skins/glow.less
+++ b/src/css/skins/glow.less
@@ -17,15 +17,17 @@
     @cue-size: .25em;
 
     @controlbar-height: 2em;
+
     #namespace > .controlbar-height();
+    #namespace > .basic-skin-styles(); // Using the above local variables
+    #namespace > .set-global-color-classes();
+
+    .skin-element-padding();
 
     .jw-background-color {
         background: fade(#333, 80%);
     }
-    
-    #namespace > .basic-skin-styles(); // Using the above local variables
-    .skin-element-padding();
-    
+
     /* For the overlay containers */
     .jw-time-tip,
     .jw-volume-tip,

--- a/src/css/skins/roundster.less
+++ b/src/css/skins/roundster.less
@@ -30,9 +30,11 @@
     @rail-height: 0.4em;
 
     @controlbar-height: 2em;
-    #namespace > .controlbar-height();
 
+    #namespace > .controlbar-height();
     #namespace > .basic-skin-styles(); // Using the above local variables
+    #namespace > .set-global-color-classes();
+
     .skin-element-padding();
     
     /* Controlbar styles */

--- a/src/css/skins/seven.less
+++ b/src/css/skins/seven.less
@@ -4,6 +4,8 @@
   @accent-color: #FFF;
   @inactive-color: #cecece;
 
+  #namespace > .set-global-color-classes();
+
   .jw-active-option {
     background-color: rgba(255, 255, 255, 0.1);
   }

--- a/src/css/skins/six.less
+++ b/src/css/skins/six.less
@@ -38,17 +38,20 @@
     @slider-height: 1.2em;
 
     @controlbar-height: 2em;
-    #namespace > .controlbar-height();
 
+    #namespace > .controlbar-height();
     #namespace > .basic-skin-styles(); // Using the above local variables
+    #namespace > .set-global-color-classes();
+
+
     .skin-element-padding();
+    /* Controlbar styles */
+    .inset-controlbar();
 
     .jw-background-color {
         background-color: @def-background-color;
     }
-    
-    /* Controlbar styles */
-    .inset-controlbar();
+
     .jw-controlbar {
         border: @def-border;
         border-radius: .3em;

--- a/src/css/skins/stormtrooper.less
+++ b/src/css/skins/stormtrooper.less
@@ -27,9 +27,11 @@
     @thumb-height: .5em;
 
     @controlbar-height: 2em;
-    #namespace > .controlbar-height();
 
+    #namespace > .controlbar-height();
     #namespace > .basic-skin-styles(); // Using the above local variables
+    #namespace > .set-global-color-classes();
+
     .skin-element-padding();
 
     /* For the overlay containers */

--- a/src/css/skins/vapor.less
+++ b/src/css/skins/vapor.less
@@ -23,11 +23,13 @@
 
     @volume-background: #333;
 
-  @controlbar-height: 2em;
-  #namespace > .controlbar-height();
+    @controlbar-height: 2em;
 
+    #namespace > .controlbar-height();
     #namespace > .basic-skin-styles(); // Using the above local variables
-	.skin-element-padding();
+    #namespace > .set-global-color-classes();
+
+    .skin-element-padding();
 	
     /* For the overlay containers */
     .jw-time-tip,

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -322,7 +322,7 @@ define([
                 '.jw-text',
                 // menu option text
                 '.jw-option',
-                // controlbar button colors<style type="text/css" data-jwplayer-id="playa1">…</style>
+                // controlbar button colors
                 '.jw-button-color',
                 // toggle button
                 '.jw-toggle.jw-off',

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -271,6 +271,25 @@ define([
             }
         }
 
+        // Set global colors, used by related plugin
+        // If a color is undefined simple-style-loader won't add their styles to the dom
+        function insertGlobalColorClasses(activeColor, inactiveColor, playerId) {
+            var activeColorSet = {
+                color: activeColor,
+                borderColor: activeColor,
+                stroke: activeColor
+            };
+            var inactiveColorSet = {
+                color: inactiveColor,
+                borderColor: inactiveColor,
+                stroke: inactiveColor
+            };
+            utils.css('#' + playerId + ' .jw-color-active', activeColorSet, playerId);
+            utils.css('#' + playerId + ' .jw-color-active-hover:hover', activeColorSet, playerId);
+            utils.css('#' + playerId + ' .jw-color-inactive', inactiveColorSet, playerId);
+            utils.css('#' + playerId + ' .jw-color-inactive-hover:hover', inactiveColorSet, playerId);
+        }
+
 
         this.onChangeSkin = function(model, newSkin) {
             utils.replaceClass(_playerElement, /jw-skin-\S+/, newSkin ? ('jw-skin-'+newSkin) : '');
@@ -352,11 +371,7 @@ define([
                 '.jw-playlist-container ::-webkit-scrollbar'
             ], 'border-color', backgroundColor);
 
-            // Set global colors, used by related plugin
-            utils.css('#' + id + ' .jw-color-active', { color: activeColor, borderColor: activeColor, stroke: activeColor }, id);
-            utils.css('#' + id + ' .jw-color-active-hover:hover', { color: activeColor, borderColor: activeColor, stroke: activeColor }, id);
-            utils.css('#' + id + ' .jw-color-inactive', { color: inactiveColor, borderColor: inactiveColor }, id);
-            utils.css('#' + id + ' .jw-color-inactive-hover:hover', { color: inactiveColor, borderColor: inactiveColor, stroke: inactiveColor }, id);
+            insertGlobalColorClasses(activeColor, inactiveColor, id);
         };
 
         this.setup = function() {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -322,7 +322,7 @@ define([
                 '.jw-text',
                 // menu option text
                 '.jw-option',
-                // controlbar button colors
+                // controlbar button colors<style type="text/css" data-jwplayer-id="playa1">…</style>
                 '.jw-button-color',
                 // toggle button
                 '.jw-toggle.jw-off',
@@ -351,6 +351,12 @@ define([
                 // area around scrollbar on the playlist.  skin fix required to remove
                 '.jw-playlist-container ::-webkit-scrollbar'
             ], 'border-color', backgroundColor);
+
+            // Set global colors, used by related plugin
+            utils.css('#' + id + ' .jw-color-active', { color: activeColor, borderColor: activeColor, stroke: activeColor }, id);
+            utils.css('#' + id + ' .jw-color-active-hover:hover', { color: activeColor, borderColor: activeColor, stroke: activeColor }, id);
+            utils.css('#' + id + ' .jw-color-inactive', { color: inactiveColor, borderColor: inactiveColor }, id);
+            utils.css('#' + id + ' .jw-color-inactive-hover:hover', { color: inactiveColor, borderColor: inactiveColor, stroke: inactiveColor }, id);
         };
 
         this.setup = function() {


### PR DESCRIPTION
- Creates 4 classes in the head, scoped to either the skin or the player: `.jw-color-active, .jw-color-active-hover, .jw-color-inactive, .jw-color-inactive-hover`

- Created as a function in `mixins.less` to avoid duplication

After the plugin is integrated into the player, the necessity of these classes should be reevaluated

Part of JW7-2610