### PR TITLE
Set min width for time display to 640px 

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -55,7 +55,7 @@ define([
             _rightClickMenu,
             _resizeMediaTimeout = -1,
             _resizeContainerRequestId = -1,
-            _minWidthForTimeDisplay = 450,
+            _minWidthForTimeDisplay = 640,
             // Function that delays the call of _setContainerDimensions so that the page has finished repainting.
             _delayResize = window.requestAnimationFrame ||
                 function(rafFunc) {


### PR DESCRIPTION
450px was way too low. 640px is a common player size and among the lowest widths before things start to look squished.

JW7-3120

