### PR TITLE
DFXP captions parser: Namespace prefixes are removed from opening and closing tags but not from text content.

### DIFF
--- a/src/js/parsers/captions/dfxp.js
+++ b/src/js/parsers/captions/dfxp.js
@@ -30,7 +30,7 @@ define([
         for (var i = 0; i < paragraphs.length; i++) {
             var p = paragraphs[i];
             var rawText = (p.innerHTML || p.textContent || p.text || '');
-            var text = strings.trim(rawText).replace(/>\s+</g, '><').replace(/tts?:/g, '').replace(/<br.*?\/>/g, '\r\n');
+            var text = strings.trim(rawText).replace(/>\s+</g, '><').replace(/(<\/?)tts?:/g, '$1').replace(/<br.*?\/>/g, '\r\n');
             if (text) {
                 var begin = p.getAttribute('begin');
                 var dur = p.getAttribute('dur');

--- a/test/unit/dfxp-test.js
+++ b/test/unit/dfxp-test.js
@@ -24,10 +24,13 @@ define([
             assert.ok(captions[7].text.indexOf('\r\n') > -1, 'Break elements are replaced by carrage returns and newlines');
         }
 
-        var DFXPns = '<?xml version="1.0" encoding="UTF-8"?><!-- v1.1 --><tt:tt xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ttp="http://www.w3.org/ns/ttml#parameter" xmlns:tts="http://www.w3.org/ns/ttml#styling" xmlns:tt="http://www.w3.org/ns/ttml" xmlns:ebuttm="urn:ebu:tt:metadata" ttp:timeBase="media" xml:lang="de" ttp:cellResolution="50 30"><tt:body><tt:div><tt:p xml:id="subtitle1" region="bottom" begin="00:00:00.000" end="00:00:02.120" style="textCenter"><tt:span style="textWhite">weiß auf schwarz</tt:span></tt:p></tt:div></tt:body></tt:tt>';
+        var DFXPns = '<?xml version="1.0" encoding="UTF-8"?><!-- v1.1 --><tt:tt xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ttp="http://www.w3.org/ns/ttml#parameter" xmlns:tts="http://www.w3.org/ns/ttml#styling" xmlns:tt="http://www.w3.org/ns/ttml" xmlns:ebuttm="urn:ebu:tt:metadata" ttp:timeBase="media" xml:lang="de" ttp:cellResolution="50 30"><tt:body><tt:div><tt:p xml:id="subtitle1" region="bottom" begin="00:00:00.000" end="00:00:02.120" style="textCenter"><tt:span style="textWhite">weiß auf schwarz, Abschnitt: eins</tt:span></tt:p></tt:div></tt:body></tt:tt>';
         captions = parseDFXP(DFXPns);
         assert.equal(captions.length, 1, 'Namespaced DXFP captions are parsed');
         assert.ok(captions[0].text.indexOf('schwarz') > -1, 'Text is parsed');
+        assert.ok(captions[0].text.indexOf('<span') > -1, 'Namespace prefixes are removed from opening tags');
+        assert.ok(captions[0].text.indexOf('</span') > -1, 'Namespace prefixes are removed from closing tags');
+        assert.ok(captions[0].text.indexOf('Abschnitt') > -1, 'Namespace prefixes are not removed from text content');
     });
 
 


### PR DESCRIPTION
### Changes proposed in this pull request:

Only remove XML namespace prefix from parsed captions text if it is part of an opening or closing tag.

Fixes #

That any text similar to namespace prefixes will be removed from regular text content.
