### PR TITLE
Show mute button for muted autoplay

### DIFF
--- a/src/css/flags/ads.less
+++ b/src/css/flags/ads.less
@@ -4,7 +4,8 @@
     .jw-dock,
     .jw-logo,
     .jw-captions.jw-captions-enabled,
-    .jw-nextup-container {
+    .jw-nextup-container,
+    .jw-autostart-mute {
         display: none;
     }
     video::-webkit-media-text-track-container {

--- a/src/css/flags/media-audio.less
+++ b/src/css/flags/media-audio.less
@@ -32,6 +32,11 @@
             max-height: 70%;  // 97% - 6.25 * 4.25em
         }
     }
+
+    // Hide autostart mute button
+    .jw-autostart-mute {
+        display: none;
+    }
 }
 .jw-flag-media-audio {
     .jw-preview {

--- a/src/css/imports/autostartmute.less
+++ b/src/css/imports/autostartmute.less
@@ -13,10 +13,10 @@
     background-color: @background-color;
     padding: 5px 4px 5px 6px;
   }
-  ~.jw-controlbar {
+}
+
+.jw-flag-autostart {
+  .jw-controlbar {
     display: none;
   }
 }
-
-
-

--- a/src/css/imports/autostartmute.less
+++ b/src/css/imports/autostartmute.less
@@ -1,0 +1,22 @@
+@import "vars";
+@import "icons";
+
+.jw-autostart-mute {
+  .jw-icon-volume;
+  position: absolute;
+  bottom: 0.5em;
+  right: 0.5em;
+  height: @mobile-touch-target;
+  width: @mobile-touch-target;
+  text-align: center;
+  &::before {
+    background-color: @background-color;
+    padding: 5px 4px 5px 6px;
+  }
+  ~.jw-controlbar {
+    display: none;
+  }
+}
+
+
+

--- a/src/css/imports/jwplayerelement.less
+++ b/src/css/imports/jwplayerelement.less
@@ -154,6 +154,7 @@
 .jw-logo,
 .jw-skip,
 .jw-display-icon-container,
-.jw-nextup-container {
+.jw-nextup-container,
+.jw-autostart-mute {
     pointer-events: all;
 }

--- a/src/css/imports/vars.less
+++ b/src/css/imports/vars.less
@@ -1,5 +1,8 @@
 @default-em-size: 16px;
 
+// mobile touch target size (iOS standard)
+@mobile-touch-target: 44px;
+
 // (160,160,160)
 // Colors
 @active-color: rgba(255, 255, 255, 1);

--- a/src/css/jwplayer.less
+++ b/src/css/jwplayer.less
@@ -15,6 +15,7 @@
 @import "imports/skipad.less";
 @import "imports/cast.less";
 @import "imports/nextup.less";
+@import "imports/autostartmute.less";
 
 // State specific
 @import "states/idle.less";

--- a/src/css/states/paused.less
+++ b/src/css/states/paused.less
@@ -12,4 +12,9 @@
     .jw-icon-playback {
         .jw-icon-play;
     }
+
+    // Hide autostart mute button when paused by the browser
+    .jw-autostart-mute {
+        display: none;
+    }
 }

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -638,7 +638,7 @@ define([
             }
 
             function _canAutoStart() {
-                return _model.get('autostart') && (!utils.isMobile() || _model.autoStartOnMobile());
+                return (_model.get('autostart') && !utils.isMobile()) || _model.autoStartOnMobile();
             }
 
             /** Controller API / public methods **/

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -42,7 +42,7 @@ define([
 
             // Videos can autoplay on mobile when the `muted` and `autoplay` attributes are set.
             if (this.autoStartOnMobile()) {
-                this.set('mute', true);
+                this.set('autostartmute', true);
             }
 
             this.updateProviders();
@@ -154,7 +154,7 @@ define([
                     break;
 
                 case 'autoplayFailed':
-                    this.setMute(false);
+                    this.set('autostartmute', false);
                     break;
             }
 
@@ -222,13 +222,13 @@ define([
             _provider.volume(_this.get('volume'));
             _provider.mute(_this.get('mute'));
 
-            if (_provider.removeAutoplayAttributes) {
-                _provider.removeAutoplayAttributes();
+            if (_provider.removeAutoplayAttribute) {
+                _provider.removeAutoplayAttribute();
             }
 
             // set autoplay attributes if on a mobile device and autostart is true
-            if (this.autoStartOnMobile() && _provider.setAutoplayAttributes) {
-                _provider.setAutoplayAttributes();
+            if (this.autoStartOnMobile() && _provider.setAutoplayAttribute) {
+                _provider.setAutoplayAttribute();
             }
             _provider.on('all', _videoEventHandler, this);
 
@@ -410,8 +410,9 @@ define([
         };
 
         this.autoStartOnMobile = function() {
-            return this.get('autostart') && !this.get('mobileSdk') &&
-                ((utils.isIOS() && utils.isSafari()) || (utils.isAndroid() && utils.isChrome())) &&
+            return this.get('autostart') && !this.get('sdkplatform') &&
+                ((utils.isIOS() && utils.isSafari()) ||
+                (utils.isAndroid() && utils.isChrome())) &&
                 (!this.get('advertising') || this.get('advertising').autoplayadsmuted);
         };
     };

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -40,11 +40,6 @@ define([
                 buffer: 0
             });
 
-            // Videos can autoplay on mobile when the `muted` and `autoplay` attributes are set.
-            if (this.autoStartOnMobile()) {
-                this.set('autostartmute', true);
-            }
-
             this.updateProviders();
 
             return this;
@@ -154,7 +149,7 @@ define([
                     break;
 
                 case 'autoplayFailed':
-                    this.set('autostartmute', false);
+                    this.set('autostartFailed', true);
                     break;
             }
 

--- a/src/js/view/components/button.js
+++ b/src/js/view/components/button.js
@@ -1,0 +1,34 @@
+define([
+    'utils/ui'
+], function(UI) {
+    var button = function (icon, apiAction, ariaText) {
+        var element = document.createElement('div');
+        element.className = 'jw-icon jw-icon-inline jw-button-color jw-reset ' + icon;
+        element.setAttribute('role', 'button');
+        element.setAttribute('tabindex', '0');
+        if (ariaText) {
+            element.setAttribute('aria-label', ariaText);
+        }
+        element.style.display = 'none';
+
+        if (apiAction) {
+            // Don't send the event to the handler so we don't have unexpected results. (e.g. play)
+            new UI(element).on('click tap', function() { apiAction(); });
+        }
+
+        return {
+            element : function() { return element; },
+            toggle : function(m) {
+                if (m) {
+                    this.show();
+                } else {
+                    this.hide();
+                }
+            },
+            show : function() { element.style.display = '';},
+            hide : function() { element.style.display = 'none';}
+        };
+    };
+
+    return button;
+});

--- a/src/js/view/controlbar.js
+++ b/src/js/view/controlbar.js
@@ -71,8 +71,8 @@ define([
                 volumeSlider = new Slider('jw-slider-volume', 'horizontal');//, vol);
                 volumeTooltip = new VolumeTooltip(this._model, 'jw-icon-volume', vol);
             }
-            // Do not show the volume toggle in the mobile SDKs
-            if (!this._model.get('mobileSdk')) {
+            // Do not show the volume toggle in the mobile SDKs or iOS9
+            if (!this._model.get('sdkplatform') && !utils.isIOS(9)) {
                 muteButton = button('jw-icon-volume', this._api.setMute, vol);
             }
 

--- a/src/js/view/controlbar.js
+++ b/src/js/view/controlbar.js
@@ -7,37 +7,9 @@ define([
     'view/components/slider',
     'view/components/timeslider',
     'view/components/menu',
-    'view/components/volumetooltip'
-], function(utils, _, Events, Constants, UI, Slider, TimeSlider, Menu, VolumeTooltip) {
-
-    function button(icon, apiAction, ariaText) {
-        var element = document.createElement('div');
-        element.className = 'jw-icon jw-icon-inline jw-button-color jw-reset ' + icon;
-        element.setAttribute('role', 'button');
-        element.setAttribute('tabindex', '0');
-        if (ariaText) {
-            element.setAttribute('aria-label', ariaText);
-        }
-        element.style.display = 'none';
-
-        if (apiAction) {
-            // Don't send the event to the handler so we don't have unexpected results. (e.g. play)
-            new UI(element).on('click tap', function() { apiAction(); });
-        }
-
-        return {
-            element : function() { return element; },
-            toggle : function(m) {
-                if (m) {
-                    this.show();
-                } else {
-                    this.hide();
-                }
-            },
-            show : function() { element.style.display = '';},
-            hide : function() { element.style.display = 'none';}
-        };
-    }
+    'view/components/volumetooltip',
+    'view/components/button'
+], function(utils, _, Events, Constants, UI, Slider, TimeSlider, Menu, VolumeTooltip, button) {
 
     function text(name, role) {
         var element = document.createElement('span');

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -17,9 +17,10 @@ define([
     'utils/underscore',
     'templates/player.html',
     'view/breakpoint',
+    'view/components/button'
 ], function(utils, events, Events, Constants, states,
             CaptionsRenderer, ClickHandler, DisplayIcon, Dock, Logo,
-            Controlbar, Preview, RightClick, Title, NextUpToolTip, _, playerTemplate, setBreakpoint) {
+            Controlbar, Preview, RightClick, Title, NextUpToolTip, _, playerTemplate, setBreakpoint, button) {
 
     var _styles = utils.style,
         _bounds = utils.bounds,
@@ -50,6 +51,7 @@ define([
             _logo,
             _title,
             _nextuptooltip,
+            _mute,
             _captionsRenderer,
             _audioMode,
             _showing = false,
@@ -640,6 +642,12 @@ define([
             _controlbar.on(events.JWPLAYER_USER_ACTION, _userActivity);
             _model.on('change:scrubbing', _dragging);
 
+            if (_model.autoStartOnMobile()) {
+                _mute = button('jw-autostart-mute jw-off', _autoplayUnmute, _model.get('localization').volume);
+                _mute.show();
+                _controlsLayer.appendChild(_mute.element());
+            }
+
             _nextuptooltip = new NextUpToolTip(_model, _api, _controlbar.elements.next);
             _nextuptooltip.setup();
 
@@ -801,6 +809,12 @@ define([
             }
 
             _captionsRenderer.resize();
+        }
+
+        function _autoplayUnmute() {
+            _mute.hide();
+            _this.api.setMute(false);
+            utils.removeClass(_mute.element(), 'jw-autostart-mute');
         }
 
         this.resize = function(width, height) {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -651,7 +651,7 @@ define([
                 _controlbar.renderVolume(true, _model.get('volume'));
                 // Hide the controlbar until the autostart flag is removed
                 utils.addClass(_playerElement, 'jw-flag-autostart');
-                _model.on('change:autostartmute', _autoplayUnmute);
+                _model.on('change:autostartFailed', _autoplayUnmute);
             }
 
             _nextuptooltip = new NextUpToolTip(_model, _api, _controlbar.elements.next);
@@ -814,16 +814,17 @@ define([
         }
 
         function _autoplayUnmute () {
-            var autostartMute = _model.get('autostartmute');
+            var autostartSucceeded = !_model.get('autostartFailed');
             var mute = _model.get('mute');
 
-            // Unmuted by user interaction, so set the player's mute state to false
-            if (autostartMute) {
+            // If autostart succeeded, it means the user has chosen to unmute the video,
+            // so we should update the model, setting mute to false
+            if (autostartSucceeded) {
                 mute = false;
             }
 
-            _model.off('change:autostartmute', _autoplayUnmute);
-            _model.set('autostartmute', false);
+            _model.off('change:autostartFailed', _autoplayUnmute);
+            _model.set('autostartFailed', undefined);
 
             _api.setMute(mute);
             // the model's mute value may not have changed. ensure the controlbar's mute button is in the right state


### PR DESCRIPTION
### Changes proposed in this pull request:
Improvements to muted autoplay:
- Show a mute icon when autoplaying on mobile
- Don't show mute icon when the browser interrupts playback, pausing the player
- Decouple muted autoplay from the player's mute state (set by user interaction or config preference)
- Gracefully degrade when autoplay is not supported or fails, removing the mute button and setting the player back to the original `mute` state

Fixes #
JW7-2955
