### PR TITLE
Keep display icons in a fixed position at breakpoint 0 & 1

### DIFF
--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -51,26 +51,15 @@ of the file to be defined separately.
   display
   */
 
+
+  // Consistent padding for display icons so they don't interfere with the time slider touch target
+  // and don't get repositioned when the timeslider is not visible
   &.jw-breakpoint-1,
   &.jw-breakpoint-0 {
-    .jw-display {
-      padding-bottom: @mobile-touch-target * 1.5;
-    }
-  }
-
-  &.jw-breakpoint-0 {
-
-    &.jw-state-paused,
-    &.jw-state-buffering,
-    &.jw-state-playing:not(.jw-flag-user-inactive) {
-
-      // add padding to top that equals height of dock icons if the video is not in aspect mode
       .jw-display {
         padding-top: @mobile-touch-target;
+        padding-bottom: @mobile-touch-target * 1.5;
       }
-
-    }
-
   }
 
   /* ==================================================


### PR DESCRIPTION
### Changes proposed in this pull request:

This ensures the display icons don't interfere with the dock icons' or timeslider's touch target area when they are present. It also ensures the display icons don't move in the idle state when casting becomes available, where the control bar is displayed. 

Fixes #
JW7-3857
