### PR TITLE
Enable small player color override styles

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -79,6 +79,9 @@ define([
             // Used to differentiate tab focus events from click events
             _focusFromClick = false,
 
+            // Colors written into this canvas to set maui color overrides
+            _canvasColorContext,
+
             _this = _.extend(this, Events);
 
         // Include the separate chunk that contains the @font-face definition.  Check webpackJsonjwplayer so we don't
@@ -307,12 +310,36 @@ define([
         this.handleColorOverrides = function() {
             var id = _model.get('id');
 
-            function addStyle(elements, attr, value) {
+            function getRgba(color, opacity) {
+                var data;
+
+                if (!_canvasColorContext) {
+                    var canvas = document.createElement('canvas');
+
+                    canvas.height = 1;
+                    canvas.width = 1;
+
+                    _canvasColorContext = canvas.getContext('2d');
+                }
+
+                _canvasColorContext.clearRect(0, 0, 1, 1);
+                _canvasColorContext.fillStyle = color;
+                _canvasColorContext.fillRect(0, 0, 1, 1);
+
+                data = _canvasColorContext.getImageData(0, 0, 1, 1).data;
+
+                return 'rgba(' + data[0] + ', ' + data[1] + ', ' + data[2] + ', ' + opacity + ')';
+            }
+
+            function addStyle(elements, attr, value, extendParent) {
                 if (!value) {
                     return;
                 }
 
-                elements = utils.prefix(elements, '#' + id + ' ');
+                /* if extendParent is true, bundle the first selector of
+                element string to the player element instead of defining it as a
+                child of the player element (default). i.e. #player.sel-1 .sel-2 vs. #player .sel-1 .sel-2 */
+                elements = utils.prefix(elements, '#' + id + (extendParent ? '' : ' '));
 
                 var o = {};
                 o[attr] = value;
@@ -323,7 +350,12 @@ define([
             // look good.
             var activeColor = _model.get('skinColorActive'),
                 inactiveColor = _model.get('skinColorInactive'),
-                backgroundColor = _model.get('skinColorBackground');
+                backgroundColor = _model.get('skinColorBackground'),
+                backgroundColorGradient = backgroundColor ? 'linear-gradient(180deg, ' +
+                    getRgba(backgroundColor, 0) + ', ' +
+                    getRgba(backgroundColor, 0.1) + ', ' +
+                    getRgba(backgroundColor, 0.2) + ', ' +
+                    getRgba(backgroundColor, 0.5) + ')' : '';
 
             // These will use standard style names for CSS since they are added directly to a style sheet
             // Using background instead of background-color so we don't have to clear gradients with background-image
@@ -373,6 +405,20 @@ define([
                 '.jw-background-color',
                 '.jw-tooltip-title'
             ], 'background', backgroundColor);
+
+            addStyle([
+                // for small player, set the control bar gradient to the config background color
+                '.jw-breakpoint-0 .jw-background-color.jw-controlbar',
+                '.jw-breakpoint-1 .jw-background-color.jw-controlbar',
+                '.jw-flag-time-slider-above .jw-background-color.jw-controlbar',
+            ], 'background', backgroundColorGradient, true);
+
+            addStyle([
+                // remove the config background color on time slider on small player
+                '.jw-breakpoint-0 .jw-background-color.jw-slider-time',
+                '.jw-breakpoint-1 .jw-background-color.jw-slider-time',
+                '.jw-flag-time-slider-above .jw-background-color.jw-slider-time',
+            ], 'background', 'none', true);
 
             insertGlobalColorClasses(activeColor, inactiveColor, id);
         };


### PR DESCRIPTION
* Lazy creation of the canvas color context
* Update color override comments
* Fix bg gradient override being set. When background color is not set in config, background gradient override was still being set. Fixed.
* Update color overrides
* Enable bundling first selector to player element via addStyle
function vs only allowing child selectors of player element
* Add small player styles/overrides for background color on time slider
and control bar

JW7-3732