### PR TITLE
Dont pop up Next Up Tooltip during live playback

### DIFF
--- a/src/js/view/components/nextuptooltip.js
+++ b/src/js/view/components/nextuptooltip.js
@@ -31,7 +31,7 @@ define([
             
             // Events
             this._model.on('change:mediaModel', this.onMediaModel, this);
-            this._model.on('change:position', this.onElapsed, this);
+            this._model.on('change:streamType', this.onStreamType, this);
             this._model.on('change:nextUp', this.onNextUp, this);
 
             this.closeButtonUI = new UI(this.closeButton, {'directSelect': true})
@@ -142,12 +142,7 @@ define([
                 this._nextButton.toggle(false);
                 return;
             }
-
             this._nextButton.toggle(true);
-            // Listen for duration changes to determine the offset from the end for when next up should be shown
-            this._model.on('change:duration', this.onDuration, this);
-            // Listen for position changes so we can show the tooltip when the offset has been crossed
-            this._model.on('change:position', this.onElapsed, this);
             this.setNextUpItem(nextUp);
         },
         onDuration: function(model, duration) {
@@ -155,17 +150,9 @@ define([
                 return;
             }
 
-            var streamType = this._model.get('streamType');
-            if (streamType === 'LIVE' || streamType === 'DVR') {
-                model.off('change:duration', this.onDuration, this);
-                model.off('change:position', this.onElapsed, this);
-                return;
-            }
-
             // Use nextupoffset if set or default to 10 seconds from the end of playback
             var offset = model.get('nextupoffset') || -10;
             offset = utils.seconds(offset);
-
             if (offset < 0) {
                 // Determine offset from the end. Duration may change.
                 offset += duration;
@@ -194,6 +181,17 @@ define([
             } else if (this.state === 'opened' || this.state === 'closed') {
                 this.state = 'tooltip';
                 this.hide();
+            }
+        },
+        onStreamType: function(model, streamType) {
+            if (streamType === 'LIVE' || streamType === 'DVR') {
+                model.off('change:duration', this.onDuration, this);
+                model.off('change:position', this.onElapsed, this);
+            } else {
+                // Listen for duration changes to determine the offset from the end for when next up should be shown
+                this._model.on('change:duration', this.onDuration, this);
+                // Listen for position changes so we can show the tooltip when the offset has been crossed
+                this._model.on('change:position', this.onElapsed, this);
             }
         },
         element: function() {

--- a/src/js/view/components/nextuptooltip.js
+++ b/src/js/view/components/nextuptooltip.js
@@ -147,6 +147,7 @@ define([
             // Listen for duration changes to determine the offset
             // for when next up should be shown
             this._model.on('change:duration', this.onDuration, this);
+            this._model.on('change:position', this.onElapsed, this);
             this.setNextUpItem(nextUp);
         },
         onDuration: function(model, duration) {
@@ -157,6 +158,7 @@ define([
             var streamType = this._model.get('streamType');
             if (streamType === 'LIVE' || streamType === 'DVR') {
                 model.off('change:duration', this.onDuration, this);
+                model.off('change:position', this.onElapsed, this);
                 return;
             }
 

--- a/src/js/view/components/nextuptooltip.js
+++ b/src/js/view/components/nextuptooltip.js
@@ -27,8 +27,6 @@ define([
             this.showNextUp = true;
             this.streamType = undefined;
 
-            this.reset();
-            
             // Events
             this._model.on('change:mediaModel', this.onMediaModel, this);
             this._model.on('change:streamType', this.onStreamType, this);
@@ -38,19 +36,19 @@ define([
             this._model.on('change:duration', this.onDuration, this);
             // Listen for position changes so we can show the tooltip when the offset has been crossed
             this._model.on('change:position', this.onElapsed, this);
-            // Listeners are also detached when
-
-            this.closeButtonUI = new UI(this.closeButton, {'directSelect': true})
-                .on('click tap', this.hide, this);
-            this.tooltipUI = new UI(this.tooltip)
-                .on('click tap', this.click, this);
 
             this.onMediaModel(this._model, this._model.get('mediaModel'));
 
+            // Close button
+            new UI(this.closeButton, {'directSelect': true})
+                .on('click tap', this.hide, this);
+            // Tooltip
+            new UI(this.tooltip)
+                .on('click tap', this.click, this);
             // Next button behavior:
             // - click = go to next playlist or related item
             // - hover = show NextUp tooltip without 'close' button
-            this.nextButtonUI = new UI(this._nextButton.element(), {'useHover': true, 'directSelect': true})
+            new UI(this._nextButton.element(), {'useHover': true, 'directSelect': true})
                 .on('click tap', this.click, this)
                 .on('over', this.show, this)
                 .on('out', this.hoverOut, this);
@@ -185,23 +183,6 @@ define([
             if (this.content) {
                 this.container.removeChild(this.content);
                 this.content = null;
-            }
-        },
-        reset: function() {
-            this._model.off('change:mediaModel', this.onMediaModel, this);
-            this._model.off('change:streamType', this.onStreamType, this);
-            this._model.off('change:nextUp', this.onNextUp, this);
-
-            if (this.nextButtonUI) {
-                this.nextButtonUI.off();
-            }
-
-            if (this.closeButtonUI) {
-                this.closeButtonUI.off();
-            }
-
-            if (this.tooltipUI) {
-                this.tooltipUI.off();
             }
         }
     });

--- a/src/js/view/components/nextuptooltip.js
+++ b/src/js/view/components/nextuptooltip.js
@@ -144,9 +144,9 @@ define([
             }
 
             this._nextButton.toggle(true);
-            // Listen for duration changes to determine the offset
-            // for when next up should be shown
+            // Listen for duration changes to determine the offset from the end for when next up should be shown
             this._model.on('change:duration', this.onDuration, this);
+            // Listen for position changes so we can show the tooltip when the offset has been crossed
             this._model.on('change:position', this.onElapsed, this);
             this.setNextUpItem(nextUp);
         },


### PR DESCRIPTION
- Detach 'change:position' handler when in Live mode.
- Reattach handler on a new Next Up item (will get detached again if it's live)

JW7-3105

