### PR TITLE
Show captions in FF when the player is in DVR mode

### DIFF
--- a/src/js/view/captionsrenderer.js
+++ b/src/js/view/captionsrenderer.js
@@ -131,6 +131,9 @@ define([
                 } else {
                     return false;
                 }
+            } else if (track.embedded && timeEvent.duration < 0) {
+                // In DVR mode, need to make alignmentPosition positive for captions to work
+                return timeEvent.position - timeEvent.duration;
             }
 
             // Default to syncing with current position


### PR DESCRIPTION
### Changes proposed in this pull request:
Ensure captions are displayed in FireFox when playing HLS streams in html5.

Fixes #
JW7-3294