### PR TITLE
Bugfix/control bar text overflow hiding long letters

### DIFF
--- a/src/css/flags/ads.less
+++ b/src/css/flags/ads.less
@@ -1,3 +1,5 @@
+@import "../imports/vars";
+
 .jwplayer.jw-flag-ads {
 
     .jw-preview,
@@ -28,6 +30,8 @@
 
         .jw-text-alt {
             display: inline-block;
+            height: auto;
+            line-height: @controlbar-height;
             margin: 0 -0.5em;
             overflow: hidden;
             text-overflow: ellipsis;

--- a/src/css/flags/live.less
+++ b/src/css/flags/live.less
@@ -1,3 +1,5 @@
+@import "../imports/vars";
+
 .jwplayer.jw-flag-live {
     .jw-controlbar {
         .jw-text-elapsed,
@@ -7,6 +9,8 @@
         }
         .jw-text-alt {
             display: inline-block;
+            height: auto;
+            line-height: @controlbar-height;
             margin: 0 -0.5em 0;
             overflow: hidden;
             text-overflow: ellipsis;

--- a/src/css/imports/jwplayerelement.less
+++ b/src/css/imports/jwplayerelement.less
@@ -94,11 +94,12 @@
 }
 
 .jw-text {
+    height: 1em;
     font-family: Arial, Helvetica, sans-serif;
     font-size: @font-size;
     font-style: normal;
     font-weight: normal;
-    line-height: @controlbar-height;
+    //line-height: 1em;
     color: white;
     text-align: center;
     font-variant: normal;

--- a/src/css/imports/jwplayerelement.less
+++ b/src/css/imports/jwplayerelement.less
@@ -94,12 +94,11 @@
 }
 
 .jw-text {
-    height: 1em;
     font-family: Arial, Helvetica, sans-serif;
     font-size: @font-size;
     font-style: normal;
     font-weight: normal;
-    //line-height: 1em;
+    line-height: @controlbar-height;
     color: white;
     text-align: center;
     font-variant: normal;


### PR DESCRIPTION
Long, lowercase letters (g, q, y, etc.) would be cut off in control bar text by the element height and computed line height. Fix overrides alt text height in ads/live and adding line height that matches control bar height to fix the problem for those scenarios.

Fixes #
JW7-3425
