### PR TITLE
Reimplement a style to position menu overlays when jw-flag-time-slider-above is active

### DIFF
--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -153,20 +153,16 @@
           display: block;
           height: @mobile-touch-target * 0.5;
         }
-
       }
-
-      &.jw-flag-ads,
-      &.jw-flag-live {
-
-        .jw-overlay::after {
-          display: none;
-        }
-
-      }
-
     }
 
+
+    &.jw-flag-ads,
+    &.jw-flag-live {
+      .jw-overlay::after {
+        display: none;
+      }
+    }
 
     /* ==================================================
     control bar icons and text


### PR DESCRIPTION
Putting a style back into its correct place so that overlays appear in the correct position when jw-flag-time-slider-above is active during live or ads mode.

JW7-3733