### PR TITLE
Clear error state when loading a new playlist item

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -425,6 +425,9 @@ define([
 
             function _item(index, meta) {
                 _stop(true);
+                if(_model.get('state') === states.ERROR) {
+                    _model.set('state', states.IDLE);
+                }
                 _setItem(index);
                 _play(meta);
             }


### PR DESCRIPTION
- Set state to `IDLE` if, when loading a new playlist item, we're in the `ERROR` state.

JW7-1066

