### PR TITLE
Ads with shaka should never use flash provider

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -224,7 +224,7 @@ define([
 
             function _loadProvidersForPlaylist(playlist) {
                 var providersManager = _model.getProviders();
-                var providersNeeded = providersManager.required(playlist);
+                var providersNeeded = providersManager.required(playlist, _model.get('primary'));
                 return providersManager.load(providersNeeded)
                     .then(function() {
                         if (!_this.getProvider()) {

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -201,9 +201,8 @@ define([
             var _this = this;
             var providersManager = _model.getProviders();
             var primary = (InstreamMethod === InstreamHtml5? 'html5' : 'flash');
-            providersManager.reorderProviders(primary);
-            
-            var providersNeeded = providersManager.required(playlist);
+            var providersNeeded = providersManager.required(playlist, primary);
+
             _model.set('hideAdsControls', false);
             providersManager.load(providersNeeded)
                 .then(function() {

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -200,7 +200,7 @@ define([
 
             var _this = this;
             var providersManager = _model.getProviders();
-            var primary = (InstreamMethod === InstreamHtml5? 'html5' : 'flash');
+            var primary = (InstreamMethod === InstreamFlash)? 'flash' : undefined;
             var providersNeeded = providersManager.required(playlist, primary);
 
             _model.set('hideAdsControls', false);

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -200,6 +200,9 @@ define([
 
             var _this = this;
             var providersManager = _model.getProviders();
+            var primary = (InstreamMethod === InstreamHtml5? 'html5' : 'flash');
+            providersManager.reorderProviders(primary);
+            
             var providersNeeded = providersManager.required(playlist);
             _model.set('hideAdsControls', false);
             providersManager.load(providersNeeded)

--- a/src/js/providers/providers.js
+++ b/src/js/providers/providers.js
@@ -83,22 +83,24 @@ define([
             }));
         },
 
-        reorderProviders: function (primary) {
-            // Remove the flash provider, and add it in front of the html5 provider
-            if (primary === 'flash') {
-                var flashIdx = _.indexOf(this.providers, _.findWhere(this.providers, {name: 'flash'}));
-                var flashProvider = this.providers.splice(flashIdx, 1)[0];
-                var html5Idx = _.indexOf(this.providers, _.findWhere(this.providers, {name: 'html5'}));
-                this.providers.splice(html5Idx, 0, flashProvider);
-            }
+        reorderProviders: function (primaryOverride) {
+            var primary = primaryOverride || this.config.primary;
+            var secondary = (primary === 'flash')? 'html5' : 'flash';
+            var flashIdx = _.indexOf(this.providers, _.findWhere(this.providers, {name: primary}));
+            var flashProvider = this.providers.splice(flashIdx, 1)[0];
+            var html5Idx = _.indexOf(this.providers, _.findWhere(this.providers, {name: secondary}));
+
+            this.providers.splice(html5Idx, 0, flashProvider);
         },
 
         providerSupports: function(provider, source) {
             return provider.supports(source);
         },
 
-        required: function(playlist) {
+        required: function(playlist, primary) {
             var _this = this;
+
+            this.reorderProviders(primary);
             playlist = playlist.slice();
             return _.compact(_.map(this.providers, function(provider) {
                 // remove items from copied playlist that can be played by provider

--- a/src/js/providers/providers.js
+++ b/src/js/providers/providers.js
@@ -9,7 +9,7 @@ define([
         this.providers = ProvidersSupported.slice();
         this.config = config || {};
 
-        this.reorderProviders();
+        this.reorderProviders(this.config.primary);
     }
 
     Providers.loaders = {
@@ -83,9 +83,9 @@ define([
             }));
         },
 
-        reorderProviders : function () {
+        reorderProviders: function (primary) {
             // Remove the flash provider, and add it in front of the html5 provider
-            if (this.config.primary === 'flash') {
+            if (primary === 'flash') {
                 var flashIdx = _.indexOf(this.providers, _.findWhere(this.providers, {name: 'flash'}));
                 var flashProvider = this.providers.splice(flashIdx, 1)[0];
                 var html5Idx = _.indexOf(this.providers, _.findWhere(this.providers, {name: 'html5'}));
@@ -93,7 +93,7 @@ define([
             }
         },
 
-        providerSupports : function(provider, source) {
+        providerSupports: function(provider, source) {
             return provider.supports(source);
         },
 

--- a/src/js/providers/providers.js
+++ b/src/js/providers/providers.js
@@ -83,18 +83,16 @@ define([
             }));
         },
 
-        getPrimary: function(primaryOverride) {
+        getPrimaryProvider: function(primaryOverride) {
             var primary = primaryOverride || this.config.primary;
 
             if (primary === 'html5' || primary === 'flash') {
                 return primary;
             }
-
-            return 'html5';
         },
 
         reorderProviders: function (primaryOverride) {
-            var primary = this.getPrimary(primaryOverride);
+            var primary = this.getPrimaryProvider(primaryOverride) || 'html5';
             var secondary = (primary === 'flash')? 'html5' : 'flash';
             var flashIdx = _.indexOf(this.providers, _.findWhere(this.providers, {name: primary}));
             var flashProvider = this.providers.splice(flashIdx, 1)[0];

--- a/src/js/providers/providers.js
+++ b/src/js/providers/providers.js
@@ -9,7 +9,7 @@ define([
         this.providers = ProvidersSupported.slice();
         this.config = config || {};
 
-        this.reorderProviders(this.config.primary);
+        this.reorderProviders();
     }
 
     Providers.loaders = {
@@ -83,8 +83,18 @@ define([
             }));
         },
 
-        reorderProviders: function (primaryOverride) {
+        getPrimary: function(primaryOverride) {
             var primary = primaryOverride || this.config.primary;
+
+            if (primary === 'html5' || primary === 'flash') {
+                return primary;
+            }
+
+            return 'html5';
+        },
+
+        reorderProviders: function (primaryOverride) {
+            var primary = this.getPrimary(primaryOverride);
             var secondary = (primary === 'flash')? 'html5' : 'flash';
             var flashIdx = _.indexOf(this.providers, _.findWhere(this.providers, {name: primary}));
             var flashProvider = this.providers.splice(flashIdx, 1)[0];

--- a/test/tests.js
+++ b/test/tests.js
@@ -19,7 +19,7 @@ define([
     'unit/playlist-filtering-test',
     'unit/playlist-item-test',
     'unit/playlist-test',
-    'unit/provider-test',
+    'unit/providers-test',
     'unit/scriptloader-test',
     'unit/setup-test',
     'unit/simplemodel-test',

--- a/test/unit/providers-test.js
+++ b/test/unit/providers-test.js
@@ -12,7 +12,7 @@ define([
     // TODO: Many of these can be moved to quint/config/{type}.source{_features}
     var videoSources = {
         'mp4': { file: 'http://content.bitsontherun.com/videos/q1fx20VZ-52qL9xLP.mp4' },
-        'flv': { file:'http://playertest.longtailvideo.com/flv-cuepoints/honda_accord.flv' },	// Flash Specific
+        'flv': { file:'http://playertest.longtailvideo.com/flv-cuepoints/honda_accord.flv' },   // Flash Specific
         'smil': { file: 'assets/os/edgecast.smil' },                                            // Flash Specific
         'f4v': { file: 'http://content.bitsontherun.com/videos/3XnJSIm4-52qL9xLP.f4v' },
         'm4v': { file: 'http://content.bitsontherun.com/videos/3XnJSIm4-52qL9xLP.m4v' },
@@ -34,16 +34,16 @@ define([
         'youtube': { file: 'http://www.youtube.com/watch?v=YE7VzlLtp-4' }
     };
 
-	// Exists to protect against undefined results.  If no provider is chosen we get undefined.
-	var getName = function(func) {
-		if (func) {
+    // Exists to protect against undefined results.  If no provider is chosen we get undefined.
+    var getName = function(func) {
+        if (func) {
             if (func.name) {
                 return func.name;
             }
             return func.toString().match(/^function\s*([^\s(]+)/)[1];
-		}
+        }
         return 'None chosen';
-	};
+    };
 
     function fileDescription(file) {
         var description = source(file).type;
@@ -89,16 +89,16 @@ define([
         var providerList = new Providers().providers;
         assert.expect(4);
 
-		assert.ok(providerList.length >= 3, 'There are at least 3 providers listed');
+        assert.ok(providerList.length >= 3, 'There are at least 3 providers listed');
 
         var keys = getKeyIndexes(providerList);
-		assert.ok(keys.html5 < keys.flash, 'HTML5 has higher priority than flash');
+        assert.ok(keys.html5 < keys.flash, 'HTML5 has higher priority than flash');
         assert.ok(keys.html5 > keys.youtube, 'HTML5 has lower priority than youtube');
         assert.ok(keys.flash > keys.youtube, 'Flash has lower priority than youtube');
     });
 
     test('html5 primary requested', function (assert) {
-		var providerList = new Providers({primary: 'html5'}).providers;
+        var providerList = new Providers({primary: 'html5'}).providers;
         assert.expect(3);
 
         var keys = getKeyIndexes(providerList);
@@ -109,7 +109,7 @@ define([
 
 
     test('flash primary requested', function (assert) {
-		var providerList = new Providers({primary: 'flash'}).providers;
+        var providerList = new Providers({primary: 'flash'}).providers;
         assert.expect(3);
 
         var keys = getKeyIndexes(providerList);
@@ -118,20 +118,20 @@ define([
         assert.ok(keys.flash > keys.youtube, 'Flash has lower priority than youtube');
     });
 
-	test('invalid primary requested', function (assert) {
-		var providerList = new Providers({primary:'invalid primary value'}).providers;
+    test('invalid primary requested', function (assert) {
+        var providerList = new Providers({primary:'invalid primary value'}).providers;
         assert.expect(3);
 
         var keys = getKeyIndexes(providerList);
         assert.ok(keys.html5 < keys.flash, 'HTML5 has higher priority than flash');
         assert.ok(keys.html5 > keys.youtube, 'HTML5 has lower priority than youtube');
         assert.ok(keys.flash > keys.youtube, 'Flash has lower priority than youtube');
-	});
+    });
 
     QUnit.module('provider.choose');
 
-	// HTML5 Primary
-	test('html5 primary', function (assert) {
+    // HTML5 Primary
+    test('html5 primary', function (assert) {
         assert.expect(17);
 
         var runTest = getProvidersTestRunner(assert, 'html5');
@@ -162,8 +162,8 @@ define([
         runTest(videoSources.hls_androidhls_true,  isAndroidWithHls ? 'None chosen' : 'None chosen');
     });
 
-	// Flash Primary
-	test('flash primary', function (assert) {
+    // Flash Primary
+    test('flash primary', function (assert) {
         assert.expect(17);
 
         var runTest = getProvidersTestRunner(assert, 'flash');


### PR DESCRIPTION
When ads are played with shaka media, then it should use the html provider for the ads, even if the primary is set to flash.

JW7-3044

***Note:*** Must be merged with https://github.com/jwplayer/jwplayer-commercial/pull/2428