### PR TITLE
Refactored skins styles to have consistent color rules

### DIFF
--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -184,7 +184,6 @@
     }
 
     .jw-group > .jw-icon {
-      color: @fixed-time-slider-inactive-color;
       font-size: 20px;
       padding: 0;
       text-align: center;
@@ -192,10 +191,6 @@
 
       &::before {
         height: auto;
-      }
-
-      &:hover {
-        color: @fixed-time-slider-hover-color;
       }
 
     }
@@ -271,10 +266,6 @@
       .jw-buffer,
       .jw-progress {
         height: @slider-fixed-rail-height;
-      }
-
-      .jw-progress {
-        background-color: @fixed-time-slider-progress-color;
       }
 
       .jw-rail {

--- a/src/css/imports/controlbar.less
+++ b/src/css/imports/controlbar.less
@@ -10,10 +10,6 @@
   padding: 0 @ui-padding;
 }
 
-.jw-background-color {
-  background-color: @background-color;
-}
-
 .jw-slider-horizontal {
   background-color: transparent;
 }
@@ -101,34 +97,4 @@
 .jw-slider-volume.jw-slider-horizontal,
 .jw-icon-inline.jw-icon-volume {
   display: none;
-}
-
-.jw-button-color {
-
-  color: @inactive-color;
-
-  &:hover {
-    color: @hover-color;
-  }
-
-  &:focus {
-    outline: none;
-    color: @hover-color;
-  }
-
-}
-
-.jw-toggle {
-
-  color: @toggle-active;
-
-  &.jw-off {
-    color: @toggle-inactive;
-  }
-
-  &:focus {
-    outline: none;
-    color: @hover-color;
-  }
-
 }

--- a/src/css/imports/display.less
+++ b/src/css/imports/display.less
@@ -80,13 +80,11 @@ display icons
 }
 
 .jw-display-icon-container {
-  background-color: @display-bkgd-color;
   border-radius: @ui-corner-round;
   display: inline-block;
   margin: 0 (@ui-padding * 0.5);
 
   .jw-icon {
-    color: @display-icon-color;
     cursor: pointer;
     height: @mobile-touch-target;
     line-height: @mobile-touch-target;
@@ -106,15 +104,6 @@ display icons
     .jw-state-idle &.jw-icon-display::before,
     .jw-state-paused &.jw-icon-display::before {
       left: 1px;
-    }
-
-  }
-
-  &:hover {
-    background: @display-bkgd-hover-color;
-
-    .jw-icon {
-      color: @display-icon-hover-color;
     }
 
   }

--- a/src/css/imports/jwplayerelement.less
+++ b/src/css/imports/jwplayerelement.less
@@ -34,7 +34,7 @@
         }
     }
 
-    .jw-aspect{
+    .jw-aspect {
         display: none;
     }
 
@@ -44,12 +44,6 @@
 
     &.jw-ie:focus {
         outline: #585858 dotted 1px;
-    }
-
-    &:hover {
-        .jw-display-icon-container {
-            background-color: @display-bkgd-hover-color;
-        }
     }
 }
 

