### PR TITLE
Dock icon margin at breakpoint 0

### DIFF
--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -33,7 +33,7 @@ of the file to be defined separately.
   }
 
   .jw-dock-button {
-    margin: 0;
+    margin: 1px;
     height: @mobile-touch-target;
     width: @mobile-touch-target;
   }


### PR DESCRIPTION
### Changes proposed in this pull request:

Add a 1px margin to dock buttons so they have slight visual separation at breakpoint 0.

Fixes #
JW7-3826
