### PR TITLE
Trigger firstFrame before dom manipulation

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -337,13 +337,15 @@ define([
 
         function _playingHandler() {
             _this.setState(states.PLAYING);
+            // For accuracy, trigger firstFrame before manipulating the DOM
+            _this.trigger(events.JWPLAYER_PROVIDER_FIRST_FRAME, {});
+
             if(!_videotag.hasAttribute('jw-played')) {
                 _setAttribute('jw-played','');
             }
             if (_videotag.hasAttribute('jw-gesture-required')) {
                 _videotag.removeAttribute('jw-gesture-required');
             }
-            _this.trigger(events.JWPLAYER_PROVIDER_FIRST_FRAME, {});
         }
 
         function _pauseHandler() {


### PR DESCRIPTION
Get a more accurate time to first frame by triggering before DOM manipulation.