### PR TITLE
Fix ID3 and Captions behavior in HLS streams

### DIFF
--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -248,13 +248,12 @@ define(['utils/underscore',
                 addTextTracks.call(this, [track]);
             }
         }
-
-        if (this._renderNatively || track.kind === 'metadata') {
-            if(_cacheVTTCue.call(this, track, cueData.cue)) {
+        if(_cacheVTTCue.call(this, track, cueData.cue)) {
+            if (this._renderNatively || track.kind === 'metadata') {
                 _addCueToTrack(track, cueData.cue);
+            } else {
+                track.data.push(cueData.cue);
             }
-        } else {
-            track.data.push(cueData.cue);
         }
     }
 
@@ -629,7 +628,8 @@ define(['utils/underscore',
                 cachedCues[cacheKey] = cacheValue;
                 return true;
             case 'metadata':
-                cacheKey = vttCue.startTime + vttCue.text;
+                var text = vttCue.data ? new Uint8Array(vttCue.data).join('') : vttCue.text;
+                cacheKey = vttCue.startTime + text;
                 if (cachedCues[cacheKey]) {
                     return false;
                 }


### PR DESCRIPTION
### Changes proposed in this pull request:
Properly cache ID3 and captions cues coming from our HLS provider to address:
- Duplicate captions in FF 
- ID3 events not being fired in FF and Chrome

Fixes #
JW7-3229, JW7-3231