### PR TITLE
Added padding so that the rewind icon is not cropped in iOS

### DIFF
--- a/src/css/imports/display.less
+++ b/src/css/imports/display.less
@@ -95,6 +95,7 @@ display icons
 
     &.jw-icon-rewind::before {
       top: 2px;
+      padding: 0.2em 0.05em 0.1em;
     }
 
     .jw-state-idle &.jw-icon-display::before,


### PR DESCRIPTION
Added some padding to the rewind icon so that it is not cropped in iOS Safari.  This allows the entire glyph to be displayed instead of being cropped.

JW7-3670