### PR TITLE
Add filter to sources with the chosen provider

### DIFF
--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -248,6 +248,7 @@ define([
 
         // Give the option for a provider to be forced
         this.chooseProvider = function(source) {
+            // if _providers.choose is null, something went wrong in filtering
             return _providers.choose(source).provider;
         };
 

--- a/src/js/playlist/playlist.js
+++ b/src/js/playlist/playlist.js
@@ -86,18 +86,24 @@ define([
             providers = new Providers({primary : providers ? 'flash' : null});
         }
 
-        var bestType = _chooseType(sources, providers);
-
-        return _.where(sources, {type : bestType});
+        var chosenProviderAndType = _chooseProviderAndType(sources, providers);
+        if (!chosenProviderAndType) {
+            return [];
+        }
+        var provider = chosenProviderAndType.provider;
+        var bestType = chosenProviderAndType.type;
+        return _.filter(sources, function(source) {
+            return source.type === bestType && providers.providerSupports(provider, source);
+        });
     };
 
     //  Choose from the sources a type which matches our most preferred provider
-    function _chooseType(sources, providers) {
+    function _chooseProviderAndType(sources, providers) {
         for (var i = 0; i < sources.length; i++) {
             var source = sources[i];
             var chosenProvider = providers.choose(source);
             if (chosenProvider) {
-                return source.type;
+                return {type: source.type, provider: chosenProvider.providerToCheck};
             }
         }
 

--- a/src/js/providers/providers.js
+++ b/src/js/providers/providers.js
@@ -135,6 +135,7 @@ define([
                         priority: priority,
                         name : provider.name,
                         type: source.type,
+                        providerToCheck: provider,
                         // If provider isn't loaded, this will be undefined
                         provider : ProvidersLoaded[provider.name]
                     };


### PR DESCRIPTION
When the stream type is hls, but the source has fairplay drm, we need to filter the source.
However, we used to only filter the source by bestType.
This resulted the first source with hls fairplay to be not filtered in caterpillar provider if the second source is hls,
since it chose hls as the bestType.
Adding a second filter to filterSource function so that we filter sources by the provider again when bestType is chosen.
JW7-2841