### PR TITLE
Fix control bar tooltip overlays

### DIFF
--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -52,11 +52,20 @@
     // adjust overlay bottom padding to match height of touch target
     .jw-overlay {
       bottom: @mobile-touch-target;
-      
+
       &::after {
         content: '';
         display: block;
         height: @mobile-touch-target * 0.5;
+      }
+
+    }
+
+    &.jw-flag-ads,
+    &.jw-flag-live {
+
+      .jw-overlay::after {
+        display: none;
       }
 
     }

--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -49,26 +49,36 @@
 
     }
 
+
+    /* ==================================================
+    control bar tooltip overlays
+    */
+
     // adjust overlay bottom padding to match height of touch target
-    .jw-overlay {
-      bottom: @mobile-touch-target;
+    .jw-controlbar {
 
-      &::after {
-        content: '';
-        display: block;
-        height: @mobile-touch-target * 0.5;
+      .jw-overlay {
+        bottom: @mobile-touch-target;
+
+        &::after {
+          content: '';
+          display: block;
+          height: @mobile-touch-target * 0.5;
+        }
+
+      }
+
+      &.jw-flag-ads,
+      &.jw-flag-live {
+
+        .jw-overlay::after {
+          display: none;
+        }
+
       }
 
     }
 
-    &.jw-flag-ads,
-    &.jw-flag-live {
-
-      .jw-overlay::after {
-        display: none;
-      }
-
-    }
 
     /* ==================================================
     control bar items

--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -49,6 +49,18 @@
 
     }
 
+    // adjust overlay bottom padding to match height of touch target
+    .jw-overlay {
+      bottom: @mobile-touch-target;
+      
+      &::after {
+        content: '';
+        display: block;
+        height: @mobile-touch-target * 0.5;
+      }
+
+    }
+
     /* ==================================================
     control bar items
     */


### PR DESCRIPTION
1) Control bar tooltip overlays would disappear when you attempted to leave the icon to use the overlay controls... fixed.
2) Control bar tooltip overlays did not clear the time slider height when positioned above.. fixed by using an ::after trick.

@dannyfinks 

Fixes #
JW7-3638