### PR TITLE
Hide play icon on mobile freewheel when paused

### DIFF
--- a/src/css/flags/ads.less
+++ b/src/css/flags/ads.less
@@ -77,6 +77,10 @@
         }
     }
 
+    &.jw-flag-touch&.jw-state-paused .jw-display-icon-container {
+      display: none;
+    }
+
     &.jw-flag-user-inactive.jw-state-playing {
         .jw-freewheel-nonlinear-container {
             bottom: 0.5em;


### PR DESCRIPTION
Hide the icon for better user experience, since video tab on freewheel does not resume playback.
JW7-3423