### PR TITLE
Ignore primary:flash when Flash is blocked

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -164,7 +164,7 @@ module.exports = function(grunt) {
                     'src/flash/com/longtailvideo/jwplayer/{,*/}*.as',
                     'src/flash/com/wowsa/{,*/}*.as'
                 ],
-                tasks: ['build-flash']
+                tasks: ['flash:debug', 'flash:debugLoader']
             }
         },
 
@@ -205,6 +205,16 @@ module.exports = function(grunt) {
             release : {
                 files : {
                     'bin-release/jwplayer.flash.swf': 'src/flash/com/longtailvideo/jwplayer/player/Player.as'
+                }
+            },
+            debugLoader : {
+                files : {
+                    'bin-debug/jwplayer.loader.swf' : 'src/flash/com/longtailvideo/jwplayer/FlashHealthCheck.as'
+                }
+            },
+            releaseLoader : {
+                files : {
+                    'bin-release/jwplayer.loader.swf': 'src/flash/com/longtailvideo/jwplayer/FlashHealthCheck.as'
                 }
             },
             library: {
@@ -326,7 +336,9 @@ module.exports = function(grunt) {
 
     grunt.registerTask('build-flash', [
         'flash:debug',
-        'flash:release'
+        'flash:release',
+        'flash:debugLoader',
+        'flash:releaseLoader'
     ]);
 
     grunt.registerTask('build', [

--- a/src/flash/com/longtailvideo/jwplayer/FlashHealthCheck.as
+++ b/src/flash/com/longtailvideo/jwplayer/FlashHealthCheck.as
@@ -1,0 +1,36 @@
+package com.longtailvideo.jwplayer {
+
+import flash.display.Sprite;
+import flash.events.Event;
+import flash.external.ExternalInterface;
+import flash.system.Security;
+
+[SWF(width="640", height="360", frameRate="30", backgroundColor="#000000")]
+
+public class FlashHealthCheck extends Sprite {
+
+    public function FlashHealthCheck() {
+        Security.allowDomain("*");
+        this.tabEnabled = false;
+        this.tabChildren = false;
+        this.focusRect = false;
+        this.buttonMode = false;
+        notifyJavaScriptOfEmbed();
+    }
+
+    private function notifyJavaScriptOfEmbed(event:Event = null):void {
+        if (ExternalInterface.available) {
+            ExternalInterface.call(<script><![CDATA[
+function(objectID) {
+    var swf = document.getElementById(objectID);
+    if (swf && typeof swf.embedCallback === 'function') {
+        swf.embedCallback();
+    }
+}]]></script>, ExternalInterface.objectID);
+        } else {
+            this.removeEventListener(Event.ENTER_FRAME, notifyJavaScriptOfEmbed);
+            this.addEventListener(Event.ENTER_FRAME, notifyJavaScriptOfEmbed);
+        }
+    }
+}
+}

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -76,12 +76,15 @@ define([
         __webpack_public_path__ = config.base;
         config.width  = _normalizeSize(config.width);
         config.height = _normalizeSize(config.height);
-        config.flashplayer = config.flashplayer || (utils.getScriptPath('jwplayer.js') || config.base) + 'jwplayer.flash.swf';
+        var pathToFlash = (utils.getScriptPath('jwplayer.js') || config.base);
+        config.flashplayer = config.flashplayer || pathToFlash + 'jwplayer.flash.swf';
+        config.flashloader = config.flashloader || pathToFlash + 'jwplayer.loader.swf';
 
         // Non ssl pages can only communicate with flash when it is loaded
         //   from a non ssl location
         if (window.location.protocol === 'http:') {
             config.flashplayer = config.flashplayer.replace('https', 'http');
+            config.flashloader = config.flashloader.replace('https', 'http');
         }
 
         config.aspectratio = _evaluateAspectRatio(config.aspectratio, config.width);

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -40,8 +40,6 @@ define([
                 buffer: 0
             });
 
-            this.updateProviders();
-
             return this;
         };
 

--- a/src/js/controller/setup-steps.js
+++ b/src/js/controller/setup-steps.js
@@ -2,11 +2,12 @@ define([
     'plugins/plugins',
     'playlist/loader',
     'utils/scriptloader',
+    'utils/embedswf',
     'utils/constants',
     'utils/underscore',
     'utils/helpers',
     'events/events'
-], function(plugins, PlaylistLoader, ScriptLoader, Constants, _, utils, events) {
+], function(plugins, PlaylistLoader, ScriptLoader, EmbedSwf, Constants, _, utils, events) {
 
     var _pluginLoader,
         _playlistLoader;
@@ -50,9 +51,13 @@ define([
                 method: _loadPlaylist,
                 depends: ['LOADED_POLYFILLS']
             },
+            CHECK_FLASH: {
+                method: _checkFlash,
+                depends : ['LOADED_POLYFILLS']
+            },
             FILTER_PLAYLIST: {
                 method: _filterPlaylist,
-                depends : ['LOAD_PLAYLIST']
+                depends : ['LOAD_PLAYLIST', 'CHECK_FLASH']
             },
             SETUP_VIEW : {
                 method: _setupView,
@@ -137,6 +142,50 @@ define([
         } else {
             resolve();
         }
+    }
+
+    function _checkFlash(resolve, _model, _api) {
+        var primaryFlash = _model.get('primary') === 'flash';
+        var flashVersion = utils.flashVersion();
+        if (primaryFlash && flashVersion) {
+            var flashHealthCheckId = '' + _model.get('id') + '-' + Math.random().toString(16).substr(2);
+            var originalContainer = _api.getContainer();
+            var parentElement = originalContainer.parentElement;
+            if (!parentElement) {
+                // Cannot perform test when player container has no parent
+                return _flashCheckComplete(resolve, _model);
+            }
+            var testContainer = document.createElement('div');
+            var flashHealthCheckSwf = _model.get('flashloader');
+            var width = _model.get('width');
+            var height = _model.get('height');
+            utils.style(testContainer, {
+                visibility: 'hidden',
+                position: 'relative',
+                width: width.toString().indexOf('%') > 0 ? width : (width+ 'px'),
+                height: height.toString().indexOf('%') > 0 ? height : (height + 'px')
+            });
+            var swf = EmbedSwf.embed(flashHealthCheckSwf, testContainer, flashHealthCheckId, null);
+            parentElement.replaceChild(testContainer, originalContainer);
+            var done = function() {
+                clearTimeout(embedTimeout);
+                parentElement.replaceChild(originalContainer, testContainer);
+                _flashCheckComplete(resolve, _model);
+            };
+            swf.embedCallback = done;
+            // If "flash.loader.swf" does not fire embedCallback in time, unset primary "flash" config option
+            var embedTimeout = setTimeout(function() {
+                _model.set('primary', undefined);
+                done();
+            }, 1500);
+        } else {
+            _flashCheckComplete(resolve, _model);
+        }
+    }
+
+    function _flashCheckComplete(resolve, _model) {
+        _model.updateProviders();
+        resolve();
     }
 
     function _filterPlaylist(resolve, _model, _api, _view, _setPlaylist) {

--- a/test/manual/flash.html
+++ b/test/manual/flash.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Flash Primary Test</title>
+    <script type="text/javascript" src="../../bin-debug/jwplayer.js"></script>
+    <link type="text/css" rel="stylesheet" href="styles/tests.css"  media="all" />
+</head>
+<body>
+
+<h2>Flash Primary Test</h2>
+<p>When primary "flash" is set in the config,
+    test if the Flash plugin is blocked on setup,
+    and if it is use html5.</p>
+
+<div id="container">[PLAYER CONTAINER]</div>
+<script type="text/javascript">
+    jwplayer("container").setup({
+        primary: 'flash',
+        playlist: [
+            {
+                sources: [
+                    { file: "http://content.bitsontherun.com/videos/q1fx20VZ-52qL9xLP.mp4" },
+                    { file: "http://content.bitsontherun.com/videos/q1fx20VZ-27m5HpIu.webm" }
+                ],
+                image: "http://content.bitsontherun.com/thumbs/q1fx20VZ-480.jpg"
+            },
+            {
+                sources: [
+                    { file: "http://content.bitsontherun.com/videos/bkaovAYt-52qL9xLP.mp4" },
+                    { file: "http://content.bitsontherun.com/videos/bkaovAYt-27m5HpIu.webm" }
+                ],
+                image: "http://content.bitsontherun.com/thumbs/bkaovAYt-480.jpg"
+            }
+        ]
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
When `primary: 'flash'` is set, and `utils.flashVersion()` is not 0, embed a swf during setup that calls back to confirm the Flash plugin is not blocked. If it doesn't callback in 1.5 seconds, set primary to `undefined` and continue setup.

The swf being embedded is a new swf called "flash.loader.swf" and is an instance of `FlashHealthCheck.as`. It is < 1k in size. It's not actually loading anything - I just couldn't think of a name that described it's role that didn't sound silly or suspicious.

When embedded it fills a temporary container that is styled to match the player's dimensions. This is so that any rules applied to the size of an object tag are applied (ex: a browser may block a 5x5 swf but not a 640x360 one).

JW7-3414