### PR TITLE
Fixed flash of NaN:NaN duration

### DIFF
--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -270,7 +270,7 @@ define([
             this.mediaModel = new MediaModel();
             this.set('mediaModel', this.mediaModel);
             this.set('position', item.starttime || 0);
-            this.set('duration', item.duration || 0);
+            this.set('duration', (item.duration && utils.seconds(item.duration)) || 0);
 
             this.setProvider(item);
         };
@@ -344,7 +344,7 @@ define([
                 item = this.get('playlist')[idx];
             }
             this.set('position', item.starttime || 0);
-            this.set('duration', item.duration || 0);
+            this.set('duration', (item.duration && utils.seconds(item.duration)) || 0);
             this.mediaModel.set('playAttempt', true);
             this.mediaController.trigger(events.JWPLAYER_MEDIA_PLAY_ATTEMPT, {'playReason': this.get('playReason')});
 


### PR DESCRIPTION
### Changes proposed in this pull request:

`item.duration` may be a string (eg. "09:45"). Duration should be in seconds before storing it in the model. 

Fixes #
JW7-3039