### PR TITLE
Use VTTCue to determine whether to use center/middle and double values instead of "auto"

### DIFF
--- a/src/js/parsers/captions/vttparser.js
+++ b/src/js/parsers/captions/vttparser.js
@@ -126,7 +126,7 @@ define(['parsers/captions/vttcue'], function(VTTCue) {
     }
     
     var defaults = new VTTCue(0,0,0);
-    var center = defaults.align == 'middle' ? 'middle' : 'center';
+    var center = defaults.align === 'middle' ? 'middle' : 'center';
 
     function parseCue(input, cue, regionList) {
         // Remember the original input if we need to throw an error.
@@ -192,14 +192,18 @@ define(['parsers/captions/vttcue'], function(VTTCue) {
             cue.region = settings.get('region', null);
             cue.vertical = settings.get('vertical', '');
             var line = settings.get('line', 'auto');
-            if (line == 'auto' && defaults.line == -1) line = -1;
+            if (line === 'auto' && defaults.line === -1) {
+                line = -1;
+            }
             cue.line = line;
             cue.lineAlign = settings.get('lineAlign', 'start');
             cue.snapToLines = settings.get('snapToLines', true);
             cue.size = settings.get('size', 100);
             cue.align = settings.get('align', center);
             var position = settings.get('position', 'auto');
-            if (position == 'auto' && defaults.position == 50) position = cue.align == 'start' || cue.align == 'left' ? 0 : cue.align == 'end' || cue.align == 'right' ? 100 : 50;
+            if (position == 'auto' && defaults.position == 50) {
+                position = cue.align === 'start' || cue.align === 'left' ? 0 : cue.align === 'end' || cue.align === 'right' ? 100 : 50;
+            }
             cue.position = position;
             cue.positionAlign = settings.get('positionAlign', 'auto');
         }

--- a/src/js/parsers/captions/vttparser.js
+++ b/src/js/parsers/captions/vttparser.js
@@ -199,7 +199,7 @@ define(['parsers/captions/vttcue'], function(VTTCue) {
             cue.size = settings.get('size', 100);
             cue.align = settings.get('align', center);
             var position = settings.get('position', 'auto');
-            if (position == 'auto' && defaults.position == 50) position = cue.align == 'left' ? 0 : cue.align == 'right' ? 100 : 50;
+            if (position == 'auto' && defaults.position == 50) position = cue.align == 'start' || cue.align == 'left' ? 0 : cue.align == 'end' || cue.align == 'right' ? 100 : 50;
             cue.position = position;
             cue.positionAlign = settings.get('positionAlign', 'auto');
         }

--- a/src/js/parsers/captions/vttparser.js
+++ b/src/js/parsers/captions/vttparser.js
@@ -201,7 +201,7 @@ define(['parsers/captions/vttcue'], function(VTTCue) {
             cue.size = settings.get('size', 100);
             cue.align = settings.get('align', center);
             var position = settings.get('position', 'auto');
-            if (position == 'auto' && defaults.position == 50) {
+            if (position === 'auto' && defaults.position === 50) {
                 position = cue.align === 'start' || cue.align === 'left' ? 0 : cue.align === 'end' || cue.align === 'right' ? 100 : 50;
             }
             cue.position = position;

--- a/src/js/parsers/captions/vttparser.js
+++ b/src/js/parsers/captions/vttparser.js
@@ -124,6 +124,9 @@ define(['parsers/captions/vttcue'], function(VTTCue) {
             callback(k, v);
         }
     }
+    
+    var defaults = new VTTCue(0,0,0);
+    var center = defaults.align == 'middle' ? 'middle' : 'center';
 
     function parseCue(input, cue, regionList) {
         // Remember the original input if we need to throw an error.
@@ -166,21 +169,21 @@ define(['parsers/captions/vttcue'], function(VTTCue) {
                         }
                         settings.alt(k, vals0, ['auto']);
                         if (vals.length === 2) {
-                            settings.alt('lineAlign', vals[1], ['start', 'middle', 'end']);
+                            settings.alt('lineAlign', vals[1], ['start', center, 'end']);
                         }
                         break;
                     case 'position':
                         vals = v.split(',');
                         settings.percent(k, vals[0]);
                         if (vals.length === 2) {
-                            settings.alt('positionAlign', vals[1], ['line-left', 'middle', 'line-right', 'auto']);
+                            settings.alt('positionAlign', vals[1], ['start', center, 'end', 'line-left', 'line-right', 'auto']);
                         }
                         break;
                     case 'size':
                         settings.percent(k, v);
                         break;
                     case 'align':
-                        settings.alt(k, v, ['start', 'middle', 'end', 'left', 'right']);
+                        settings.alt(k, v, ['start', center, 'end', 'left', 'right']);
                         break;
                 }
             }, /:/, /\s/);
@@ -188,12 +191,16 @@ define(['parsers/captions/vttcue'], function(VTTCue) {
             // Apply default values for any missing fields.
             cue.region = settings.get('region', null);
             cue.vertical = settings.get('vertical', '');
-            cue.line = settings.get('line', 'auto');
+            var line = settings.get('line', 'auto');
+            if (line == 'auto' && defaults.line == -1) line = -1;
+            cue.line = line;
             cue.lineAlign = settings.get('lineAlign', 'start');
             cue.snapToLines = settings.get('snapToLines', true);
             cue.size = settings.get('size', 100);
-            cue.align = settings.get('align', 'middle');
-            cue.position = settings.get('position', 'auto');
+            cue.align = settings.get('align', center);
+            var position = settings.get('position', 'auto');
+            if (position == 'auto' && defaults.position == 50) position = cue.align == 'left' ? 0 : cue.align == 'right' ? 100 : 50;
+            cue.position = position;
             cue.positionAlign = settings.get('positionAlign', 'auto');
         }
 


### PR DESCRIPTION
Different browsers disagree on the default values for align, line, and position.

Firefox: "center", "auto", "auto"
Chrome: "middle", "auto", "auto"
Safari: "middle", -1, 50

Safari does not support "auto" at all for line and position.

My fix creates an empty VTTCue, checks the default values, and changes the parser behavior to match.