### PR TITLE
Revert iOS googima preroll pause fix

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -73,7 +73,7 @@ define([
 
         this.type = 'instream';
 
-        this.init = function(sharedVideoTag) {
+        this.init = function() {
 
             // Keep track of the original player state
             _oldProvider = _model.getVideo();
@@ -102,7 +102,7 @@ define([
 
             // If the player's currently playing, pause the video tag
             var currState = _model.get('state');
-            if (!sharedVideoTag && (currState === states.PLAYING || currState === states.BUFFERING)) {
+            if (currState === states.PLAYING || currState === states.BUFFERING) {
                 _oldProvider.pause();
             }
 


### PR DESCRIPTION
Revert the following fix: https://github.com/jwplayer/jwplayer/commit/786dce1831810f24557831855eea04bfd86ca881
A proper fix has been made in googima project.