### PR TITLE
Set autostartMuted to false when setMute is called

### DIFF
--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -332,7 +332,7 @@ define([
 
         this.setMute = function(mute) {
             if (!utils.exists(mute)) {
-                mute = !this.get('mute');
+                mute = !(this.get('autostartMuted') || this.get('mute'));
             }
             this.set('mute', mute);
             if (_provider) {
@@ -340,6 +340,7 @@ define([
             }
             if (!mute) {
                 var volume = Math.max(10, this.get('volume'));
+                this.set('autostartMuted', false);
                 this.setVolume(volume);
             }
         };

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -652,6 +652,7 @@ define([
                 utils.addClass(_playerElement, 'jw-flag-autostart');
                 _model.set('autostartMuted', true);
                 _model.on('change:autostartFailed', _autoplayUnmute);
+                _model.on('change:autostartMuted', _autoplayUnmute);
                 _model.on('change:mute', _autoplayUnmute);
             }
 
@@ -829,15 +830,11 @@ define([
             if (autostartSucceeded) {
                 mute = false;
             }
-
             _model.off('change:autostartFailed', _autoplayUnmute);
             _model.off('change:mute', _autoplayUnmute);
+            _model.off('change:autostartMuted', _autoplayUnmute);
             _model.set('autostartFailed', undefined);
             _model.set('autostartMuted', undefined);
-
-            if (_instreamModel) {
-                _instreamModel.getVideo().mute(mute);
-            }
             _api.setMute(mute);
             // the model's mute value may not have changed. ensure the controlbar's mute button is in the right state
             _controlbar.renderVolume(mute, _model.get('volume'));


### PR DESCRIPTION
When setMute is called with mute false, set autostartMuted to false.
Listen to the change in autostartMuted property to handle unmute with ads properly.
JW7-3469