### PR TITLE
Don't set a default value for positionAlign

### DIFF
--- a/src/js/parsers/captions/vttparser.js
+++ b/src/js/parsers/captions/vttparser.js
@@ -126,6 +126,8 @@ define(['parsers/captions/vttcue'], function(VTTCue) {
     }
     
     var defaults = new VTTCue(0,0,0);
+    // 'middle' was changed to 'center' in the spec: https://github.com/w3c/webvtt/pull/244
+    // Chrome and Safari don't yet support this change, but FF does
     var center = defaults.align === 'middle' ? 'middle' : 'center';
 
     function parseCue(input, cue, regionList) {
@@ -193,6 +195,7 @@ define(['parsers/captions/vttcue'], function(VTTCue) {
             cue.vertical = settings.get('vertical', '');
             var line = settings.get('line', 'auto');
             if (line === 'auto' && defaults.line === -1) {
+                // set numeric line number for Safari
                 line = -1;
             }
             cue.line = line;
@@ -202,10 +205,10 @@ define(['parsers/captions/vttcue'], function(VTTCue) {
             cue.align = settings.get('align', center);
             var position = settings.get('position', 'auto');
             if (position === 'auto' && defaults.position === 50) {
+                // set numeric position for Safari
                 position = cue.align === 'start' || cue.align === 'left' ? 0 : cue.align === 'end' || cue.align === 'right' ? 100 : 50;
             }
             cue.position = position;
-            cue.positionAlign = settings.get('positionAlign', 'auto');
         }
 
         function skipWhitespace() {


### PR DESCRIPTION
### Changes proposed in this pull request:

Don't set a default value for positionAlign when parsing VTT files. FF is the only browser that supports this property in its VTTCue interface and defaults to `center`. This value is of no use in Chrome or Safari, where it's not supported. In IE/Edge, where we polyfill the VTTCue interface and fallback to TextTrackCue, this value breaks the parser.


Fixes #
JW7-3569
