### PR TITLE
Use Object.define to workaround Chrome 56 object property bug

### DIFF
--- a/src/js/utils/embedswf.js
+++ b/src/js/utils/embedswf.js
@@ -14,6 +14,10 @@ define([
         object.appendChild(param);
     }
 
+    function addGetter(obj, property, value) {
+        Object.defineProperty(obj, property, { get: function() { return value; } });
+    }
+
     function embed(swfUrl, container, id, wmode) {
         var swf;
         var queueCommands = true;
@@ -74,10 +78,14 @@ define([
         }
 
         // flash can trigger events
-        _.extend(swf, Events);
+        addGetter(swf, 'on', Events.on);
+        addGetter(swf, 'once', Events.once);
+        addGetter(swf, 'off', Events.off);
+        addGetter(swf, 'trigger', Events.trigger);
+        addGetter(swf, '_events', {});
 
         // javascript can trigger SwfEventRouter callbacks
-        swf.triggerFlash = function(name) {
+        addGetter(swf, 'triggerFlash', function(name) {
             if (name === 'setupCommandQueue') {
                 queueCommands = false;
             }
@@ -119,10 +127,10 @@ define([
                 }
             }
             return swf;
-        };
+        });
 
         // commands are queued when __externalCall is not available
-        swf.__commandQueue = [];
+        addGetter(swf, '__commandQueue', []);
 
         return swf;
     }


### PR DESCRIPTION
In Chrome 56 setting properties on object elements fails. The player depends on methods it adds to the object element for communication between Flash and JavaScript.

These changes workaround the issue and ensure we only setup with primary flash when swf object properties are being set.

We've opened an issue with Chrome to resolve the issue for existing players:
https://bugs.chromium.org/p/chromium/issues/detail?id=678986

JW7-3794
Fixes #1684

