### PR TITLE
Fix handling cues with missing end times

### DIFF
--- a/src/js/view/captionsrenderer.js
+++ b/src/js/view/captionsrenderer.js
@@ -102,9 +102,26 @@ define([
         };
 
         this.getCurrentCues = function(allCues, pos) {
-            return _.filter(allCues, function (cue) {
-                return pos >= (cue.startTime) && (!cue.endTime || pos <= cue.endTime);
-            });
+            function getEndTime(cue, i) {
+                if (cue.endTime ||  _.last(allCues) === cue) {
+                    return cue.endTime;
+                }
+
+                if (cue.startTime < allCues[i+1].startTime) {
+                    return allCues[i+1].startTime;
+                }
+
+                return getEndTime(cue, i+1);
+            }
+
+            return _.reduce(allCues, function (cues, cue, i) {
+                var endTime = getEndTime(cue, i);
+
+                if (pos >= cue.startTime && (!endTime || pos <= endTime)) {
+                    cues.push(cue);
+                }
+                return cues;
+            }, []);
         };
 
         this.updateCurrentCues = function(cues) {

--- a/test/unit/captionsrenderer-test.js
+++ b/test/unit/captionsrenderer-test.js
@@ -32,14 +32,14 @@ define([
 
     test('should show the correct number of cues at any given position in time with some missing end times', function (assert) {
         var allCues = [
-            new VTTCue(0, undefined, 'HG: Morning, Rob.'),
+            new VTTCue(0, 0, 'HG: Morning, Rob.'),
             new VTTCue(4, 5, 'How are you?'),
             new VTTCue(7, 10, 'RW: Good, and you?'),
-            new VTTCue(10, undefined, 'I\'m great!'),
+            new VTTCue(10, 0, 'I\'m great!'),
             new VTTCue(12, 15, 'EG: Hey, Jo...'),
-            new VTTCue(13, undefined, 'JB: Yeah?'),
+            new VTTCue(13, 0, 'JB: Yeah?'),
             new VTTCue(13, 14, 'JP: Yeah?'),
-            new VTTCue(16, undefined, 'The End')
+            new VTTCue(16, 0, 'The End')
         ];
         var currentNumCues = [1, 1, 1, 1, 2, 1, 0, 1, 1, 1, 2, 1, 2, 3, 3, 2, 2, 1, 1, 1];
 
@@ -50,14 +50,14 @@ define([
 
     test('should show the correct number of cues at any given position in time with missing end times', function (assert) {
         var allCues = [
-            new VTTCue(0, undefined, 'HG: Morning, Rob.'),
-            new VTTCue(4, undefined, 'How are you?'),
-            new VTTCue(7, undefined, 'RW: Good, and you?'),
-            new VTTCue(10, undefined, 'I\'m great!'),
-            new VTTCue(12, undefined, 'EG: Hey, Jo...'),
-            new VTTCue(13, undefined, 'JB: Yeah?'),
-            new VTTCue(13, undefined, 'JP: Yeah?'),
-            new VTTCue(16, undefined, 'The End')
+            new VTTCue(0, 0, 'HG: Morning, Rob.'),
+            new VTTCue(4, 0, 'How are you?'),
+            new VTTCue(7, 0, 'RW: Good, and you?'),
+            new VTTCue(10, 0, 'I\'m great!'),
+            new VTTCue(12, 0, 'EG: Hey, Jo...'),
+            new VTTCue(13, 0, 'JB: Yeah?'),
+            new VTTCue(13, 0, 'JP: Yeah?'),
+            new VTTCue(16, 0, 'The End')
         ];
         var currentNumCues = [1, 1, 1, 1, 2, 1, 1, 2, 1, 1, 2, 1, 2, 3, 2, 2, 3, 1];
 

--- a/test/unit/captionsrenderer-test.js
+++ b/test/unit/captionsrenderer-test.js
@@ -21,9 +21,45 @@ define([
             new VTTCue(12, 15, 'EG: Hey, Jo...'),
             new VTTCue(13, 14, 'JB: Yeah?'),
             new VTTCue(13, 14, 'JP: Yeah?'),
-            new VTTCue(16, null, 'The End')
+            new VTTCue(16, 18, 'The End')
         ];
-        var currentNumCues = [1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 2, 1, 2, 4, 4, 1, 1];
+        var currentNumCues = [1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 2, 1, 2, 4, 4, 1, 1, 1, 1, 0, 0, 0];
+
+        for (var i = 0; i < currentNumCues.length; i += 1) {
+            assert.equal(captionsRenderer.getCurrentCues(allCues, i).length, currentNumCues[i], 'Invalid number of cues at position ' + i);
+        }
+    });
+
+    test('should show the correct number of cues at any given position in time with some missing end times', function (assert) {
+        var allCues = [
+            new VTTCue(0, undefined, 'HG: Morning, Rob.'),
+            new VTTCue(4, 5, 'How are you?'),
+            new VTTCue(7, 10, 'RW: Good, and you?'),
+            new VTTCue(10, undefined, 'I\'m great!'),
+            new VTTCue(12, 15, 'EG: Hey, Jo...'),
+            new VTTCue(13, undefined, 'JB: Yeah?'),
+            new VTTCue(13, 14, 'JP: Yeah?'),
+            new VTTCue(16, undefined, 'The End')
+        ];
+        var currentNumCues = [1, 1, 1, 1, 2, 1, 0, 1, 1, 1, 2, 1, 2, 3, 3, 2, 2, 1, 1, 1];
+
+        for (var i = 0; i < currentNumCues.length; i += 1) {
+            assert.equal(captionsRenderer.getCurrentCues(allCues, i).length, currentNumCues[i], 'Invalid number of cues at position ' + i);
+        }
+    });
+
+    test('should show the correct number of cues at any given position in time with missing end times', function (assert) {
+        var allCues = [
+            new VTTCue(0, undefined, 'HG: Morning, Rob.'),
+            new VTTCue(4, undefined, 'How are you?'),
+            new VTTCue(7, undefined, 'RW: Good, and you?'),
+            new VTTCue(10, undefined, 'I\'m great!'),
+            new VTTCue(12, undefined, 'EG: Hey, Jo...'),
+            new VTTCue(13, undefined, 'JB: Yeah?'),
+            new VTTCue(13, undefined, 'JP: Yeah?'),
+            new VTTCue(16, undefined, 'The End')
+        ];
+        var currentNumCues = [1, 1, 1, 1, 2, 1, 1, 2, 1, 1, 2, 1, 2, 3, 2, 2, 3, 1];
 
         for (var i = 0; i < currentNumCues.length; i += 1) {
             assert.equal(captionsRenderer.getCurrentCues(allCues, i).length, currentNumCues[i], 'Invalid number of cues at position ' + i);


### PR DESCRIPTION
When cues do not have end times, the start time of the following cue,
that does not have the same start time, should be used.

JW7-2854