### PR TITLE
Remove max width of floating controlbars

### DIFF
--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -28,7 +28,6 @@
         display: inline-block;
         // width assignment is required for IE11 to center correctly
         width: 96%;
-        max-width: 50em;
         margin: 0 auto;
         bottom: .7em;
         left: 2%;


### PR DESCRIPTION
Floating control bars no longer have max-width set. Allows control bars to stretch to near the edge of player.

Fixes #
JW7-3247