### PR TITLE
Sideloaded Captions in IE9

### DIFF
--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -301,7 +301,8 @@ define([
             //  an item was actually loaded
             this.trigger('itemReady', item);
 
-            // In IE9, trigger this event, since it does not getting triggered at the correct time
+            // In IE9, trigger this event, since the loadeddata event is firing before it binds the
+            // subtitlesTracks event listener
             if (utils.isIE(9) && _currentProvider._textTracks && _currentProvider._textTracks.length) {
                 _currentProvider.trigger('subtitlesTracks', {tracks: _currentProvider._textTracks});
             }

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -295,17 +295,6 @@ define([
             if (_currentProvider.init) {
                 _currentProvider.init(item);
             }
-
-            // Listening for change:item won't suffice when loading the same index or file
-            // We also can't listen for change:mediaModel because it triggers whether or not
-            //  an item was actually loaded
-            this.trigger('itemReady', item);
-
-            // In IE9, trigger this event, since the loadeddata event is firing before it binds the
-            // subtitlesTracks event listener
-            if (utils.isIE(9) && _currentProvider._textTracks && _currentProvider._textTracks.length) {
-                _currentProvider.trigger('subtitlesTracks', {tracks: _currentProvider._textTracks});
-            }
         };
 
         this.getProviders = function() {

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -295,6 +295,11 @@ define([
             if (_currentProvider.init) {
                 _currentProvider.init(item);
             }
+
+            // Listening for change:item won't suffice when loading the same index or file
+            // We also can't listen for change:mediaModel because it triggers whether or not
+            //  an item was actually loaded
+            this.trigger('itemReady', item);
         };
 
         this.getProviders = function() {

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -300,6 +300,11 @@ define([
             // We also can't listen for change:mediaModel because it triggers whether or not
             //  an item was actually loaded
             this.trigger('itemReady', item);
+
+            // In IE9, trigger this event, since it does not getting triggered at the correct time
+            if (utils.isIE(9) && _currentProvider._textTracks && _currentProvider._textTracks.length) {
+                _currentProvider.trigger('subtitlesTracks', {tracks: _currentProvider._textTracks});
+            }
         };
 
         this.getProviders = function() {

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -323,6 +323,8 @@ define([
                 _setMediaType();
             }
             if (_isIE9) {
+                // In IE9, set tracks here since they are not ready
+                // on load
                 _this.setTextTracks(_this._textTracks);
             }
             _sendBufferFull();

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -338,7 +338,6 @@ define([
                 _videotag.muted = false;
                 _videotag.muted = true;
             }
-
             _videotag.setAttribute('jw-loaded', 'meta');
             _sendMetaEvent();
         }

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -13,6 +13,7 @@ define([
     var clearTimeout = window.clearTimeout,
         STALL_DELAY = 256,
         _isIE = utils.isIE(),
+        _isIE9 = utils.isIE(9),
         _isMSIE = utils.isMSIE(),
         _isMobile = utils.isMobile(),
         _isFirefox = utils.isFF(),
@@ -321,6 +322,9 @@ define([
             if (!_isAndroidHLS) {
                 _setMediaType();
             }
+            if (_isIE9) {
+                _this.setTextTracks(_this._textTracks);
+            }
             _sendBufferFull();
         }
 
@@ -334,6 +338,7 @@ define([
                 _videotag.muted = false;
                 _videotag.muted = true;
             }
+
             _videotag.setAttribute('jw-loaded', 'meta');
             _sendMetaEvent();
         }


### PR DESCRIPTION
In IE9, set subtitles tracks event itemReady, since the loadeddata event is firing before it binds the subtitlesTracks event listener, which results in tracks not loading correctly.

***NOTE:*** This does not fix the issue for namespace dfxp captions

JW7-2678