### PR TITLE
Wait until canplay on iOS to send the bufferFull event

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -346,7 +346,8 @@ define([
         }
 
         function _sendBufferFull() {
-            if (!_bufferFull || (utils.isIOS() && _canPlay)) {
+            // Wait until the canplay event on iOS to send the bufferFull event
+            if (!_bufferFull && (!utils.isIOS() || _canPlay)) {
                 _bufferFull = true;
                 _canPlay = false;
                 _this.trigger(events.JWPLAYER_MEDIA_BUFFER_FULL);


### PR DESCRIPTION
### Changes proposed in this pull request:

When autoplaying on iOS, we were triggering the `bufferFull` event in `_completeLoad`, which is before there's enough data buffered to start playback. Doing so when the `canplay` event is raised guarantees the play promise will be fulfilled. 

For manual play attempts, the `bufferFull` event will be raised slightly later than before, but this does not affect playback and should not introduce any side effects. 

Fixes #
JW7-3362