### PR TITLE
Treat browser as Firefox if it has "Gecko/" in user agent string

### DIFF
--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -23,7 +23,7 @@ define([
         return flashVersion && flashVersion >= __FLASH_VERSION__;
     };
 
-    browser.isFF = _browserCheck(/firefox/i);
+    browser.isFF = _browserCheck(/gecko\//i);
     browser.isIPod = _browserCheck(/iP(hone|od)/i);
     browser.isIPad = _browserCheck(/iPad/i);
     browser.isSafari602 = _browserCheck(/Macintosh.*Mac OS X 10_8.*6\.0\.\d* Safari/i);


### PR DESCRIPTION
### Changes proposed in this pull request:

Changes the Firefox detection to look for any browser that says it uses Gecko.

JW Player currently checks if a browser is Firefox or Chrome before trying to play HLS in HTML5. There are some rarely used browsers (which are not officially supported by JW Player) that are able to play HLS streams in HTML5, but - depending on the user settings - might not get the chance.

- In particular, the next version of Pale Moon (27) is able to play HLS in HTML5 using JW Player, but only does so if the user has selected "Firefox compatibility" in their user agent settings. The default is "Gecko compatibility", which does not include a "Firefox" token but does include a "Gecko/20100101" token.
- This also affects SeaMonkey users who have changed their settings to turn "Advertise Firefox compatiblity" off.

Because this pull request has isFF() look for "Gecko/" instead of just "Gecko", it should avoid a false positive on IE 11, Chrome, and Safari (which include "like Gecko" in their UA strings.) To my knowledge, only browsers that actually use Gecko include "Gecko/" (except for Pale Moon, which uses a fork of Gecko.)