### PR TITLE
Position Freewheel nonlinear above control bar with timeSliderAbove

### DIFF
--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -367,7 +367,8 @@
     }
 
     /* Move non-linear ad display above the time slider */
-    .jw-plugin {
+    .jw-plugin,
+    &.jw-flag-ads-freewheel .jw-freewheel-nonlinear-container {
       bottom: (@mobile-touch-target * 1.5);
     }
 


### PR DESCRIPTION
Position Freewheel nonlinear above control bar with timeSliderAbove.  This must be done because Freewheel does not position its nonlinear in its plugin container.

JW7-3768