### PR TITLE
Fix issues with android chrome preroll autoplay

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -329,12 +329,6 @@ define([
             if (!_attached) {
                 return;
             }
-
-            //fixes Chrome bug where it doesn't like being muted before video is loaded
-            if (_videotag.muted) {
-                _videotag.muted = false;
-                _videotag.muted = true;
-            }
             _setAttribute('jw-loaded', 'meta');
             _sendMetaEvent();
         }


### PR DESCRIPTION
After autoplay preroll, it was toggling mute on video tag if mute was set.
As soon as mute is set to false, the video tag sends pause event, causing the playback after preroll to be paused.
Fixing by removing this block of code to toggle.
JW7-3478