### PR TITLE
Hide rightclick menu on mouseout after 3 seconds

### DIFF
--- a/src/js/view/rightclick.js
+++ b/src/js/view/rightclick.js
@@ -94,8 +94,10 @@ define([
         },
 
         hideMenu : function() {
+            this.elementUI.off('out', this.hideMenu, this);
             if (this.mouseOverContext) {
-                // If mouse is over the menu, do nothing
+                // If mouse is over the menu, hide the menu when mouse moves out
+                this.elementUI.on('out', this.hideMenu, this);
                 return;
             }
             utils.removeClass(this.playerElement, 'jw-flag-rightclick-open');


### PR DESCRIPTION
If the mouse was over the right click menu when 3 seconds elapsed, we did not do anything so the right click menu stayed.
We want to hide the menu on mouse out when this happens.
JW7-2941