### PR TITLE
Remove autoplay muted icon when mute state changes

### DIFF
--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -405,9 +405,17 @@ define([
             this.set('nextUp', nextUp);
         };
 
+        function _autoStartSupportedIOS() {
+            if (!utils.isIOS()) {
+                return false;
+            }
+            // Autostart only supported in iOS 10 or higher - check if the version is 9 or less
+            return !(utils.isIOS(6) || utils.isIOS(7) || utils.isIOS(8) || utils.isIOS(9));
+        }
+
         this.autoStartOnMobile = function() {
             return this.get('autostart') && !this.get('sdkplatform') &&
-                ((utils.isIOS() && utils.isSafari()) || (utils.isAndroid() && utils.isChrome())) &&
+                ((_autoStartSupportedIOS() && utils.isSafari()) || (utils.isAndroid() && utils.isChrome())) &&
                 (!this.get('advertising') || this.get('advertising').autoplayadsmuted);
         };
     };

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -643,7 +643,7 @@ define([
             _model.on('change:scrubbing', _dragging);
 
             // Ignore iOS9. Muted autoplay is supported in iOS 10+
-            if (_model.autoStartOnMobile() && !(utils.isIOS(8) || utils.isIOS(9))) {
+            if (_model.autoStartOnMobile()) {
                 _mute = button('jw-autostart-mute jw-off', _autoplayUnmute, _model.get('localization').volume);
                 _mute.show();
                 _controlsLayer.appendChild(_mute.element());
@@ -653,6 +653,7 @@ define([
                 utils.addClass(_playerElement, 'jw-flag-autostart');
                 _model.set('autostartMuted', true);
                 _model.on('change:autostartFailed', _autoplayUnmute);
+                _model.on('change:mute', _autoplayUnmute);
             }
 
             _nextuptooltip = new NextUpToolTip(_model, _api, _controlbar.elements.next, _playerElement);
@@ -831,6 +832,7 @@ define([
             }
 
             _model.off('change:autostartFailed', _autoplayUnmute);
+            _model.off('change:mute', _autoplayUnmute);
             _model.set('autostartFailed', undefined);
             _model.set('autostartMuted', undefined);
 


### PR DESCRIPTION
Whenever there is a change to mute state, we should stop showing autostart muted.
JW7-2955