### PR TITLE
Hide dock buttons when in controlbar only mode

### DIFF
--- a/src/css/flags/audioplayer.less
+++ b/src/css/flags/audioplayer.less
@@ -14,7 +14,8 @@
     .jw-preview, // overrides 'block' from .jw-state-idle
     .jw-display-icon-container, // overrides 'block' from .jw-flag-touch.jw-state-paused
     .jw-title, // overrides 'block' from .jw-state-idle
-    .jw-nextup-container {
+    .jw-nextup-container,
+    .jw-dock {
         display: none;
     }
 


### PR DESCRIPTION
### Changes proposed in this pull request:

Fixes #
JW7-3047