### PR TITLE
Add missing “interaction” play reason metadata

### DIFF
--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -182,11 +182,11 @@ define([
         };
 
         this.play = function (state, meta) {
-            if (!_.isBoolean(state)) {
+            if (_.isObject(state) && state.reason) {
                 meta = state;
             }
             if (!meta) {
-                meta = {reason: 'external'};
+                meta = { reason: 'external' };
             }
             if (state === true) {
                 _controller.play(meta);
@@ -209,12 +209,12 @@ define([
             return _this;
         };
 
-        this.pause = function (state) {
+        this.pause = function (state, meta) {
             if (_.isBoolean(state)) {
-                return this.play(!state);
+                return this.play(!state, meta);
             }
 
-            return this.play();
+            return this.play(meta);
         };
 
         this.createInstream = function () {

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -160,7 +160,7 @@ define([
                 if (state) {
                     _pause();
                 } else {
-                    _play();
+                    _play({ reason: 'interaction' });
                 }
             });
 
@@ -227,7 +227,7 @@ define([
                         // Only play if the video is in the viewport
                         _observeVideo(_video().video);
                     } else {
-                        _this.play({reason: 'autostart'});
+                        _autoStart();
                     }
                 }
             }
@@ -307,7 +307,7 @@ define([
                 _stop(true);
 
                 if (_canAutoStart()) {
-                    _model.once('itemReady', _play);
+                    _model.once('itemReady', _autoStart);
                 }
                 _this.trigger('destroyPlugin', {});
 
@@ -407,9 +407,13 @@ define([
                 return true;
             }
 
+            function _autoStart() {
+                _play({ reason: 'autostart' });
+            }
+
             function _stop(internal) {
                 // Reset the autostart play
-                _model.off('itemReady', _play);
+                _model.off('itemReady', _autoStart);
 
                 var fromApi = !internal;
 
@@ -478,12 +482,12 @@ define([
                 return (state === states.IDLE || state === states.COMPLETE || state === states.ERROR);
             }
 
-            function _seek(pos) {
+            function _seek(pos, meta) {
                 if (_model.get('state') === states.ERROR) {
                     return;
                 }
                 if (!_model.get('scrubbing') && _model.get('state') !== states.PLAYING) {
-                    _play(true);
+                    _play(meta);
                 }
                 _video().seek(pos);
             }

--- a/src/js/view/components/timeslider.js
+++ b/src/js/view/components/timeslider.js
@@ -35,6 +35,10 @@ define([
         }
     });
 
+    function reasonInteraction() {
+        return {reason: 'interaction'};
+    }
+
     var TimeSlider = Slider.extend({
         constructor : function(_model, _api) {
             this._model = _model;
@@ -151,13 +155,13 @@ define([
             var streamType = this._model.get('streamType');
             var position;
             if (duration === 0) {
-                this._api.play();
+                this._api.play(reasonInteraction());
             } else if (streamType === 'DVR') {
                 position = (100 - percent) / 100 * duration;
-                this._api.seek(position);
+                this._api.seek(position, reasonInteraction());
             } else {
                 position = percent / 100 * duration;
-                this._api.seek(Math.min(position, duration - 0.25));
+                this._api.seek(Math.min(position, duration - 0.25), reasonInteraction());
             }
         },
         showTimeTooltip: function(evt) {

--- a/src/js/view/controlbar.js
+++ b/src/js/view/controlbar.js
@@ -26,6 +26,10 @@ define([
         return createdMenu;
     }
 
+    function reasonInteraction() {
+        return {reason: 'interaction'};
+    }
+
     function buildGroup(group, elements) {
         var elem = document.createElement('div');
         elem.className = 'jw-group jw-controlbar-' + group+'-group jw-reset';
@@ -78,7 +82,7 @@ define([
 
             this.elements = {
                 alt: text('jw-text-alt', 'status'),
-                play: button('jw-icon-playback', this._api.play.bind(this, {reason: 'interaction'}), play),
+                play: button('jw-icon-playback', this._api.play.bind(this, reasonInteraction()), play),
                 rewind: button('jw-icon-rewind', this.rewind.bind(this), rewind),
                 next: button('jw-icon-next', null, next), // the click/tap event listener is in the nextup tooltip
                 elapsed: text('jw-text-elapsed', 'timer'),
@@ -214,7 +218,7 @@ define([
                 if (this._model.get('streamType') === 'DVR') {
                     // Seek to "Live" position within live buffer, but not before current position
                     var currentPosition = this._model.get('position');
-                    this._api.seek(Math.max(Constants.dvrSeekLimit, currentPosition));
+                    this._api.seek(Math.max(Constants.dvrSeekLimit, currentPosition), reasonInteraction());
                 }
             }, this);
 
@@ -341,7 +345,7 @@ define([
                 startPosition = duration;
             }
             // Seek 10s back. Seek value should be >= 0 in VOD mode and >= (negative) duration in DVR mode
-            this._api.seek(Math.max(rewindPosition, startPosition));
+            this._api.seek(Math.max(rewindPosition, startPosition), reasonInteraction());
         },
         onStreamTypeChange : function(model) {
             // Hide rewind button when in LIVE mode

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -114,6 +114,10 @@ define([
             document.msExitFullscreen;
         _elementSupportsFullscreen = _requestFullscreen && _exitFullscreen;
 
+        function reasonInteraction() {
+            return {reason: 'interaction'};
+        }
+
         function adjustSeek(amount) {
             var min = 0;
             var max = _model.get('duration');
@@ -123,7 +127,7 @@ define([
                 max = Math.max(position, Constants.dvrSeekLimit);
             }
             var newSeek = utils.between(position + amount, min, max);
-            _api.seek(newSeek);
+            _api.seek(newSeek, reasonInteraction());
         }
 
         function adjustVolume(amount) {
@@ -161,7 +165,7 @@ define([
                     break;
                 case 13: // enter
                 case 32: // space
-                    _api.play({reason: 'interaction'});
+                    _api.play(reasonInteraction());
                     break;
                 case 37: // left-arrow, if not adMode
                     if (!_instreamModel) {
@@ -198,7 +202,7 @@ define([
                         // if 0-9 number key, move to n/10 of the percentage of the video
                         var number = evt.keyCode - 48;
                         var newSeek = (number / 10) * _model.get('duration');
-                        _api.seek(newSeek);
+                        _api.seek(newSeek, reasonInteraction());
                     }
                     break;
             }
@@ -493,7 +497,7 @@ define([
                 _model.get('state') === states.PAUSED ||
                 (_instreamModel && _instreamModel.get('state') === states.PAUSED)) &&
                 _model.get('controls')) {
-                _api.play({reason: 'interaction'});
+                _api.play(reasonInteraction());
             }
 
             // Toggle visibility of the controls when clicking the media or play icon
@@ -508,10 +512,10 @@ define([
             if (!evt.link) {
                 //_togglePlay();
                 if (_model.get('controls')) {
-                    _api.play({reason: 'interaction'});
+                    _api.play(reasonInteraction());
                 }
             } else {
-                _api.pause(true);
+                _api.pause(true, reasonInteraction());
                 _api.setFullscreen(false);
                 window.open(evt.link, evt.linktarget);
             }
@@ -568,7 +572,7 @@ define([
             _displayClickHandler.on('click', function() {
                 forward({type : events.JWPLAYER_DISPLAY_CLICK});
                 if(_model.get('controls')) {
-                    _api.play({reason: 'interaction'});
+                    _api.play(reasonInteraction());
                 }
             });
             _displayClickHandler.on('tap', function() {
@@ -583,7 +587,7 @@ define([
             //toggle playback
             displayIcon.on('click', function() {
                 forward({type : events.JWPLAYER_DISPLAY_CLICK});
-                _api.play({reason: 'interaction'});
+                _api.play(reasonInteraction());
             });
             displayIcon.on('tap', function() {
                 forward({type : events.JWPLAYER_DISPLAY_CLICK});


### PR DESCRIPTION
I found many calls in the view that would result in a play with no play reason data. This is not the reason for all unknown plays, but should improve reporting on "interaction" plays.

JW7-3344