### PR TITLE
use host for equality test

### DIFF
--- a/src/js/providers/flash.js
+++ b/src/js/providers/flash.js
@@ -17,7 +17,7 @@ define([
         var a = document.createElement('a');
         a.href = config.flashplayer;
 
-        var sameHost = (a.hostname === window.location.host);
+        var sameHost = (a.host === window.location.host);
 
         return utils.isChrome() && !sameHost;
     }


### PR DESCRIPTION
cases where a port is part of the hostname will fail the condition.

this changes the comparison to both be host based