### PR TITLE
Apply layout to chromecast button, not it’s container

### DIFF
--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -190,7 +190,6 @@ of the file to be defined separately.
 
     .jw-group {
       .jw-icon-cast {
-        width: auto;
 
         button {
           font-size: inherit;

--- a/src/css/imports/controlbar.less
+++ b/src/css/imports/controlbar.less
@@ -93,7 +93,6 @@
 
 .jw-icon-cast {
   display: none;
-  width: auto;
   margin: 0;
   padding: 0;
 

--- a/src/css/imports/controlbar.less
+++ b/src/css/imports/controlbar.less
@@ -93,15 +93,16 @@
 
 .jw-icon-cast {
   display: none;
+  width: auto;
   margin: 0;
   padding: 0;
-  width: 2.25em;
 
   button {
     background-color: transparent;
     border: none;
     cursor: pointer;
     font-size: inherit;
+    width: 2.25em;
   }
 }
 


### PR DESCRIPTION
Chromecast button hides itself when no devices are available (as far as our API is concerned casting is available in Chrome when the Chromecast SDK is loaded). This puts the layout on the button so that when it's hidden, it does not take up space.

JW7-3841
