### PR TITLE
Fix timeslider padding

### DIFF
--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -133,7 +133,7 @@ of the file to be defined separately.
 
       .jw-controlbar {
         height: @mobile-touch-target * 1.5;
-        padding: @slider-fixed-height 15px 0;
+        padding: @slider-fixed-height 0 0;
       }
 
     }


### PR DESCRIPTION
### Changes proposed in this pull request:

Set controlbar left/right padding to 0. This keeps button spacing consistent while ensuring that the time slider has consistent left and right padding.

Fixes #
JW7-3790
