### PR TITLE
Add breakpoint declarations for control bar ad text

### DIFF
--- a/src/css/flags/ads.less
+++ b/src/css/flags/ads.less
@@ -27,7 +27,11 @@
         }
 
         .jw-text-alt {
-            display: inline;
+            text-overflow: ellipsis;
+            overflow: hidden;
+            margin: 0 -0.5em;
+            display: inline-block;
+            white-space: nowrap;
         }
 
         .jw-slider-volume.jw-slider-horizontal,
@@ -38,6 +42,29 @@
             display : none;
         }
     }
+
+    &.jw-breakpoint-0 .jw-text-alt {
+      max-width: 80px;
+    }
+    &.jw-breakpoint-1 .jw-text-alt {
+      max-width: 150px;
+    }
+    &.jw-breakpoint-2 .jw-text-alt {
+      max-width: 250px;
+    }
+    &.jw-breakpoint-3 .jw-text-alt {
+      max-width: 370px;
+    }
+    &.jw-breakpoint-4 .jw-text-alt {
+      max-width: 470px;
+    }
+    &.jw-breakpoint-5 .jw-text-alt {
+      max-width: 630px;
+    }
+    &.jw-breakpoint-6 .jw-text-alt {
+      max-width: 790px;
+    }
+
 }
 
 .jwplayer.jw-flag-ads-freewheel {
@@ -102,4 +129,3 @@
         display : none !important;
     }
 }
-

--- a/src/css/flags/ads.less
+++ b/src/css/flags/ads.less
@@ -27,10 +27,10 @@
         }
 
         .jw-text-alt {
-            text-overflow: ellipsis;
-            overflow: hidden;
-            margin: 0 -0.5em;
             display: inline-block;
+            margin: 0 -0.5em;
+            overflow: hidden;
+            text-overflow: ellipsis;
             white-space: nowrap;
         }
 

--- a/src/css/flags/live.less
+++ b/src/css/flags/live.less
@@ -6,7 +6,35 @@
             display: none;
         }
         .jw-text-alt {
-            display: inline;
+            display: inline-block;
+            margin: 3px -0.5em 0;
+            overflow: hidden;
+            position: relative;
+            text-overflow: ellipsis;
+            top: 2px;
+            white-space: nowrap;
         }
+    }
+
+    &.jw-breakpoint-0 .jw-text-alt {
+      max-width: 80px;
+    }
+    &.jw-breakpoint-1 .jw-text-alt {
+      max-width: 150px;
+    }
+    &.jw-breakpoint-2 .jw-text-alt {
+      max-width: 250px;
+    }
+    &.jw-breakpoint-3 .jw-text-alt {
+      max-width: 370px;
+    }
+    &.jw-breakpoint-4 .jw-text-alt {
+      max-width: 470px;
+    }
+    &.jw-breakpoint-5 .jw-text-alt {
+      max-width: 630px;
+    }
+    &.jw-breakpoint-6 .jw-text-alt {
+      max-width: 790px;
     }
 }


### PR DESCRIPTION
Prevent text from overflowing vertically and truncate with ellipses.

Fixes #
JW7-3249

