### PR TITLE
Resume ad playback when the play display icon is tapped on mobile

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -491,7 +491,7 @@ define([
             if( (_model.get('state') === states.IDLE ||
                 _model.get('state') === states.COMPLETE ||
                 _model.get('state') === states.PAUSED ||
-                _model.get('state') === states.BUFFERING) &&
+                (_instreamModel && _instreamModel.get('state') === states.PAUSED)) &&
                 _model.get('controls')) {
                 _api.play({reason: 'interaction'});
             }

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -490,7 +490,8 @@ define([
         function _touchHandler() {
             if( (_model.get('state') === states.IDLE ||
                 _model.get('state') === states.COMPLETE ||
-                _model.get('state') === states.PAUSED) &&
+                _model.get('state') === states.PAUSED ||
+                _model.get('state') === states.BUFFERING) &&
                 _model.get('controls')) {
                 _api.play({reason: 'interaction'});
             }


### PR DESCRIPTION
### Changes proposed in this pull request:
Allow the user to resume playback by tapping the `play` display icon when an ad is paused.

Fixes #
JW7-3563