### PR TITLE
Allow muted autostart of ads on mobile

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -216,8 +216,8 @@ define([
                 if (related) {
                     related.on('nextUp', _model.setNextUp, _model);
                 }
-                // Start playback on desktop and mobile browsers
-                if (_model.get('autostart')) {
+                // Start playback on desktop and mobile browsers when allowed
+                if (_canAutoStart()) {
                     _this.play({reason: 'autostart'});
                 }
             }
@@ -257,7 +257,7 @@ define([
                 }
                 _stop(true);
 
-                if (_model.get('autostart')) {
+                if (_canAutoStart()) {
                     _model.once('itemReady', _play);
                 }
 
@@ -635,6 +635,10 @@ define([
                 if (related) {
                     related.next();
                 }
+            }
+
+            function _canAutoStart() {
+                return _model.get('autostart') && (!utils.isMobile() || _model.autoStartOnMobile());
             }
 
             /** Controller API / public methods **/

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -40,8 +40,7 @@ define([
                 buffer: 0
             });
 
-            // Videos autostart on mobile when the `muted` and `autoplay` attributes are set.
-            // Mute the player on a mobile device if autostart is set to true
+            // Videos can autoplay on mobile when the `muted` and `autoplay` attributes are set.
             if (this.autoStartOnMobile()) {
                 this.set('mute', true);
             }
@@ -407,7 +406,8 @@ define([
         };
 
         this.autoStartOnMobile = function() {
-            return this.get('autostart') && utils.isMobile() && !this.get('mobileSdk');
+            return this.get('autostart') && utils.isMobile() && !this.get('mobileSdk') &&
+                (!this.get('advertising') || this.get('advertising').autoplayadsmuted);
         };
     };
 


### PR DESCRIPTION
### Changes proposed in this pull request:
Publishers can now opt in to autostarting with ads if `autostart` is `true` and the advertising block has `autoplayadsmuted` set to `true`.

Fixes #
JW7-3159, JW7-3015