### PR TITLE
Update class name on the Error display to center the error icon

### DIFF
--- a/src/templates/error.html
+++ b/src/templates/error.html
@@ -4,7 +4,7 @@
         <div class="jw-title-secondary jw-reset">{{body}}</div>
     </div>
 
-    <div class="jw-icon-container jw-reset">
+    <div class="jw-display-container jw-reset">
         <div class="jw-display-icon-container jw-background-color jw-reset">
             <div class="jw-icon jw-icon-display jw-reset" aria-hidden="true"></div>
         </div>


### PR DESCRIPTION
Update the class name on the error display so that the error icon is centered in the display.

JW7-3690