### PR TITLE
Captions show after replaying and preroll

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -282,8 +282,12 @@ define([
                 loader.load(toLoad);
             }
 
+            function _getAdState() {
+                return _this._instreamAdapter && _this._instreamAdapter.getState();
+            }
+
             function _getState() {
-                var adState = _this._instreamAdapter && _this._instreamAdapter.getState();
+                var adState = _getAdState();
                 if (_.isString(adState)) {
                     return adState;
                 }
@@ -301,7 +305,7 @@ define([
                     return;
                 }
 
-                var adState = _this._instreamAdapter && _this._instreamAdapter.getState();
+                var adState = _getAdState();
                 if (_.isString(adState)) {
                     // this will resume the ad. _api.playAd would load a new ad
                     return _api.pauseAd(false);
@@ -377,7 +381,7 @@ define([
             function _pause() {
                 _actionOnAttach = null;
 
-                var adState = _this._instreamAdapter && _this._instreamAdapter.getState();
+                var adState = _getAdState();
                 if (_.isString(adState)) {
                     return _api.pauseAd(true);
                 }
@@ -641,6 +645,7 @@ define([
             this.getVisualQuality = _getVisualQuality;
             this.getConfig = _getConfig;
             this.getState = _getState;
+            this.getAdState = _getAdState;
 
             // Model passthroughs
             this.setVolume = _model.setVolume.bind(_model);
@@ -728,9 +733,8 @@ define([
             this.createInstream = function() {
                 this.instreamDestroy();
                 this._instreamAdapter = new InstreamAdapter(this, _model, _view);
-                // Persist the current captions track so the index
-                // is  set correctly after ad playback ends
-                _model.persistCaptionsTrack();
+                _model.set('adState', this.getAdState());
+
                 return this._instreamAdapter;
             };
 
@@ -738,12 +742,14 @@ define([
                 if (this._instreamAdapter) {
                     this._instreamAdapter.skipAd();
                 }
+                _model.set('adState', this.getAdState());
             };
 
             this.instreamDestroy = function() {
                 if (_this._instreamAdapter) {
                     _this._instreamAdapter.destroy();
                 }
+                _model.set('adState', this.getAdState());
             };
 
             _setup.start();

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -100,7 +100,7 @@ define([
                 case events.JWPLAYER_MEDIA_BUFFER:
                     this.set('buffer', data.bufferPercent);
 
-                    /* falls through */
+                /* falls through */
                 case events.JWPLAYER_MEDIA_META:
                     var duration = data.duration;
                     if (_.isNumber(duration) && !_.isNaN(duration)) {
@@ -111,10 +111,10 @@ define([
 
                 case events.JWPLAYER_MEDIA_BUFFER_FULL:
                     // media controller
-                    if(this.mediaModel.get('playAttempt')) {
+                    if (this.mediaModel.get('playAttempt')) {
                         this.playVideo();
                     } else {
-                        this.mediaModel.on('change:playAttempt', function() {
+                        this.mediaModel.on('change:playAttempt', function () {
                             this.playVideo();
                         }, this);
                     }
@@ -148,7 +148,11 @@ define([
                     this.setCurrentAudioTrack(data.currentTrack, data.tracks);
                     break;
                 case 'subtitlesTrackChanged':
-                    this.setVideoSubtitleTrack(data.currentTrack, data.tracks);
+                    var adState = this.get('adState');
+                    if (!_.isString(adState)) {
+                        this.setVideoSubtitleTrack(data.currentTrack, data.tracks);
+                        this.persistCaptionsTrack();
+                    }
                     break;
 
                 case 'visualQuality':

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -114,7 +114,7 @@ define([
                     if (this.mediaModel.get('playAttempt')) {
                         this.playVideo();
                     } else {
-                        this.mediaModel.on('change:playAttempt', function () {
+                        this.mediaModel.on('change:playAttempt', function() {
                             this.playVideo();
                         }, this);
                     }
@@ -149,9 +149,11 @@ define([
                     break;
                 case 'subtitlesTrackChanged':
                     var adState = this.get('adState');
+
+                    // We only want to update the tracks ands persist the select track
+                    // when an ad is not playing
                     if (!_.isString(adState)) {
-                        this.setVideoSubtitleTrack(data.currentTrack, data.tracks);
-                        this.persistCaptionsTrack();
+                        this.persistVideoSubtitleTrack(data.currentTrack, data.tracks);
                     }
                     break;
 
@@ -183,7 +185,7 @@ define([
             }
         };
 
-        this.onMediaContainer = function () {
+        this.onMediaContainer = function() {
             var container = this.get('mediaContainer');
             _currentProvider.setContainer(container);
         };
@@ -388,8 +390,8 @@ define([
 
         };
 
-        this.persistVideoSubtitleTrack = function(trackIndex) {
-            this.setVideoSubtitleTrack(trackIndex);
+        this.persistVideoSubtitleTrack = function(trackIndex, tracks) {
+            this.setVideoSubtitleTrack(trackIndex, tracks);
             this.persistCaptionsTrack();
         };
     };

--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -295,6 +295,7 @@ define(['../utils/underscore',
         this._unknownCount = 0;
         this._activeCuePosition = null;
         if (this._renderNatively) {
+            // Removing listener first to ensure that removing cues does not trigger it unnecessarily
             this.removeTracksListener(this.video.textTracks, 'change', this.textTrackChangeHandler);
             _removeCues.call(this, this.video.textTracks);
         }

--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -120,7 +120,7 @@ define(['../utils/underscore',
         if (!itemTracks) {
             return;
         }
-        
+
         if (!alreadyLoaded) {
             // Add tracks if we're starting playback or resuming after a midroll
             this._renderNatively = _nativeRenderingSupported(this.getName().name);
@@ -295,6 +295,7 @@ define(['../utils/underscore',
         this._unknownCount = 0;
         this._activeCuePosition = null;
         if (this._renderNatively) {
+            this.removeTracksListener(this.video.textTracks, 'change', this.textTrackChangeHandler);
             _removeCues.call(this, this.video.textTracks);
         }
     }


### PR DESCRIPTION
Need to keep track on wether an ad is being played so that we can correctly persist the selected captions. This is done by saving the ad state in the model, and not just the overall state. Also needed to remove the tracks listener before we removed the cue so that it is not triggered unnecessarily.

JW7-2818