### PR TITLE
Clear playlist item track data before loading side loaded captions

### DIFF
--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -394,8 +394,8 @@ define(['../utils/underscore',
                 // Cues are inaccessible if the track is disabled. While hidden,
                 // we can remove cues while the track is in a non-visible state
                 track.mode = 'hidden';
-                while (track.cues.length) {
-                    track.removeCue(track.cues[0]);
+                for (var i = track.cues.length; i--;) {
+                    track.removeCue(track.cues[i]);
                 }
                 track.mode = 'disabled';
                 track.inuse = false;

--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -348,6 +348,7 @@ define(['../utils/underscore',
             var textTrackAny = _createTrack.call(this, itemTrack);
             _addTrackToList.call(this, textTrackAny);
             if (itemTrack.file) {
+                itemTrack.data = [];
                 itemTrack.xhr = _loadTrack.call(this, itemTrack, textTrackAny);
             }
         }


### PR DESCRIPTION
Playlist item track "data" is an array with all cues added to it for rendering with VTT.js. With sideloaded tracks this object was being reused every time an item is replayed without clearing the array. We didn't see the duplicate cues because they were not rendered until #1348 was fixed.

Now the array is reset before reloading the track.

JW7-2826