### PR TITLE
Don't reposition the display icon in the buffering state

### DIFF
--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -51,8 +51,11 @@ of the file to be defined separately.
   display
   */
 
-  .jw-display {
-    padding-bottom: @mobile-touch-target * 1.5;
+  &.jw-breakpoint-1,
+  &.jw-breakpoint-0 {
+    .jw-display {
+      padding-bottom: @mobile-touch-target * 1.5;
+    }
   }
 
   &.jw-breakpoint-0 {
@@ -64,29 +67,6 @@ of the file to be defined separately.
       // add padding to top that equals height of dock icons if the video is not in aspect mode
       .jw-display {
         padding-top: @mobile-touch-target;
-      }
-
-    }
-
-  }
-
-  &:not(.jw-breakpoint-0) {
-
-    &.jw-state-paused,
-    &.jw-state-buffering,
-    &.jw-state-playing:not(.jw-flag-user-inactive),
-    &.jw-flag-cast-available,
-    &.jw-flag-casting {
-
-      // add top padding to display that equals height of dock icons
-      .jw-display {
-        padding-top: @mobile-touch-target;
-      }
-
-      // and add top padding to display-container to cover total of dock button top and bottom margins
-      // goal here is to clear the dock icon outer height
-      .jw-display-container {
-        padding-top: 4%;
       }
 
     }

--- a/src/css/flags/user-inactive.less
+++ b/src/css/flags/user-inactive.less
@@ -26,9 +26,6 @@
       .jw-controlbar {
           display: none;
       }
-      .jw-display {
-        padding-bottom: @mobile-touch-target;
-      }
   }
 
   &.jw-flag-casting {


### PR DESCRIPTION
### Changes proposed in this pull request:

Also tweaked the `jw-display` padding so the display icons are pushed up only at breakpoint 1 and 0. This ensures they're above the timeslider and makes them look centered/balanced. 

Fixes #
JW7-3845
