### PR TITLE
Feature/breakpoints

### DIFF
--- a/src/css/flags/breakpoints.less
+++ b/src/css/flags/breakpoints.less
@@ -1,0 +1,27 @@
+/*
+Breakpoints (px):
+>= 1280: 6
+>= 960: 5
+>= 800: 4
+>= 640: 3
+>= 540: 2
+>= 420: 1
+< 420: 0
+*/
+
+
+.jw-breakpoint-0 {
+  .jw-text-elapsed,
+  .jw-text-duration {
+    display: none;
+  }
+}
+
+.jw-flag-touch.jw-breakpoint-2,
+.jw-flag-touch.jw-breakpoint-1,
+.jw-flag-touch.jw-breakpoint-0 {
+    .jw-text-elapsed,
+    .jw-text-duration {
+      display: none;
+    }
+}

--- a/src/css/jwplayer.less
+++ b/src/css/jwplayer.less
@@ -38,6 +38,7 @@
 @import "flags/touch";
 @import "flags/compact-player";
 @import "flags/audioplayer.less";
+@import "flags/breakpoints.less";
 
 // Skins
 @import "skins/seven";

--- a/src/js/view/breakpoint.js
+++ b/src/js/view/breakpoint.js
@@ -1,0 +1,29 @@
+define([
+    'utils/helpers',
+    'utils/underscore',
+], function (utils) {
+    return function setBreakpoint(playerElement, playerWidth, playerHeight) {
+        var className = 'jw-breakpoint-';
+        var width = playerWidth;
+        var height = playerHeight;
+
+        if (width >= 1280) {
+            className += '6';
+        } else if (width >= 960) {
+            className += '5';
+        } else if (width >= 800) {
+            className += '4';
+        } else if (width >= 640) {
+            className += '3';
+        } else if (width >= 540) {
+            className += '2';
+        } else if (width >= 420) {
+            className += '1';
+        } else {
+            className = '';
+        }
+
+        utils.replaceClass(playerElement, /jw-breakpoint-\d+/, className);
+        utils.toggleClass(playerElement, 'jw-orientation-portrait', (height > width));
+    };
+});

--- a/src/js/view/breakpoint.js
+++ b/src/js/view/breakpoint.js
@@ -20,7 +20,7 @@ define([
         } else if (width >= 420) {
             className += '1';
         } else {
-            className = '';
+            className += '0';
         }
 
         utils.replaceClass(playerElement, /jw-breakpoint-\d+/, className);

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -15,10 +15,11 @@ define([
     'view/title',
     'view/components/nextuptooltip',
     'utils/underscore',
-    'templates/player.html'
+    'templates/player.html',
+    'view/breakpoint',
 ], function(utils, events, Events, Constants, states,
             CaptionsRenderer, ClickHandler, DisplayIcon, Dock, Logo,
-            Controlbar, Preview, RightClick, Title, NextUpToolTip, _, playerTemplate) {
+            Controlbar, Preview, RightClick, Title, NextUpToolTip, _, playerTemplate, setBreakpoint) {
 
     var _styles = utils.style,
         _bounds = utils.bounds,
@@ -55,7 +56,6 @@ define([
             _rightClickMenu,
             _resizeMediaTimeout = -1,
             _resizeContainerRequestId = -1,
-            _minWidthForTimeDisplay = 450,
             // Function that delays the call of _setContainerDimensions so that the page has finished repainting.
             _delayResize = window.requestAnimationFrame ||
                 function(rafFunc) {
@@ -256,6 +256,8 @@ define([
 
             _model.set('containerWidth', containerWidth);
             _model.set('containerHeight', containerHeight);
+            setBreakpoint(_playerElement, containerWidth, containerHeight);
+
             _this.trigger(events.JWPLAYER_RESIZE, {
                 width: containerWidth,
                 height: containerHeight
@@ -822,10 +824,6 @@ define([
             }
 
             _captionsRenderer.resize();
-            
-            var hideTimeInControl = width && width < _minWidthForTimeDisplay;
-            utils.toggleClass(_playerElement, 'jw-flag-compact-player', hideTimeInControl);
-
         }
 
         this.resize = function(width, height) {

--- a/test/unit/breakpoint-test.js
+++ b/test/unit/breakpoint-test.js
@@ -1,0 +1,54 @@
+define([
+    'utils/helpers',
+    'view/breakpoint'
+], function (utils, breakpoint) {
+    /* jshint qunit: true */
+    QUnit.module('browser');
+    var test = QUnit.test.bind(QUnit);
+
+    function breakpointClassname(width, height) {
+        var mockPlayer = utils.createElement();
+        breakpoint(mockPlayer, width, height);
+        return mockPlayer.className;
+    }
+
+    test('width >= 1280 sets jw-breakpoint-6', function (assert) {
+        expect(1);
+        assert.equal(breakpointClassname(1280), 'jw-breakpoint-6');
+    });
+
+    test('width >= 960 sets jw-breakpoint-5', function (assert) {
+        expect(1);
+        assert.equal(breakpointClassname(960), 'jw-breakpoint-5');
+    });
+
+    test('width >= 800 sets jw-breakpoint-4', function (assert) {
+        expect(1);
+        assert.equal(breakpointClassname(800), 'jw-breakpoint-4');
+    });
+
+    test('width >= 640 sets jw-breakpoint-3', function (assert) {
+        expect(1);
+        assert.equal(breakpointClassname(640), 'jw-breakpoint-3');
+    });
+
+    test('width >= 540 sets jw-breakpoint-2', function (assert) {
+        expect(1);
+        assert.equal(breakpointClassname(540), 'jw-breakpoint-2');
+    });
+
+    test('width >= 420 sets jw-breakpoint-1', function (assert) {
+        expect(1);
+        assert.equal(breakpointClassname(420), 'jw-breakpoint-1');
+    });
+
+    test('width < 420 sets no breakpoint', function (assert) {
+        expect(1);
+        assert.equal(breakpointClassname(419), '');
+    });
+
+    test('if height > width jw-orientation-portrait is set', function (assert) {
+        expect(1);
+        assert.equal(breakpointClassname(419, 420), 'jw-orientation-portrait');
+    })
+});

--- a/test/unit/breakpoint-test.js
+++ b/test/unit/breakpoint-test.js
@@ -42,13 +42,13 @@ define([
         assert.equal(breakpointClassname(420), 'jw-breakpoint-1');
     });
 
-    test('width < 420 sets no breakpoint', function (assert) {
+    test('width < 420 sets jw-breakpoint-0', function (assert) {
         expect(1);
-        assert.equal(breakpointClassname(419), '');
+        assert.equal(breakpointClassname(419), 'jw-breakpoint-0');
     });
 
     test('if height > width jw-orientation-portrait is set', function (assert) {
         expect(1);
-        assert.equal(breakpointClassname(419, 420), 'jw-orientation-portrait');
+        assert.equal(breakpointClassname(419, 420), 'jw-breakpoint-0 jw-orientation-portrait');
     })
 });


### PR DESCRIPTION
- Move breakpoint function out of Related & into the Player itself
- Use breakpoints to show/hide controlbar text items

If we want to do more cosmetic enhancements we should make a new ticket


JW7-3120 (1/2)
