### PR TITLE
Replace "middle" with "center"

### DIFF
--- a/src/js/parsers/captions/vttparser.js
+++ b/src/js/parsers/captions/vttparser.js
@@ -188,7 +188,7 @@ define(['parsers/captions/vttcue'], function(VTTCue) {
             // Apply default values for any missing fields.
             cue.region = settings.get('region', null);
             cue.vertical = settings.get('vertical', '');
-            cue.line = settings.get('line', -1);
+            cue.line = settings.get('line', 'auto');
             cue.lineAlign = settings.get('lineAlign', 'start');
             cue.snapToLines = settings.get('snapToLines', true);
             cue.size = settings.get('size', 100);

--- a/src/js/parsers/captions/vttparser.js
+++ b/src/js/parsers/captions/vttparser.js
@@ -173,7 +173,7 @@ define(['parsers/captions/vttcue'], function(VTTCue) {
                         vals = v.split(',');
                         settings.percent(k, vals[0]);
                         if (vals.length === 2) {
-                            settings.alt('positionAlign', vals[1], ['start', 'center', 'end']);
+                            settings.alt('positionAlign', vals[1], ['line-left', 'center', 'line-right', 'auto']);
                         }
                         break;
                     case 'size':
@@ -193,20 +193,8 @@ define(['parsers/captions/vttcue'], function(VTTCue) {
             cue.snapToLines = settings.get('snapToLines', true);
             cue.size = settings.get('size', 100);
             cue.align = settings.get('align', 'center');
-            cue.position = settings.get('position', {
-                start: 0,
-                left: 0,
-                center: 50,
-                end: 100,
-                right: 100
-            }, cue.align);
-            cue.positionAlign = settings.get('positionAlign', {
-                start: 'start',
-                left: 'start',
-                center: 'center',
-                end: 'end',
-                right: 'end'
-            }, cue.align);
+            cue.position = settings.get('position', 'auto');
+            cue.positionAlign = settings.get('positionAlign', 'auto');
         }
 
         function skipWhitespace() {

--- a/src/js/parsers/captions/vttparser.js
+++ b/src/js/parsers/captions/vttparser.js
@@ -166,21 +166,21 @@ define(['parsers/captions/vttcue'], function(VTTCue) {
                         }
                         settings.alt(k, vals0, ['auto']);
                         if (vals.length === 2) {
-                            settings.alt('lineAlign', vals[1], ['start', 'middle', 'end']);
+                            settings.alt('lineAlign', vals[1], ['start', 'center', 'end']);
                         }
                         break;
                     case 'position':
                         vals = v.split(',');
                         settings.percent(k, vals[0]);
                         if (vals.length === 2) {
-                            settings.alt('positionAlign', vals[1], ['start', 'middle', 'end']);
+                            settings.alt('positionAlign', vals[1], ['start', 'center', 'end']);
                         }
                         break;
                     case 'size':
                         settings.percent(k, v);
                         break;
                     case 'align':
-                        settings.alt(k, v, ['start', 'middle', 'end', 'left', 'right']);
+                        settings.alt(k, v, ['start', 'center', 'end', 'left', 'right']);
                         break;
                 }
             }, /:/, /\s/);
@@ -192,18 +192,18 @@ define(['parsers/captions/vttcue'], function(VTTCue) {
             cue.lineAlign = settings.get('lineAlign', 'start');
             cue.snapToLines = settings.get('snapToLines', true);
             cue.size = settings.get('size', 100);
-            cue.align = settings.get('align', 'middle');
+            cue.align = settings.get('align', 'center');
             cue.position = settings.get('position', {
                 start: 0,
                 left: 0,
-                middle: 50,
+                center: 50,
                 end: 100,
                 right: 100
             }, cue.align);
             cue.positionAlign = settings.get('positionAlign', {
                 start: 'start',
                 left: 'start',
-                middle: 'middle',
+                center: 'center',
                 end: 'end',
                 right: 'end'
             }, cue.align);


### PR DESCRIPTION
Replaces instances of "middle" with "center" to adhere to the valid VTT values.

Fixes #
JW7-1474

The enum value of "middle" is not valid, the correct value is "center". This applies to line, position, and align.

https://w3c.github.io/webvtt/#the-vttcue-interface