### PR TITLE
Constrain control elements to display inside the player

### DIFF
--- a/src/css/imports/jwplayerelement.less
+++ b/src/css/imports/jwplayerelement.less
@@ -72,8 +72,7 @@
 }
 
 .jw-controls {
-
-  // display: flex;
+    overflow: hidden;
 
     &.jw-controls-disabled {
         display: none;


### PR DESCRIPTION
Prevent the control elements (particularly the jw-control-bar) from overflowing out control container.  This ensures that elements in the controller won't display during the right click state, which allows child elements of the player to display outside the player.

JW7-3786