### PR TITLE
Do not forward complete event for vpaid ads

### DIFF
--- a/src/js/controller/instream-html5.js
+++ b/src/js/controller/instream-html5.js
@@ -136,10 +136,15 @@ define([
                     return;
                 }
 
+                var isVpaidProvider = provider.type === 'vpaid';
+
                 provider.off();
 
                 provider.on('all', function(type, data) {
                     data = _.extend({}, data, {type: type});
+                    if (isVpaidProvider && (type === events.JWPLAYER_MEDIA_COMPLETE)) {
+                        return;
+                    }
                     this.trigger(type, data);
                 }, _this);
 


### PR DESCRIPTION
Complete event for vpaid provider destroys the instream, resulting the next ad pod to not play.
JW7-3749