### PR TITLE
Preserve localization defaults

### DIFF
--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -65,6 +65,8 @@ define([
 
         _deserialize(allOptions);
 
+        allOptions.localization = _.extend({}, Defaults.localization, allOptions.localization);
+
         var config = _.extend({}, Defaults, allOptions);
         if (config.base === '.') {
             config.base = utils.getScriptPath('jwplayer.js');


### PR DESCRIPTION
### Changes proposed in this pull request:
Underscore's `_.extend` does a shallow copy. We need to extend nested objects before extending the object itself.

Fixes #
JW7-2894