### PR TITLE
Do not pause oldProvider on init when shared video

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -73,7 +73,7 @@ define([
 
         this.type = 'instream';
 
-        this.init = function() {
+        this.init = function(sharedVideoTag) {
 
             // Keep track of the original player state
             _oldProvider = _model.getVideo();
@@ -102,7 +102,7 @@ define([
 
             // If the player's currently playing, pause the video tag
             var currState = _model.get('state');
-            if (currState === states.PLAYING || currState === states.BUFFERING) {
+            if (!sharedVideoTag && (currState === states.PLAYING || currState === states.BUFFERING)) {
                 _oldProvider.pause();
             }
 


### PR DESCRIPTION
On iOS, same video tag is used for ads in googima.
Do not pause the oldProvider because this will pause googima ad on start.
JW7-3641