### PR TITLE
Disable track first to remove visible caption in Firefox

### DIFF
--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -366,7 +366,11 @@ define(['utils/underscore',
         if (this._textTracks) {
             var track = this._textTracks[this._currentTextTrackIndex];
             if (track) {
-                track.mode = (track.embedded || track._id === 'nativecaptions') ? 'hidden' : 'disabled';
+                // FF does not remove the active cue from the dom when the track is hidden, so we must disable it
+                track.mode = 'disabled';
+                if (track.embedded || track._id === 'nativecaptions') {
+                    track.mode = 'hidden';
+                }
             }
         }
     }


### PR DESCRIPTION
### Changes proposed in this pull request:
..so the last active cue doesn't show during an ad break.

Fixes #
JW7-3659
