### PR TITLE
Fix display icon visibility for all breakpoints and states

### DIFF
--- a/src/css/flags/touch.less
+++ b/src/css/flags/touch.less
@@ -32,6 +32,16 @@
         pointer-events: none;
     }
 
+    &.jw-state-paused,
+    &.jw-state-playing {
+        &:not(.jw-breakpoint-1) {
+            .jw-display-icon-next,
+            .jw-display-icon-rewind {
+                display: none;
+            }
+        }
+    }
+
     &.jw-state-paused.jw-flag-dragging {
         .jw-display {
             display: none;

--- a/src/css/flags/touch.less
+++ b/src/css/flags/touch.less
@@ -32,12 +32,6 @@
         pointer-events: none;
     }
 
-    // This has higher specificity to overwrite jw-state-paused jw-display-container that hides the display
-    &.jw-state-paused .jw-display,
-    &.jw-state-playing .jw-display {
-        display: table;
-    }
-
     &.jw-state-paused.jw-flag-dragging {
         .jw-display {
             display: none;

--- a/src/css/imports/breakpoints.less
+++ b/src/css/imports/breakpoints.less
@@ -45,7 +45,8 @@ control bar items
 */
 
 .jw-breakpoint-0,
-.jw-breakpoint-1 {
+.jw-breakpoint-1,
+.jw-breakpoint-2 {
 
   .jw-group {
 
@@ -192,7 +193,8 @@ display
 }
 
 .jw-breakpoint-0,
-.jw-breakpoint-1 {
+.jw-breakpoint-1,
+.jw-breakpoint-2 {
 
   .jw-display {
     display: table;

--- a/src/css/imports/breakpoints.less
+++ b/src/css/imports/breakpoints.less
@@ -45,8 +45,7 @@ control bar items
 */
 
 .jw-breakpoint-0,
-.jw-breakpoint-1,
-.jw-breakpoint-2 {
+.jw-breakpoint-1 {
 
   .jw-group {
 
@@ -193,22 +192,7 @@ display
 }
 
 .jw-breakpoint-0,
-.jw-breakpoint-1,
-.jw-breakpoint-2 {
-
-  .jw-display {
-    display: table;
-  }
-
-  &.jw-state-playing,
-  &.jw-state-paused,
-  &.jw-state-buffering {
-
-    .jw-display {
-      display: table;
-    }
-
-  }
+.jw-breakpoint-1 {
 
 }
 

--- a/src/css/states/complete.less
+++ b/src/css/states/complete.less
@@ -10,6 +10,8 @@
             .jw-icon-replay;
         }
 
+        .jw-display-icon-next,
+        .jw-display-icon-rewind,
         .jw-text {
             display: none;
         }

--- a/src/css/states/error.less
+++ b/src/css/states/error.less
@@ -36,6 +36,11 @@ body .jw-error, .jwplayer.jw-state-error {
             color: #fff;
         }
     }
+
+    .jw-display-icon-next,
+    .jw-display-icon-rewind {
+        display: none;
+    }
 }
 
 body .jw-error {

--- a/src/css/states/paused.less
+++ b/src/css/states/paused.less
@@ -2,15 +2,13 @@
 
 .jwplayer.jw-state-paused {
 
-  .jw-display {
-    display: none;
-
-    .jw-icon-display {
-      .jw-icon-play;
+  &:not(.jw-flag-touch):not(.jw-breakpoint-0):not(.jw-breakpoint-1) {
+    .jw-display {
+      display: none;
     }
-
   }
 
+  .jw-display .jw-icon-display,
   .jw-icon-playback {
     .jw-icon-play;
   }

--- a/src/css/states/playing.less
+++ b/src/css/states/playing.less
@@ -2,15 +2,13 @@
 
 .jwplayer.jw-state-playing {
 
-  .jw-display {
-    display: none;
-
-    .jw-icon-display {
-      .jw-icon-pause;
+  &:not(.jw-flag-touch):not(.jw-breakpoint-0):not(.jw-breakpoint-1) {
+    .jw-display {
+      display: none;
     }
-
   }
 
+  .jw-display .jw-icon-display,
   .jw-icon-playback {
     .jw-icon-pause;
   }


### PR DESCRIPTION
### Changes proposed in this pull request:

- Show play/pause at all breakpoints on touch devices
- Show all display icons at breakpoint 1
- Don’t show rewind/next icons in complete or error state

Fixes #
JW7-3671, JW7-3676, JW7-3687
