### PR TITLE
Fire beforePlay after playlistItem

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -214,7 +214,9 @@ define([
                 // Send queued events
                 for (var i = 0; i < _eventQueuedUntilReady.length; i++) {
                     var event = _eventQueuedUntilReady[i];
+                    _preplay = (event.type === events.JWPLAYER_MEDIA_BEFOREPLAY);
                     _this.trigger(event.type, event.args);
+                    _preplay = false;
                 }
 
                 var related = _api.getPlugin('related');
@@ -377,7 +379,7 @@ define([
                 }
                 if (!_preplay) {
                     _preplay = true;
-                    _this.trigger(events.JWPLAYER_MEDIA_BEFOREPLAY, {'playReason': _model.get('playReason')});
+                    _this.triggerAfterReady(events.JWPLAYER_MEDIA_BEFOREPLAY, {'playReason': _model.get('playReason')});
                     _preplay = false;
                     if (_interruptPlay) {
                         _interruptPlay = false;


### PR DESCRIPTION
Fixes an issue with prerolls not firing with googima when playback is started by calling player from a ready event handler.

With these changes, when this happens beforePlay will be queued so that it follows the playlistItem event when is required for googima to setup to the adsManager.

```js
{
    file: "//content.jwplatform.com/videos/SJnBN5W3-B2XWaEP9.mp4",
    advertising: {
        client: "googima",
        tag: "https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ct%3Dlinear&correlator="
    }
    ,
    events: {
        onReady: function () {
            this.play();
        }
    }
}
```

Fixes
JW7-3658
