### PR TITLE
Assign bottom of jw-plugins based on @mobile-touch-target values

### DIFF
--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -366,6 +366,10 @@
       }
     }
 
+    /* Move non-linear ad display above the time slider */
+    .jw-plugin {
+      bottom: (@mobile-touch-target * 1.5);
+    }
 
     /* ==================================================
     captions


### PR DESCRIPTION
Assign bottom of jw-plugins based on the @mobile-touch-target value in the same way that it is used for the jw-nextup-container.  This results in using pixel values and is more consistent with how the controller is styled.  Issues that are brought up with the "bottom" CSS value of other plugins (related and sharing) are handled in their respective repos.

JW7-3666
