### PR TITLE
Show the Display Icon in the Buffering, Error or Complete States when auto starting on mobile

### DIFF
--- a/src/css/imports/autostartmute.less
+++ b/src/css/imports/autostartmute.less
@@ -17,7 +17,8 @@
 
 .jw-flag-autostart {
   .jw-controlbar,
-  .jw-nextup {
+  .jw-nextup,
+  &:not(.jw-state-buffering):not(.jw-state-error):not(.jw-state-complete) .jw-display {
     display: none;
   }
 }


### PR DESCRIPTION
… 
This fix shows the display icon during the buffering, error and complete states when auto starting on mobile in order to allow user interaction and to show the state of the player.  When the replay button is pressed, the player exits the autoplay mute state due to the user interaction and displays the control bar as per normal.  This also fixes the issue where the pause button would appear on the player when auto starting.

JW7-3672