### PR TITLE
Add tmp "jwplayerPluginJsonp" global for plugins to register themselves

### DIFF
--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -35,7 +35,8 @@ define([
                 args = {};
             }
             args.type = type;
-            if (window.jwplayer && window.jwplayer.debug) {
+            var jwplayer = window.jwplayer;
+            if (jwplayer && jwplayer.debug) {
                 return Events.trigger.call(_this, type, args);
             }
             return Events.triggerSafe.call(_this, type, args);

--- a/src/js/controller/setup-steps.js
+++ b/src/js/controller/setup-steps.js
@@ -122,6 +122,7 @@ define([
     }
 
     function _loadPlugins(resolve, _model) {
+        window.jwplayerPluginJsonp = plugins.registerPlugin;
         _pluginLoader = plugins.loadPlugins(_model.get('id'), _model.get('plugins'));
         _pluginLoader.on(events.COMPLETE, resolve);
         _pluginLoader.on(events.ERROR, _.partial(_pluginsError, resolve));
@@ -129,8 +130,8 @@ define([
     }
 
     function _initPlugins(resolve, _model, _api) {
+        delete window.jwplayerPluginJsonp;
         _pluginLoader.setupPlugins(_api, _model);
-        
         resolve();
     }
 

--- a/src/js/controller/storage.js
+++ b/src/js/controller/storage.js
@@ -3,7 +3,6 @@ define([
     'utils/helpers'
 ], function(_, utils) {
 
-    var jwplayer = window.jwplayer;
     var storage = {
         removeItem: utils.noop
     };
@@ -31,6 +30,7 @@ define([
             storage[jwPrefix(name)] = value;
         } catch(e) {
             // ignore QuotaExceededError unless debugging
+            var jwplayer = window.jwplayer;
             if (jwplayer && jwplayer.debug) {
                 console.error(e);
             }

--- a/src/js/utils/trycatch.js
+++ b/src/js/utils/trycatch.js
@@ -7,7 +7,8 @@ define([
         args = args || [];
 
         // if in debug mode, let 'er blow!
-        if (window.jwplayer && window.jwplayer.debug) {
+        var jwplayer = window.jwplayer;
+        if (jwplayer && jwplayer.debug) {
             return fn.apply(ctx, args);
         }
 


### PR DESCRIPTION
Allows for plugins to load and register themselves without the dependency on the "jwplayer" global. The "jwplayerPluginJsonp" global is only added to the window temporarily during setup while plugins are loading. Allows AMD loading of jwplayer to work as expected.

JW7-2529