### PR TITLE
Support IMA HTML5 SDK over Flash Provider

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -280,6 +280,8 @@ define([
                 if (_view.clickHandler()) {
                     _view.clickHandler().revertAlternateClickHandlers();
                 }
+
+                _model.off(null, null, _instream);
                 _instream.instreamDestroy();
 
                 // Must happen after instream.instreamDestroy()

--- a/src/js/controller/instream-flash.js
+++ b/src/js/controller/instream-flash.js
@@ -51,16 +51,7 @@ define([
                 }, this);
             }
 
-            this.swf.on('instream:state', function(evt) {
-                switch (evt.newstate) {
-                    case states.PLAYING:
-                        this._adModel.set('state', evt.newstate);
-                        break;
-                    case states.PAUSED:
-                        this._adModel.set('state', evt.newstate);
-                        break;
-                }
-            }, this)
+            this.swf.on('instream:state', this.stateHandler, this)
             .on('instream:time', function(evt) {
                 this._adModel.set('position', evt.position);
                 this._adModel.set('duration', evt.duration);
@@ -82,7 +73,22 @@ define([
                 this.model.on('change:mute', function(data, value) {
                     provider.mute(value);
                 }, this);
+
+                // update admodel state when set from from googima
+                provider.off();
+                provider.on(events.JWPLAYER_PLAYER_STATE, this.stateHandler, this);
             };
+        },
+
+        stateHandler: function(evt) {
+            switch (evt.newstate) {
+            case states.PLAYING:
+                this._adModel.set('state', evt.newstate);
+                break;
+            case states.PAUSED:
+                this._adModel.set('state', evt.newstate);
+                break;
+            }
         },
 
         instreamDestroy: function() {

--- a/src/js/controller/instream-flash.js
+++ b/src/js/controller/instream-flash.js
@@ -83,8 +83,6 @@ define([
         stateHandler: function(evt) {
             switch (evt.newstate) {
             case states.PLAYING:
-                this._adModel.set('state', evt.newstate);
-                break;
             case states.PAUSED:
                 this._adModel.set('state', evt.newstate);
                 break;

--- a/src/js/controller/instream-html5.js
+++ b/src/js/controller/instream-html5.js
@@ -151,8 +151,6 @@ define([
         function stateHandler(evt) {
             switch (evt.newstate) {
                 case states.PLAYING:
-                    _adModel.set('state', evt.newstate);
-                    break;
                 case states.PAUSED:
                     _adModel.set('state', evt.newstate);
                     break;


### PR DESCRIPTION
In order to use the html5 IMA sdk over flash, our insteam-flash module needs to update playback state the same way that the insteam-html5 does.

In this code "provider" is actually the Google IMA or VAST plugin that passes a reference of itself to the instream adapter via `applyProviderListeners`. Listening to play/pause state events and updating the adModel keeps the player in sync with the state of the ad played by the plugin.

Other notes on changes:
- model listeners for instream-adapter where not being detached when insteam is destroyed (`_model.off(null, null, _instream)`)
- made state handler case statement fall-through per @egreaves suggestion

JW7-2640