### PR TITLE
Toggle controls for ads using model attribute "hideAdsControls"

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -201,6 +201,7 @@ define([
             var _this = this;
             var providersManager = _model.getProviders();
             var providersNeeded = providersManager.required(playlist);
+            _model.set('hideAdsControls', false);
             providersManager.load(providersNeeded)
                 .then(function() {
                     if (_instream === null) {
@@ -240,10 +241,6 @@ define([
 
         this.pause = function() {
             _instream.instreamPause();
-        };
-
-        this.hide = function() {
-            _instream.hide();
         };
 
         this.addClickHandler = function() {
@@ -330,7 +327,7 @@ define([
 
         // This method is triggered by plugins which want to hide player controls
         this.hide = function() {
-            _view.useExternalControls();
+            _model.set('hideAdsControls', true);
         };
 
     };

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -441,6 +441,10 @@ define([
             _model.on('change:castActive', _onCastActive);
             _onCastActive(_model, _model.get('castActive'));
 
+            _model.on('change:hideAdsControls', function(model, val) {
+                utils.toggleClass(_playerElement, 'jw-flag-ads-hide-controls', val);
+            });
+
             // set initial state
             if(_model.get('stretching')){
                 _onStretchChange(_model, _model.get('stretching'));
@@ -1027,10 +1031,6 @@ define([
             _controlbar.setAltText(text);
         };
 
-        this.useExternalControls = function() {
-            utils.addClass(_playerElement, 'jw-flag-ads-hide-controls');
-        };
-
         this.destroyInstream = function() {
             _instreamMode = false;
             if (_instreamModel) {
@@ -1038,8 +1038,8 @@ define([
                 _instreamModel = null;
             }
             this.setAltText('');
-            utils.removeClass(_playerElement, 'jw-flag-ads');
-            utils.removeClass(_playerElement, 'jw-flag-ads-hide-controls');
+            utils.removeClass(_playerElement, ['jw-flag-ads', 'jw-flag-ads-hide-controls']);
+            _model.set('hideAdsControls', false);
             if (_model.getVideo) {
                 var provider = _model.getVideo();
                 provider.setContainer(_videoLayer);


### PR DESCRIPTION
Use model to toggle controls for ads. Remove unused hide method and avoid needing to expose public view methods to instream.

JW7-2762

