### PR TITLE
Do not fire ad complete on skipped

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -82,7 +82,7 @@ define([
 
             _instream.on('all', _instreamForward, this);
             _instream.on(events.JWPLAYER_MEDIA_TIME, _instreamTime, this);
-            _instream.on(events.JWPLAYER_MEDIA_COMPLETE, _instreamItemNext, this);
+            _instream.on(events.JWPLAYER_MEDIA_COMPLETE, _instreamItemComplete, this);
             _instream.init();
 
             // Make sure the original player's provider stops broadcasting events (pseudo-lock...)
@@ -157,19 +157,20 @@ define([
             _instream._adModel.set('position', evt.position);
         }
 
-        var _instreamItemNext = function(e) {
+        function _instreamItemComplete(e) {
             var data = {};
             if (_options.tag) {
                 data.tag = _options.tag;
             }
+            this.trigger(events.JWPLAYER_MEDIA_COMPLETE, data);
+            _instreamItemNext(e);
+        }
 
+        var _instreamItemNext = function(e) {
             if (_array && _arrayIndex + 1 < _array.length) {
-                // fire complete event
-                this.trigger(events.JWPLAYER_MEDIA_COMPLETE, data);
                 _loadNextItem();
             } else {
                 if (e.type === events.JWPLAYER_MEDIA_COMPLETE) {
-                    this.trigger(events.JWPLAYER_MEDIA_COMPLETE, data);
                     // Dispatch playlist complete event for ad pods
                     this.trigger(events.JWPLAYER_PLAYLIST_COMPLETE, {});
                 }


### PR DESCRIPTION
Ad skip and ad complete both call instreamItemNext to see if there is any other ads in the ad pod.
Do not fire adComplete event in instreamItemNext, since skipping an ad can also fire adComplete.
Instead, make instreamItemComplete function that fires adComplete, and let that function call instreamItemNext to check for next adpod item.
JW7-3777