--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -95,14 +95,8 @@
 #namespace() {
     .basic-skin-styles() {
 
-        &.jwplayer:hover {
-            .jw-display-icon-container {
-                background-color: @display-bkgd-hover-color;
-            }
-        }
-
         .jw-background-color {
-            background: @display-bkgd-color;
+            background: @controlbar-background;
         }
 
         .jw-controlbar {
@@ -139,16 +133,11 @@
             &.jw-off {
                 color: @inactive-color;
             }
+            &:hover {
+              color: @hover-color;
+            }
             &:focus {
                 outline: none;
-            }
-        }
-
-        /* Color for list item text in menu lists */
-        .jw-option {
-            color: @inactive-color;
-            &.jw-active-option {
-                color: @hover-color;
             }
         }
 
@@ -218,9 +207,13 @@
         .jw-time-tip,
         .jw-volume-tip,
         .jw-menu {
-            background: @volume-background;
+            background: @controlbar-background;
             border: @volume-border;
             padding: @volume-padding;
+        }
+
+        .jw-menu.jw-background-color {
+          background: @controlbar-background;
         }
 
         .jw-skip {
@@ -241,7 +234,7 @@
         .jw-time-tip,
         .jw-dock-button {
             .jw-text {
-                color: #bbb;
+                color: @inactive-color;
             }
         }
 
@@ -295,7 +288,7 @@
           color: @nextup-close-button-color-hover;
         }
 
-        // fixed time slider
+        // time slider above
         &.jw-flag-time-slider-above,
         &.jw-breakpoint-0,
         &.jw-breakpoint-1 {
@@ -303,11 +296,6 @@
           .jw-controlbar-center-group {
 
             .jw-slider-horizontal {
-
-              .jw-progress {
-                background-color: @fixed-time-slider-progress-color;
-              }
-
               .jw-knob {
                 border-radius: @slider-fixed-knob-border-radius;
                 height: @slider-fixed-knob-height;
@@ -316,30 +304,6 @@
                 width: @slider-fixed-knob-width;
               }
             }
-          }
-
-          .jw-controlbar-left-group,
-          .jw-controlbar-right-group {
-
-            .jw-icon {
-              color: @fixed-time-slider-inactive-color;
-              &:hover {
-                color: @fixed-time-slider-hover-color;
-              }
-            }
-
-            .jw-text {
-              color: @fixed-time-slider-inactive-color;
-            }
-
-          }
-
-          .jw-slider-horizontal {
-
-            .jw-progress {
-              background-color: @fixed-time-slider-progress-color;
-            }
-
           }
 
           .jw-tooltip-time {
@@ -428,6 +392,12 @@
     }
     // Set color classes in the skin so they can be reused in other parts of the player (i.e. the related overlay)
     .set-global-color-classes() {
+        &.jwplayer:hover {
+          .jw-display-icon-container {
+            background-color: @display-bkgd-hover-color;
+          }
+        }
+
         .jw-color-active {
             color: @active-color;
             stroke: @active-color;
@@ -454,6 +424,17 @@
                 stroke: @inactive-color;
                 border-color: @inactive-color;
             }
+        }
+        /* Color for list item text in menu lists */
+        .jw-option {
+          color: @option-inactive-color;
+          &:hover {
+            color: @hover-color;
+          }
+          &.jw-active-option {
+            color: @option-active-color;
+            background-color: @option-active-bg-color;
+          }
         }
     }
 

--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -133,7 +133,8 @@
             color: @hover-color;
             &.jw-off {
                 color: @inactive-color;
-                &:hover {
+                &:hover,
+                &:focus {
                   color: @hover-color;
                 }
             }

--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -115,6 +115,7 @@
 
         .jw-knob {
             color: @inactive-color;
+            background-color: @active-color;
         }
 
         .jw-button-color {
@@ -132,9 +133,9 @@
             color: @hover-color;
             &.jw-off {
                 color: @inactive-color;
-            }
-            &:hover {
-              color: @hover-color;
+                &:hover {
+                  color: @hover-color;
+                }
             }
             &:focus {
                 outline: none;

--- a/src/css/imports/slider.less
+++ b/src/css/imports/slider.less
@@ -40,7 +40,6 @@
 }
 
 .jw-knob {
-    background-color: @active-color;
     width: @thumb-size;
     height: @thumb-size;
     border-radius: @ui-corner-round;

--- a/src/css/imports/tooltip.less
+++ b/src/css/imports/tooltip.less
@@ -69,20 +69,11 @@
         height: 1.5em;
         font-family: inherit;
         line-height: 1.5em;
-        color: @inactive-color;
         padding: 0 0.5em;
         font-size: 0.8em;
-
-        &:hover,
-        &:before:hover {
-            color: @hover-color;
-        }
 
         &:before {
             padding-right: 0.125em;
         }
-      &.jw-active-option {
-        color: @hover-color;
-      }
     }
 }

--- a/src/css/imports/vars.less
+++ b/src/css/imports/vars.less
@@ -26,6 +26,9 @@
 @inactive-color: rgba(255, 255, 255, .6);
 @background-color: rgba(33, 33, 33, 0.8);
 @accent-color: rgba(255, 255, 255, 1);
+@option-inactive-color: @inactive-color;
+@option-active-color: @active-color;
+@option-active-bg-color: rgba(255, 255, 255, 0.1);
 
 @rail-color: rgba(255, 255, 255, 0.2);
 @buffer-color: rgba(255, 255, 255, 0.3);

--- a/src/css/skins/beelden.less
+++ b/src/css/skins/beelden.less
@@ -2,7 +2,7 @@
 
 .jw-skin-beelden {
 
-    @active-color: #fff;
+    @active-color: #C93835;
     @inactive-color: #c7c7c7;
     @hover-color: @active-color;
 
@@ -20,16 +20,18 @@
     @controlbar-background: @controlbar-background-gradient;
 
     @volume-padding: 0.4em;;
-    @volume-background: rgba(0, 0, 0, 0.5);
+    @volume-background: @controlbar-background-color;
     @volume-border: 1px solid #000;
 
     @display-icon-color: @inactive-color;
     @display-icon-hover-color: @active-color;
-    @display-bkgd-color: @volume-background;
-    @display-bkgd-hover-color: @controlbar-background-color;
+    @display-bkgd-color: @controlbar-background-color;
+    @display-bkgd-hover-color: @inactive-color;
 
-    @cc-inactive: #7d7d7d;
-    @cc-active: @active-color;
+    @option-active-bg-color: rgba(255, 255, 255, 0.6);
+
+    @toggle-active: @active-color;
+    @toggle-inactive: #7d7d7d;
 
     @rail-height: .5em;
     @slider-height: @rail-height;
@@ -99,11 +101,11 @@
         }
 
         .jw-rail {
-            background-color: #353535;
+            background-color: @rail-color;
         }
 
         .jw-progress {
-            background-color: #c93835;
+            background-color: @progress-color;
         }
 
         .jw-buffer {
@@ -151,7 +153,6 @@
         }
 
         .jw-slider-vertical {
-            //bottom: 5px;
 
             .jw-slider-container {
                 width: 0.4em;
@@ -203,14 +204,6 @@
     .jw-dock-button,
     .jw-skip {
         border-radius: @ui-padding;
-    }
-
-    .jw-toggle {
-        color: @cc-active;
-
-        &.jw-off {
-            color: @cc-inactive;
-        }
     }
 
 }

--- a/src/css/skins/bekle.less
+++ b/src/css/skins/bekle.less
@@ -25,9 +25,6 @@
     @display-bkgd-color: @rail-color;
     @display-bkgd-hover-color: @active-color;
 
-    @cc-inactive: #5e6575;
-    @cc-active: @active-color;
-
     @volume-background: fade(#505863,90%);
 
     @controlbar-height: 2em;

--- a/src/css/skins/five.less
+++ b/src/css/skins/five.less
@@ -15,13 +15,14 @@
     @thumb-color: @progress-color;
     @volume-background: #333;
 
-    @display-icon-color: @controlbar-background;
-    @display-icon-hover-color: #fff;
-    @display-bkgd-color: rgba(51, 51, 51, 0.7);
-    @display-bkgd-hover-color: #333;
+    @display-icon-color: @inactive-color;
+    @display-icon-hover-color: @active-color;
+    @display-bkgd-color: @buffer-color;
+    @display-bkgd-hover-color: @rail-color;
 
-    @cc-inactive: @rail-color;
-    @cc-active: @active-color;
+    @option-active-bg-color: rgba(255, 255, 255, 0.6);
+
+
 
     @rail-height: .2em;
     @thumb-size: 1em;
@@ -55,16 +56,6 @@
     /* Styles for play button container on idle */
     .jw-display-icon-container {
         border-radius: @five-border-radius;
-    }
-
-    /* Styles for menu list items */
-    .jw-option {
-        color: #bbb;
-
-        &:hover,
-        &.jw-active-option {
-            color: #fff;
-        }
     }
 
     /* Playlist title */
@@ -121,12 +112,8 @@
               width: @rail-height;
           }
 
-          .jw-progress {
-              background: #fff;
-          }
-
           .jw-rail {
-              background: #737373;
+              background: @inactive-color;
           }
 
           .jw-knob {

--- a/src/css/skins/glow.less
+++ b/src/css/skins/glow.less
@@ -2,16 +2,13 @@
 
 .jw-skin-glow {
     @active-color: #fff;
-    @inactive-color: #fff;
+    @inactive-color: #95979b;
     @hover-color: @active-color;
     @progress-color: #fff;
-    @buffer-color: #3B3D41;
+    @buffer-color: @inactive-color;
     @rail-color: #2A2C2E;
     @controlbar-background: fade(#131415, 80%);
     @volume-background: #333;
-
-    @cc-inactive: @buffer-color;
-    @cc-active: @active-color;
 
     @rail-height: .4em;
     @cue-size: .25em;
@@ -81,10 +78,6 @@
     /* Volume slider */
     .jw-slider-vertical {
         bottom: 5px;
-
-        .jw-rail {
-            background-color: #141516;
-        }
 
         .jw-rail,
         .jw-progress {

--- a/src/css/skins/roundster.less
+++ b/src/css/skins/roundster.less
@@ -11,6 +11,8 @@
     @display-bkgd-color: @inactive-color;
     @display-bkgd-hover-color: @active-color;
 
+    @option-active-bg-color: rgba(255, 255, 255, 0.5);
+
     @progress-color: @active-color;
     @buffer-color: #9c9a9d;
     @rail-color: #878fa2;
@@ -96,9 +98,6 @@
 
     /* Volume slider */
     .jw-slider-vertical {
-        .jw-rail {
-            background-color: #434853;
-        }
 
         .jw-rail,
         .jw-progress {

--- a/src/css/skins/seven.less
+++ b/src/css/skins/seven.less
@@ -11,10 +11,6 @@
 
   #namespace > .set-global-color-classes();
 
-  .jw-active-option {
-    background-color: rgba(255, 255, 255, 0.1);
-  }
-
   .jw-display-icon-container {
     border-radius: 3.5em;
 

--- a/src/css/skins/seven.less
+++ b/src/css/skins/seven.less
@@ -9,6 +9,7 @@
 
   @controlbar-height: 2.5em;
 
+  #namespace > .basic-skin-styles();
   #namespace > .set-global-color-classes();
 
   .jw-display-icon-container {

--- a/src/css/skins/stormtrooper.less
+++ b/src/css/skins/stormtrooper.less
@@ -131,13 +131,13 @@
 
     /* Toggle icons */
     .jw-icon-cc {
-        &.jw-off:before {
+        &:before {
             content: "\e604";
         }
     }
 
     .jw-icon-hd {
-        &.jw-off:before {
+        &:before {
             content: "\e609";
         }
     }

--- a/src/css/skins/vapor.less
+++ b/src/css/skins/vapor.less
@@ -1,7 +1,7 @@
 @import "../imports/mixins";
 
 .jw-skin-vapor {
-		@active-color: #fff;
+		@active-color: #0f9e60;
     @inactive-color: rgba(0, 0, 0, 0.5);
    	@hover-color: @active-color;
 
@@ -10,11 +10,10 @@
     @display-bkgd-color: @inactive-color;
     @display-bkgd-hover-color: #000;
 
-		@fixed-time-slider-inactive-color: @display-bkgd-color;
-    @fixed-time-slider-hover-color: @display-icon-hover-color;
+    @option-active-bg-color: rgba(255, 255, 255, 0.5);
 
     @controlbar-background: @rail-color;
-		@progress-color: #0f9e60;
+    @progress-color: #0f9e60;
     @buffer-color: @inactive-color;
     @rail-color: rgba(255, 255, 255, 0.4);
     @thumb-color: @progress-color;
@@ -59,16 +58,6 @@
         border-radius: @ui-padding;
     }
 
-    /* Styles for menu list items */
-    .jw-option {
-        color: @active-color;
-
-        &:hover,
-        &.jw-active-option {
-            color: @progress-color;
-        }
-    }
-
     /* Playlist title */
     .jw-tooltip-title {
         border-bottom: 1px solid #000;
@@ -110,10 +99,6 @@
 		            display: none;
 		        }
 
-				.jw-rail {
-					background-color: rgba(0, 0, 0, 0.8);
-				}
-
 				.jw-rail,
 				.jw-progress {
 					border: 1px solid #000;
@@ -135,13 +120,13 @@
 
     /* Toggle icons */
     .jw-icon-cc {
-        &.jw-off:before {
+        &:before {
             content: "\e604";
         }
     }
 
     .jw-icon-hd {
-        &.jw-off:before {
+        &:before {
             content: "\e609";
         }
     }

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -331,12 +331,16 @@ define([
             // Apply active color
             addStyle([
                 // Toggle and menu button active colors
-                '.jw-toggle',
-                '.jw-button-color:hover'
+                '.jw-button-color.jw-toggle',
+                '.jw-button-color:hover',
+                '.jw-button-color.jw-toggle.jw-off:hover',
+                '.jw-option:hover',
+                '.jw-option.jw-active-option',
+                '.jw-nextup-header'
             ], 'color', activeColor);
             addStyle([
                 // menu active option
-                '.jw-active-option',
+
                 // slider fill color
                 '.jw-progress',
             ], 'background', activeColor);
@@ -352,12 +356,15 @@ define([
                 // toggle button
                 '.jw-toggle.jw-off',
                 '.jw-tooltip-title',
-                '.jw-skip .jw-skip-icon'
+                '.jw-skip .jw-skip-icon',
+                '.jw-nextup-body'
             ], 'color', inactiveColor);
             addStyle([
                 // slider children
                 '.jw-cue',
-                '.jw-knob'
+                '.jw-knob',
+                '.jw-active-option',
+                '.jw-nextup-header'
             ], 'background', inactiveColor);
 
             // Apply background color


### PR DESCRIPTION
### Changes proposed in this pull request:

- Move color rules from composite elements to mixins and override them in skins
- Added vars for tooltip states and removed cc specific rules since they are just tooltips
- Tweaked some skin colors to make states more distinguishable
Fixes #
JW7-3669