### PR TITLE
Expose function to set autostartMuted to false

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -177,6 +177,10 @@ define([
             }
         };
 
+        this.clearAutostartMute = function() {
+            _model.set('autostartMuted', false);
+        };
+
         this.loadItem = function(item, options) {
             if (utils.isAndroid(2.3)) {
                 this.trigger({


### PR DESCRIPTION
This function is needed for ad platforms to listen to volume change in vpaid 2 ads and clear autostartMuted icon.
JW7-3503