### PR TITLE
Increase size of display icons as the player gets larger

### DIFF
--- a/src/css/imports/breakpoints.less
+++ b/src/css/imports/breakpoints.less
@@ -52,24 +52,7 @@ control bar groups
 display
 */
 
-.jw-breakpoint-3 {
-
-  .jw-display .jw-icon {
-    height: @mobile-touch-target * 1.25;
-    line-height: @mobile-touch-target * 1.25;
-    width: @mobile-touch-target * 1.25;
-
-    &::before {
-      font-size: @mobile-touch-target * 0.625;
-    }
-
-  }
-
-}
-
-.jw-breakpoint-4,
-.jw-breakpoint-5 {
-
+.jw-breakpoint-2 {
   .jw-display .jw-icon {
     height: @mobile-touch-target * 1.5;
     line-height: @mobile-touch-target * 1.5;
@@ -83,6 +66,9 @@ display
 
 }
 
+.jw-breakpoint-3,
+.jw-breakpoint-4,
+.jw-breakpoint-5,
 .jw-breakpoint-6,
 .jw-breakpoint-7 {
 

--- a/src/css/imports/display.less
+++ b/src/css/imports/display.less
@@ -54,7 +54,7 @@ display icons
 
   display: table;
   height: 100%;
-  padding-bottom: @controlbar-height;
+  padding: @controlbar-height 0;
   position: relative;
   width: 100%;
 


### PR DESCRIPTION
Increase size of display icons as the player gets larger by setting the player to use larger icons earlier.  Breakpoint 2 starts having its size increased, 3 is larger still, and the icons reach maximum size at breakpoint 4.  This provides a smoother transition in display icon sizes and makes the size transitions more like earlier versions of the seven skin.  Also adds a style to ensure that the display icon is centered in the player.

JW7-3741