### PR TITLE
Feature/update controlbar title text overflow

### DIFF
--- a/src/css/flags/ads.less
+++ b/src/css/flags/ads.less
@@ -30,9 +30,8 @@
             display: inline-block;
             margin: 0 -0.5em;
             overflow: hidden;
-            position: relative;
             text-overflow: ellipsis;
-            top: 2px;
+            vertical-align: middle;
             white-space: nowrap;
         }
 

--- a/src/css/flags/ads.less
+++ b/src/css/flags/ads.less
@@ -30,7 +30,9 @@
             display: inline-block;
             margin: 0 -0.5em;
             overflow: hidden;
+            position: relative;
             text-overflow: ellipsis;
+            top: 2px;
             white-space: nowrap;
         }
 

--- a/src/css/flags/live.less
+++ b/src/css/flags/live.less
@@ -9,9 +9,8 @@
             display: inline-block;
             margin: 0 -0.5em 0;
             overflow: hidden;
-            position: relative;
             text-overflow: ellipsis;
-            top: 2px;
+            vertical-align: middle;
             white-space: nowrap;
         }
     }

--- a/src/css/flags/live.less
+++ b/src/css/flags/live.less
@@ -7,7 +7,7 @@
         }
         .jw-text-alt {
             display: inline-block;
-            margin: 3px -0.5em 0;
+            margin: 0 -0.5em 0;
             overflow: hidden;
             position: relative;
             text-overflow: ellipsis;


### PR DESCRIPTION
Fix vertical center issue where text did not align with controls. The issue occurred because **overflow: hidden**, which necessary to create truncated text with ellipses, kills the way the text renders vertical alignment.

Fixes JW7-3249

