### PR TITLE
Removing :not() rules to reduce specificity

### DIFF
--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -367,7 +367,7 @@
     }
 
     /* Move non-linear ad display above the time slider */
-    .jw-plugin:not(.jw-plugin-related):not(.jw-plugin-sharing) {
+    .jw-plugin {
       bottom: (@mobile-touch-target * 1.5);
     }
 


### PR DESCRIPTION
Removing :not() rules to reduce specificity.  This makes nonlinear ads drop to the correct location while the player is playing back.  Specificity increased in related and sharing so that they will not receive bottom style increases.

JW7-3666