### PR TITLE
Apply lighter active color to display icon background

### DIFF
--- a/src/css/skins/seven.less
+++ b/src/css/skins/seven.less
@@ -6,6 +6,8 @@
   @inactive-color: #cecece;
 
   @controlbar-background: rgba(33, 33, 33, 0.8);
+  @display-bkgd-color: @controlbar-background;
+  @display-bkgd-hover-color: rgba(33, 33, 33, 1);
 
   @controlbar-height: 2.5em;
 
@@ -27,6 +29,11 @@
   }
 
   .jw-dock-button {
+    // Seven skin dock buttons do not highlight, they only show the tooltip
+    &:hover{
+      background: @controlbar-background;
+    }
+    
     border-radius: 2.5em;
   }
 


### PR DESCRIPTION
Apply lighter active color to display icon background when hovering over the player to match previous styles of the Seven skin.

JW7-3685