### PR TITLE
Loading item during ad playback

### DIFF
--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -179,6 +179,7 @@ define([
         this.load = function (toLoad) {
             var plugin = this.getPlugin('vast') || this.getPlugin('googima');
             if (plugin) {
+                _controller._model.set('preInstreamState', 'instream-idle');
                 plugin.destroy();
             }
             _controller.load(toLoad);


### PR DESCRIPTION
During ad playback, when an item is loaded, the player is treating the
loaded item as if the ad just ended, forcing it to play when it
shouldn’t be.

JW7-3000