### PR TITLE
Add audio mode check to prevent undefined

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -266,6 +266,7 @@ define([
 
             _model.set('containerWidth', containerWidth);
             _model.set('containerHeight', containerHeight);
+            _checkAudioMode(containerHeight);
             var breakPoint = setBreakpoint(_playerElement, containerWidth, containerHeight);
             _setTimesliderFlags(breakPoint, _model.get('audioMode'));
 


### PR DESCRIPTION
Audio mode flag would be applied despite value being undefined, which is because _model.get('audioMode') hasn't been set prior to calling _setTimesliderFlags to determine player flags. Added call to check audio mode and give it boolean value.

Bug created by result of 'undefined' value:
<img width="509" alt="screen shot 2017-01-18 at 5 54 06 pm" src="https://cloud.githubusercontent.com/assets/498069/22086541/25cd3ee8-dda7-11e6-9abc-bfde4ccc59ad.png">
