### PR TITLE
Fix display icon alignment inconsistency

### DIFF
--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -72,6 +72,7 @@ of the file to be defined separately.
   &:not(.jw-breakpoint-0) {
 
     &.jw-state-paused,
+    &.jw-state-buffering,
     &.jw-state-playing:not(.jw-flag-user-inactive),
     &.jw-flag-cast-available,
     &.jw-flag-casting {

--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -58,6 +58,7 @@ of the file to be defined separately.
   &.jw-breakpoint-0 {
 
     &.jw-state-paused,
+    &.jw-state-buffering,
     &.jw-state-playing:not(.jw-flag-user-inactive) {
 
       // add padding to top that equals height of dock icons if the video is not in aspect mode

--- a/src/css/flags/user-inactive.less
+++ b/src/css/flags/user-inactive.less
@@ -26,6 +26,9 @@
       .jw-controlbar {
           display: none;
       }
+      .jw-display {
+        padding-bottom: @mobile-touch-target;
+      }
   }
 
   &.jw-flag-casting {


### PR DESCRIPTION
* Buffering state would cause a small jump up in location of display icon
* Buffering icon not centered on player viewport when under user inactive flag because padding of element was not consistent with other states

JW7-3742