### PR TITLE
Update breakpoint when audio player is resized

### DIFF
--- a/src/js/view/breakpoint.js
+++ b/src/js/view/breakpoint.js
@@ -3,11 +3,6 @@ define([
     'utils/underscore',
 ], function (utils) {
     return function setBreakpoint(playerElement, playerWidth, playerHeight) {
-
-        if (utils.hasClass(playerElement, 'jw-flag-audio-player')) {
-          return;
-        }
-
         var className = 'jw-breakpoint-';
         var width = playerWidth;
         var height = playerHeight;


### PR DESCRIPTION
### Changes proposed in this pull request:
The breakpoint should always reflect the player width, even for the audio player.

Fixes #
JW7-3766
