### PR TITLE
Do not forward video click event before ad starts

### DIFF
--- a/src/css/flags/ads.less
+++ b/src/css/flags/ads.less
@@ -41,7 +41,7 @@
 }
 
 .jwplayer.jw-flag-ads-freewheel {
-    &.jw-state-idle {
+    &.jw-freewheel-before-impression {
         .jw-media {
             video {
                 pointer-events: none;


### PR DESCRIPTION
On mobile devices, an ad click is initiated on the first video touch event to start the video.
FreeWheel should only be getting an ad click event after an impression event fires.
JW7-3369 JW7-3370