### PR TITLE
Convert VTTCue to TextTrackCue for rendering captions in Edge

### DIFF
--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -402,7 +402,7 @@ define(['../utils/underscore',
     //////////////////////
 
     function _addCueToTrack(track, vttCue) {
-        if (!utils.isEdge()) {
+        if (!utils.isEdge() || !window.TextTrackCue) {
             track.addCue(vttCue);
             return;
         }

--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -88,7 +88,7 @@ define(['../utils/underscore',
                     if (this._cuesByTrackId[track._id] && !this._cuesByTrackId[track._id].loaded) {
                         var cues = this._cuesByTrackId[track._id].cues;
                         while ((cue = cues.shift())) {
-                            track.addCue(cue);
+                            _addCueToTrack(track, cue);
                         }
                         track.mode = mode;
                         this._cuesByTrackId[track._id].loaded = true;
@@ -236,7 +236,7 @@ define(['../utils/underscore',
             track = _createTrack.call(this, itemTrack);
             this.setTextTracks(this.video.textTracks);
         }
-        track.addCue(cueData.cue);
+        _addCueToTrack(track, cueData.cue);
     }
 
     function addCuesToTrack(cueData) {
@@ -401,6 +401,18 @@ define(['../utils/underscore',
     ////// PRIVATE METHODS
     //////////////////////
 
+    function _addCueToTrack(track, vttCue) {
+        if (!utils.isEdge()) {
+            track.addCue(vttCue);
+            return;
+        }
+        // There's no support for the VTTCue interface in Edge.
+        // We need to convert VTTCue to TextTrackCue before adding them to the TextTrack
+        // This unfortunately removes positioning properties from the cues
+        var textTrackCue = new window.TextTrackCue(vttCue.startTime, vttCue.endTime, vttCue.text);
+        track.addCue(textTrackCue);
+    }
+
     function _removeCues(tracks) {
         if (tracks.length) {
             _.each(tracks, function(track) {
@@ -519,7 +531,7 @@ define(['../utils/underscore',
             this._cuesByTrackId[track._id] = { cues: vttCues, loaded: true };
 
             while((cue = vttCues.shift())) {
-                textTrack.addCue(cue);
+                _addCueToTrack(textTrack, cue);
             }
         } else {
             track.data = vttCues;
@@ -542,7 +554,7 @@ define(['../utils/underscore',
             var parser = new VTTParser(window);
             if (renderNatively) {
                 parser.oncue = function(cue) {
-                    track.addCue(cue);
+                    _addCueToTrack(track, cue);
                 };
             } else {
                 track.data = track.data || [];


### PR DESCRIPTION
### Changes proposed in this pull request:
Since Edge has support for HLS, the player now uses native rendering for 608 captions tracks. This means that cues from sideloaded tracks need to be of type `TextTrackCue` when  added to a TextTrack.

Fixes #
JW7-2678