### PR TITLE
Show play button for paused ads on touch devices

### DIFF
--- a/src/css/flags/ads.less
+++ b/src/css/flags/ads.less
@@ -78,10 +78,6 @@
         .jw-controlbar {
             font-size: 1em;
         }
-
-        &.jw-state-paused .jw-display {
-            display: none;
-        }
     }
 
     &.jw-skin-seven .jw-controlbar {


### PR DESCRIPTION
### Changes proposed in this pull request:
At breakpoints 0 and 1, where there's no play/pause button in the control bar, showing the play button when an ad is paused gives the user a visual cue that tapping will resume ad playback.

Fixes #
JW7-3818
