### PR TITLE
Resume flash streams after cast disconnection

### DIFF
--- a/src/js/providers/flash.js
+++ b/src/js/providers/flash.js
@@ -262,7 +262,6 @@ define([
                         removeBlockedCheck();
                         // After plugins load, then execute commandqueue
                         _swf.once('pluginsLoaded', function() {
-                            _swf.queueCommands = false;
                             _flashCommand('setupCommandQueue', _swf.__commandQueue);
                             _swf.__commandQueue = [];
                         });


### PR DESCRIPTION
The flag that handles the queue commands was not being updated
correctly, causing the flash provider to not be able to resume playing
the current item.

JW7-3755