### PR TITLE
Fixed iOS scrubbing scrolls page

### DIFF
--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -122,7 +122,7 @@ define([
         if (!element || !document.body.contains(element)) {
             return bounds;
         }
-        var rect = element.getBoundingClientRect(element),
+        var rect = element.getBoundingClientRect(),
             scrollOffsetY = window.pageYOffset,
             scrollOffsetX = window.pageXOffset;
         if (!rect.width && !rect.height && !rect.left && !rect.top) {

--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -62,8 +62,8 @@ define([
         if (evt.preventManipulation) {
             evt.preventManipulation();
         }
-        // When cancelable is false, it means the page is likely scrolling
-        if (evt.cancelable && evt.preventDefault) {
+        // prevent scrolling
+        if (evt.preventDefault) {
             evt.preventDefault();
         }
     }
@@ -156,6 +156,11 @@ define([
                 _touchListenerTarget.addEventListener('touchmove', interactDragHandler);
                 _touchListenerTarget.addEventListener('touchcancel', interactEndHandler);
                 _touchListenerTarget.addEventListener('touchend', interactEndHandler);
+                
+                // Prevent scrolling the screen dragging while dragging on mobile.
+                if (options.preventScrolling) {
+                    preventDefault(evt);
+                }
             }
         }
 
@@ -197,10 +202,11 @@ define([
                 document.removeEventListener('mousemove', interactDragHandler);
                 document.removeEventListener('mouseup', interactEndHandler);
             }
-
-            _touchListenerTarget.removeEventListener('touchmove', interactDragHandler);
-            _touchListenerTarget.removeEventListener('touchcancel', interactEndHandler);
-            _touchListenerTarget.removeEventListener('touchend', interactEndHandler);
+            if (_touchListenerTarget) {
+                _touchListenerTarget.removeEventListener('touchmove', interactDragHandler);
+                _touchListenerTarget.removeEventListener('touchcancel', interactEndHandler);
+                _touchListenerTarget.removeEventListener('touchend', interactEndHandler);
+            }
 
             if (_hasMoved) {
                 triggerEvent(touchEvents.DRAG_END, evt);

--- a/src/js/view/controlbar.js
+++ b/src/js/view/controlbar.js
@@ -333,23 +333,6 @@ define([
         element: function() {
             return this.el;
         },
-
-        getVisibleBounds : function (){
-            var el = this.el,
-                // getComputedStyle for modern browsers, currentStyle is for IE8
-                curStyle = (getComputedStyle) ? getComputedStyle(el) : el.currentStyle,
-                bounds;
-
-            if(curStyle.display === 'table'){
-                return utils.bounds(el);
-            } else {
-                el.style.visibility = 'hidden';
-                el.style.display = 'table';
-                bounds = utils.bounds(el);
-                el.style.visibility = el.style.display = '';
-                return bounds;
-            }
-        },
         setAltText : function(altText) {
             this.elements.alt.innerHTML = altText;
         },


### PR DESCRIPTION
`Event.preventDefault` was not being called on 'touchstart'. So the event that starts scrubbing, also starts scrolling the page.

JW7-3126