### PR TITLE
Bump of specificity of googima controlbar

### DIFF
--- a/src/css/flags/ads.less
+++ b/src/css/flags/ads.less
@@ -78,7 +78,7 @@
 
 }
 
-.jwplayer.jw-flag-ads-googleima {
+.jwplayer.jw-flag-ads.jw-flag-ads-googleima {
 
     .jw-controlbar {
         display: table;


### PR DESCRIPTION
This had less specificity than inactive, so controlbar was being hidden when inactive.
JW7-3740