### PR TITLE
Do not whitelist Android Firefox for HLS support

### DIFF
--- a/src/js/providers/html5-android-hls.js
+++ b/src/js/providers/html5-android-hls.js
@@ -1,0 +1,23 @@
+define([
+    'utils/browser'
+], function(browser) {
+
+    return function getIsAndroidHLS(source) {
+        if (source.type === 'hls') {
+            if (source.androidhls === false && browser.isAndroid()) {
+                return false;
+            } else {
+                // When androidhls is not set to false, allow HLS playback on Android 4.1 and up
+                var isAndroidNative = browser.isAndroidNative;
+                if (isAndroidNative(2) || isAndroidNative(3) || isAndroidNative('4.0')) {
+                    return false;
+                } else if (browser.isAndroid() && !browser.isFF()) {
+                    // skip canPlayType check
+                    // canPlayType returns '' in native browser even though HLS will play
+                    return true;
+                }
+            }
+        }
+        return null;
+    };
+});

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -1,4 +1,5 @@
 define([
+    'providers/html5-android-hls',
     'utils/css',
     'utils/helpers',
     'utils/dom',
@@ -9,7 +10,7 @@ define([
     'utils/backbone.events',
     'providers/tracks-mixin',
     'utils/browser'
-], function(cssUtils, utils, dom, _, events, states, DefaultProvider, Events, Tracks) {
+], function(getIsAndroidHLS, cssUtils, utils, dom, _, events, states, DefaultProvider, Events, Tracks) {
 
     var clearTimeout = window.clearTimeout,
         STALL_DELAY = 256,
@@ -35,25 +36,6 @@ define([
         utils.foreach(eventsHash, function(evt, evtCallback) {
             videoTag.removeEventListener(evt, evtCallback, false);
         });
-    }
-
-    function _useAndroidHLS(source) {
-        if (source.type === 'hls') {
-            //when androidhls is not set to false, allow HLS playback on Android 4.1 and up
-            if (source.androidhls !== false) {
-                var isAndroidNative = utils.isAndroidNative;
-                if (isAndroidNative(2) || isAndroidNative(3) || isAndroidNative('4.0')) {
-                    return false;
-                } else if (utils.isAndroid()) { //utils.isAndroidNative()) {
-                    // skip canPlayType check
-                    // canPlayType returns '' in native browser even though HLS will play
-                    return true;
-                }
-            } else if (utils.isAndroid()) {
-                return false;
-            }
-        }
-        return null;
     }
 
     function VideoProvider(_playerId, _playerConfig) {
@@ -542,7 +524,7 @@ define([
             }
             _canSeek = false;
             _bufferFull = false;
-            _isAndroidHLS = _useAndroidHLS(source);
+            _isAndroidHLS = getIsAndroidHLS(source);
             if (source.preload && source.preload !== _videotag.getAttribute('preload')) {
                 _setAttribute('preload', source.preload);
             }

--- a/src/js/providers/providers-supported.js
+++ b/src/js/providers/providers-supported.js
@@ -1,27 +1,9 @@
 define([
+    'providers/html5-android-hls',
     'utils/helpers',
     'utils/underscore',
     'utils/video'
-], function(utils, _, video) {
-
-    function _useAndroidHLS(source) {
-        if (source.type === 'hls') {
-            //when androidhls is not set to false, allow HLS playback on Android 4.1 and up
-            if (source.androidhls !== false) {
-                var isAndroidNative = utils.isAndroidNative;
-                if (isAndroidNative(2) || isAndroidNative(3) || isAndroidNative('4.0')) {
-                    return false;
-                } else if (utils.isAndroid()) { //utils.isAndroidNative()) {
-                    // skip canPlayType check
-                    // canPlayType returns '' in native browser even though HLS will play
-                    return true;
-                }
-            } else if (utils.isAndroid()) {
-                return false;
-            }
-        }
-        return null;
-    }
+], function(getIsAndroidHLS, utils, _, video) {
 
     var SupportsMatrix = [
         {
@@ -58,7 +40,7 @@ define([
                 var file = source.file;
                 var type = source.type;
 
-                var isAndroidHLS = _useAndroidHLS(source);
+                var isAndroidHLS = getIsAndroidHLS(source);
                 if (isAndroidHLS !== null) {
                     return isAndroidHLS;
                 }


### PR DESCRIPTION
Remove repeated code and exclude Firefox on Android from HLS Android whitelisting.

Fixes #1500