### PR TITLE
Fix browser checks for IE/Edge and iOS Chrome

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -247,12 +247,7 @@ define([
             // start listening for ad click
             _view.clickHandler().setAlternateClickHandlers(_clickHandler, _doubleClickHandler);
 
-            //if (utils.isMSIE()) {
-                //_oldProvider.parentElement.addEventListener('click', _view.clickHandler().clickHandler);
-            //}
-
             _instream.on(events.JWPLAYER_MEDIA_META, this.metaHandler, this);
-
         };
 
         this.skipAd = function(evt) {

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -572,9 +572,9 @@ define([
             }
             _clearVideotagSource();
             this.clearTracks();
-            // IE may continue to play a video after changing source and loading a new media file.
-            // https://connect.microsoft.com/IE/feedbackdetail/view/2000141/htmlmediaelement-autoplays-after-src-is-changed-and-load-is-called
-            if(utils.isIETrident()) {
+            // IE/Edge continue to play a video after changing video.src and calling video.load()
+            // https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/5383483/ (not fixed in Edge 14)
+            if (utils.isIE()) {
                 _videotag.pause();
             }
             this.setState(states.IDLE);

--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -28,18 +28,16 @@ define([
     browser.isIPad = _browserCheck(/iPad/i);
     browser.isSafari602 = _browserCheck(/Macintosh.*Mac OS X 10_8.*6\.0\.\d* Safari/i);
     browser.isOSX = _browserCheck(/Mac OS X/i);
-    browser.isEdge = _browserCheck(/\sedge\/\d+/i);
 
-    var _isIETrident = browser.isIETrident = function(browserVersion) {
-        if(browser.isEdge()){
-            return true;
-        }
+    var _isEdge = browser.isEdge = function(browserVersion) {
         if (browserVersion) {
-            browserVersion = parseFloat(browserVersion).toFixed(1);
-            return _userAgentMatch(new RegExp('trident/.+rv:\\s*' + browserVersion, 'i'));
+            return _userAgentMatch(new RegExp('\\sedge\\/' + browserVersion, 'i'));
         }
-        return _userAgentMatch(/trident/i);
+        return _userAgentMatch(/\sEdge\/\d+/i);
     };
+
+
+    var _isIETrident = browser.isIETrident = _browserCheck(/trident\/.+rv:\s*11/i);
 
 
     var _isMSIE = browser.isMSIE = function(browserVersion) {
@@ -50,22 +48,22 @@ define([
         return _userAgentMatch(/msie/i);
     };
 
-    var _isChrome = _browserCheck(/chrome/i);
-
-    browser.isChrome = function(){
-        return _isChrome() && !browser.isEdge();
+    browser.isChrome = function() {
+        return _userAgentMatch(/\s(?:Chrome|CriOS)\//i) && !browser.isEdge();
     };
 
     browser.isIE = function(browserVersion) {
         if (browserVersion) {
             browserVersion = parseFloat(browserVersion).toFixed(1);
-            if (browserVersion >= 11) {
-                return _isIETrident(browserVersion);
+            if (browserVersion >= 12) {
+                return _isEdge(browserVersion);
+            } else if (browserVersion >= 11) {
+                return _isIETrident();
             } else {
                 return _isMSIE(browserVersion);
             }
         }
-        return _isMSIE() || _isIETrident();
+        return _isEdge() || _isIETrident() || _isMSIE();
     };
 
     browser.isSafari = function() {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -596,7 +596,7 @@ define([
             });
 
             // make displayIcon clickthrough on chrome for flash to avoid power safe throttle
-            if (utils.isChrome()) {
+            if (utils.isChrome() && !utils.isMobile()) {
                 displayIcon.el.addEventListener('mousedown', function() {
                     var provider = _model.getVideo();
                     var isFlash = (provider && provider.getName().name.indexOf('flash') === 0);


### PR DESCRIPTION
- isIE(11) should not return true for Edge
- isIE() should return true for Edge
- isTrident( * ) should only return true for IE11
- isChrome() should be true in iOS Chrome
- player code using these methods incorrectly should be updated appropriately (html5 pause when src is changed, view mousedown for flash throttle, caterpillar gate for IE)

JW7-2965