### PR TITLE
Reimplements "jw-hide" styles for the config option logo

### DIFF
--- a/src/css/flags/controls-hidden.less
+++ b/src/css/flags/controls-hidden.less
@@ -1,6 +1,7 @@
 .jwplayer.jw-flag-controls-hidden {
   .jw-controlbar,
-  .jw-dock {
+  .jw-dock,
+  .jw-logo.jw-hide {
     display: none;
   }
 


### PR DESCRIPTION
Reimplements "jw-hide" styles for the config option logo that were removed in the refactor.

JW7-3748