### PR TITLE
Don't detach resize event handlers if the player isn't found on the page

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -263,6 +263,7 @@ define([
             if (document.body.contains(_playerElement)) {
                 _cancelDelayResize(_resizeContainerRequestId);
                 _resizeContainerRequestId = _delayResize(_setContainerDimensions);
+            }
         }
 
         // Set global colors, used by related plugin

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -260,15 +260,9 @@ define([
         }
 
         function _responsiveListener() {
-            if (!document.body.contains(_playerElement)) {
-                window.removeEventListener('resize', _responsiveListener);
-                if (_isMobile) {
-                    window.removeEventListener('orientationchange', _responsiveListener);
-                }
-            } else {
+            if (document.body.contains(_playerElement)) {
                 _cancelDelayResize(_resizeContainerRequestId);
                 _resizeContainerRequestId = _delayResize(_setContainerDimensions);
-            }
         }
 
         // Set global colors, used by related plugin


### PR DESCRIPTION
In Android Chrome, an `orientationchange` event will fire right as the page loads and before the player is attached to the DOM. This causes the `orientationchange` event handler to become detached (meaning it will never fire again). After some discussion we came to the conclusion that detaching the handlers isn't necessary because the `destroy` method detaches the handlers when the player is destroyed.

JW7-2910