### PR TITLE
Do not use pointer events in Chrome. It doesn't work over Flash.

### DIFF
--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -4,7 +4,7 @@ define([
     'utils/underscore',
     'utils/helpers'
 ], function(Events, events, _, utils) {
-    var _usePointerEvents = !_.isUndefined(window.PointerEvent);
+    var _usePointerEvents = !_.isUndefined(window.PointerEvent) && !utils.isChrome();
     var _useTouchEvents = !_usePointerEvents && utils.isMobile();
     var _useMouseEvents = !_usePointerEvents && ! _useTouchEvents;
     var _isOSXFirefox = utils.isFF() && utils.isOSX();


### PR DESCRIPTION
Chrome 55 introduces `window.PointerEvent` but the event handling does not work over a swf object element.

I've communicated this to the Chrome team https://bugs.chromium.org/p/chromium/issues/detail?id=659670

To be safe we will only use mouse or touch events in Chrome. Sorry Chromebooks with touch screens and Surface users running Chrome.  

JW7-3388

I'm labelling this as ads tech-debt, but really the tech debt was already there. We should be able to support touch and mouse events simultaneously. Then we could ignore pointer events all together - https://github.com/jwplayer/jwplayer/issues/1538