### PR TITLE
Captions after pre-roll and mid-roll

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -808,6 +808,9 @@ define([
          */
         this.detachMedia = function() {
             clearTimeout(_playbackTimeout);
+            // Stop listening to track changes so disabling the current track doesn't update the model
+            this.removeTracksListener(_videotag.textTracks, 'change', this.textTrackChangeHandler);
+            // Prevent tracks from showing during ad playback
             this.disableTextTrack();
             _attached = false;
             return _videotag;
@@ -825,6 +828,10 @@ define([
 
             // In case the video tag was modified while we shared it
             _videotag.loop = false;
+
+            // If there was a showing track, re-enable it
+            this.enableTextTrack();
+            this.addTracksListener(_videotag.textTracks, 'change', this.textTrackChangeHandler);
 
             // This is after a postroll completes
             if (_beforecompleted) {


### PR DESCRIPTION
### Changes proposed in this pull request:
- Remove track listener and disable showing track before ad playback
- Re-enable track and re-add listener after ad completes
- Cache 608 and metadata cues to prevent adding duplicate cues

Fixes #
JW7-3195, JW7-3170