### PR TITLE
Don't adjust next up position at larger breakpoints

### DIFF
--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -259,11 +259,14 @@
     /* Override default touch flag styles */
     .touch-flag-skin-styles() {
         &.jw-flag-touch {
-
-            .jw-nextup-container {
-              bottom: @nextup-position-bottom-touch;
+            &.jw-breakpoint-3,
+            &.jw-breakpoint-4,
+            &.jw-breakpoint-5,
+            &.jw-breakpoint-6 {
+                .jw-nextup-container {
+                    bottom: @nextup-position-bottom-touch;
+                }
             }
-
         }
     }
 


### PR DESCRIPTION
@madikarizma @johnBartos we should revisit touch + breakpoint flags. It might make sense to create higher level mobile breakpoints to simplify these rules and organize them in one place.

This change is a follow up to https://github.com/jwplayer/jwplayer/pull/1448

Fixes JW7-3090