### PR TITLE
Timeout webpack requires

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -234,7 +234,6 @@ define([
                     .then(function() {
                         if (!_this.getProvider()) {
                             _model.setProvider(_model.get('playlistItem'));
-
                             _executeQueuedEvents();
                         }
                     });
@@ -264,10 +263,11 @@ define([
                         _loadPlaylist(item);
                         break;
                     case 'object':
-                        var success = _setPlaylist(item);
-                        if (success) {
+                        _setPlaylist(item).then(function() {
                             _setItem(0);
-                        }
+                        }).catch(function(error) {
+                            _this.triggerError(error);
+                        });
                         break;
                     case 'number':
                         _setItem(item);
@@ -445,15 +445,12 @@ define([
                 _model.set('playlist', playlist);
 
                 if (!_.isArray(playlist) || playlist.length === 0) {
-                    _this.triggerError({
+                    throw {
                         message: 'Error loading playlist: No playable sources found'
-                    });
-                    return false;
+                    };
                 }
 
-                _loadProvidersForPlaylist(playlist);
-
-                return true;
+                return _loadProvidersForPlaylist(playlist);
             }
 
             function _setItem(index) {

--- a/src/js/providers/providers.js
+++ b/src/js/providers/providers.js
@@ -11,25 +11,31 @@ define([
     }
 
     Providers.loaders = {
-        html5: function(resolvePromise) {
+        html5: function(resolve, reject) {
+            var timeout = setTimeout(reject, 8000);
             require.ensure(['providers/html5'], function(require) {
+                clearTimeout(timeout);
                 var provider = require('providers/html5');
                 registerProvider(provider);
-                resolvePromise(provider);
+                resolve(provider);
             }, 'provider.html5');
         },
-        flash: function(resolvePromise) {
+        flash: function(resolve, reject) {
+            var timeout = setTimeout(reject, 8000);
             require.ensure(['providers/flash'], function(require) {
+                clearTimeout(timeout);
                 var provider = require('providers/flash');
                 registerProvider(provider);
-                resolvePromise(provider);
+                resolve(provider);
             }, 'provider.flash');
         },
-        youtube: function(resolvePromise) {
+        youtube: function(resolve, reject) {
+            var timeout = setTimeout(reject, 8000);
             require.ensure(['providers/youtube'], function(require) {
+                clearTimeout(timeout);
                 var provider = require('providers/youtube');
                 registerProvider(provider);
-                resolvePromise(provider);
+                resolve(provider);
             }, 'provider.youtube');
         }
     };
@@ -70,12 +76,17 @@ define([
 
         load: function(providersToLoad) {
             return Promise.all(_.map(providersToLoad, function(provider) {
-                return new Promise(function(resolvePromise) {
+                return new Promise(function(resolve, reject) {
                     var providerLoaderMethod = Providers.loaders[provider.name];
                     if (providerLoaderMethod) {
-                        providerLoaderMethod(resolvePromise);
+                        var rejectProviderLoaded = function() {
+                            reject({
+                                message: 'Could not load "' + provider.name + '" provider'
+                            });
+                        };
+                        providerLoaderMethod(resolve, rejectProviderLoaded);
                     } else {
-                        resolvePromise(/* unknown registered module */);
+                        resolve(/* unknown registered module */);
                     }
                 });
             }));


### PR DESCRIPTION
Timeout several potential points of failure in the setup process to provide accurate error messages when player setup cannot complete. The first polyfill or provider to timeout will trigger the setup error.

- Provider loading times out after 8 seconds with message 'Error: Could not load "`provider.name`" provider'
- Polyfill loading times out after 5 seconds with message 'Could not load polyfill: `polyfill.name`'