### PR TITLE
Keep NextUp above control bar

### DIFF
--- a/src/css/flags/touch.less
+++ b/src/css/flags/touch.less
@@ -9,7 +9,8 @@
             font-size: 1.5em;
         }
 
-        .jw-captions {
+        .jw-captions,
+        .jw-nextup-container {
             // control bar is (1.5*2.5 = 3.75)em for mobile, so bottom should be 0.5 above that
             bottom: 4.25em;
         }


### PR DESCRIPTION
### Changes proposed in this pull request:

Add bottom padding to nextup to account for control bar size on touch devices at larger breakpoints.

Fixes #
JW7-3870
