### PR TITLE
Show volume button in muted state when auto starting

### DIFF
--- a/src/css/flags/ads.less
+++ b/src/css/flags/ads.less
@@ -4,7 +4,8 @@
     .jw-dock,
     .jw-logo,
     .jw-captions.jw-captions-enabled,
-    .jw-nextup-container {
+    .jw-nextup-container,
+    .jw-autostart-mute {
         display: none;
     }
     video::-webkit-media-text-track-container {

--- a/src/css/imports/autostartmute.less
+++ b/src/css/imports/autostartmute.less
@@ -1,0 +1,22 @@
+@import "vars";
+@import "icons";
+
+.jw-autostart-mute {
+  .jw-icon-volume;
+  position: absolute;
+  bottom: 0.5em;
+  right: 0.5em;
+  height: @mobile-touch-target;
+  width: @mobile-touch-target;
+  text-align: center;
+  &::before {
+    background-color: @background-color;
+    padding: 5px 4px 5px 6px;
+  }
+  ~.jw-controlbar {
+    display: none;
+  }
+}
+
+
+

--- a/src/css/imports/jwplayerelement.less
+++ b/src/css/imports/jwplayerelement.less
@@ -154,6 +154,7 @@
 .jw-logo,
 .jw-skip,
 .jw-display-icon-container,
-.jw-nextup-container {
+.jw-nextup-container,
+.jw-autostart-mute {
     pointer-events: all;
 }

--- a/src/css/imports/vars.less
+++ b/src/css/imports/vars.less
@@ -1,5 +1,8 @@
 @default-em-size: 16px;
 
+// mobile touch target size (iOS standard)
+@mobile-touch-target: 44px;
+
 // (160,160,160)
 // Colors
 @active-color: rgba(255, 255, 255, 1);

--- a/src/css/jwplayer.less
+++ b/src/css/jwplayer.less
@@ -15,6 +15,7 @@
 @import "imports/skipad.less";
 @import "imports/cast.less";
 @import "imports/nextup.less";
+@import "imports/autostartmute.less";
 
 // State specific
 @import "states/idle.less";

--- a/src/js/view/components/button.js
+++ b/src/js/view/components/button.js
@@ -1,0 +1,34 @@
+define([
+    'utils/ui'
+], function(UI) {
+    var button = function (icon, apiAction, ariaText) {
+        var element = document.createElement('div');
+        element.className = 'jw-icon jw-icon-inline jw-button-color jw-reset ' + icon;
+        element.setAttribute('role', 'button');
+        element.setAttribute('tabindex', '0');
+        if (ariaText) {
+            element.setAttribute('aria-label', ariaText);
+        }
+        element.style.display = 'none';
+
+        if (apiAction) {
+            // Don't send the event to the handler so we don't have unexpected results. (e.g. play)
+            new UI(element).on('click tap', function() { apiAction(); });
+        }
+
+        return {
+            element : function() { return element; },
+            toggle : function(m) {
+                if (m) {
+                    this.show();
+                } else {
+                    this.hide();
+                }
+            },
+            show : function() { element.style.display = '';},
+            hide : function() { element.style.display = 'none';}
+        };
+    };
+
+    return button;
+});

--- a/src/js/view/controlbar.js
+++ b/src/js/view/controlbar.js
@@ -7,37 +7,9 @@ define([
     'view/components/slider',
     'view/components/timeslider',
     'view/components/menu',
-    'view/components/volumetooltip'
-], function(utils, _, Events, Constants, UI, Slider, TimeSlider, Menu, VolumeTooltip) {
-
-    function button(icon, apiAction, ariaText) {
-        var element = document.createElement('div');
-        element.className = 'jw-icon jw-icon-inline jw-button-color jw-reset ' + icon;
-        element.setAttribute('role', 'button');
-        element.setAttribute('tabindex', '0');
-        if (ariaText) {
-            element.setAttribute('aria-label', ariaText);
-        }
-        element.style.display = 'none';
-
-        if (apiAction) {
-            // Don't send the event to the handler so we don't have unexpected results. (e.g. play)
-            new UI(element).on('click tap', function() { apiAction(); });
-        }
-
-        return {
-            element : function() { return element; },
-            toggle : function(m) {
-                if (m) {
-                    this.show();
-                } else {
-                    this.hide();
-                }
-            },
-            show : function() { element.style.display = '';},
-            hide : function() { element.style.display = 'none';}
-        };
-    }
+    'view/components/volumetooltip',
+    'view/components/button'
+], function(utils, _, Events, Constants, UI, Slider, TimeSlider, Menu, VolumeTooltip, button) {
 
     function text(name, role) {
         var element = document.createElement('span');

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -17,9 +17,10 @@ define([
     'utils/underscore',
     'templates/player.html',
     'view/breakpoint',
+    'view/components/button'
 ], function(utils, events, Events, Constants, states,
             CaptionsRenderer, ClickHandler, DisplayIcon, Dock, Logo,
-            Controlbar, Preview, RightClick, Title, NextUpToolTip, _, playerTemplate, setBreakpoint) {
+            Controlbar, Preview, RightClick, Title, NextUpToolTip, _, playerTemplate, setBreakpoint, button) {
 
     var _styles = utils.style,
         _bounds = utils.bounds,
@@ -50,6 +51,7 @@ define([
             _logo,
             _title,
             _nextuptooltip,
+            _mute,
             _captionsRenderer,
             _audioMode,
             _showing = false,
@@ -640,6 +642,12 @@ define([
             _controlbar.on(events.JWPLAYER_USER_ACTION, _userActivity);
             _model.on('change:scrubbing', _dragging);
 
+            if (_model.autoStartOnMobile()) {
+                _mute = button('jw-autostart-mute jw-off', _autoplayUnmute, _model.get('localization').volume);
+                _mute.show();
+                _controlsLayer.appendChild(_mute.element());
+            }
+
             _nextuptooltip = new NextUpToolTip(_model, _api, _controlbar.elements.next);
             _nextuptooltip.setup();
 
@@ -801,6 +809,12 @@ define([
             }
 
             _captionsRenderer.resize();
+        }
+
+        function _autoplayUnmute() {
+            _mute.hide();
+            _this.api.setMute(false);
+            utils.removeClass(_mute.element(), 'jw-autostart-mute');
         }
 
         this.resize = function(width, height) {


### PR DESCRIPTION
### Changes proposed in this pull request:

When autostarting, hide the control bar and show the volume icon in the 'muted' state, except when there's a preroll.

Fixes #
JW7-2955