### PR TITLE
Fix next up container overlapping with time slider

### DIFF
--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -137,7 +137,7 @@
 
       .jw-controlbar {
         height: @mobile-touch-target * 1.5;
-        padding: @slider-fixed-height (@mobile-touch-target / 4) 0;
+        padding: @slider-fixed-height 15px 0;
       }
 
     }
@@ -376,6 +376,23 @@
       max-height: calc(100% - 6.25em * (4.125em));
     }
 
+    /* ==================================================
+    next up
+    */
+
+    .jw-nextup-container {
+      bottom: (@mobile-touch-target * 1.5);
+      padding: 5px 20px;
+    }
+
+    &.jw-flag-ads,
+    &.jw-flag-live {
+
+      .jw-nextup-container {
+        bottom: @mobile-touch-target;
+      }
+
+    }
 
   }
 

--- a/src/css/imports/breakpoints.less
+++ b/src/css/imports/breakpoints.less
@@ -10,37 +10,6 @@
 }
 
 /* ==================================================
-control bar
-*/
-
-.jw-breakpoint-6,
-.jw-breakpoint-7 {
-
-  &.jw-flag-time-slider-above {
-
-    .jw-controlbar {
-      height: (@slider-fixed-height * 1.5) + (@mobile-touch-target * 1.5);
-      padding: (@slider-fixed-height * 1.5) 40px 0;
-    }
-
-    .jw-controlbar-center-group {
-      padding: 0 40px;
-    }
-
-    &.jw-flag-ads,
-    &.jw-flag-live {
-
-      .jw-controlbar-center-group {
-        padding: 0;
-      }
-
-    }
-
-  }
-
-}
-
-/* ==================================================
 control bar items
 */
 
@@ -53,55 +22,6 @@ control bar items
     > .jw-icon-next,
     > .jw-icon-playback {
       display: none;
-    }
-
-  }
-
-}
-
-.jw-breakpoint-6,
-.jw-breakpoint-7 {
-
-  &.jw-flag-time-slider-above {
-
-    .jw-group {
-
-      > .jw-icon,
-      > .jw-text {
-        height: @mobile-touch-target * 1.5;
-        line-height: (@mobile-touch-target * 1.5) - 7px;
-      }
-
-      > .jw-icon,
-      > .jw-text:not(.jw-text-alt) {
-        width: @mobile-touch-target * 1.5;
-      }
-
-      > .jw-text {
-        font-size: 18px;
-      }
-
-    }
-
-    &.jw-flag-ads,
-    &.jw-flag-live {
-
-      .jw-group {
-
-        > .jw-text {
-          line-height: (@mobile-touch-target * 1.5) - 26px;
-        }
-
-      }
-
-    }
-
-    .jw-controlbar {
-
-      .jw-slider-volume.jw-slider-horizontal {
-        margin-bottom: 7px;
-      }
-
     }
 
   }
@@ -129,33 +49,6 @@ control bar groups
   }
 
 }
-
-/* ==================================================
-slider
-*/
-
-.jw-breakpoint-6,
-.jw-breakpoint-7 {
-
-  &.jw-flag-time-slider-above {
-
-    .jw-tooltip-time {
-      bottom: (@mobile-touch-target * 0.75) + 5px;
-
-      .jw-time-tip {
-        padding: 4px 6px;
-      }
-
-      .jw-text {
-        font-size: 1.25em;
-      }
-
-    }
-
-  }
-
-}
-
 
 /* ==================================================
 display
@@ -253,49 +146,6 @@ ads flag
       max-width: 790px;
     }
 
-  }
-
-}
-
-
-/*
-
-captions
-
-*/
-//
-// .jw-breakpoint-2,
-// .jw-breakpoint-3 {
-//
-//   &.jw-flag-time-slider-above {
-//     .jw-captions,
-//     video::-webkit-media-text-track-container {
-//       // max-height: calc(100% - 6.25em * (4.125em + 0.5em));
-//     }
-//   }
-//
-// }
-//
-// .jw-breakpoint-4,
-// .jw-breakpoint-5 {
-//
-//   &.jw-flag-time-slider-above {
-//     .jw-captions,
-//     video::-webkit-media-text-track-container {
-//       // max-height: calc(100% - 6.25em * (4.125em + 1em));
-//     }
-//   }
-//
-// }
-
-.jw-breakpoint-6,
-.jw-breakpoint-7 {
-
-  &.jw-flag-time-slider-above {
-    .jw-captions,
-    video::-webkit-media-text-track-container {
-      max-height: calc(100% - 6.25em * (4.125em + 2em));
-    }
   }
 
 }

--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -258,7 +258,7 @@
         /* Next up display */
         .jw-nextup-container {
           bottom: @controlbar-height;
-          padding: 0 @ui-padding;
+          padding: 5px @ui-padding;
         }
 
         .jw-nextup {
@@ -348,31 +348,6 @@
               border-radius: @ui-corner-round;
             }
 
-          }
-
-          .jw-nextup-container {
-            bottom: (@mobile-touch-target * 1.5);
-          }
-
-          &.jw-breakpoint-2,
-          &.jw-breakpoint-3 {
-            .jw-nextup-container {
-              bottom: (@mobile-touch-target * 1.5) + 7px;
-            }
-          }
-
-          &.jw-breakpoint-4,
-          &.jw-breakpoint-5 {
-            .jw-nextup-container {
-              bottom: (@mobile-touch-target * 1.5) + 10px;
-            }
-          }
-
-          &.jw-breakpoint-6,
-          &.jw-breakpoint-7 {
-            .jw-nextup-container {
-              bottom: (@mobile-touch-target * 2) + 15px;
-            }
           }
 
         }

--- a/src/css/imports/nextup.less
+++ b/src/css/imports/nextup.less
@@ -2,7 +2,6 @@
 @import "icons";
 
 .jw-nextup-container {
-
   -webkit-font-smoothing: antialiased;
   -moz-font-smoothing: antialiased;
   background-color: transparent;
@@ -20,22 +19,9 @@
   visibility: hidden;
   width: 100%;
 
-  .jw-flag-time-slider-above &,
-  .jw-breakpoint-0 &,
-  .jw-breakpoint-1 & {
-    bottom: (@mobile-touch-target * 1.5);
-    padding: 5px 20px;
-  }
-
   .jw-breakpoint-0 &,
   .jw-breakpoint-1 & {
     display: none;
-  }
-
-  .jw-flag-time-slider-above.jw-breakpoint-6 &,
-  .jw-flag-time-slider-above.jw-breakpoint-7 & {
-    height: @slider-fixed-height + (@mobile-touch-target * 1.5);
-    padding: 0 40px;
   }
 
 }


### PR DESCRIPTION
At some breakpoints, next up container would overlap with time slider/controls when that breakpoint added padding to the control bar area. Padding has been removed to create consistency throughout all breakpoints. Next up code under time slider above flag has been moved to it's appropriate place.

Fixes #
JW7-3677