### PR TITLE
Prevent VTTCue cropping

### DIFF
--- a/src/css/imports/captions.less
+++ b/src/css/imports/captions.less
@@ -61,4 +61,9 @@
         max-height: calc(97% - 6.25 * (@controlbar-height));
         line-height: 1.3em;
     }
+    video::-webkit-media-text-track-display {
+        // Ensure captions aren't cropped when the pseudo
+        // element's width cannot accommodate all the text
+        min-width: -webkit-min-content;
+    }
 }


### PR DESCRIPTION
### Changes proposed in this pull request:

Setting `min-width` ensures VTTCues aren't cropped when the pseudo element's width cannot accommodate all the text in the cue.
 
Fixes #
JW7-3717
