### PR TITLE
Next Up Display

### DIFF
--- a/src/css/flags/ads.less
+++ b/src/css/flags/ads.less
@@ -3,7 +3,8 @@
     .jw-preview,
     .jw-dock,
     .jw-logo,
-    .jw-captions.jw-captions-enabled {
+    .jw-captions.jw-captions-enabled,
+    .jw-nextup-container {
         display: none;
     }
     video::-webkit-media-text-track-container {

--- a/src/css/flags/media-audio.less
+++ b/src/css/flags/media-audio.less
@@ -9,6 +9,9 @@
         .jw-controlbar {
             display: table;
         }
+        .jw-nextup-container {
+          bottom: calc(@controlbar-height + 0.5em);
+        }
     }
     // This has higher specificity to overwrite caption position when user inactive in playing state
     &.jw-flag-user-inactive.jw-state-playing {

--- a/src/css/flags/user-inactive.less
+++ b/src/css/flags/user-inactive.less
@@ -9,7 +9,8 @@
             display: none;
         }
 
-        .jw-plugin {
+        .jw-plugin,
+        .jw-nextup-container {
             bottom: 0.5em;
         }
 
@@ -29,6 +30,9 @@
     &.jw-state-buffering {
         .jw-controlbar {
             display: none;
+        }
+        .jw-nextup-container {
+            bottom: 0.5em;
         }
     }
 }

--- a/src/css/imports/jwplayerelement.less
+++ b/src/css/imports/jwplayerelement.less
@@ -148,8 +148,7 @@
 
 // These items can intercept pointer-events
 .jw-overlays > div,
-.jw-media, .jw-controlbar, .jw-dock, .jw-logo, .jw-skip, .jw-display-icon-container {
+.jw-media, .jw-controlbar, .jw-dock, .jw-logo, .jw-skip, .jw-display-icon-container,
+.jw-nextup-container {
     pointer-events: all;
 }
-
-

--- a/src/css/imports/nextup.less
+++ b/src/css/imports/nextup.less
@@ -1,4 +1,5 @@
 @import "vars";
+@import "icons";
 
 .jw-nextup-container {
   -webkit-font-smoothing: antialiased;
@@ -9,6 +10,7 @@
   min-width: 200px;
   opacity: 0;
   position: absolute;
+  cursor: pointer;
   right: 0.5em;
   transform: translateY(5px);
   transition: opacity 150ms ease, transform 150ms ease, visibility 150ms ease;

--- a/src/css/imports/nextup.less
+++ b/src/css/imports/nextup.less
@@ -3,7 +3,8 @@
 .jw-nextup-container {
   position: absolute;
   float: right;
-  bottom: @controlbar-height;
+  bottom: calc(@controlbar-height + 0.5em);
   right: 0.5em;
   width: 30%;
 }
+

--- a/src/css/imports/nextup.less
+++ b/src/css/imports/nextup.less
@@ -1,0 +1,9 @@
+@import "vars";
+
+.jw-nextup-container {
+  position: absolute;
+  float: right;
+  bottom: @controlbar-height;
+  right: 0.5em;
+  width: 30%;
+}

--- a/src/css/imports/nextup.less
+++ b/src/css/imports/nextup.less
@@ -1,10 +1,112 @@
 @import "vars";
 
 .jw-nextup-container {
-  position: absolute;
-  float: right;
+  -webkit-font-smoothing: antialiased;
+  -moz-font-smoothing: antialiased;
+  background-color: transparent;
   bottom: calc(@controlbar-height + 0.5em);
+  max-width: 300px;
+  min-width: 200px;
+  opacity: 0;
+  position: absolute;
   right: 0.5em;
-  width: 30%;
+  transform: translateY(5px);
+  transition: opacity 150ms ease, transform 150ms ease, visibility 150ms ease;
+  visibility: hidden;
+  width: 40%;
 }
 
+.jw-nextup-container-visible {
+  opacity: 1;
+  transform: translateY(0);
+  visibility: visible;
+}
+
+.jw-nextup {
+  position: relative;
+}
+
+.jw-nextup-header {
+  background: rgba(71, 84, 112, 0.8);
+  box-sizing: border-box;
+  color: white;
+  font-size: 13px;
+  font-weight: bold;
+  line-height: normal;
+  padding: 7px;
+}
+
+.jw-nextup-body {
+  color: white;
+  overflow: hidden;
+}
+
+.jw-nextup-thumbnail {
+  background-position: center;
+  background-size: cover;
+  display: none;
+  float: left;
+  height: 60px;
+  width: 45%;
+}
+
+.jw-nextup-thumbnail-visible {
+  display: block;
+}
+
+.jw-nextup-title {
+  box-sizing: border-box;
+  float: left;
+  font-size: 13px;
+  font-weight: bold;
+  line-height: 1.3;
+  overflow: hidden;
+  padding: 7px;
+  position: relative;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 100%;
+}
+
+.jw-nextup-thumbnail-visible + .jw-nextup-title {
+  height: 60px;
+  white-space: normal;
+  width: 55%;
+}
+
+.jw-nextup-thumbnail-visible + .jw-nextup-title::after {
+  background-image: linear-gradient(
+    -180deg,
+    rgba(33, 33, 33, 0) 0%,
+    rgba(33, 33, 33, 1) 100%
+  );
+  bottom: 0;
+  content: '';
+  height: 30px;
+  left: 0;
+  position: absolute;
+  width: 100%;
+}
+
+.jw-nextup-close {
+  .jw-icon-display;
+  .jw-icon-close;
+  border: none;
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 13px;
+  opacity: 0;
+  position: absolute;
+  right: 5px;
+  top: 6px;
+  transition: color 150ms ease, opacity 150ms ease, visibility 150ms ease;
+  visibility: hidden;
+}
+
+.jw-nextup-close:hover {
+  color: rgba(255, 255, 255, 1);
+}
+
+.jw-nextup-sticky .jw-nextup-close {
+  opacity: 1;
+  visibility: visible;
+}

--- a/src/css/jwplayer.less
+++ b/src/css/jwplayer.less
@@ -14,6 +14,7 @@
 @import "imports/tooltip.less";
 @import "imports/skipad.less";
 @import "imports/cast.less";
+@import "imports/nextup.less";
 
 // State specific
 @import "states/idle.less";

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -38,7 +38,8 @@ define([
             more: 'More',
             liveBroadcast: 'Live broadcast',
             loadingAd: 'Loading ad',
-            rewind: 'Rewind 10s'
+            rewind: 'Rewind 10s',
+            nextup: 'Next Up'
         }
         //qualityLabel: '480p',     // specify a default quality
         //captionLabel: 'English',  // specify a default Caption

--- a/src/js/view/components/nextuptooltip.js
+++ b/src/js/view/components/nextuptooltip.js
@@ -1,0 +1,178 @@
+define([
+    'utils/ui',
+    'view/components/tooltip',
+    'utils/helpers',
+    'templates/nextup.html'
+], function(UI, Tooltip, utils, nextUpTemplate) {
+    var NextUpTooltip = Tooltip.extend({
+        'constructor' : function(_model, _api, nextEl, ariaText) {
+            this._model = _model;
+            this._api = _api;
+            this.sticky = false;
+            this.nextEl = nextEl;
+            this._nextUpText = ariaText || 'Next Up';
+            var related = _api.getPlugin('related');
+            var nextUp;
+            if(related) {
+                nextUp = related.controller_.getNextUpItem();
+            }
+
+            // Prevent NextUp tooltip button from being aria-hidden="true"
+            //Tooltip.call(this, name, ariaText, true);
+
+            //utils.removeClass(this.el, 'jw-hidden');
+            // hide initially
+            //this.hide();
+
+            this.container = document.createElement('div');
+            this.container.className = 'jw-nextup-container jw-background-color jw-reset';
+            this.hide();
+            this.openClass = 'jw-open';
+
+            this.onPlaylistItem(this._model);
+            this.onMediaModel(this._model, this._model.get('mediaModel'));
+            this._model.on('change:playlistItem', this.onPlaylistItem, this);
+            this._model.on('change:mediaModel', this.onMediaModel, this);
+            this._model.on('change:position', this.onElapsed, this);
+
+            new UI(this.nextEl, {'useHover': true, 'directSelect': true})
+                .on('click tap', this.click, this)
+                .on('over', this.open, this)
+                .on('out', this.close, this);
+
+        },
+        setNextUpItem : function(item) {
+            var element = utils.createElement(nextUpTemplate());
+            this.addContent(element);
+            this.closeButton = element.getElementsByClassName('jw-nextup-close')[0];
+            new UI(this.closeButton)
+                .on('click tap', this.close, this);
+
+            new UI(this.content)
+                .on('click tap', this.playNext, this);
+            // setup thumbnail
+            this.img = element.getElementsByClassName('jw-nextup-thumbnail')[0];
+            this.image(this.loadThumbnail(item.image));
+
+            // set header
+            this.header = element.getElementsByClassName('jw-nextup-header')[0];
+            this.header.innerText = this._nextUpText;
+            // set title
+            this.title = element.getElementsByClassName('jw-nextup-title')[0];
+            this.title.innerText = item.title || 'title';
+            this.hide(this.closeButton);
+        },
+        loadThumbnail : function(url) {
+            var style = {
+                display: 'block',
+                margin: '0 auto',
+                backgroundPosition: '0 0',
+                width: '30px',
+                height: '20px'
+            };
+            this.nextUpImage = new Image();
+            this.nextUpImage.onload = (function () {
+                this.nextUpImage.onload = null;
+            }).bind(this);
+            this.nextUpImage.src = url;
+
+            style.backgroundImage = 'url("' + url + '")';
+            return style;
+        },
+        image : function(style) {
+            utils.style(this.img, style);
+        },
+        click : function() {
+            //this.trigger('click');
+            this.sticky = false;
+            this._api.playlistNext({reason: 'interaction'});
+
+            this.close();
+        },
+        show : function(el) {
+            el = el || this.container;
+            el.style.display = '';
+        },
+        hide : function(el) {
+            el = el || this.container;
+            el.style.display = 'none';
+        },
+        toggle : function(m, el) {
+            if (m) {
+                this.show(el);
+            } else {
+                this.hide(el);
+            }
+        },
+        open : function () {
+            if (!this.sticky) {
+                console.log('open tooltip');
+                this.show();
+            }
+        },
+        close : function (evt) {
+            if (evt && evt.currentTarget === this.closeButton || !this.sticky) {
+                this.hide();
+                console.log('close tooltip');
+            }
+        },
+        showTilEnd : function() {
+            // show next up til playback ends
+            // don't hide even when controlbar is idle
+            if (this.sticky) {
+                return;
+            }
+            this.show(this.closeButton);
+            this.content.className = 'jw-nextup jw-reset jw-nextup-sticky';
+            this.open();
+            this.sticky = true;
+            console.log('open tooltip til end');
+        },
+        onPlaylistItem : function(model) {
+            //var playlist = model.get('playlist');
+            var playlistItem = model.get('playlistItem');
+            if (playlistItem) {
+                this.setNextUpItem(playlistItem);
+            }
+        },
+        onMediaModel : function (model, mediaModel) {
+            mediaModel.on('change:state', function(model, state) {
+                if(state === 'complete') {
+                    this.sticky = false;
+                    this.close();
+                }
+            }, this);
+        },
+        onElapsed : function(model, val) {
+            var duration = model.get('duration');
+
+            if (duration - val <= 10) {
+                // Show nextup when we're 10s away from the end and not playing an ad
+                this.showTilEnd();
+            }
+        },
+        element : function () {
+            return this.container;
+        },
+        addContent : function (elem) {
+            if(this.content){
+                this.removeContent();
+            }
+
+            this.content = elem;
+            this.container.appendChild(elem);
+        },
+        removeContent : function(){
+            if(this.content) {
+                this.container.removeChild(this.content);
+                this.content = null;
+            }
+        },
+        playNext : function(evt) {
+            this.close(evt);
+            this._api.playlistNext();
+        }
+    });
+
+    return NextUpTooltip;
+});

--- a/src/js/view/components/nextuptooltip.js
+++ b/src/js/view/components/nextuptooltip.js
@@ -1,9 +1,10 @@
 define([
+    'utils/dom',
     'utils/ui',
     'view/components/tooltip',
     'utils/helpers',
     'templates/nextup.html'
-], function(UI, Tooltip, utils, nextUpTemplate) {
+], function(dom, UI, Tooltip, utils, nextUpTemplate) {
     var NextUpTooltip = Tooltip.extend({
         'constructor' : function(_model, _api, nextEl, ariaText) {
             this._model = _model;
@@ -13,7 +14,7 @@ define([
             this._nextUpText = ariaText || 'Next Up';
 
             this.container = document.createElement('div');
-            this.container.className = 'jw-nextup-container jw-background-color jw-reset';
+            this.container.className = 'jw-nextup-container jw-reset';
             this.hide();
             this.openClass = 'jw-open';
 
@@ -29,13 +30,7 @@ define([
 
         },
         loadThumbnail : function(url) {
-            var style = {
-                display: 'block',
-                margin: '0 auto',
-                backgroundPosition: '0 0',
-                width: '30px',
-                height: '20px'
-            };
+            var style = {};
             this.nextUpImage = new Image();
             this.nextUpImage.onload = (function () {
                 this.nextUpImage.onload = null;
@@ -57,11 +52,11 @@ define([
         },
         show : function(el) {
             el = el || this.container;
-            el.style.display = '';
+            dom.addClass(el, 'jw-nextup-container-visible');
         },
         hide : function(el) {
             el = el || this.container;
-            el.style.display = 'none';
+            dom.removeClass(el, 'jw-nextup-container-visible');
         },
         toggle : function(m, el) {
             if (m) {
@@ -114,14 +109,19 @@ define([
                 .on('click tap', this.playNext, this);
             // setup thumbnail
             this.img = element.getElementsByClassName('jw-nextup-thumbnail')[0];
-            this.image(this.loadThumbnail(nextUpItem.image));
+            if (nextUpItem.image) {
+              this.image(this.loadThumbnail(nextUpItem.image));
+              dom.addClass(this.img, 'jw-nextup-thumbnail-visible');
+            } else {
+              dom.removeClass(this.img, 'jw-nextup-thumbnail-visible');
+            }
 
             // set header
             this.header = element.getElementsByClassName('jw-nextup-header')[0];
             this.header.innerText = this._nextUpText;
             // set title
             this.title = element.getElementsByClassName('jw-nextup-title')[0];
-            this.title.innerText = nextUpItem.title || 'title';
+            this.title.innerText = nextUpItem.title || 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.';
             this.hide(this.closeButton);
         },
         onRelatedPlaylist : function(evt) {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -648,6 +648,7 @@ define([
             _model.on('change:compactUI', _onCompactUIChange);
 
             _nextuptooltip = new NextUpToolTip(_model, _api, _controlbar.elements.next.element());
+            _nextuptooltip.setup();
 
             // NextUp needs to be behind the controlbar to not block other tooltips
             _controlsLayer.appendChild(_nextuptooltip.element());

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -647,9 +647,9 @@ define([
             _model.on('change:scrubbing', _dragging);
             _model.on('change:compactUI', _onCompactUIChange);
 
-            _nextuptooltip = new NextUpToolTip(_model, _api, _controlbar.elements.next.element(),
-                _model.get('localization').nextup);
-            // NextUp needs to be before the controlbar to not block other tooltips
+            _nextuptooltip = new NextUpToolTip(_model, _api, _controlbar.elements.next.element());
+
+            // NextUp needs to be behind the controlbar to not block other tooltips
             _controlsLayer.appendChild(_nextuptooltip.element());
             _controlsLayer.appendChild(_controlbar.element());
 

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -13,11 +13,12 @@ define([
     'view/preview',
     'view/rightclick',
     'view/title',
+    'view/components/nextuptooltip',
     'utils/underscore',
     'templates/player.html'
 ], function(utils, events, Events, Constants, states,
             CaptionsRenderer, ClickHandler, DisplayIcon, Dock, Logo,
-            Controlbar, Preview, RightClick, Title, _, playerTemplate) {
+            Controlbar, Preview, RightClick, Title, NextUpToolTip, _, playerTemplate) {
 
     var _styles = utils.style,
         _bounds = utils.bounds,
@@ -47,6 +48,7 @@ define([
             _dock,
             _logo,
             _title,
+            _nextuptooltip,
             _captionsRenderer,
             _audioMode,
             _showing = false,
@@ -645,7 +647,14 @@ define([
             _model.on('change:scrubbing', _dragging);
             _model.on('change:compactUI', _onCompactUIChange);
 
+            _nextuptooltip = new NextUpToolTip(_model, _api, _controlbar.elements.next.element(),
+                _model.get('localization').nextup);
+            // NextUp needs to be before the controlbar to not block other tooltips
+            _controlsLayer.appendChild(_nextuptooltip.element());
             _controlsLayer.appendChild(_controlbar.element());
+
+
+
 
             _playerElement.addEventListener('focus', handleFocus);
             _playerElement.addEventListener('blur', handleBlur);

--- a/src/templates/nextup.html
+++ b/src/templates/nextup.html
@@ -1,0 +1,13 @@
+<div class="jw-nextup jw-reset">
+    <div class="jw-nextup-header jw-reset">
+        {{this.nextUpText}}
+    </div>
+    <div class="nextup-body jw-reset">
+        <div class="jw-nextup-thumbnail jw-reset">
+        </div>
+        <div class="jw-nextup-title jw-reset">{{this.title}}</div>
+    </div>
+    <button class="jw-nextup-close">
+        X (close)
+    </button>
+</div>

--- a/src/templates/nextup.html
+++ b/src/templates/nextup.html
@@ -1,10 +1,12 @@
 <div class="jw-nextup jw-reset">
-    <div class="jw-nextup-header jw-reset">
-        {{this.nextUpText}}
-    </div>
-    <div class="jw-nextup-body jw-background-color jw-reset">
-        <div class="jw-nextup-thumbnail jw-reset"></div>
-        <div class="jw-nextup-title jw-reset">{{this.title}}</div>
+    <div class="jw-nextup-tooltip jw-reset">
+        <div class="jw-nextup-header jw-reset">
+            {{this.nextUpText}}
+        </div>
+        <div class="jw-nextup-body jw-background-color jw-reset">
+            <div class="jw-nextup-thumbnail jw-reset"></div>
+            <div class="jw-nextup-title jw-reset">{{this.title}}</div>
+        </div>
     </div>
     <button class="jw-nextup-close"></button>
 </div>

--- a/src/templates/nextup.html
+++ b/src/templates/nextup.html
@@ -2,12 +2,9 @@
     <div class="jw-nextup-header jw-reset">
         {{this.nextUpText}}
     </div>
-    <div class="nextup-body jw-reset">
-        <div class="jw-nextup-thumbnail jw-reset">
-        </div>
+    <div class="jw-nextup-body jw-background-color jw-reset">
+        <div class="jw-nextup-thumbnail jw-reset"></div>
         <div class="jw-nextup-title jw-reset">{{this.title}}</div>
     </div>
-    <button class="jw-nextup-close">
-        X (close)
-    </button>
+    <button class="jw-nextup-close"></button>
 </div>


### PR DESCRIPTION
### Changes proposed in this pull request:
Give users a visual indication of which item will be played next.

- Display a tooltip for the NextUp item when hovering over the `next` button.
- Keep the NextUp tooltip open (opened state) when playback position passes the `nextupoffset` (default: 10s before playback ends).
- Allow the user to close the NextUp tooltip when it is in the opened state.
- Play the NextUp item when the user clicks/taps on the tooltip and close the tooltip.
- Close the tooltip if the user seeks back to a position that is before the `nextupoffset`.
- In playlist mode, NextUp shows the next playlist item.
- In related mode, NextUp is only shown when autoplaying and the autoplay timer is set to 0. NextUp shows the same item that would be seen in the "Next Up" area if the overlay were open. 
- Do not show the NextUp tooltip when playing ads.

Fixes #
JW7-2511, JW7-2896
