### PR TITLE
Hide elapsed time and duration in audio player below 420px

### DIFF
--- a/src/css/flags/audioplayer.less
+++ b/src/css/flags/audioplayer.less
@@ -62,4 +62,12 @@
     .jw-controlbar-center-group {
         padding-bottom: 2px;
     }
+
+    &.jw-breakpoint-1,
+    &.jw-breakpoint-0 {
+        .jw-text-elapsed,
+        .jw-text-duration {
+            display: none;
+        }
+    }
 }


### PR DESCRIPTION
### Changes proposed in this pull request:
Do not show elapsed time and duration at breakpoint 0 and 1 when showing the controlbar only. This gives the time slider more real estate.

Fixes #
JW7-3747
