### PR TITLE
Replace html breaks with line breaks for proper VTTCue rendering of DFXP subtitles.

### DIFF
--- a/src/js/parsers/captions/dfxp.js
+++ b/src/js/parsers/captions/dfxp.js
@@ -30,7 +30,7 @@ define([
         for (var i = 0; i < paragraphs.length; i++) {
             var p = paragraphs[i];
             var rawText = (p.innerHTML || p.textContent || p.text || '');
-            var text = strings.trim(rawText).replace(/>\s+</g, '><').replace(/tts?:/g, '');
+            var text = strings.trim(rawText).replace(/>\s+</g, '><').replace(/tts?:/g, '').replace(/<br.*?\/>/g, '\r\n');
             if (text) {
                 var begin = p.getAttribute('begin');
                 var dur = p.getAttribute('dur');

--- a/test/tests.js
+++ b/test/tests.js
@@ -7,7 +7,7 @@ define([
     'unit/constants-test',
     'unit/css-test',
     'unit/dom-test',
-    'unit/dxfp-test',
+    'unit/dfxp-test',
     'unit/embed-swf-test',
     'unit/fetch-test',
     'unit/extendable-test',

--- a/test/unit/dfxp-test.js
+++ b/test/unit/dfxp-test.js
@@ -17,6 +17,7 @@ define([
         var captions = parseDFXP(DFXP);
         assert.equal(captions.length, 8, 'DXFP captions are parsed');
         assert.equal(captions[7].text.indexOf('www.bigbuckbunny.org'), 0, 'Text is parsed');
+        assert.ok(captions[7].text.indexOf('\r\n') > -1, 'Break elements are replaced by carrage returns and newlines');
 
         var DFXPns = '<?xml version="1.0" encoding="UTF-8"?><!-- v1.1 --><tt:tt xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ttp="http://www.w3.org/ns/ttml#parameter" xmlns:tts="http://www.w3.org/ns/ttml#styling" xmlns:tt="http://www.w3.org/ns/ttml" xmlns:ebuttm="urn:ebu:tt:metadata" ttp:timeBase="media" xml:lang="de" ttp:cellResolution="50 30"><tt:body><tt:div><tt:p xml:id="subtitle1" region="bottom" begin="00:00:00.000" end="00:00:02.120" style="textCenter"><tt:span style="textWhite">weiß auf schwarz</tt:span></tt:p></tt:div></tt:body></tt:tt>';
         captions = parseDFXP(DFXPns);


### PR DESCRIPTION
Replace html breaks with line breaks for proper VTTCue rendering of DFXP subtitles.

This fixes that br-elements are ignored and multi line subtitles are displayed on a single line with no space in between.

".*?" in the RegExp is needed since the element may contain a xmlns-attribute.

See this change to the SRT-parser for reference: https://github.com/jwplayer/jwplayer/commit/d10b4faf738c0a2e4690805c2cdbc8adf0c7fae5