### PR TITLE
Workaround for Android 'inert-visual-viewport' behavior

### DIFF
--- a/src/js/view/components/slider.js
+++ b/src/js/view/components/slider.js
@@ -5,6 +5,18 @@ define([
     'utils/helpers'
 ], function(Extendable, UI, SliderTemplate, utils) {
 
+    var getRailBounds = function(elementRail) {
+        var bounds = utils.bounds(elementRail);
+        // Partial workaround of Android 'inert-visual-viewport'
+        // https://bugs.chromium.org/p/chromium/issues/detail?id=489206
+        var pageXOffset = window.pageXOffset;
+        if (pageXOffset && utils.isAndroid() && document.body.parentElement.getBoundingClientRect().left >= 0) {
+            bounds.left -= pageXOffset;
+            bounds.right -= pageXOffset;
+        }
+        return bounds;
+    };
+
     var Slider = Extendable.extend({
         constructor : function(className, orientation) {
             this.className = className + ' jw-background-color jw-reset';
@@ -41,7 +53,7 @@ define([
         },
         dragStart : function() {
             this.trigger('dragStart');
-            this.railBounds = utils.bounds(this.elementRail);
+            this.railBounds = getRailBounds(this.elementRail);
         },
         dragEnd : function(evt) {
             this.dragMove(evt);
@@ -49,7 +61,7 @@ define([
         },
         dragMove : function(evt) {
             var dimension,
-                bounds = this.railBounds = (this.railBounds) ? this.railBounds : utils.bounds(this.elementRail),
+                bounds = this.railBounds = (this.railBounds) ? this.railBounds : getRailBounds(this.elementRail),
                 percentage;
 
             if (this.orientation === 'horizontal'){
@@ -80,7 +92,7 @@ define([
             return false;
         },
         tap : function(evt){
-            this.railBounds = utils.bounds(this.elementRail);
+            this.railBounds = getRailBounds(this.elementRail);
             this.dragMove(evt);
         },
 


### PR DESCRIPTION
This is limited to horizontal sliders on Android where pageXOffset is not 0 - assuming this means the viewport is offset from zooming and not scrolling the page. It's not intended for all viewport settings where horizontal scrolling without zooming the viewport can occur. Most pages only scroll vertically at 100% (not zoomed), and only scroll horizontally when zoomed in so this should help compatibility with 'inert-visual-viewport' behavior.

JW7-1078