### PR TITLE
Set poster image for video elements in html5-provider.

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -278,7 +278,7 @@ define([
             }
             _position = currentTime;
         }
-        
+
         function _getDuration() {
             var duration = _videotag.duration;
             var end = _getSeekableEnd();
@@ -291,7 +291,7 @@ define([
             }
             return duration;
         }
-        
+
         function _updateDuration(duration) {
             _duration = duration;
             if (_delayedSeek && duration && duration !== Infinity) {
@@ -608,6 +608,11 @@ define([
             _visualQuality.reason = '';
             _setVideotagSource(_levels[_currentQuality]);
             this.setupSideloadedTracks(item.tracks);
+
+            // Update poster image for video element.
+            if (item.image) {
+                _setAttribute('poster', item.image);
+            }
         };
 
         this.load = function(item) {


### PR DESCRIPTION
### Changes proposed in this pull request:

Set the poster attribute on the video element in html5-provider to show the image until the first frame of video is displayed, or during entire playback for audio-only sources.
(I hope `init(item)` is the right place to do this.)
### Fixes

That a black background is displayed instead of the image for audio-only sources, eg. MP3 HLS-streams. See #1330 
