### PR TITLE
Ensure track id is the same in all providers

### DIFF
--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -33,8 +33,8 @@ define(['utils/helpers',
                 _addTrack(track);
             }
             var captionsMenu = _captionsMenu();
-            this.setCaptionsList(captionsMenu);
             _selectDefaultIndex();
+            this.setCaptionsList(captionsMenu);
         }
 
         var _item = {},
@@ -75,8 +75,8 @@ define(['utils/helpers',
             }
 
             var captionsMenu = _captionsMenu();
-            this.setCaptionsList(captionsMenu);
             _selectDefaultIndex();
+            this.setCaptionsList(captionsMenu);
         }
 
         function _kindSupported(kind) {

--- a/src/js/controller/tracks-helper.js
+++ b/src/js/controller/tracks-helper.js
@@ -8,7 +8,7 @@ define([
             if (track.default || track.defaulttrack) {
                 trackId = 'default';
             } else {
-                trackId = track._id || track.name || track.file || track.label || (prefix + tracksCount);
+                trackId = track._id || track.file || track.name || track.label || (prefix + tracksCount);
             }
             return trackId;
         },

--- a/test/unit/tracks-helper-test.js
+++ b/test/unit/tracks-helper-test.js
@@ -135,10 +135,10 @@ define([
         assertProperty(assert, 'default', 'default',
             'track.defaulttrack is 2nd priority even if other properties are set');
         assertProperty(assert, 'defaulttrack', '_id', 'track._id is used if track.default is undefined');
-        assertProperty(assert, '_id', 'name', 'track.name is used if track.default or track._id is undefined');
-        assertProperty(assert, 'name', 'file',
-            'track.file is prioritized over track.label if other properties are undefined.');
-        assertProperty(assert, 'file', 'label', 'track.label only has a higher priority than track.kind');
+        assertProperty(assert, '_id', 'file', 'track.file is used if track.default or track._id is undefined');
+        assertProperty(assert, 'file', 'name',
+            'track.name is prioritized over track.label if other properties are undefined.');
+        assertProperty(assert, 'name', 'label', 'track.label only has a higher priority than track.kind');
         setCount();
         assertProperty(assert, 'label', 'kind' + count, 'track.kind is lowest priority');
         setCount();


### PR DESCRIPTION
### Changes proposed in this pull request:
- Ensure `track._id` is consistent across providers for sideloaded tracks
- Set `captionsIndex` before `captionsList` so the index is a part of the `onCaptionsList` event data

Fixes #
JW7-3290