### PR TITLE
Fixed deadzone in dock container

### DIFF
--- a/src/css/imports/jwplayerelement.less
+++ b/src/css/imports/jwplayerelement.less
@@ -147,10 +147,10 @@
 }
 
 // These items can intercept pointer-events
-.jw-overlays > div,
+.jw-overlays .jw-plugin,
+.jw-dock .jw-dock-button,
 .jw-media,
 .jw-controlbar,
-.jw-dock > div,
 .jw-logo,
 .jw-skip,
 .jw-display-icon-container,

--- a/src/css/imports/jwplayerelement.less
+++ b/src/css/imports/jwplayerelement.less
@@ -148,7 +148,12 @@
 
 // These items can intercept pointer-events
 .jw-overlays > div,
-.jw-media, .jw-controlbar, .jw-dock, .jw-logo, .jw-skip, .jw-display-icon-container,
+.jw-media,
+.jw-controlbar,
+.jw-dock > div,
+.jw-logo,
+.jw-skip,
+.jw-display-icon-container,
 .jw-nextup-container {
     pointer-events: all;
 }


### PR DESCRIPTION
### Changes proposed in this pull request:
Fixed the dock container so the click event results in a play or pause when not hovering over a dock button.

Fixes #
JW7-2636, JW7-2869