### PR TITLE
Add :not()s for plugins to keep affecting styles in one place

### DIFF
--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -367,7 +367,7 @@
     }
 
     /* Move non-linear ad display above the time slider */
-    .jw-plugin {
+    .jw-plugin:not(.jw-plugin-related):not(.jw-plugin-sharing) {
       bottom: (@mobile-touch-target * 1.5);
     }
 


### PR DESCRIPTION
Add :not()s for plugins which are affected by this change (related and sharing) to keep styles relating to time-slider-above changes in a single location instead of forcing specificity in the css in their repos.  This should keep things easier to follow and prevent issues where too many overrides are added.

JW7-3666