### PR TITLE
Hide nextup, elapsed and duration starting at breakpoint 1

### DIFF
--- a/src/css/flags/breakpoints.less
+++ b/src/css/flags/breakpoints.less
@@ -11,7 +11,6 @@ Breakpoints (px):
 */
 
 
-.jw-breakpoint-2,
 .jw-breakpoint-1,
 .jw-breakpoint-0 {
   .jw-text-elapsed,


### PR DESCRIPTION
### Changes proposed in this pull request:

There's sufficient real estate to display nextup, elapsed and duration at breakpoint 2. Only hide them at player widths smaller than 420 px.
Fixes #
JW7-3260