### PR TITLE
Don’t clear track cues before ad breaks

### DIFF
--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -19,7 +19,6 @@ define(['utils/underscore',
         _activeCuePosition: null,
         _initTextTracks: _initTextTracks,
         addTracksListener: addTracksListener,
-        clearCues: clearCues,
         clearTracks: clearTracks,
         disableTextTrack: disableTextTrack,
         enableTextTrack: enableTextTrack,
@@ -468,15 +467,6 @@ define(['utils/underscore',
         }
     }
 
-    // Clear the cues from all tracks
-    function clearCues() {
-        var tracks = this.video.textTracks;
-        if (tracks) {
-            // Second argument allows tracks to be reused
-            _removeCues(tracks, true);
-        }
-    }
-
     //////////////////////
     ////// PRIVATE METHODS
     //////////////////////
@@ -493,7 +483,7 @@ define(['utils/underscore',
         track.addCue(textTrackCue);
     }
 
-    function _removeCues(tracks, keepTracks) {
+    function _removeCues(tracks) {
         if (tracks.length) {
             _.each(tracks, function(track) {
                 // Cues are inaccessible if the track is disabled. While hidden,
@@ -507,9 +497,7 @@ define(['utils/underscore',
                 if (!track.embedded) {
                     track.mode = 'disabled';
                 }
-                if (!keepTracks) {
-                    track.inuse = false;
-                }
+                track.inuse = false;
             });
         }
     }


### PR DESCRIPTION
### Changes proposed in this pull request:
Captions didn't show after a preroll with hls streams because the cues were being cleared. 

Fixes #
JW7-3659
