### PR TITLE
DFXP captions parser should replace break elements with newlines even when `innerHTML` isn't supported.

### DIFF
--- a/src/js/parsers/captions/dfxp.js
+++ b/src/js/parsers/captions/dfxp.js
@@ -29,6 +29,13 @@ define([
 
         for (var i = 0; i < paragraphs.length; i++) {
             var p = paragraphs[i];
+
+            var breaks = p.getElementsByTagName('br');
+            for (var j = 0; j < breaks.length; j++) {
+                var b = breaks[j];
+                b.parentNode.replaceChild(xmlDoc.createTextNode('\r\n'), b);
+            }
+
             var rawText = (p.innerHTML || p.textContent || p.text || '');
             var text = strings.trim(rawText).replace(/>\s+</g, '><').replace(/(<\/?)tts?:/g, '$1').replace(/<br.*?\/>/g, '\r\n');
             if (text) {

--- a/test/unit/dfxp-test.js
+++ b/test/unit/dfxp-test.js
@@ -22,14 +22,11 @@ define([
         var captions = parseDFXP(DFXP);
         assert.equal(captions.length, 8, 'DXFP captions are parsed');
         assert.equal(captions[7].text.indexOf('www.bigbuckbunny.org'), 0, 'Text is parsed');
-        if (innerXmlSupported) {
-            assert.ok(captions[7].text.indexOf('\r\n') > -1, 'Break elements are replaced by carrage returns and newlines');
-        }
+        assert.ok(captions[7].text.indexOf('\r\n') > -1, 'Break elements are replaced by carriage returns and newlines');
 
         var DFXPns = '<?xml version="1.0" encoding="UTF-8"?><!-- v1.1 --><tt:tt xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ttp="http://www.w3.org/ns/ttml#parameter" xmlns:tts="http://www.w3.org/ns/ttml#styling" xmlns:tt="http://www.w3.org/ns/ttml" xmlns:ebuttm="urn:ebu:tt:metadata" ttp:timeBase="media" xml:lang="de" ttp:cellResolution="50 30"><tt:body><tt:div><tt:p xml:id="subtitle1" region="bottom" begin="00:00:00.000" end="00:00:02.120" style="textCenter"><tt:span style="textWhite">weiß auf schwarz, Abschnitt: eins</tt:span></tt:p></tt:div></tt:body></tt:tt>';
         captions = parseDFXP(DFXPns);
         assert.equal(captions.length, 1, 'Namespaced DXFP captions are parsed');
-        console.log(captions[0].text);
         assert.ok(captions[0].text.indexOf('schwarz') > -1, 'Text is parsed');
         assert.ok(captions[0].text.indexOf('Abschnitt') > -1, 'Namespace prefixes are not removed from text content');
         if (innerXmlSupported) {


### PR DESCRIPTION
### Changes proposed in this pull request:

DFXP parser will replace `<br>`-elements with text nodes containing a newline before extracting text content from the paragraph.
Fixes that newlines are lost if `innerHTML` is unsupported. 

This fixes same issue as #1381 but for Edge.