### PR TITLE
Call instreamItemNext with this

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -163,7 +163,7 @@ define([
                 data.tag = _options.tag;
             }
             this.trigger(events.JWPLAYER_MEDIA_COMPLETE, data);
-            _instreamItemNext(e);
+            _instreamItemNext.call(this, e);
         }
 
         var _instreamItemNext = function(e) {


### PR DESCRIPTION
```this``` was undefined because it was not being called with ```.call```
JW7-3777