### PR TITLE
Hide display icons and the controls gradient during a VPAID ad

### DIFF
--- a/src/css/flags/ads.less
+++ b/src/css/flags/ads.less
@@ -108,8 +108,12 @@
 
 .jwplayer.jw-flag-ads-vpaid,
 .jwplayer.jw-flag-touch.jw-flag-ads-vpaid {
-    .jw-controlbar, .jw-skip {
+    .jw-controlbar, .jw-display-container, .jw-skip {
         display: none;
+    }
+
+    .jw-controls {
+        background: none;
     }
 }
 

--- a/src/css/flags/ads.less
+++ b/src/css/flags/ads.less
@@ -112,7 +112,8 @@
         display: none;
     }
 
-    .jw-controls {
+    &.jw-breakpoint-0 .jw-controls,
+    &.jw-breakpoint-1 .jw-controls {
         background: none;
     }
 }

--- a/src/css/flags/ads.less
+++ b/src/css/flags/ads.less
@@ -111,10 +111,14 @@
     .jw-controlbar, .jw-display-container, .jw-skip {
         display: none;
     }
+}
 
-    &.jw-breakpoint-0 .jw-controls,
-    &.jw-breakpoint-1 .jw-controls {
-        background: none;
+.jwplayer.jw-flag-ads-vpaid {
+    &.jw-breakpoint-0,
+    &.jw-breakpoint-1 {
+        .jw-controls {
+            background: none;
+        }
     }
 }
 


### PR DESCRIPTION
Hide display icons and the controls gradient during a VPAID ad so that do not receive play/pause buttons at small sizes and we do not get the jw-controls background gradient at small sizes.

JW7-3706