### PR TITLE
Update minimum Flash Player to version 15.0

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -189,10 +189,7 @@ module.exports = function(grunt) {
             options: {
                 targetCompilerOptions : [
                     '-define+=JWPLAYER::version,\'' + packageInfo.version + '\''
-                ],
-                // prefer AIR_HOME for faster compilation and JRE 7 64-bit support
-                sdk: env.AIR_HOME || env.FLEX_HOME,
-                ascshdPort: 11123
+                ]
             },
             debug : {
                 options : {

--- a/README.md
+++ b/README.md
@@ -48,10 +48,7 @@ You also have the power to programatically set any configuration within the play
 ### Build Instructions
 
  1. Install [Node.js](https://nodejs.org/download)
- 1. Install [Adobe AIR SDK](http://www.adobe.com/devnet/air/air-sdk-download.html)
  1. Install [Java](https://java.com/en/download/)
- 1. Download [player.swc 11.2](http://fpdownload.macromedia.com/get/flashplayer/installers/archive/playerglobal/playerglobal11_2.swc)
- 1. Rename and move the .swc file to ```{AIRSDK_Compiler}/frameworks/libs/player/11.2/playerglobal.swc```
 
 ```sh
     # First time set up

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "grunt-contrib-connect": "1.0.2",
     "grunt-contrib-jshint": "1.0.0",
     "grunt-contrib-watch": "1.0.0",
-    "grunt-flash-compiler": "0.2.2",
+    "grunt-flash-compiler": "0.3.1",
     "grunt-karma": "2.0.0",
     "grunt-recess": "1.0.1",
     "handlebars": "4.0.5",

--- a/test/config.js
+++ b/test/config.js
@@ -1,8 +1,8 @@
 (function () {
 
     // This allows us to test modules without loading full player
-    window.__BUILD_VERSION__ = '7.3.0';
-    window.__FLASH_VERSION__ = 11.2;
+    window.__BUILD_VERSION__ = '7.7.0';
+    window.__FLASH_VERSION__ = 15;
     window.__REPO__ = '';
     window.__SELF_HOSTED__ = true;
     window.__DEBUG__ = false;

--- a/test/unit/providers-test.js
+++ b/test/unit/providers-test.js
@@ -6,7 +6,7 @@ define([
     /* jshint maxlen: 1000, qunit: true */
 
     browser.flashVersion = function() {
-        return 11.2;
+        return 15.0;
     };
 
     // TODO: Many of these can be moved to quint/config/{type}.source{_features}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,7 @@ var _ = require('lodash');
 var argv = require('minimist')(process.argv.slice(2));
 
 var packageInfo = require('./package.json');
-var flashVersion = 11.2;
+var flashVersion = 15.0;
 
 function getBuildVersion(packageInfo) {
     // Build Version: {major.minor.revision}


### PR DESCRIPTION
Remove external FLEX SDK dependency by updating to a new version of grunt-flash-compiler that includes the flex-sdk as an npm dependency.

The minimum Flash version has been updated to 15 in order to add automatic support for StageVideo attempted here https://github.com/jwplayer/jwplayer/pull/1398

With these changes, the AIR_HOME or FLEX_HOME environment variables are no longer needed for Flash compilation.