### PR TITLE
Display replay icon in control-bar in complete state

### DIFF
--- a/src/css/states/complete.less
+++ b/src/css/states/complete.less
@@ -18,7 +18,11 @@
     }
 
     .jw-icon-playback {
-        .jw-icon-play;
+        .jw-icon-replay;
+
+        &:before {
+            font-size: 1.55em;
+        }
     }
 
     .jw-captions {


### PR DESCRIPTION
### Changes proposed in this pull request:

*- In complete state, display the replay icon in the control-bar, not the play icon*
