### PR TITLE
Improve time slider above background gradient. #3753

### DIFF
--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -96,8 +96,10 @@
     .jw-controlbar {
       background: linear-gradient(
         180deg,
-        fade(black, 0%),
-        fade(black, 50%)
+        rgba(0, 0, 0, 0),
+        rgba(0, 0, 0, 0.1),
+        rgba(0, 0, 0, 0.2),
+        rgba(0, 0, 0, 0.5)
       );
       height: @mobile-touch-target;
       padding: 0 10px;

--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -97,7 +97,7 @@
       background: linear-gradient(
         180deg,
         fade(black, 0%),
-        fade(black, 75%)
+        fade(black, 50%)
       );
       height: @mobile-touch-target;
       padding: 0 10px;

--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -94,13 +94,8 @@
     controls
     */
 
-    .jw-controls {
-      background: linear-gradient(
-        180deg,
-        fade(mix(black, white, 90%), 0%),
-        fade(mix(black, white, 90%), 25%),
-        fade(mix(black, white, 90%), 75%)
-      );
+    .jw-controlbar {
+
     }
 
     /* do not show the controls background linear gradient when video is idle
@@ -111,7 +106,7 @@
     &.jw-state-playing.jw-flag-user-inactive:not(.jw-flag-casting) {
 
       .jw-controls {
-        background: none;
+        // background: none;
       }
 
     }
@@ -122,7 +117,11 @@
     */
 
     .jw-controlbar {
-      background: none;
+      background: linear-gradient(
+        180deg,
+        fade(black, 0%),
+        fade(black, 75%)
+      );
       height: @mobile-touch-target;
       padding: 0 10px;
     }

--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -89,29 +89,6 @@
 
   &:not(.jw-flag-audio-player) {
 
-
-    /* ==================================================
-    controls
-    */
-
-    .jw-controlbar {
-
-    }
-
-    /* do not show the controls background linear gradient when video is idle
-    state (except when cast available and we show controls on idle state) or
-    playing state when user inactive (the gradient in other scenarios blocks
-    video from clashing with the video colors, making it easy to see/use) */
-    &.jw-state-idle:not(.jw-flag-cast-available),
-    &.jw-state-playing.jw-flag-user-inactive:not(.jw-flag-casting) {
-
-      .jw-controls {
-        // background: none;
-      }
-
-    }
-
-
     /* ==================================================
     control bar
     */

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -307,23 +307,47 @@ define([
         this.handleColorOverrides = function() {
             var id = _model.get('id');
 
-            function addStyle(elements, attr, value) {
+            function getRgba(color, opacity) {
+                var canvas, context, data;
+
+                canvas = document.createElement('canvas');
+                canvas.height = 1;
+                canvas.width = 1;
+
+                context = canvas.getContext('2d');
+                context.fillStyle = color;
+                context.fillRect(0, 0, 1, 1);
+
+                data = context.getImageData(0, 0, 1, 1).data;
+
+                return 'rgba(' + data[0] + ', ' + data[1] + ', ' + data[2] + ', ' + opacity + ')';
+            }
+
+            function addStyle(elements, attr, value, bundle) {
                 if (!value) {
                     return;
                 }
 
-                elements = utils.prefix(elements, '#' + id + ' ');
+                /* if bundle is true, bundle the first selector string to the
+                player element versus defaulting to setting as a child of. i.e.
+                #player1.jw-breakpoint-0 vs. #player1 .jw-breakpoint-0 */
+                elements = utils.prefix(elements, '#' + id + (bundle ? '' : ' '));
 
                 var o = {};
                 o[attr] = value;
                 utils.css(elements.join(', '), o, id);
+
+                console.log(elements);
             }
 
             // We can assume that the user will define both an active and inactive color because otherwise it doesn't
             // look good.
             var activeColor = _model.get('skinColorActive'),
                 inactiveColor = _model.get('skinColorInactive'),
-                backgroundColor = _model.get('skinColorBackground');
+                backgroundColor = _model.get('skinColorBackground'),
+                backgroundColorGradient = 'linear-gradient(180deg, ' +
+                  getRgba(backgroundColor, 0) + ', ' +
+                  getRgba(backgroundColor, 50) + ')';
 
             // These will use standard style names for CSS since they are added directly to a style sheet
             // Using background instead of background-color so we don't have to clear gradients with background-image
@@ -366,6 +390,20 @@ define([
                 '.jw-background-color',
                 '.jw-tooltip-title'
             ], 'background', backgroundColor);
+
+            addStyle([
+                // control bar gradient background color for small player size only
+                '.jw-breakpoint-0 .jw-background-color.jw-controlbar',
+                '.jw-breakpoint-1 .jw-background-color.jw-controlbar',
+                '.jw-flag-time-slider-above .jw-background-color.jw-controlbar',
+            ], 'background', backgroundColorGradient, true);
+
+            addStyle([
+                // time slider gradient background color for small player size only
+                '.jw-breakpoint-0 .jw-background-color.jw-slider-time',
+                '.jw-breakpoint-1 .jw-background-color.jw-slider-time',
+                '.jw-flag-time-slider-above .jw-background-color.jw-slider-time',
+            ], 'background', 'none', true);
 
             insertGlobalColorClasses(activeColor, inactiveColor, id);
         };

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -323,21 +323,19 @@ define([
                 return 'rgba(' + data[0] + ', ' + data[1] + ', ' + data[2] + ', ' + opacity + ')';
             }
 
-            function addStyle(elements, attr, value, bundle) {
+            function addStyle(elements, attr, value, extendParent) {
                 if (!value) {
                     return;
                 }
 
-                /* if bundle is true, bundle the first selector string to the
-                player element versus defaulting to setting as a child of. i.e.
-                #player1.jw-breakpoint-0 vs. #player1 .jw-breakpoint-0 */
-                elements = utils.prefix(elements, '#' + id + (bundle ? '' : ' '));
+                /* if extendParent is true, bundle the first selector of
+                element string to the player element instead of defining it as a
+                child of the player element (default). i.e. #player.sel-1 .sel-2 vs. #player .sel-1 .sel-2 */
+                elements = utils.prefix(elements, '#' + id + (extendParent ? '' : ' '));
 
                 var o = {};
                 o[attr] = value;
                 utils.css(elements.join(', '), o, id);
-
-                console.log(elements);
             }
 
             // We can assume that the user will define both an active and inactive color because otherwise it doesn't
@@ -345,9 +343,11 @@ define([
             var activeColor = _model.get('skinColorActive'),
                 inactiveColor = _model.get('skinColorInactive'),
                 backgroundColor = _model.get('skinColorBackground'),
-                backgroundColorGradient = 'linear-gradient(180deg, ' +
-                  getRgba(backgroundColor, 0) + ', ' +
-                  getRgba(backgroundColor, 50) + ')';
+                backgroundColorGradient = backgroundColor ? 'linear-gradient(180deg, ' +
+                    getRgba(backgroundColor, 0) + ', ' +
+                    getRgba(backgroundColor, 0.1) + ', ' +
+                    getRgba(backgroundColor, 0.2) + ', ' +
+                    getRgba(backgroundColor, 0.5) + ')' : '';
 
             // These will use standard style names for CSS since they are added directly to a style sheet
             // Using background instead of background-color so we don't have to clear gradients with background-image


### PR DESCRIPTION
* Remove gradient from controls element
* Apply gradient to controlbar element
* Fixes captions, ads, and any other displays appearing above the time slider in time slider above move from being covered by gradient background

Fixes #
JW7-3753
