### PR TITLE
Adjust time slider above slider padding

### DIFF
--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -219,7 +219,7 @@ of the file to be defined separately.
     .jw-controlbar-center-group {
       height: @slider-fixed-height;
       left: 0;
-      padding: 0 20px;
+      padding: 0 15px;
       position: absolute;
       right: 0;
       top: 0;


### PR DESCRIPTION
@egreaves removed control bar padding. This adjusts the time slider padding to align better with control bar elements on the ends.