### PR TITLE
Allow toggling controls on mobile when player is paused

### DIFF
--- a/src/css/flags/controls-hidden.less
+++ b/src/css/flags/controls-hidden.less
@@ -1,0 +1,27 @@
+.jwplayer.jw-flag-controls-hidden {
+  .jw-controlbar,
+  .jw-dock {
+    display: none;
+  }
+
+  .jw-logo.jw-hide {
+    display: none;
+  }
+
+  .jw-plugin,
+  .jw-nextup-container {
+    bottom: 0.5em;
+  }
+
+  .jw-media {
+    cursor: none;
+    -webkit-cursor-visibility: auto-hide;
+  }
+
+  .jw-captions {
+    max-height: none;
+  }
+  video::-webkit-media-text-track-container {
+    max-height: none;
+  }
+}

--- a/src/css/flags/controls-hidden.less
+++ b/src/css/flags/controls-hidden.less
@@ -4,18 +4,9 @@
     display: none;
   }
 
-  .jw-logo.jw-hide {
-    display: none;
-  }
-
   .jw-plugin,
   .jw-nextup-container {
     bottom: 0.5em;
-  }
-
-  .jw-media {
-    cursor: none;
-    -webkit-cursor-visibility: auto-hide;
   }
 
   .jw-captions {
@@ -23,5 +14,15 @@
   }
   video::-webkit-media-text-track-container {
     max-height: none;
+  }
+}
+
+.jw-flag-controls-hidden {
+  .jw-controls {
+    visibility: hidden;
+  }
+
+  .jw-logo {
+    visibility: visible;
   }
 }

--- a/src/css/flags/touch.less
+++ b/src/css/flags/touch.less
@@ -44,4 +44,10 @@
             display: none;
         }
     }
+    &.jw-state-paused.jw-flag-controls-hidden {
+        .jw-controls {
+            display : none;
+        }
+    }
+
 }

--- a/src/css/flags/touch.less
+++ b/src/css/flags/touch.less
@@ -1,4 +1,5 @@
 @import "../imports/icons";
+@import "controls-disabled";
 
 .jw-flag-touch {
     &.jw-breakpoint-7,

--- a/src/css/flags/touch.less
+++ b/src/css/flags/touch.less
@@ -1,5 +1,4 @@
 @import "../imports/icons";
-@import "controls-disabled";
 
 .jw-flag-touch {
     &.jw-breakpoint-7,
@@ -45,9 +44,4 @@
             display: none;
         }
     }
-    
-    &.jw-state-paused.jw-flag-controls-hidden {
-        .jw-flag-controls-disabled;
-    }
-
 }

--- a/src/css/flags/touch.less
+++ b/src/css/flags/touch.less
@@ -44,10 +44,9 @@
             display: none;
         }
     }
+    
     &.jw-state-paused.jw-flag-controls-hidden {
-        .jw-controls {
-            display : none;
-        }
+        .jw-flag-controls-disabled;
     }
 
 }

