### PR TITLE
Add minDvrWindow item-level config, create new model prop streamType

### DIFF
--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -270,8 +270,8 @@ define([
             this.mediaModel = new MediaModel();
             this.set('mediaModel', this.mediaModel);
             this.set('position', item.starttime || 0);
-            this.set('duration', (item.duration && utils.seconds(item.duration)) || 0);
             this.set('minDvrWindow', item.minDvrWindow);
+            this.set('duration', (item.duration && utils.seconds(item.duration)) || 0);
             this.setProvider(item);
         };
 

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -271,7 +271,7 @@ define([
             this.set('mediaModel', this.mediaModel);
             this.set('position', item.starttime || 0);
             this.set('duration', (item.duration && utils.seconds(item.duration)) || 0);
-
+            this.set('minDvrWindow', item.minDvrWindow);
             this.setProvider(item);
         };
 

--- a/src/js/playlist/item.js
+++ b/src/js/playlist/item.js
@@ -10,11 +10,11 @@ define([
         //mediaid: undefined,
         //title: undefined,
         sources: [],
-        tracks: []
+        tracks: [],
+        minDvrWindow: 120
     };
 
-    var PlaylistItem = function (config) {
-
+    return function (config) {
         config = config || {};
         if (!_.isArray(config.tracks)) {
             delete config.tracks;
@@ -69,6 +69,4 @@ define([
 
         return _playlistItem;
     };
-
-    return PlaylistItem;
 });

--- a/src/js/utils/parser.js
+++ b/src/js/utils/parser.js
@@ -139,14 +139,15 @@ define([
 
     /**
      * Determine the adaptive type
+     * Duration can be positive or negative, but minDvrWindow should always be positive
      */
-    parser.adaptiveType = function(duration) {
+    parser.adaptiveType = function(duration, _minDvrWindow) {
+        var minDvrWindow = _.isUndefined(_minDvrWindow) ? 120 : _minDvrWindow;
+
         if (duration !== 0) {
-            var MIN_DVR_DURATION = -120;
-            if (duration <= MIN_DVR_DURATION) {
+            if (duration !== Infinity && Math.abs(duration) >= Math.max(minDvrWindow, 0)) {
                 return 'DVR';
-            }
-            if (duration < 0 || duration === Infinity) {
+            } else if (duration < 0 || duration === Infinity) {
                 return 'LIVE';
             }
         }

--- a/src/js/utils/parser.js
+++ b/src/js/utils/parser.js
@@ -143,15 +143,17 @@ define([
      */
     parser.streamType = function(duration, _minDvrWindow) {
         var minDvrWindow = _.isUndefined(_minDvrWindow) ? 120 : _minDvrWindow;
+        var streamType = 'VOD';
 
         if (duration !== 0) {
             if (duration !== Infinity && Math.abs(duration) >= Math.max(minDvrWindow, 0)) {
-                return 'DVR';
+                streamType = 'DVR';
             } else if (duration < 0 || duration === Infinity) {
-                return 'LIVE';
+                streamType = 'LIVE';
             }
         }
-        return 'VOD';
+
+        return streamType;
     };
 
     return parser;

--- a/src/js/utils/parser.js
+++ b/src/js/utils/parser.js
@@ -141,7 +141,7 @@ define([
      * Determine the adaptive type
      * Duration can be positive or negative, but minDvrWindow should always be positive
      */
-    parser.adaptiveType = function(duration, _minDvrWindow) {
+    parser.streamType = function(duration, _minDvrWindow) {
         var minDvrWindow = _.isUndefined(_minDvrWindow) ? 120 : _minDvrWindow;
 
         if (duration !== 0) {

--- a/src/js/utils/parser.js
+++ b/src/js/utils/parser.js
@@ -145,14 +145,20 @@ define([
         var minDvrWindow = _.isUndefined(_minDvrWindow) ? 120 : _minDvrWindow;
         var streamType = 'VOD';
 
-        if (duration !== 0) {
-            if (duration !== Infinity && Math.abs(duration) >= Math.max(minDvrWindow, 0)) {
+        if (duration === Infinity) {
+            // Live streams are always Infinity duration
+            streamType = 'LIVE';
+        } else if (duration < 0) {
+            // Negative durations are always either DVR or Live
+            // It's DVR if the duration is above the minDvrWindow, live otherwise
+            if (Math.abs(duration) >= Math.max(minDvrWindow, 0)) {
                 streamType = 'DVR';
-            } else if (duration < 0 || duration === Infinity) {
+            } else {
                 streamType = 'LIVE';
             }
         }
 
+        // Default option is VOD (i.e. positive or non-infinite)
         return streamType;
     };
 

--- a/src/js/view/components/nextuptooltip.js
+++ b/src/js/view/components/nextuptooltip.js
@@ -69,7 +69,6 @@ define([
         },
         click: function() {
             this.state = 'tooltip';
-
             if (this.relatedMode && this._related.selectItem_) {
                  this._related.selectItem_(this.nextUpItem, 'interaction');
             } else if (!this.relatedMode) {
@@ -182,7 +181,8 @@ define([
                 return;
             }
 
-            if (utils.adaptiveType(duration) === 'LIVE' || utils.adaptiveType(duration) === 'DVR') {
+            var streamType = this._model.get('streamType');
+            if (streamType === 'LIVE' || streamType === 'DVR') {
                 model.off('change:duration', this.onDuration, this);
                 return;
             }

--- a/src/js/view/components/timeslider.js
+++ b/src/js/view/components/timeslider.js
@@ -76,8 +76,8 @@ define([
                 return this.activeCue.pct;
             }
             var duration = this._model.get('duration');
-            var adaptiveType = utils.adaptiveType(duration);
-            if (adaptiveType === 'DVR') {
+            var streamType = this._model.get('streamType');
+            if (streamType === 'DVR') {
                 var position = (1 - (percent / 100)) * duration;
                 var currentPosition = this._model.get('position');
                 var updatedPosition = Math.min(position, Math.max(Constants.dvrSeekLimit, currentPosition));
@@ -120,10 +120,10 @@ define([
         updateTime : function(position, duration) {
             var pct = 0;
             if (duration) {
-                var adaptiveType = utils.adaptiveType(duration);
-                if(adaptiveType === 'DVR') {
+                var streamType = this._model.get('streamType');
+                if (streamType === 'DVR') {
                     pct = (duration - position) / duration * 100;
-                } else if (adaptiveType === 'VOD') {
+                } else if (streamType === 'VOD') {
                     pct = position / duration * 100;
                 }
             }
@@ -148,11 +148,11 @@ define([
         performSeek : function() {
             var percent = this.seekTo;
             var duration = this._model.get('duration');
-            var adaptiveType = utils.adaptiveType(duration);
+            var streamType = this._model.get('streamType');
             var position;
             if (duration === 0) {
                 this._api.play();
-            } else if (adaptiveType === 'DVR') {
+            } else if (streamType === 'DVR') {
                 position = (100 - percent) / 100 * duration;
                 this._api.seek(position);
             } else {

--- a/src/js/view/controlbar.js
+++ b/src/js/view/controlbar.js
@@ -197,6 +197,7 @@ define([
             this._model.on('change:fullscreen', this.onFullscreen, this);
             this._model.on('change:captionsList', this.onCaptionsList, this);
             this._model.on('change:captionsIndex', this.onCaptionsIndex, this);
+            this._model.on('change:streamType', this.onStreamTypeChange, this);
 
             // Event listeners
 
@@ -237,7 +238,7 @@ define([
             }, this);
 
             new UI(this.elements.duration).on('click tap', function(){
-                if (utils.adaptiveType(this._model.get('duration')) === 'DVR') {
+                if (this._model.get('streamType') === 'DVR') {
                     // Seek to "Live" position within live buffer, but not before current position
                     var currentPosition = this._model.get('position');
                     this._api.seek(Math.max(Constants.dvrSeekLimit, currentPosition));
@@ -315,7 +316,7 @@ define([
         onElapsed : function(model, val) {
             var elapsedTime;
             var duration = model.get('duration');
-            if (utils.adaptiveType(duration) === 'DVR') {
+            if (model.get('streamType') === 'DVR') {
                 elapsedTime = '-' + utils.timeFormat(-duration);
             } else {
                 elapsedTime = utils.timeFormat(val);
@@ -324,15 +325,12 @@ define([
         },
         onDuration : function(model, val) {
             var totalTime;
-            if (utils.adaptiveType(val) === 'DVR') {
+            if (model.get('streamType') === 'DVR') {
                 totalTime = 'Live';
             } else {
                 totalTime = utils.timeFormat(val);
             }
             this.elements.duration.innerHTML = totalTime;
-
-            // Hide rewind button when in LIVE mode
-            this.elements.rewind.toggle(utils.adaptiveType(val) !== 'LIVE');
         },
         onFullscreen : function(model, val) {
             utils.toggleClass(this.elements.fullscreen.element(), 'jw-off', val);
@@ -387,11 +385,15 @@ define([
                 startPosition = 0;
 
             // duration is negative in DVR mode
-            if (utils.adaptiveType(duration) === 'DVR') {
+            if (this._model.get('streamType') === 'DVR') {
                 startPosition = duration;
             }
             // Seek 10s back. Seek value should be >= 0 in VOD mode and >= (negative) duration in DVR mode
             this._api.seek(Math.max(rewindPosition, startPosition));
+        },
+        onStreamTypeChange : function(model) {
+            // Hide rewind button when in LIVE mode
+            this.elements.rewind.toggle(model.get('streamType') !== 'LIVE');
         }
     });
 

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -943,8 +943,11 @@ define([
         }
 
         function _setLiveMode(model, duration){
-            var minDvrWindow = model.get('playlistItem').minDvrWindow;
-            var live = utils.adaptiveType(duration, minDvrWindow) === 'LIVE';
+            var minDvrWindow = model.get('minDvrWindow');
+            var streamType = utils.adaptiveType(duration, minDvrWindow);
+            var live = streamType === 'LIVE';
+
+            model.set('streamType', streamType);
             utils.toggleClass(_playerElement, 'jw-flag-live', live);
             _this.setAltText((live) ? model.get('localization').liveBroadcast : '');
         }

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -943,7 +943,8 @@ define([
         }
 
         function _setLiveMode(model, duration){
-            var live = utils.adaptiveType(duration) === 'LIVE';
+            var minDvrWindow = model.get('playlistItem').minDvrWindow;
+            var live = utils.adaptiveType(duration, minDvrWindow) === 'LIVE';
             utils.toggleClass(_playerElement, 'jw-flag-live', live);
             _this.setAltText((live) ? model.get('localization').liveBroadcast : '');
         }

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -117,7 +117,7 @@ define([
             var min = 0;
             var max = _model.get('duration');
             var position = _model.get('position');
-            if (utils.adaptiveType(max) === 'DVR') {
+            if (_model.get('streamType') === 'DVR') {
                 min = max;
                 max = Math.max(position, Constants.dvrSeekLimit);
             }
@@ -944,8 +944,8 @@ define([
 
         function _setLiveMode(model, duration){
             var minDvrWindow = model.get('minDvrWindow');
-            var streamType = utils.adaptiveType(duration, minDvrWindow);
-            var live = streamType === 'LIVE';
+            var streamType = utils.streamType(duration, minDvrWindow);
+            var live = (streamType === 'LIVE');
 
             model.set('streamType', streamType);
             utils.toggleClass(_playerElement, 'jw-flag-live', live);

--- a/test/unit/parser-test.js
+++ b/test/unit/parser-test.js
@@ -131,45 +131,45 @@ define([
         assert.equal(time, '00:00', 'timeFormat with minutes seconds');
     });
 
-    test('parser.adaptiveType', function(assert) {
+    test('parser.streamType', function(assert) {
         var minDvrWindow = 120;
-        var type = parser.adaptiveType(0, minDvrWindow);
-        assert.equal(type, 'VOD', 'adaptiveType with 0 and 120');
+        var type = parser.streamType(0, minDvrWindow);
+        assert.equal(type, 'VOD', 'streamType with 0 and 120');
 
-        type = parser.adaptiveType(0, 0);
-        assert.equal(type, 'VOD', 'adaptiveType with 0 and 0');
+        type = parser.streamType(0, 0);
+        assert.equal(type, 'VOD', 'streamType with 0 and 0');
 
-        type = parser.adaptiveType(10, minDvrWindow);
-        assert.equal(type, 'VOD', 'adaptiveType with 10 and 120');
+        type = parser.streamType(10, minDvrWindow);
+        assert.equal(type, 'VOD', 'streamType with 10 and 120');
 
-        type = parser.adaptiveType(10, undefined);
-        assert.equal(type, 'VOD', 'adaptiveType with 10 and undefined');
+        type = parser.streamType(10, undefined);
+        assert.equal(type, 'VOD', 'streamType with 10 and undefined');
 
-        type = parser.adaptiveType(-120, minDvrWindow);
-        assert.equal(type, 'DVR', 'adaptiveType with -120 and 120');
+        type = parser.streamType(-120, minDvrWindow);
+        assert.equal(type, 'DVR', 'streamType with -120 and 120');
 
-        type = parser.adaptiveType(120, -10);
-        assert.equal(type, 'DVR', 'adaptiveType with 120 and -10');
+        type = parser.streamType(120, -10);
+        assert.equal(type, 'DVR', 'streamType with 120 and -10');
 
-        type = parser.adaptiveType(120, 0);
-        assert.equal(type, 'DVR', 'adaptiveType with 120 and 0');
+        type = parser.streamType(120, 0);
+        assert.equal(type, 'DVR', 'streamType with 120 and 0');
 
-        type = parser.adaptiveType(-120, 0);
-        assert.equal(type, 'DVR', 'adaptiveType with -120 and 0');
+        type = parser.streamType(-120, 0);
+        assert.equal(type, 'DVR', 'streamType with -120 and 0');
 
-        type = parser.adaptiveType(120, undefined);
-        assert.equal(type, 'DVR', 'adaptiveType with 120 and undefined');
+        type = parser.streamType(120, undefined);
+        assert.equal(type, 'DVR', 'streamType with 120 and undefined');
 
-        type = parser.adaptiveType(-20, minDvrWindow);
-        assert.equal(type, 'LIVE', 'adaptiveType with -20');
+        type = parser.streamType(-20, minDvrWindow);
+        assert.equal(type, 'LIVE', 'streamType with -20');
 
-        type = parser.adaptiveType(-1, minDvrWindow);
-        assert.equal(type, 'LIVE', 'adaptiveType with -1');
+        type = parser.streamType(-1, minDvrWindow);
+        assert.equal(type, 'LIVE', 'streamType with -1');
 
-        type = parser.adaptiveType(Infinity, minDvrWindow);
-        assert.equal(type, 'LIVE', 'adaptiveType with Infinity');
+        type = parser.streamType(Infinity, minDvrWindow);
+        assert.equal(type, 'LIVE', 'streamType with Infinity');
 
-        type = parser.adaptiveType(-20, undefined);
-        assert.equal(type, 'LIVE', 'adaptiveType with -20 and undefined');
+        type = parser.streamType(-20, undefined);
+        assert.equal(type, 'LIVE', 'streamType with -20 and undefined');
     });
 });

--- a/test/unit/parser-test.js
+++ b/test/unit/parser-test.js
@@ -132,22 +132,44 @@ define([
     });
 
     test('parser.adaptiveType', function(assert) {
-        var type = parser.adaptiveType(0);
-        assert.equal(type, 'VOD', 'adaptiveType with 0');
+        var minDvrWindow = 120;
+        var type = parser.adaptiveType(0, minDvrWindow);
+        assert.equal(type, 'VOD', 'adaptiveType with 0 and 120');
 
-        type = parser.adaptiveType(10);
-        assert.equal(type, 'VOD', 'adaptiveType with 10');
+        type = parser.adaptiveType(0, 0);
+        assert.equal(type, 'VOD', 'adaptiveType with 0 and 0');
 
-        type = parser.adaptiveType(-120);
-        assert.equal(type, 'DVR', 'adaptiveType with -120');
+        type = parser.adaptiveType(10, minDvrWindow);
+        assert.equal(type, 'VOD', 'adaptiveType with 10 and 120');
 
-        type = parser.adaptiveType(-20);
+        type = parser.adaptiveType(10, undefined);
+        assert.equal(type, 'VOD', 'adaptiveType with 10 and undefined');
+
+        type = parser.adaptiveType(-120, minDvrWindow);
+        assert.equal(type, 'DVR', 'adaptiveType with -120 and 120');
+
+        type = parser.adaptiveType(120, -10);
+        assert.equal(type, 'DVR', 'adaptiveType with 120 and -10');
+
+        type = parser.adaptiveType(120, 0);
+        assert.equal(type, 'DVR', 'adaptiveType with 120 and 0');
+
+        type = parser.adaptiveType(-120, 0);
+        assert.equal(type, 'DVR', 'adaptiveType with -120 and 0');
+
+        type = parser.adaptiveType(120, undefined);
+        assert.equal(type, 'DVR', 'adaptiveType with 120 and undefined');
+
+        type = parser.adaptiveType(-20, minDvrWindow);
         assert.equal(type, 'LIVE', 'adaptiveType with -20');
 
-        type = parser.adaptiveType(-1);
+        type = parser.adaptiveType(-1, minDvrWindow);
         assert.equal(type, 'LIVE', 'adaptiveType with -1');
 
-        type = parser.adaptiveType(Infinity);
+        type = parser.adaptiveType(Infinity, minDvrWindow);
         assert.equal(type, 'LIVE', 'adaptiveType with Infinity');
+
+        type = parser.adaptiveType(-20, undefined);
+        assert.equal(type, 'LIVE', 'adaptiveType with -20 and undefined');
     });
 });

--- a/test/unit/parser-test.js
+++ b/test/unit/parser-test.js
@@ -148,23 +148,23 @@ define([
         type = parser.streamType(-120, minDvrWindow);
         assert.equal(type, 'DVR', 'streamType with -120 and 120');
 
-        type = parser.streamType(120, -10);
+        type = parser.streamType(-120, -10);
         assert.equal(type, 'DVR', 'streamType with 120 and -10');
 
-        type = parser.streamType(120, 0);
+        type = parser.streamType(-120, 0);
         assert.equal(type, 'DVR', 'streamType with 120 and 0');
 
         type = parser.streamType(-120, 0);
         assert.equal(type, 'DVR', 'streamType with -120 and 0');
 
-        type = parser.streamType(120, undefined);
+        type = parser.streamType(-120, undefined);
         assert.equal(type, 'DVR', 'streamType with 120 and undefined');
 
         type = parser.streamType(-20, minDvrWindow);
-        assert.equal(type, 'LIVE', 'streamType with -20');
+        assert.equal(type, 'LIVE', 'streamType with -20 and 120');
 
         type = parser.streamType(-1, minDvrWindow);
-        assert.equal(type, 'LIVE', 'streamType with -1');
+        assert.equal(type, 'LIVE', 'streamType with -1 and 120');
 
         type = parser.streamType(Infinity, minDvrWindow);
         assert.equal(type, 'LIVE', 'streamType with Infinity');

--- a/test/unit/playlist-item-test.js
+++ b/test/unit/playlist-item-test.js
@@ -21,7 +21,7 @@ define([
     function testItemComplete(assert, config) {
         var item = testItem(assert, config);
 
-        var attrs = ['image', 'description', 'mediaid', 'title'];
+        var attrs = ['image', 'description', 'mediaid', 'title', 'minDvrWindow'];
         _.each(attrs, function(a) {
             assert.ok(_.has(item, a), 'Item has ' + a + ' attribute');
         });

--- a/test/unit/utils-defs-test.js
+++ b/test/unit/utils-defs-test.js
@@ -18,7 +18,7 @@ define([
         assert.equal(typeof utils.serialize, 'function', 'serialize function is defined');
         assert.equal(typeof utils.parseDimension, 'function', 'parseDimension function is defined');
         assert.equal(typeof utils.timeFormat, 'function', 'timeFormat function is defined');
-        assert.equal(typeof utils.adaptiveType, 'function', 'adaptiveType function is defined');
+        assert.equal(typeof utils.streamType, 'function', 'streamType function is defined');
 
         // inherit from validator
         assert.equal(typeof utils.exists, 'function', 'exists function is defined');


### PR DESCRIPTION
- Add `minDvrWindow` on the item level with a default of 120
- New model prop: `minDvrWindow` (number) set on setting an item
- New model prop: `streamType` (`VOD`, `DVR`, or `LIVE`)
- `streamType` is set `onDuration` in the view
- Discontinue use of `utils.adaptiveType` except when determining `streamType` for the model
- Rename instances of `adaptiveType` to `streamType`
- Add tests 

Fixes #
JW7-2504 (1/2)

https://github.com/jwplayer/jwplayer-commercial/pull/2404 (2/2)


