### PR TITLE
Truncate ad text in control bar

### DIFF
--- a/src/css/flags/ads.less
+++ b/src/css/flags/ads.less
@@ -47,18 +47,6 @@
 
         .jw-text-alt {
             display: inline-block;
-            height: @controlbar-height;
-            line-height: @controlbar-height;
-            margin: auto -0.5em;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            vertical-align: middle;
-            white-space: nowrap;
-            position: absolute;
-            top: 0;
-            bottom: 0;
-            width: 100%;
-            text-align: left;
         }
 
         .jw-slider-volume.jw-slider-horizontal,
@@ -68,9 +56,6 @@
         .jw-icon-tooltip.jw-icon-volume {
             display: none;
         }
-    }
-    .jw-controlbar-center-group {
-        position: relative;
     }
 }
 

--- a/src/css/flags/ads.less
+++ b/src/css/flags/ads.less
@@ -47,13 +47,18 @@
 
         .jw-text-alt {
             display: inline-block;
-            height: auto;
+            height: @controlbar-height;
             line-height: @controlbar-height;
-            margin: 0 -0.5em;
+            margin: auto -0.5em;
             overflow: hidden;
             text-overflow: ellipsis;
             vertical-align: middle;
             white-space: nowrap;
+            position: absolute;
+            top: 0;
+            bottom: 0;
+            width: 100%;
+            text-align: left;
         }
 
         .jw-slider-volume.jw-slider-horizontal,
@@ -64,7 +69,9 @@
             display: none;
         }
     }
-
+    .jw-controlbar-center-group {
+        position: relative;
+    }
 }
 
 .jwplayer.jw-flag-ads-googleima {

--- a/src/css/flags/live.less
+++ b/src/css/flags/live.less
@@ -15,13 +15,6 @@
         }
         .jw-text-alt {
             display: inline-block;
-            height: auto;
-            line-height: @controlbar-height;
-            margin: 0 -0.5em 0;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            vertical-align: middle;
-            white-space: nowrap;
         }
     }
 

--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -218,23 +218,24 @@ of the file to be defined separately.
     */
 
     // position the time slider group above other control bar elements
-    .jw-controlbar-center-group {
-      height: @slider-fixed-height;
-      left: 0;
-      padding: 0 15px;
-      position: absolute;
-      right: 0;
-      top: 0;
-      width: 100%;
-    }
+    &:not(.jw-flag-ads) {
+      .jw-controlbar-center-group {
+        height: @slider-fixed-height;
+        left: 0;
+        padding: 0 15px;
+        position: absolute;
+        right: 0;
+        top: 0;
+        width: 100%;
+      }
+      .jw-controlbar-left-group {
+        margin-left: -5px;
 
-    .jw-controlbar-left-group {
-      margin-left: -5px;
-
-      .jw-text-elapsed,
-      .jw-text-duration,
-      .jw-text-countdown {
-        padding: 0 10px;
+        .jw-text-elapsed,
+        .jw-text-duration,
+        .jw-text-countdown {
+          padding: 0 10px;
+        }
       }
     }
 
@@ -375,23 +376,6 @@ of the file to be defined separately.
         padding-right: 5px;
       }
 
-      .jw-controlbar-center-group {
-        height: auto;
-        overflow: hidden;
-        padding: 0;
-        position: static;
-        text-overflow: ellipsis;
-        width: 100%;
-      }
-
-      .jw-group > .jw-text-alt {
-        display: block;
-        margin: 0;
-        position: relative;
-        text-align: left;
-        top: -1px;
-      }
-
       .jw-text-duration {
         display: none;
       }
@@ -433,8 +417,10 @@ of the file to be defined separately.
           display: none;
         }
 
-        .jw-group > .jw-text-alt {
-          margin: 0;
+        &:not(.jw-flag-ads) {
+          .jw-group > .jw-text-alt {
+            margin: 0;
+          }
         }
 
       }

--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -218,7 +218,7 @@ of the file to be defined separately.
     */
 
     // position the time slider group above other control bar elements
-    &:not(.jw-flag-ads) {
+    &:not(.jw-flag-ads):not(.jw-flag-live) {
       .jw-controlbar-center-group {
         height: @slider-fixed-height;
         left: 0;
@@ -376,6 +376,17 @@ of the file to be defined separately.
         padding-right: 5px;
       }
 
+      .jw-controlbar-center-group {
+        height: auto;
+        padding: 0;
+      }
+
+      .jw-group > .jw-text-alt {
+        display: inline-block;
+        margin: 0;
+        line-height: @mobile-touch-target;
+      }
+
       .jw-text-duration {
         display: none;
       }
@@ -416,13 +427,7 @@ of the file to be defined separately.
         .jw-controlbar-left-group {
           display: none;
         }
-
-        &:not(.jw-flag-ads) {
-          .jw-group > .jw-text-alt {
-            margin: 0;
-          }
-        }
-
+        
       }
 
     }

--- a/src/css/imports/controlbar.less
+++ b/src/css/imports/controlbar.less
@@ -21,6 +21,7 @@
 .jw-controlbar-center-group {
 
   padding: 0 @ui-padding;
+  position: relative;
   width: 100%;
 
   .jw-slider-time, .jw-text-alt {
@@ -29,6 +30,19 @@
 
   .jw-text-alt {
     display: none;
+    position: absolute;
+    top: -1px;
+    bottom: 0;
+    width: 100%;
+    height: auto;
+    line-height: @controlbar-height;
+    margin: 0.5em 0;
+    padding-right: 0.5em;
+    overflow: hidden;
+    text-align: left;
+    text-overflow: ellipsis;
+    vertical-align: middle;
+    white-space: nowrap;
   }
 
 }


### PR DESCRIPTION
### Changes proposed in this pull request:

Ensure ad text doesn't break the control bar by pushing buttons on the right up. This truncates the text with an ellipses and keeps the control bar's height fixed.
Fixes #
JW7-3829
