### PR TITLE
Don’t hide swf or remove container for IE11

### DIFF
--- a/src/js/controller/setup-steps.js
+++ b/src/js/controller/setup-steps.js
@@ -161,7 +161,6 @@ define([
             var width = _model.get('width');
             var height = _model.get('height');
             utils.style(testContainer, {
-                visibility: 'hidden',
                 position: 'relative',
                 width: width.toString().indexOf('%') > 0 ? width : (width+ 'px'),
                 height: height.toString().indexOf('%') > 0 ? height : (height + 'px')
@@ -170,7 +169,7 @@ define([
             parentElement.replaceChild(testContainer, originalContainer);
             var done = function() {
                 clearTimeout(embedTimeout);
-                parentElement.replaceChild(originalContainer, testContainer);
+                swf.embedCallback = null;
                 resolve();
             };
             swf.embedCallback = done;


### PR DESCRIPTION
This fixes flash canplay detection on IE11 and keeps the test element in the DOM until it's replaced by the view which prevents a potential flicker when replacing an unstyled container.
JW7-3414