### PR TITLE
Manage player css flags

### DIFF
--- a/src/css/flags/ads.less
+++ b/src/css/flags/ads.less
@@ -15,14 +15,13 @@
         display: none;
     }
 
-    &:not(.jw-breakpoint-0):not(.jw-breakpoint-1) {
+    &:not(.jw-flag-small-player) {
       .jw-display {
         display: none;
       }
     }
 
-    &.jw-breakpoint-0,
-    &.jw-breakpoint-1 {
+    &.jw-flag-small-player {
       .jw-display-icon-rewind,
       .jw-display-icon-next {
         display: none;
@@ -98,8 +97,7 @@
 }
 
 .jwplayer.jw-flag-ads-vpaid {
-    &.jw-breakpoint-0,
-    &.jw-breakpoint-1 {
+    &.jw-flag-small-player {
         .jw-controls {
             background: none;
         }

--- a/src/css/flags/audioplayer.less
+++ b/src/css/flags/audioplayer.less
@@ -58,8 +58,7 @@
         padding-bottom: 2px;
     }
 
-    &.jw-breakpoint-1,
-    &.jw-breakpoint-0 {
+    &.jw-flag-small-player {
         .jw-text-elapsed,
         .jw-text-duration {
             display: none;

--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -1,12 +1,3 @@
-/*
-Some refactoring is still necessary to prevent selectors such as:
-- .jw-breakpoint-0:not(.jw-flag-audio-player).jw-breakpoint-0
-- .jw-breakpoint-0:not(.jw-breakpoint-0)
-
-We can probably pull some of these breakpoint 0 and 1 styles down the the bottom
-of the file to be defined separately.
-*/
-
 @import "../imports/vars";
 
 /* time slider above or small player (both override player into same UI) */
@@ -48,8 +39,7 @@ of the file to be defined separately.
 
   // Consistent padding for display icons so they don't interfere with the time slider touch target
   // and don't get repositioned when the timeslider is not visible
-  &.jw-breakpoint-1,
-  &.jw-breakpoint-0 {
+  &.jw-flag-small-player {
       .jw-display {
         padding-top: @mobile-touch-target;
         padding-bottom: @mobile-touch-target * 1.5;
@@ -164,8 +154,7 @@ of the file to be defined separately.
       }
     }
 
-    &.jw-breakpoint-0,
-    &.jw-breakpoint-1 {
+    &.jw-flag-small-player {
       .jw-group {
         > .jw-icon-rewind,
         > .jw-icon-next,
@@ -239,8 +228,7 @@ of the file to be defined separately.
       margin-bottom: 2px;
     }
 
-    &.jw-breakpoint-0,
-    &.jw-breakpoint-1 {
+    &.jw-flag-small-player {
       .jw-controlbar .jw-slider-volume.jw-slider-horizontal {
         display: none;
       }
@@ -386,8 +374,7 @@ of the file to be defined separately.
         display: table-cell;
       }
 
-      &.jw-breakpoint-0,
-      &.jw-breakpoint-1 {
+      &.jw-flag-small-player {
 
         .jw-display {
           display: none;

--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -10,9 +10,7 @@ of the file to be defined separately.
 @import "../imports/vars";
 
 /* time slider above or small player (both override player into same UI) */
-.jw-flag-time-slider-above,
-.jw-breakpoint-0,
-.jw-breakpoint-1 {
+.jw-flag-time-slider-above {
 
 
   /* ==================================================
@@ -30,21 +28,17 @@ of the file to be defined separately.
       padding: 0 1%;
     }
 
+    // give dock buttons some space between each other above smallest breakpoint
+    .jw-dock-button {
+      margin: 2% 1%;
+    }
+
   }
 
   .jw-dock-button {
     margin: 1px;
     height: @mobile-touch-target;
     width: @mobile-touch-target;
-  }
-
-  &:not(.jw-breakpoint-0) {
-
-    // give dock buttons some space between each other above smallest breakpoint
-    .jw-dock-button {
-      margin: 2% 1%;
-    }
-
   }
 
   /* ==================================================
@@ -66,7 +60,7 @@ of the file to be defined separately.
   to avoid overriding audio player on small size
   */
 
-  &:not(.jw-flag-audio-player) {
+  &.jwplayer {
 
     /* ==================================================
     control bar
@@ -402,7 +396,7 @@ of the file to be defined separately.
         .jw-group .jw-icon-playback {
           display: inline-block;
         }
-        
+
       }
 
     }

--- a/src/css/imports/jwplayerelement.less
+++ b/src/css/imports/jwplayerelement.less
@@ -83,8 +83,7 @@
     }
 }
 
-.jw-breakpoint-0 .jw-controls,
-.jw-breakpoint-1 .jw-controls {
+.jw-flag-small-player .jw-controls {
   text-align: center;
 }
 

--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -23,7 +23,7 @@
 
 .inset-controlbar() {
 
-  &.jw-flag-time-slider-default:not(.jw-flag-audio-player):not(.jw-breakpoint-0):not(.jw-breakpoint-1) {
+  &:not(.jw-flag-time-slider-above):not(.jw-flag-audio-player):not(.jw-flag-small-player) {
 
     .jw-controlbar {
       bottom: .7em;
@@ -364,7 +364,7 @@
 
     .controlbar-height() {
 
-      &.jw-flag-time-slider-default:not(.jw-breakpoint-0):not(.jw-breakpoint-1) {
+      &:not(.jw-flag-time-slider-above):not(.jw-flag-small-player) {
 
         .jw-controlbar {
 

--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -323,9 +323,7 @@
 
         &:not(.jw-flag-audio-player) {
             // time slider above
-            &.jw-flag-time-slider-above,
-            &.jw-breakpoint-0,
-            &.jw-breakpoint-1 {
+            &.jw-flag-time-slider-above {
 
                 .jw-controlbar-center-group {
 

--- a/src/css/imports/nextup.less
+++ b/src/css/imports/nextup.less
@@ -19,8 +19,7 @@
   visibility: hidden;
   width: 100%;
 
-  .jw-breakpoint-0 &,
-  .jw-breakpoint-1 & {
+  .jw-flag-small-player & {
     display: none;
   }
 

--- a/src/css/imports/title.less
+++ b/src/css/imports/title.less
@@ -32,8 +32,7 @@
     margin-top: -.5em;
 }
 
-.jw-breakpoint-0,
-.jw-breakpoint-1 {
+.jw-flag-small-player {
 
   .jw-title {
     background: linear-gradient(180deg, fade(mix(black, white, 80%), 75%), fade(mix(black, white, 80%), 0%));

--- a/src/css/skins/five.less
+++ b/src/css/skins/five.less
@@ -132,9 +132,7 @@
     }
 
     // override control bar element colors that don't look good in time slider above mode
-    &.jw-flag-time-slider-above,
-    &.jw-breakpoint-0,
-    &.jw-breakpoint-1 {
+    &.jw-flag-time-slider-above {
       .jw-controlbar .jw-group {
         > .jw-text {
           color: rgba(255, 255, 255, 0.6);

--- a/src/css/skins/vapor.less
+++ b/src/css/skins/vapor.less
@@ -143,9 +143,7 @@
     }
 
 		// adjust horizontal time slider under time slider above flag/small player
-		&.jw-flag-time-slider-above,
-		&.jw-breakpoint-0,
-		&.jw-breakpoint-1 {
+		&.jw-flag-time-slider-above {
 
 			.jw-slider-volume.jw-slider-horizontal {
 				height: 0.5em;

--- a/src/css/states/paused.less
+++ b/src/css/states/paused.less
@@ -2,7 +2,7 @@
 
 .jwplayer.jw-state-paused {
 
-  &:not(.jw-flag-touch):not(.jw-breakpoint-0):not(.jw-breakpoint-1) {
+  &:not(.jw-flag-touch):not(.jw-flag-small-player) {
     .jw-display {
       display: none;
     }

--- a/src/css/states/playing.less
+++ b/src/css/states/playing.less
@@ -2,7 +2,7 @@
 
 .jwplayer.jw-state-playing {
 
-  &:not(.jw-flag-touch):not(.jw-breakpoint-0):not(.jw-breakpoint-1) {
+  &:not(.jw-flag-touch):not(.jw-flag-small-player) {
     .jw-display {
       display: none;
     }

--- a/src/js/view/breakpoint.js
+++ b/src/js/view/breakpoint.js
@@ -3,29 +3,30 @@ define([
     'utils/underscore',
 ], function (utils) {
     return function setBreakpoint(playerElement, playerWidth, playerHeight) {
-        var className = 'jw-breakpoint-';
         var width = playerWidth;
         var height = playerHeight;
 
+        var breakPoint = 0;
         if (width >= 1280) {
-            className += '7';
+            breakPoint = 7;
         } else if (width >= 960) {
-            className += '6';
+            breakPoint = 6;
         } else if (width >= 800) {
-            className += '5';
+            breakPoint = 5;
         } else if (width >= 640) {
-            className += '4';
+            breakPoint = 4;
         } else if (width >= 540) {
-            className += '3';
+            breakPoint = 3;
         } else if (width >= 420) {
-            className += '2';
+            breakPoint = 2;
         } else if (width >= 320) {
-            className += '1';
-        } else {
-            className += '0';
+            breakPoint = 1;
         }
 
+        var className = 'jw-breakpoint-' + breakPoint;
         utils.replaceClass(playerElement, /jw-breakpoint-\d+/, className);
         utils.toggleClass(playerElement, 'jw-orientation-portrait', (height > width));
+
+        return breakPoint;
     };
 });

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -277,10 +277,11 @@ define([
 
 
         function _setTimesliderFlags(breakPoint, audioMode) {
+            var smallPlayer = breakPoint < 2;
+            var timeSliderAbove = !audioMode && (_model.get('timeSliderAbove') || smallPlayer);
+            utils.toggleClass(_playerElement, 'jw-flag-small-player', smallPlayer);
             utils.toggleClass(_playerElement, 'jw-flag-audio-player', audioMode);
-            var timeSliderAbove = !audioMode && (_model.get('timeSliderAbove') || breakPoint < 2);
             utils.toggleClass(_playerElement, 'jw-flag-time-slider-above', timeSliderAbove);
-            utils.toggleClass(_playerElement, 'jw-flag-time-slider-default', !timeSliderAbove);
         }
 
         function _responsiveListener() {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -55,7 +55,6 @@ define([
             _nextuptooltip,
             _mute,
             _captionsRenderer,
-            _audioMode,
             _showing = false,
             _rightClickMenu,
             _resizeMediaTimeout = -1,
@@ -267,12 +266,21 @@ define([
 
             _model.set('containerWidth', containerWidth);
             _model.set('containerHeight', containerHeight);
-            setBreakpoint(_playerElement, containerWidth, containerHeight);
+            var breakPoint = setBreakpoint(_playerElement, containerWidth, containerHeight);
+            _setTimesliderFlags(breakPoint, _model.get('audioMode'));
 
             _this.trigger(events.JWPLAYER_RESIZE, {
                 width: containerWidth,
                 height: containerHeight
             });
+        }
+
+
+        function _setTimesliderFlags(breakPoint, audioMode) {
+            utils.toggleClass(_playerElement, 'jw-flag-audio-player', audioMode);
+            var timeSliderAbove = !audioMode && (_model.get('timeSliderAbove') || breakPoint < 2);
+            utils.toggleClass(_playerElement, 'jw-flag-time-slider-above', timeSliderAbove);
+            utils.toggleClass(_playerElement, 'jw-flag-time-slider-default', !timeSliderAbove);
         }
 
         function _responsiveListener() {
@@ -433,13 +441,6 @@ define([
                 _model.once('change:skin-loading', function() {
                     utils.removeClass(_playerElement, 'jw-flag-skin-loading');
                 });
-            }
-
-            // display time slider above control bar if configured
-            if (_model.get('timeSliderAbove') && !utils.hasClass(_playerElement, 'jw-flag-audio-player')) {
-              utils.addClass(_playerElement, 'jw-flag-time-slider-above');
-            } else {
-              utils.addClass(_playerElement, 'jw-flag-time-slider-default');
             }
 
             this.onChangeSkin(_model, _model.get('skin'), '');
@@ -779,15 +780,14 @@ define([
         }
 
         function _checkAudioMode(height) {
-            _audioMode = _isAudioMode(height);
+            var audioMode = _isAudioMode(height);
             if (_controlbar) {
-                if (!_audioMode) {
+                if (!audioMode) {
                     var model = _instreamModel ? _instreamModel : _model;
                     _stateHandler(model, model.get('state'));
                 }
             }
-
-            utils.toggleClass(_playerElement, 'jw-flag-audio-player', _audioMode);
+            _model.set('audioMode', audioMode);
         }
 
         function _isAudioMode(height) {


### PR DESCRIPTION
- audio mode and time slider above are exclusive of each other
- removed time-slider-above
- breakpoint < 2 gets time-slider-above and ads small-player flag
- using small player flag reduces redundant rule strings in css

JW7-3831