### PR TITLE
Adds padding to small breakpoint titles to prevent showing scrollbars

### DIFF
--- a/src/css/imports/title.less
+++ b/src/css/imports/title.less
@@ -44,7 +44,7 @@
   .jw-title-primary,
   .jw-title-secondary {
     min-height: inherit;
-    padding: 0 @default-em-size;
+    padding: 1px @default-em-size;
   }
 
   .jw-title-secondary {


### PR DESCRIPTION
Adds a small amount of vertical padding so that titles in small players will fit correctly and not display scrollbars.

JW7-3686