### PR TITLE
Destroy plugin before playlist item

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -310,11 +310,11 @@ define([
                 _model.set('preInstreamState', 'instream-idle');
 
                 _stop(true);
+                _this.trigger('destroyPlugin', {});
 
                 if (_canAutoStart()) {
                     _model.once('itemReady', _autoStart);
                 }
-                _this.trigger('destroyPlugin', {});
 
                 switch (typeof item) {
                     case 'string':


### PR DESCRIPTION
Moves "destroyPlugin" event added in #1523 to before "itemReady".

Triggering "destroyPlugin" after "itemReady" destroys advertising logic setup on "playlistItem". It should be called before "itemReady" so that ad plugins can work as designed from the "playlistItem" event forward.

