### PR TITLE
Ignore pause events before playback starts

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -368,8 +368,8 @@ define([
                 return;
             }
 
-            // If "pause" fires before "complete", we still don't want to propagate it
-            if (_videotag.currentTime === _videotag.duration) {
+            // If "pause" fires before "complete" or before playback starts, we don't want to propagate it
+            if (_videotag.currentTime === 0 || _videotag.currentTime === _videotag.duration) {
                 return;
             }
 


### PR DESCRIPTION
### Changes proposed in this pull request:

This ensures that we ignore pause events raised by the browser before playback starts when autoplaying on mobile.

Fixes #
JW7-3362