### PR TITLE
Fix tracks-mixin texttrack change recursion with multiple captions tracks

### DIFF
--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -79,6 +79,10 @@ define(['utils/underscore',
                     } else {
                         track._id = tracksHelper.createId(track, this._textTracks.length);
                     }
+                    if (this._tracksById[track._id]) {
+                        // tracks without unique ids must not be marked as "inuse"
+                        continue;
+                    }
                     track.inuse = true;
                 }
                 if (!track.inuse || this._tracksById[track._id]) {


### PR DESCRIPTION
Prevent recursion caused by `_tracksModified` "inuse" check when tracks have duplicate ids.