### PR TITLE
Fix Time to First Frame with Inactive Tabs

### DIFF
--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -137,7 +137,7 @@ define([
             var qoeItem = _controller.getItemQoe();
 
             var setupTime = _qoe.between('setup', 'ready');
-            var firstFrame = qoeItem.between(events.JWPLAYER_MEDIA_PLAY_ATTEMPT, events.JWPLAYER_MEDIA_FIRST_FRAME);
+            var firstFrame = qoeItem.getFirstFrame();
 
             return {
                 setupTime : setupTime,

--- a/src/js/controller/qoe.js
+++ b/src/js/controller/qoe.js
@@ -1,8 +1,19 @@
 define([
     'utils/timer',
-    'events/events',
     'utils/underscore'
-], function(Timer, events, _) {
+], function(Timer, _) {
+
+    // Copied from events.js until we can export individual constants with ES6
+    var JWPLAYER_PLAYLIST_ITEM = 'playlistItem';
+    var JWPLAYER_MEDIA_PLAY_ATTEMPT = 'playAttempt';
+    var JWPLAYER_PROVIDER_FIRST_FRAME = 'providerFirstFrame';
+    var JWPLAYER_MEDIA_FIRST_FRAME = 'firstFrame';
+    var JWPLAYER_MEDIA_TIME = 'time';
+
+    var TAB_HIDDEN = 'tabHidden';
+    var TAB_VISIBLE = 'tabVisible';
+
+    var VISIBILITY_CHANGE = 'visibilitychange';
 
     // This is to provide a first frame event even when
     //  a provider does not give us one.
@@ -20,9 +31,10 @@ define([
     });
 
     function unbindFirstFrameEvents(model) {
-        model.mediaController.off(events.JWPLAYER_MEDIA_PLAY_ATTEMPT, model._onPlayAttempt);
-        model.mediaController.off(events.JWPLAYER_PROVIDER_FIRST_FRAME, model._triggerFirstFrame);
-        model.mediaController.off(events.JWPLAYER_MEDIA_TIME, model._onTime);
+        model.mediaController.off(JWPLAYER_MEDIA_PLAY_ATTEMPT, model._onPlayAttempt);
+        model.mediaController.off(JWPLAYER_PROVIDER_FIRST_FRAME, model._triggerFirstFrame);
+        model.mediaController.off(JWPLAYER_MEDIA_TIME, model._onTime);
+        document.removeEventListener(VISIBILITY_CHANGE, model._onTabVisible);
     }
 
     function trackFirstFrame(model) {
@@ -31,22 +43,33 @@ define([
         // When it occurs, send the event, and unbind all listeners
         model._triggerFirstFrame = _.once(function() {
             var qoeItem = model._qoeItem;
-            qoeItem.tick(events.JWPLAYER_MEDIA_FIRST_FRAME);
+            qoeItem.tick(JWPLAYER_MEDIA_FIRST_FRAME);
 
-            var time = qoeItem.between(events.JWPLAYER_MEDIA_PLAY_ATTEMPT, events.JWPLAYER_MEDIA_FIRST_FRAME);
-            model.mediaController.trigger(events.JWPLAYER_MEDIA_FIRST_FRAME, {loadTime : time});
+            var time = qoeItem.getFirstFrame();
+            model.mediaController.trigger(JWPLAYER_MEDIA_FIRST_FRAME, {loadTime : time});
             unbindFirstFrameEvents(model);
         });
 
         model._onTime = onTimeIncreasesGenerator(model._triggerFirstFrame);
 
         model._onPlayAttempt = function() {
-            model._qoeItem.tick(events.JWPLAYER_MEDIA_PLAY_ATTEMPT);
+            model._qoeItem.tick(JWPLAYER_MEDIA_PLAY_ATTEMPT);
         };
 
-        model.mediaController.on(events.JWPLAYER_MEDIA_PLAY_ATTEMPT, model._onPlayAttempt);
-        model.mediaController.once(events.JWPLAYER_PROVIDER_FIRST_FRAME, model._triggerFirstFrame);
-        model.mediaController.on(events.JWPLAYER_MEDIA_TIME, model._onTime);
+        // track visibility change
+        model._onTabVisible = function(e) {
+            var hidden = e.target.hidden;
+            if (hidden === true) {
+                model._qoeItem.tick(TAB_HIDDEN);
+            } else if (hidden === false) {
+                model._qoeItem.tick(TAB_VISIBLE);
+            }
+        };
+        document.addEventListener(VISIBILITY_CHANGE, model._onTabVisible, false);
+
+        model.mediaController.on(JWPLAYER_MEDIA_PLAY_ATTEMPT, model._onPlayAttempt);
+        model.mediaController.once(JWPLAYER_PROVIDER_FIRST_FRAME, model._triggerFirstFrame);
+        model.mediaController.on(JWPLAYER_MEDIA_TIME, model._onTime);
     }
 
     function initModel(model) {
@@ -58,7 +81,17 @@ define([
             }
             // reset item level qoe
             model._qoeItem = new Timer();
-            model._qoeItem.tick(events.JWPLAYER_PLAYLIST_ITEM);
+            model._qoeItem.getFirstFrame = function() {
+                var time = this.between(JWPLAYER_MEDIA_PLAY_ATTEMPT, JWPLAYER_MEDIA_FIRST_FRAME);
+                // If time between the tab becoming visible and first frame is valid
+                // and less than the time since play attempt, play was not attempted until the tab became visible
+                var timeActive = this.between(TAB_VISIBLE, JWPLAYER_MEDIA_FIRST_FRAME);
+                if (timeActive > 0 && timeActive < time) {
+                    return timeActive;
+                }
+                return time;
+            };
+            model._qoeItem.tick(JWPLAYER_PLAYLIST_ITEM);
             model._qoeItem.start(mediaModel.get('state'));
 
             trackFirstFrame(model);


### PR DESCRIPTION
Fixes time-to-first-frame QOE metric when tab is opened in background, and playback is not started until tab becomes visible.

When command-clicking a url in Chrome, it is opened in the background. Video playback will not start until after clicking on the tab to make it active. As a result we are tracking a lot of invalid time-to-first-frame values.

This fix improves the tracking of
- “firstFrame” event `event.loadTime`
- `jwplayer().qoe().firstFrame`
- “ff” ping param value

JW7-3704