### PR TITLE
Flashplayer path in config should be relative to base path if unset.

### DIFF
--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -75,7 +75,7 @@ define([
         __webpack_public_path__ = config.base;
         config.width  = _normalizeSize(config.width);
         config.height = _normalizeSize(config.height);
-        config.flashplayer = config.flashplayer || utils.getScriptPath('jwplayer.js') + 'jwplayer.flash.swf';
+        config.flashplayer = config.flashplayer || config.base + 'jwplayer.flash.swf';
 
         // Non ssl pages can only communicate with flash when it is loaded
         //   from a non ssl location

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -75,7 +75,7 @@ define([
         __webpack_public_path__ = config.base;
         config.width  = _normalizeSize(config.width);
         config.height = _normalizeSize(config.height);
-        config.flashplayer = config.flashplayer || config.base + 'jwplayer.flash.swf';
+        config.flashplayer = config.flashplayer || (utils.getScriptPath('jwplayer.js') || config.base) + 'jwplayer.flash.swf';
 
         // Non ssl pages can only communicate with flash when it is loaded
         //   from a non ssl location


### PR DESCRIPTION
### Changes proposed in this pull request:

Flashplayer path in config should be relative to base path if unset.
Base path is already relative to script path if unset.

### Fixes

That flashplayer is not found if unset even if base path is set correctly in config. 
This happens if `getScriptPath('jwplayer.js')` does not find the path to `jwplayer.js`, eg. due to asset bundling.
