### PR TITLE
Next Up Display fixes

### DIFF
--- a/src/css/flags/audioplayer.less
+++ b/src/css/flags/audioplayer.less
@@ -13,7 +13,8 @@
 
     .jw-preview, // overrides 'block' from .jw-state-idle
     .jw-display-icon-container, // overrides 'block' from .jw-flag-touch.jw-state-paused
-    .jw-title { // overrides 'block' from .jw-state-idle
+    .jw-title, // overrides 'block' from .jw-state-idle
+    .jw-nextup-container {
         display: none;
     }
 

--- a/src/js/view/components/nextuptooltip.js
+++ b/src/js/view/components/nextuptooltip.js
@@ -22,15 +22,8 @@ define([
             var element = utils.createElement(nextUpTemplate());
             this.addContent(element);
 
-            var relatedBlock = this._model.get('related');
-
             // Next Up is always shown for playlist items
             this.showNextUp = true;
-
-            // If there are related items, Next Up is shown when we're autoplaying and the timer is set to 0
-            if (relatedBlock) {
-                this.showNextUp = relatedBlock.oncomplete === 'autoplay' && relatedBlock.autoplaytimer === 0;
-            }
 
             this.reset();
             
@@ -38,7 +31,11 @@ define([
             this._model.on('change:mediaModel', this.onMediaModel, this);
             this._model.on('change:position', this.onElapsed, this);
             this._api.onPlaylistItem(this.onPlaylistItem.bind(this));
-            this._api.onReady(this.onReady.bind(this));
+
+            // If there's a related block, wait until the plugin is available
+            if (this._model.get('related')) {
+                this._api.onReady(this.onReady.bind(this));
+            }
 
             this.onMediaModel(this._model, this._model.get('mediaModel'));
 
@@ -178,6 +175,10 @@ define([
         onRelatedPlaylist: function(evt) {
             if (evt.playlist && evt.playlist.length) {
                 this.relatedMode = true;
+                var relatedBlock = this._model.get('related');
+                // If there are related items, Next Up is shown when we're autoplaying and the timer is set to 0
+                this.showNextUp = relatedBlock.oncomplete === 'autoplay' && relatedBlock.autoplaytimer === 0;
+
                 this.setNextUpItem(evt.playlist[0]);
             }
         },

--- a/src/js/view/controlbar.js
+++ b/src/js/view/controlbar.js
@@ -105,7 +105,7 @@ define([
                 alt: text('jw-text-alt', 'status'),
                 play: button('jw-icon-playback', this._api.play.bind(this, {reason: 'interaction'}), play),
                 rewind: button('jw-icon-rewind', this.rewind.bind(this), rewind),
-                next: button('jw-icon-next', this._api.playlistNext.bind(this, {reason: 'interaction'}), next),
+                next: button('jw-icon-next', null, next), // the click/tap event listener is in the nextup tooltip
                 elapsed: text('jw-text-elapsed', 'timer'),
                 time: timeSlider,
                 duration: text('jw-text-duration', 'timer'),


### PR DESCRIPTION
### Changes proposed in this pull request:

- Removed click/tap handler from next button. This behavior is added in the nextuptooltip so the next button knows the item to play in both playlist and related modes.
- Wait until we have a playlist of related content to switch to related mode. Determine if we should show the NextUp tooltip then.
- Hide the Next Up tooltip when the player is in audio mode.

Fixes #
JW7-2511