### PR TITLE
Destroy advertising plugins on load

### DIFF
--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -177,7 +177,7 @@ define([
         };
 
         this.load = function (toLoad) {
-            var plugin = this.getPlugin('vast') || this.getPlugin('googima');
+            var plugin = _this.getPlugin('vast') || _this.getPlugin('googima') || _this.getPlugin('freewheel');
             if (plugin) {
                 _controller._model.set('preInstreamState', 'instream-idle');
                 plugin.destroy();


### PR DESCRIPTION
Advertising plugins need to be destroyed when load is called to stop ad playback before the playlist is changed.

This is tech-debt we should remove in 7.8/7.9 by calling `destroy` on playlist events in the plugins (destroy doesn't actually tear down the plugin itself, just all active advertising players and schedule managers running in the plugin). Instream destroy would also insure any ad playback mechanisms in the player are removed

```js
this.load = function (toLoad) {
    _controller.instreamDestroy();
    _controller.load(toLoad);
    return _this;
};
```