--- a/src/css/flags/user-inactive.less
+++ b/src/css/flags/user-inactive.less
@@ -2,6 +2,11 @@
 
 .jwplayer.jw-flag-user-inactive.jw-state-playing {
     .jwplayer.jw-flag-controls-hidden;
+
+    .jw-media {
+        cursor: none;
+        -webkit-cursor-visibility: auto-hide;
+    }
 }
 .jwplayer.jw-flag-user-inactive.jw-state-buffering {
     .jw-controlbar {

--- a/src/css/flags/user-inactive.less
+++ b/src/css/flags/user-inactive.less
@@ -1,38 +1,13 @@
-.jwplayer.jw-flag-user-inactive {
-    &.jw-state-playing {
-        .jw-controlbar,
-        .jw-dock {
-            display: none;
-        }
+@import "controls-hidden";
 
-        .jw-logo.jw-hide {
-            display: none;
-        }
-
-        .jw-plugin,
-        .jw-nextup-container {
-            bottom: 0.5em;
-        }
-
-        .jw-media {
-            cursor: none;
-            -webkit-cursor-visibility: auto-hide;
-        }
-
-        .jw-captions {
-            max-height: none;
-        }
-        video::-webkit-media-text-track-container {
-            max-height: none;
-        }
+.jwplayer.jw-flag-user-inactive.jw-state-playing {
+    .jwplayer.jw-flag-controls-hidden;
+}
+.jwplayer.jw-flag-user-inactive.jw-state-buffering {
+    .jw-controlbar {
+        display: none;
     }
-
-    &.jw-state-buffering {
-        .jw-controlbar {
-            display: none;
-        }
-        .jw-nextup-container {
-            bottom: 0.5em;
-        }
+    .jw-nextup-container {
+        bottom: 0.5em;
     }
 }

--- a/src/css/jwplayer.less
+++ b/src/css/jwplayer.less
@@ -1,44 +1,45 @@
-@import "imports/reset.less";
+@import "imports/reset";
 
-@import "imports/jwplayerelement.less";
-@import "imports/video.less";
-@import "imports/display.less";
-@import "imports/controlbar.less";
-@import "imports/dock.less";
-@import "imports/title.less";
-@import "imports/slider.less";
+@import "imports/jwplayerelement";
+@import "imports/video";
+@import "imports/display";
+@import "imports/controlbar";
+@import "imports/dock";
+@import "imports/title";
+@import "imports/slider";
 
-@import "imports/captions.less";
-@import "imports/rightclick.less";
-@import "imports/logo.less";
-@import "imports/tooltip.less";
-@import "imports/skipad.less";
-@import "imports/cast.less";
-@import "imports/nextup.less";
-@import "imports/autostartmute.less";
+@import "imports/captions";
+@import "imports/rightclick";
+@import "imports/logo";
+@import "imports/tooltip";
+@import "imports/skipad";
+@import "imports/cast";
+@import "imports/nextup";
+@import "imports/autostartmute";
 
 // State specific
-@import "states/idle.less";
-@import "states/playing.less";
-@import "states/paused.less";
-@import "states/buffering.less";
-@import "states/complete.less";
-@import "states/error.less";
+@import "states/idle";
+@import "states/playing";
+@import "states/paused";
+@import "states/buffering";
+@import "states/complete";
+@import "states/error";
 
-@import "flags/cast-available.less";
-@import "flags/skinloading.less";
-@import "flags/fullscreen.less";
-@import "flags/live.less";
-@import "flags/user-inactive.less";
-@import "flags/media-audio.less";
-@import "flags/ads.less";
-@import "flags/overlay.less";
+@import "flags/cast-available";
+@import "flags/skinloading";
+@import "flags/fullscreen";
+@import "flags/live";
+@import "flags/controls-hidden";
+@import "flags/user-inactive";
+@import "flags/media-audio";
+@import "flags/ads";
+@import "flags/overlay";
 @import "flags/rightclick-open";
 @import "flags/controls-disabled";
 @import "flags/flash-blocked";
 @import "flags/touch";
-@import "flags/audioplayer.less";
-@import "flags/breakpoints.less";
+@import "flags/audioplayer";
+@import "flags/breakpoints";
 
 // Skins
 @import "skins/seven";

--- a/src/css/skins-test.less
+++ b/src/css/skins-test.less
@@ -1,30 +1,30 @@
-@import "imports/vars.less";
+@import "imports/vars";
 
-@import "imports/reset.less";
-@import "imports/icons.less";
+@import "imports/reset";
+@import "imports/icons";
 
 // UI Components
-@import "imports/jwplayerelement.less";
-@import "imports/display.less";
-@import "imports/controlbar.less";
-@import "imports/dock.less";
-@import "imports/tooltip.less";
-@import "imports/title.less";
-@import "imports/slider.less";
-@import "imports/captions.less";
-@import "imports/rightclick.less";
-@import "imports/logo.less";
+@import "imports/jwplayerelement";
+@import "imports/display";
+@import "imports/controlbar";
+@import "imports/dock";
+@import "imports/tooltip";
+@import "imports/title";
+@import "imports/slider";
+@import "imports/captions";
+@import "imports/rightclick";
+@import "imports/logo";
 
 // States
-@import "states/idle.less";
-@import "states/playing.less";
-@import "states/paused.less";
-@import "states/buffering.less";
-@import "states/complete.less";
-@import "states/error.less";
+@import "states/idle";
+@import "states/playing";
+@import "states/paused";
+@import "states/buffering";
+@import "states/complete";
+@import "states/error";
 
 // Flags
-@import "flags/audioplayer.less";
-@import "flags/fullscreen.less";
-@import "flags/live.less";
-@import "flags/ads.less";
+@import "flags/audioplayer";
+@import "flags/fullscreen";
+@import "flags/live";
+@import "flags/ads";

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -1023,6 +1023,7 @@ define([
             }
             if (state !== states.PAUSED && _controlsHidden) {
                 utils.removeClass(_playerElement, 'jw-flag-controls-hidden');
+                _controlsHidden = false;
             }
         }
 

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -935,15 +935,9 @@ define([
         }
 
         function _toggleControls() {
-            if (_controlsHidden){
-                utils.removeClass(_playerElement, 'jw-flag-controls-hidden');
-                _captionsRenderer.renderCues(true);
-                _controlsHidden = false;
-            } else {
-                utils.addClass(_playerElement, 'jw-flag-controls-hidden');
-                _captionsRenderer.renderCues(true);
-                _controlsHidden = true;
-            }
+            _controlsHidden = !_controlsHidden;
+            utils.toggleClass(_playerElement, 'jw-flag-controls-hidden', _controlsHidden);
+            _captionsRenderer.renderCues(true);
         }
 
         function _playlistCompleteHandler() {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -54,7 +54,6 @@ define([
             _captionsRenderer,
             _audioMode,
             _showing = false,
-            _controlsHidden = false,
             _rightClickMenu,
             _resizeMediaTimeout = -1,
             _resizeContainerRequestId = -1,
@@ -489,15 +488,17 @@ define([
         }
 
         function _touchHandler(displayIcon) {
-            if ((_model.get('state') === states.IDLE ||
-                _model.get('state') === states.COMPLETE ||
-                (displayIcon && _model.get('state') === states.PAUSED) ||
+            var state = _model.get('state');
+
+            if ((state === states.IDLE ||
+                state === states.COMPLETE ||
+                (displayIcon && state === states.PAUSED) ||
                 (_instreamModel && _instreamModel.get('state') === states.PAUSED)) &&
                 _model.get('controls')) {
                 _api.play({reason: 'interaction'});
             }
 
-            if (_model.get('state') === states.PAUSED && !displayIcon) {
+            if (state === states.PAUSED && !displayIcon) {
                 // Toggle visibility of the controls when tapping the media
                 _toggleControls();
             } else {
@@ -935,8 +936,7 @@ define([
         }
 
         function _toggleControls() {
-            _controlsHidden = !_controlsHidden;
-            utils.toggleClass(_playerElement, 'jw-flag-controls-hidden', _controlsHidden);
+            utils.toggleClass(_playerElement, 'jw-flag-controls-hidden');
             _captionsRenderer.renderCues(true);
         }
 
@@ -1015,9 +1015,8 @@ define([
                     _stateUpdate(model, state);
                 }, 33);
             }
-            if (state !== states.PAUSED && _controlsHidden) {
+            if (state !== states.PAUSED && utils.hasClass(_playerElement, 'jw-flag-controls-hidden')) {
                 utils.removeClass(_playerElement, 'jw-flag-controls-hidden');
-                _controlsHidden = false;
             }
         }
 


### PR DESCRIPTION
### Changes proposed in this pull request:

On a mobile device when the player is paused, tapping on the view toggles the controls instead of resuming playback. Playback resumes when the user taps the display icon or the play button in the control bar.

Fixes #
JW7-3248