### PR TITLE
Align time/cuepoint tooltip in timeSliderAbove mode

### DIFF
--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -302,30 +302,24 @@
     }
 
     .jw-tooltip-time {
-      bottom: 5px;
-      height: auto;
+      bottom: 0;
+      height: @mobile-touch-target * 0.5;
       line-height: normal;
       padding: 0;
       pointer-events: none;
       transform: translateX(-50%);
 
       .jw-overlay {
-        bottom: auto;
-        left: auto;
-        position: static;
+        bottom: @mobile-touch-target * 0.5;
+
+        &:after {
+          content: none;
+        }
       }
 
       .jw-time-tip {
-        border-radius: @ui-corner-round;
-        left: auto;
-        padding: 1px 5px;
-        position: static;
+        bottom: 0;
       }
-
-      .jw-text {
-        height: auto;
-      }
-
     }
 
 

--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -303,13 +303,14 @@
 
     .jw-tooltip-time {
       bottom: 0;
-      height: @mobile-touch-target * 0.5;
+      height: auto;
       line-height: normal;
       padding: 0;
       pointer-events: none;
       transform: translateX(-50%);
 
       .jw-overlay {
+        // Place the overlay above the time slider and aligned with the volume overlay
         bottom: @mobile-touch-target * 0.5;
 
         &:after {


### PR DESCRIPTION
Align time/cuepoint tooltip in timeSliderAbove mode.  Trying to use fewer styles to maintain the same functionality.

JW7-3667