### PR TITLE
Hide overflow on titles to prevent scrollbars appearing

### DIFF
--- a/src/css/imports/title.less
+++ b/src/css/imports/title.less
@@ -21,7 +21,7 @@
     color: white;
     white-space: nowrap;
     text-overflow: ellipsis;
-    overflow-x: hidden;
+    overflow: hidden;
 }
 
 .jw-title-primary {


### PR DESCRIPTION
Hide overflow on titles to prevent scrollbars appearing.  We were getting vertical scrollbars on smaller-sized breakpoints so we want to hide the vertical scrollbars.

JW7-3686