### PR TITLE
Destroy freeWheel plugin on new item load

### DIFF
--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -177,7 +177,7 @@ define([
         };
 
         this.load = function (toLoad) {
-            var plugin = this.getPlugin('vast') || this.getPlugin('googima');
+            var plugin = this.getPlugin('vast') || this.getPlugin('googima') || this.getPlugin('freewheel');
             if (plugin) {
                 _controller._model.set('preInstreamState', 'instream-idle');
                 plugin.destroy();


### PR DESCRIPTION
Add freewheel to plugin destroy list along with vast and googima.