### PR TITLE
Check for null before checking the provider

### DIFF
--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -248,7 +248,8 @@ define([
 
         // Give the option for a provider to be forced
         this.chooseProvider = function(source) {
-            return _providers.choose(source).provider;
+            var providerChosen = _providers.choose(source);
+            return providerChosen ? providerChosen.provider : null;
         };
 
         this.setItemIndex = function(index) {


### PR DESCRIPTION
When providers.choose returns null, we need to check that before checking the chosen provider.
JW7-2841