### PR TITLE
Fix hidden volume slider on small players (when not touch device)

### DIFF
--- a/src/css/imports/breakpoints.less
+++ b/src/css/imports/breakpoints.less
@@ -152,18 +152,6 @@ slider
 
 }
 
-/* ==================================================
-volume overlay
-*/
-
-.jw-breakpoint-0,
-.jw-breakpoint-1 {
-
-  .jw-icon-volume .jw-overlay {
-    display: none;
-  }
-
-}
 
 /* ==================================================
 display


### PR DESCRIPTION
Touch devices handle this on their own. Non-touch devices should show this slider. Fixed.

Fixes #
JW7-3680