### PR TITLE
Add a countdown element to players at breakpoint 0

### DIFF
--- a/src/css/flags/live.less
+++ b/src/css/flags/live.less
@@ -9,6 +9,7 @@
     .jw-controlbar {
         .jw-text-elapsed,
         .jw-text-duration,
+        .jw-text-countdown,
         .jw-slider-time {
             display: none;
         }

--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -206,10 +206,13 @@
       margin-left: -5px;
 
       .jw-text-elapsed,
-      .jw-text-duration {
+      .jw-text-duration,
+      .jw-text-countdown {
         padding: 0 10px;
       }
+    }
 
+    &:not(.jw-breakpoint-0){
       .jw-text-duration {
         display: inline-block;
         padding-left: 0;
@@ -219,7 +222,6 @@
           padding-right: 6px;
         }
       }
-
     }
 
     .jw-controlbar-right-group {

--- a/src/css/imports/controlbar.less
+++ b/src/css/imports/controlbar.less
@@ -52,7 +52,8 @@
 .jw-icon-tooltip,
 .jw-slider-horizontal,
 .jw-text-elapsed,
-.jw-text-duration {
+.jw-text-duration,
+.jw-text-countdown {
   display: inline-block;
   height: @controlbar-height;
   position: relative;
@@ -106,4 +107,15 @@
 .jw-slider-volume.jw-slider-horizontal,
 .jw-icon-inline.jw-icon-volume {
   display: none;
+}
+
+.jwplayer:not(.jw-breakpoint-0) .jw-text-countdown {
+  display: none;
+}
+
+.jw-breakpoint-0 .jw-controlbar {
+  .jw-text-duration,
+  .jw-text-elapsed {
+    display: none;
+  }
 }

--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -80,6 +80,7 @@
     .jw-icon-inline,
     .jw-icon-tooltip,
     .jw-text-elapsed,
+    .jw-text-countdown,
     .jw-text-duration {
         padding: 0 @ui-padding;
     }
@@ -395,7 +396,8 @@
         .jw-icon-inline,
         .jw-icon-tooltip,
         .jw-text-elapsed,
-        .jw-text-duration {
+        .jw-text-duration,
+        .jw-text-countdown {
             height: @controlbar-height;
             line-height: @controlbar-height;
         }
@@ -409,7 +411,8 @@
           .jw-icon-inline,
           .jw-icon-tooltip,
           .jw-text-elapsed,
-          .jw-text-duration {
+          .jw-text-duration,
+          .jw-text-countdown {
               height: auto;
               line-height: normal;
           }

--- a/src/css/skins/vapor.less
+++ b/src/css/skins/vapor.less
@@ -68,7 +68,8 @@
     .jw-icon-tooltip,
     .jw-slider-horizontal,
     .jw-text-elapsed,
-    .jw-text-duration {
+    .jw-text-duration,
+    .jw-text-countdown {
         height: @controlbar-height;
         line-height: @controlbar-height;
     }

--- a/src/js/view/controlbar.js
+++ b/src/js/view/controlbar.js
@@ -125,6 +125,7 @@ define([
                 rewind: button('jw-icon-rewind', this.rewind.bind(this), rewind),
                 next: button('jw-icon-next', null, next), // the click/tap event listener is in the nextup tooltip
                 elapsed: text('jw-text-elapsed', 'timer'),
+                countdown: text('jw-text-countdown', 'timer'),
                 time: timeSlider,
                 duration: text('jw-text-duration', 'timer'),
                 durationLeft: text('jw-text-duration', 'timer'),
@@ -143,7 +144,8 @@ define([
                     this.elements.play,
                     this.elements.rewind,
                     this.elements.elapsed,
-                    this.elements.durationLeft
+                    this.elements.durationLeft,
+                    this.elements.countdown
                 ],
                 center: [
                     this.elements.time,
@@ -299,6 +301,7 @@ define([
             this.elements.duration.innerHTML = '00:00';
             this.elements.durationLeft.innerHTML = '00:00';
             this.elements.elapsed.innerHTML = '00:00';
+            this.elements.countdown.innerHTML = '00:00';
 
             this.elements.audiotracks.setup();
         },
@@ -355,6 +358,7 @@ define([
                 elapsedTime = utils.timeFormat(val);
             }
             this.elements.elapsed.innerHTML = elapsedTime;
+            this.elements.countdown.innerHTML = '-' + utils.timeFormat(duration - val);
         },
         onDuration : function(model, val) {
             var totalTime;

--- a/src/js/view/controlbar.js
+++ b/src/js/view/controlbar.js
@@ -350,15 +350,17 @@ define([
             }
         },
         onElapsed: function(model, val) {
-            var elapsedTime;
+            var elapsedTime,
+                countdownTime;
             var duration = model.get('duration');
             if (model.get('streamType') === 'DVR') {
-                elapsedTime = '-' + utils.timeFormat(-duration);
+                elapsedTime = countdownTime = '-' + utils.timeFormat(-duration);
             } else {
                 elapsedTime = utils.timeFormat(val);
+                countdownTime = ((duration - val > 1) ? '-' : '') + utils.timeFormat(duration - val);
             }
             this.elements.elapsed.innerHTML = elapsedTime;
-            this.elements.countdown.innerHTML = '-' + utils.timeFormat(duration - val);
+            this.elements.countdown.innerHTML = countdownTime;
         },
         onDuration : function(model, val) {
             var totalTime;

--- a/src/js/view/controlbar.js
+++ b/src/js/view/controlbar.js
@@ -357,7 +357,7 @@ define([
                 elapsedTime = countdownTime = '-' + utils.timeFormat(-duration);
             } else {
                 elapsedTime = utils.timeFormat(val);
-                countdownTime = ((duration - val > 1) ? '-' : '') + utils.timeFormat(duration - val);
+                countdownTime = utils.timeFormat(duration - val);
             }
             this.elements.elapsed.innerHTML = elapsedTime;
             this.elements.countdown.innerHTML = countdownTime;


### PR DESCRIPTION
This adds a countdown element to players at breakpoint 0 instead of using the elapsed time and total duration UI elements.  This saves some space and lets the UI breathe more.

JW7-3383