### PR TITLE
Keep player textTracks in sync with browser textTracks

### DIFF
--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -31,7 +31,6 @@ define(['utils/helpers',
             var tracks = e.tracks || [];
             for (var i = 0; i < tracks.length; i++) {
                 var track = tracks[i];
-                track.name = track.label || track.name || track.language;
                 _addTrack(track);
             }
             var captionsMenu = _captionsMenu();
@@ -104,6 +103,7 @@ define(['utils/helpers',
         function _addTrack(track) {
 
             track.data = track.data || [];
+            track.name = track.label || track.name || track.language;
 
             if (!track.name) {
                 track.name = 'Unknown CC';

--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -31,7 +31,7 @@ define(['utils/helpers',
             var tracks = e.tracks || [];
             for (var i = 0; i < tracks.length; i++) {
                 var track = tracks[i];
-                track.label = track.label || track.name || track.language;
+                track.name = track.label || track.name || track.language;
                 _addTrack(track);
             }
             var captionsMenu = _captionsMenu();
@@ -105,11 +105,11 @@ define(['utils/helpers',
 
             track.data = track.data || [];
 
-            if (!track.label) {
-                track.label = 'Unknown CC';
+            if (!track.name) {
+                track.name = 'Unknown CC';
                 _unknownCount++;
                 if (_unknownCount > 1) {
-                    track.label += ' (' + _unknownCount + ')';
+                    track.name += ' (' + _unknownCount + ')';
                 }
             }
             _tracks.push(track);
@@ -124,7 +124,7 @@ define(['utils/helpers',
             for (var i = 0; i < _tracks.length; i++) {
                 list.push({
                     id: _tracks[i]._id,
-                    label: _tracks[i].label || 'Unknown CC'
+                    label: _tracks[i].name || 'Unknown CC'
                 });
             }
             return list;
@@ -143,7 +143,7 @@ define(['utils/helpers',
 
             for (var i = 0; i < _tracks.length; i++) {
                 var track = _tracks[i];
-                if (label && label === track.label) {
+                if (label && label === track.name) {
                     captionsMenuIndex = i + 1;
                     break;
                 } else if (track['default'] || track.defaulttrack || track._id === 'default') {

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -366,7 +366,7 @@ define([
 
             if (track) {
                 // update preference if an option was selected
-                this.set('captionLabel', track.label);
+                this.set('captionLabel', track.name);
             } else {
                 this.set('captionLabel', 'Off');
             }

--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -356,7 +356,7 @@ define(['utils/underscore',
         if (this._textTracks) {
             var track = this._textTracks[this._currentTextTrackIndex];
             if (track) {
-                track.mode = track.embedded ? 'hidden' : 'disabled';
+                track.mode = (track.embedded || track._id === 'nativecaptions') ? 'hidden' : 'disabled';
             }
         }
     }

--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -560,7 +560,6 @@ define(['utils/underscore',
     }
 
     function _addTrackToList(track) {
-        // TODO: remove old track
         this._textTracks.push(track);
         this._tracksById[track._id] = track;
     }


### PR DESCRIPTION
### Changes proposed in this pull request:

While there's no api method to [remove text tracks](https://lists.w3.org/Archives/Public/public-html/2015Feb/0017.html) programmatically added to the video tag, textTracks can be added/removed by Safari when playing HLS streams with ad breaks. This causes the player's internal tracklist to get out of sync with the browser. 

This PR addresses the following issues:
- Keep player and browser 608 and id3 tracks in sync
- Use the custom `name` property with the CC menu since `label` is read only and may not have a value in Safari
- Change track mode to `hidden` instead of `disabled` during ad playback so Safari can update `VTTCue.endTime`

Fixes #
JW7-2947