### PR TITLE
Load plugin once and use for all player instances

### DIFF
--- a/src/js/plugins/loader.js
+++ b/src/js/plugins/loader.js
@@ -137,12 +137,27 @@ define([
                 }
 
                 var status = utils.tryCatch(function() {
-                    if (jsPlugin && pluginsConfig[pluginURL]) {
+                    if (jsPlugin) {
+                        var pluginConfig = pluginsConfig[pluginURL];
+
+                        if (!pluginConfig) {
+                            // Find the plugin's config by name if the plugin was already loaded from a different url
+                            pluginConfig = _.find(pluginsConfig, function(config, url) {
+                                return url.indexOf(pluginName) > 0;
+                            });
+
+                            if (!pluginConfig) {
+                                return;
+                            }
+
+                            utils.log('"' + pluginName + '" plugin already loaded from: ' + pluginURL);
+                        }
+
                         var div = document.createElement('div');
                         div.id = api.id + '_' + pluginName;
                         div.className = 'jw-plugin jw-reset';
 
-                        var pluginOptions = _.extend({}, pluginsConfig[pluginURL]);
+                        var pluginOptions = _.extend({}, pluginConfig);
                         var pluginInstance = pluginObj.getNewInstance(api, pluginOptions, div);
 
                         pluginInstance.addToPlayer   = _addToPlayerGenerator(api, pluginInstance, div);

--- a/src/js/plugins/loader.js
+++ b/src/js/plugins/loader.js
@@ -141,16 +141,8 @@ define([
                         var pluginConfig = pluginsConfig[pluginURL];
 
                         if (!pluginConfig) {
-                            // Find the plugin's config by name if the plugin was already loaded from a different url
-                            pluginConfig = _.find(pluginsConfig, function(config, url) {
-                                return url.indexOf(pluginName) > 0;
-                            });
-
-                            if (!pluginConfig) {
-                                return;
-                            }
-
-                            utils.log('"' + pluginName + '" plugin already loaded from: ' + pluginURL);
+                            utils.log('JW Plugin already loaded', pluginName, pluginURL);
+                            return;
                         }
 
                         var div = document.createElement('div');


### PR DESCRIPTION
### Changes proposed in this pull request:
Previously, if there were multiple players on a page attempting to load the same plugin from different urls, the plugin would only be available in players that requested the plugin from the same url.

This change ensures that we load the plugin once and use it for all instances of the player on the page.

Fixes #
JW7-3100