### PR TITLE
Update getMute() and setVolume() to return correct mute state on mobile devices

### DIFF
--- a/src/js/api/api-mutators.js
+++ b/src/js/api/api-mutators.js
@@ -12,7 +12,6 @@ define([
             'duration',
             'fullscreen',
             'volume',
-            'mute',
             'item', // this was playlistindex
             'stretching',
             'playlist',

--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -176,6 +176,11 @@ define([
             return 'html5';
         };
 
+        this.getMute = function () {
+            var model = _controller._model;
+            return model.get('autostartMuted') || model.get('mute');
+        };
+
         this.load = function (toLoad) {
             _controller.load(toLoad);
             return _this;

--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -177,8 +177,7 @@ define([
         };
 
         this.getMute = function () {
-            var model = _controller._model;
-            return model.get('autostartMuted') || model.get('mute');
+            return _controller._model.getMute();
         };
 
         this.load = function (toLoad) {

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -325,7 +325,7 @@ define([
                 _provider.volume(volume);
             }
             var mute = (volume === 0);
-            if (mute !== this.get('mute')) {
+            if (mute !== (this.get('autostartMuted') || this.get('mute'))) {
                 this.setMute(mute);
             }
         };

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -325,14 +325,18 @@ define([
                 _provider.volume(volume);
             }
             var mute = (volume === 0);
-            if (mute !== (this.get('autostartMuted') || this.get('mute'))) {
+            if (mute !== (this.getMute())) {
                 this.setMute(mute);
             }
         };
 
+        this.getMute = function() {
+            return this.get('autostartMuted') || this.get('mute');
+        };
+
         this.setMute = function(mute) {
             if (!utils.exists(mute)) {
-                mute = !(this.get('autostartMuted') || this.get('mute'));
+                mute = !(this.getMute());
             }
             this.set('mute', mute);
             if (_provider) {

--- a/test/config.js
+++ b/test/config.js
@@ -20,9 +20,6 @@
     if (!('Promise' in window)) {
         deps.push('polyfills/promise');
     }
-    if (!('IntersectionObserver' in window)) {
-        deps.push('polyfills/intersection-observer');
-    }
     if (!('console' in window) || !('log' in window.console)) {
         window.console = {
             log: function() {

--- a/test/config.js
+++ b/test/config.js
@@ -20,6 +20,9 @@
     if (!('Promise' in window)) {
         deps.push('polyfills/promise');
     }
+    if (!('IntersectionObserver' in window)) {
+        deps.push('polyfills/intersection-observer');
+    }
     if (!('console' in window) || !('log' in window.console)) {
         window.console = {
             log: function() {

--- a/test/tests.js
+++ b/test/tests.js
@@ -32,5 +32,6 @@ define([
     'unit/validator-test',
     'unit/playlist-loader-test',
     'unit/captionsrenderer-test',
-    'unit/tracks-helper-test'
+    'unit/tracks-helper-test',
+    'unit/autostart-mute-test'
 ]);

--- a/test/unit/autostart-mute-test.js
+++ b/test/unit/autostart-mute-test.js
@@ -1,0 +1,70 @@
+define([
+    'test/underscore',
+    'utils/helpers',
+    'api/api'
+], function (_, utils, Api) {
+    var test = QUnit.test.bind(QUnit);
+
+    var tru = function () { return true; };
+    var fals = function () { return false; };
+
+    var config = {
+        file: 'http://playertest.longtailvideo.com/mp4.mp4'
+    };
+
+    function createConfig(mute) {
+        return _.extend(config, {autostart: true, mute: mute});
+    }
+
+    function assertMuteState (assert, mobile, mute, result) {
+        var done = assert.async();
+        assert.expect(2);
+
+        utils.isIOS = function (version) {
+            return mobile && (!version || version > 9);
+        };
+        utils.isSafari = tru;
+        utils.isAndroid = fals;
+        utils.isMobile = mobile ? tru : fals;
+
+        var api = createApi('player');
+        var c = createConfig(mute);
+
+        api.setup(c)
+            .on('ready', function() {
+                var muted = api.getMute();
+                assert.equal(muted, result, 'api.getMute() = ' + muted);
+                api.setVolume(20);
+                muted = api.getMute();
+                assert.equal(muted, false,  'after setting volume to 20, api.getMute() = ' + muted);
+                done();
+            });
+    }
+
+    QUnit.module('api.getMute');
+
+    test('api.getMute() on mobile when autostart: true & mute: false', function (assert) {
+        assertMuteState(assert, true, false, true);
+    });
+    test('api.getMute() on mobile when autostart: true & mute: true', function (assert) {
+        assertMuteState(assert, true, true, true);
+    });
+
+    test('api.getMute() on desktop when autostart: true & mute: false', function (assert) {
+        assertMuteState(assert, false, false, false);
+    });
+    test('api.getMute() on desktop when autostart: true & mute: true', function (assert) {
+        assertMuteState(assert, false, true, true);
+    });
+
+    function createApi(id, globalRemoveCallback) {
+        var container = createContainer(id);
+        return new Api(container, globalRemoveCallback || _.noop);
+    }
+
+    function createContainer(id) {
+        var container = $('<div id="' + id + '"></div>')[0];
+        $('#qunit-fixture').append(container);
+        return container;
+    }
+});

--- a/test/unit/autostart-mute-test.js
+++ b/test/unit/autostart-mute-test.js
@@ -16,6 +16,8 @@ define([
         return _.extend(config, {autostart: true, mute: mute});
     }
 
+    // Test autostart mute behavior in Safari Desktop and iOS
+
     function assertMuteState (assert, mobile, mute, result) {
         var done = assert.async();
         assert.expect(2);


### PR DESCRIPTION
### Changes proposed in this pull request:

- `getMute()` should return `true` when the player is muted for autoplay on mobile.
- `setVolume()` should unmute the player.

Addresses https://github.com/jwplayer/jwplayer/issues/1597.
Fixes #
JW7-3682