### PR TITLE
Fix dock and display icons colliding on smaller part of breakpoint 1

### DIFF
--- a/src/css/imports/breakpoints.less
+++ b/src/css/imports/breakpoints.less
@@ -176,6 +176,19 @@ display
     display: none;
   }
 
+  &:not(.jw-state-idle) {
+
+    .jw-display {
+      padding-top: 0;
+    }
+
+    .jw-display-container {
+      margin-bottom: 5px;
+      vertical-align: bottom;
+    }
+
+  }
+
 }
 
 .jw-breakpoint-0,
@@ -191,14 +204,6 @@ display
 
     .jw-display {
       display: table;
-    }
-
-  }
-
-  &:not(.jw-state-idle) {
-
-    .jw-display {
-      padding-top: 14px; // knob height - rail height (replace with vars)
     }
 
   }
@@ -307,7 +312,7 @@ ads flag
 captions
 
 */
-// 
+//
 // .jw-breakpoint-2,
 // .jw-breakpoint-3 {
 //

--- a/src/css/imports/display.less
+++ b/src/css/imports/display.less
@@ -54,7 +54,7 @@ display icons
 
   display: table;
   height: 100%;
-  padding-bottom: 66px;
+  padding: @mobile-touch-target 0 66px;
   position: relative;
   width: 100%;
 
@@ -63,7 +63,7 @@ display icons
   }
 
   .jw-state-idle & {
-    padding-bottom: 0;
+    padding: 0;
   }
 
 }
@@ -91,7 +91,7 @@ display icons
     &::before {
       font-size: @mobile-touch-target * 0.5;
       position: relative;
-      top: 1px;
+      // top: 1px;
     }
 
     &.jw-icon-rewind::before {

--- a/src/css/imports/display.less
+++ b/src/css/imports/display.less
@@ -91,7 +91,6 @@ display icons
     &::before {
       font-size: @mobile-touch-target * 0.5;
       position: relative;
-      // top: 1px;
     }
 
     &.jw-icon-rewind::before {


### PR DESCRIPTION
Acceptable that the only remaining scenario is when there are more than 2 dock icons and the player size is below ~270px. We can't really get around this without a design change that should be saved for JW8.

Fixes #
JW7-3636

