### PR TITLE
Don’t hide controlbar buttons in controlbar only mode

### DIFF
--- a/src/css/imports/breakpoints.less
+++ b/src/css/imports/breakpoints.less
@@ -15,17 +15,15 @@ control bar items
 
 .jw-breakpoint-0,
 .jw-breakpoint-1 {
-
-  .jw-group {
-
-    > .jw-icon-rewind,
-    > .jw-icon-next,
-    > .jw-icon-playback {
-      display: none;
+  &:not(.jw-flag-audio-player) {
+    .jw-group {
+      > .jw-icon-rewind,
+      > .jw-icon-next,
+      > .jw-icon-playback {
+        display: none;
+      }
     }
-
   }
-
 }
 
 /* ==================================================


### PR DESCRIPTION
### Changes proposed in this pull request:

Control bar buttons should not be hidden when showing the control bar only.

Fixes #
JW7-3747
