### PR TITLE
Update styles for freewheel plugin

### DIFF
--- a/src/css/flags/ads.less
+++ b/src/css/flags/ads.less
@@ -41,16 +41,18 @@
 }
 
 .jwplayer.jw-flag-ads-freewheel {
-    .jw-controlbar {
-        display: none;
-        bottom: 0;
-    }
-
     &.jw-state-idle {
         .jw-media {
             video {
                 pointer-events: none;
             }
+        }
+    }
+
+    span {
+        pointer-events: none;
+        iframe {
+            pointer-events: all;
         }
     }
 }


### PR DESCRIPTION
Show control bars for freewheel ads.
Make freewheel span a click through, as this is an overlaying element on the video when freewheel overlay ad appears.
Make iframe inside the span a clickable, as this is the actual ad that needs to be clickable.

JW7-2985 JW7-2987