### PR TITLE
Quick fix for mobile fullscreen icon

### DIFF
--- a/src/css/flags/compact-player.less
+++ b/src/css/flags/compact-player.less
@@ -1,0 +1,6 @@
+.jw-flag-compact-player {
+  .jw-text-elapsed,
+  .jw-text-duration {
+    display: none;
+  }
+}

--- a/src/css/jwplayer.less
+++ b/src/css/jwplayer.less
@@ -36,6 +36,7 @@
 @import "flags/controls-disabled";
 @import "flags/flash-blocked";
 @import "flags/touch";
+@import "flags/compact-player";
 @import "flags/audioplayer.less";
 
 // Skins

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -824,10 +824,10 @@ define([
             }
 
             _captionsRenderer.resize();
-            if (_isMobile) {
-                var hideTimeInControl = width && width < _minWidthForTimeDisplay;
-                utils.toggleClass(_playerElement, 'jw-flag-compact-player', hideTimeInControl);
-            }
+            
+            var hideTimeInControl = width && width < _minWidthForTimeDisplay;
+            utils.toggleClass(_playerElement, 'jw-flag-compact-player', hideTimeInControl);
+
         }
 
         this.resize = function(width, height) {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -53,6 +53,7 @@ define([
             _rightClickMenu,
             _resizeMediaTimeout = -1,
             _resizeContainerRequestId = -1,
+            _minWidthForTimeDisplay = 450,
             // Function that delays the call of _setContainerDimensions so that the page has finished repainting.
             _delayResize = window.requestAnimationFrame ||
                 function(rafFunc) {
@@ -823,6 +824,10 @@ define([
             }
 
             _captionsRenderer.resize();
+            if (_isMobile) {
+                var hideTimeInControl = width && width < _minWidthForTimeDisplay;
+                utils.toggleClass(_playerElement, 'jw-flag-compact-player', hideTimeInControl);
+            }
         }
 
         this.resize = function(width, height) {


### PR DESCRIPTION
After removing small UI, the icons were too big to fit on fullscreen android.
Making a quick fix before addressing this better with feed UI so that we do not display duration and time elapsed on mobile fullscreen small size.
JW7-2933