### PR TITLE
Fix control bar showing during playback despite user inactive

### DIFF
--- a/src/css/imports/controlbar.less
+++ b/src/css/imports/controlbar.less
@@ -2,7 +2,7 @@
 @import "vars";
 
 .jw-controlbar {
-  display: table;
+  display: inline-block; // for correct display in IE browsers
   position: absolute;
   bottom: 0;
   height: @controlbar-height;

--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -35,6 +35,13 @@
       width: 96%; // width assignment is required for IE11 to center correctly
     }
 
+    &.jw-flag-user-inactive.jw-state-playing,
+    &.jw-flag-user-inactive.jw-state-buffering {
+      .jw-controlbar {
+        display: none;
+      }
+    }
+
     &.jw-state-idle .jw-controlbar {
       display: none;
     }
@@ -474,7 +481,7 @@
             background-color: @option-active-bg-color;
           }
         }
-        
+
         &:not(.jw-flag-touch) .jw-option:hover {
             color: @hover-color;
         }

--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -27,19 +27,11 @@
 
     .jw-controlbar {
       bottom: .7em;
-      display: inline-block; // for correct display in IE browsers
       max-width: @min-breakpoint-5-width;
       margin: 0 auto;
       left: 2%;
       right: 2%;
       width: 96%; // width assignment is required for IE11 to center correctly
-    }
-
-    &.jw-flag-user-inactive.jw-state-playing,
-    &.jw-flag-user-inactive.jw-state-buffering {
-      .jw-controlbar {
-        display: none;
-      }
     }
 
     &.jw-state-idle .jw-controlbar {


### PR DESCRIPTION
Inset control bars do not hide during playback/buffering when user inactive flag takes over.

@robwalch @egreaves This may be the one scenario where there's no choice but to have a big selector, as the following is pretty specific and overrides the flags for inset control bar skins:

&:not(.jw-flag-time-slider-above):not(.jw-flag-audio-player):not(.jw-flag-small-player)

JW7-3860