### PR TITLE
Workaround for iOS autoplay HLS not completing

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -387,6 +387,12 @@ define([
                 return;
             }
 
+            // Workaround for iOS not completing after midroll with HLS streams
+            if (utils.isIOS() && (_videotag.duration - _videotag.currentTime <= 0.1)) {
+                _endedHandler();
+                return;
+            }
+
             _this.setState(states.STALLED);
         }
 


### PR DESCRIPTION
Sometimes after midroll on iOS autoplay, the duration is not updated properly if playback is an HLS stream, resulting the stream to never go to a complete state.
Making a workaround for this specific case so that the stream ends.
JW7-3477