### PR TITLE
Default skin fixes and cleanup

### DIFF
--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -66,6 +66,10 @@
       padding: 0 10px;
     }
 
+    .jw-progress {
+      background: @fixed-time-slider-progress-color;
+    }
+
     /* do not show the controls background linear gradient when video is idle
     state (except when cast available and we show controls on idle state) or
     playing state when user inactive (the gradient in other scenarios blocks
@@ -179,6 +183,16 @@
         right: 0;
         top: 0;
         width: 100%;
+
+        .jw-slider-horizontal {
+          .jw-knob {
+            border-radius: @slider-fixed-knob-border-radius;
+            height: @slider-fixed-knob-height;
+            margin-left: @slider-fixed-knob-width / -2;
+            margin-top: @slider-fixed-knob-height / -2;
+            width: @slider-fixed-knob-width;
+          }
+        }
       }
       .jw-controlbar-left-group {
         margin-left: -5px;
@@ -312,6 +326,7 @@
 
       .jw-time-tip {
         bottom: 0;
+        border-radius: @ui-corner-round;
       }
     }
 

--- a/src/css/imports/controlbar.less
+++ b/src/css/imports/controlbar.less
@@ -31,12 +31,11 @@
   .jw-text-alt {
     display: none;
     position: absolute;
-    top: -1px;
-    bottom: 0;
+    top: 50%;
+    transform: translateY(-50%);
     width: 100%;
     height: auto;
     line-height: @controlbar-height;
-    margin: 0.5em 0;
     padding-right: 0.5em;
     overflow: hidden;
     text-align: left;

--- a/src/css/imports/controlbar.less
+++ b/src/css/imports/controlbar.less
@@ -31,11 +31,12 @@
   .jw-text-alt {
     display: none;
     position: absolute;
-    top: 50%;
-    transform: translateY(-50%);
+    top: -1px;
+    bottom: 0;
     width: 100%;
     height: auto;
     line-height: @controlbar-height;
+    margin: 0.5em 0;
     padding-right: 0.5em;
     overflow: hidden;
     text-align: left;

--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -306,6 +306,13 @@
 
     .controlbar-height() {
 
+      .jw-controlbar .jw-controlbar-center-group .jw-text-alt  {
+        top: 50%;
+        transform: translateY(-50%);
+        margin: auto;
+        bottom: auto;
+      }
+
       &:not(.jw-flag-time-slider-above):not(.jw-flag-small-player) {
 
         .jw-controlbar {

--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -162,6 +162,8 @@
         }
 
         .jw-slider-horizontal {
+            height: @rail-height;
+
             .jw-rail,
             .jw-buffer,
             .jw-progress {

--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -94,12 +94,6 @@
             color: @inactive-color;
         }
 
-        /* Text color in thumbnail that appears upon hovering on the timeline slider */
-        .jw-tooltip-title {
-            color: @inactive-color;
-            border-bottom: 1px solid @inactive-color;
-        }
-
         .jw-knob {
             color: @inactive-color;
             background-color: @active-color;

--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -90,10 +90,6 @@
             background: @controlbar-background;
         }
 
-        .jw-controlbar {
-            background: @controlbar-background;
-        }
-
         .jw-text {
             color: @inactive-color;
         }
@@ -172,9 +168,6 @@
         }
 
         .jw-slider-horizontal {
-            background: @controlbar-background;
-            height: @rail-height;
-
             .jw-rail,
             .jw-buffer,
             .jw-progress {
@@ -202,7 +195,6 @@
         .jw-menu,
         .jw-time-tip,
         .jw-volume-tip {
-            background: @controlbar-background;
             border: @volume-border;
         }
 
@@ -215,12 +207,7 @@
             padding: @volume-padding;
         }
 
-        .jw-menu.jw-background-color {
-            background: @controlbar-background;
-        }
-
         .jw-skip {
-            background: @controlbar-background;
             padding: @ui-padding;
 
             .jw-skiptext,
@@ -319,46 +306,6 @@
           color: @nextup-close-button-color-hover;
         }
 
-
-        &:not(.jw-flag-audio-player) {
-            // time slider above
-            &.jw-flag-time-slider-above {
-
-                .jw-controlbar-center-group {
-
-                    .jw-slider-horizontal {
-                        .jw-knob {
-                            border-radius: @slider-fixed-knob-border-radius;
-                            height: @slider-fixed-knob-height;
-                            margin-left: @slider-fixed-knob-width / -2;
-                            margin-top: @slider-fixed-knob-height / -2;
-                            width: @slider-fixed-knob-width;
-                        }
-                    }
-                }
-
-                .jw-progress {
-                    background: @fixed-time-slider-progress-color;
-                }
-
-                .jw-tooltip-time {
-
-                    .jw-time-tip {
-                        border-radius: @ui-corner-round;
-                    }
-
-                }
-
-            }
-        }
-
-    }
-
-    /* Override default touch flag styles */
-    .touch-flag-skin-styles() {
-        &.jw-flag-touch {
-            //
-        }
     }
 
     .controlbar-height() {

--- a/src/css/imports/slider.less
+++ b/src/css/imports/slider.less
@@ -48,6 +48,7 @@
 .jw-slider-horizontal {
     height: @slider-height;
     padding: 0;
+    margin: 0 0.5em;
 
     &.jw-slider-volume {
         width: @volume-rail-length;

--- a/src/css/skins/beelden.less
+++ b/src/css/skins/beelden.less
@@ -48,7 +48,6 @@
 
     #namespace > .controlbar-height();
     #namespace > .basic-skin-styles(); // Using the above local variables
-    #namespace > .touch-flag-skin-styles(); // Using the above local variables
     #namespace > .set-global-color-classes();
 
     .skin-element-padding();
@@ -179,12 +178,6 @@
     .jw-skip {
         box-shadow: inset 0px 7px 1px -5px rgba(128,128,128,1);
         border-radius: .3em;
-    }
-
-    /* Playlist title */
-    .jw-tooltip-title {
-        border-bottom: 1px solid #000;
-        background-color: #282828;
     }
 
     /* Styles for play button on idle */

--- a/src/css/skins/bekle.less
+++ b/src/css/skins/bekle.less
@@ -39,7 +39,6 @@
 
     #namespace > .controlbar-height();
     #namespace > .basic-skin-styles(); // Using the above local variables
-    #namespace > .touch-flag-skin-styles(); // Using the above local variables
     #namespace > .set-global-color-classes();
 
     .skin-element-padding();
@@ -47,11 +46,6 @@
 
     .jw-controlbar {
         border-radius: .3em;
-    }
-
-    .jw-tooltip-title {
-        border-bottom: 1px solid @controlbar-background;
-        background-color: @controlbar-background;
     }
 
     .jw-time-tip,

--- a/src/css/skins/five.less
+++ b/src/css/skins/five.less
@@ -46,7 +46,6 @@
 
     #namespace > .controlbar-height();
     #namespace > .basic-skin-styles(); // Using the above local variables
-    #namespace > .touch-flag-skin-styles(); // Using the above local variables
     #namespace > .set-global-color-classes();
 
     .skin-element-padding();
@@ -54,12 +53,6 @@
     /* Styles for play button container on idle */
     .jw-display-icon-container {
         border-radius: @five-border-radius;
-    }
-
-    /* Playlist title */
-    .jw-tooltip-title {
-        border-bottom: 1px solid #000;
-        background-color : #ECECEC;
     }
 
     /* Slider styles */

--- a/src/css/skins/glow.less
+++ b/src/css/skins/glow.less
@@ -22,7 +22,6 @@
 
     #namespace > .controlbar-height();
     #namespace > .basic-skin-styles(); // Using the above local variables
-    #namespace > .touch-flag-skin-styles(); // Using the above local variables
     #namespace > .set-global-color-classes();
 
     .skin-element-padding();
@@ -42,12 +41,6 @@
     .jw-volume-tip,
     .jw-menu {
         bottom: .3em;
-    }
-
-    /* Playlist title */
-    .jw-tooltip-title {
-        border-bottom: 1px solid #000;
-        background-color: #3B3D41;
     }
 
     /* Rail/slider styles */

--- a/src/css/skins/roundster.less
+++ b/src/css/skins/roundster.less
@@ -43,7 +43,6 @@
 
     #namespace > .controlbar-height();
     #namespace > .basic-skin-styles(); // Using the above local variables
-    #namespace > .touch-flag-skin-styles(); // Using the above local variables
     #namespace > .set-global-color-classes();
 
     .skin-element-padding();
@@ -53,12 +52,6 @@
     .jw-controlbar {
         border-radius: @roundster-corners;
         padding: 0 @roundster-corners;
-    }
-
-    /* Playlist title */
-    .jw-tooltip-title {
-        border-bottom: 1px solid #747D92;
-        background-color: @rail-color;
     }
 
     /* Rail/slider styles */

--- a/src/css/skins/six.less
+++ b/src/css/skins/six.less
@@ -54,7 +54,6 @@
 
     #namespace > .controlbar-height();
     #namespace > .basic-skin-styles(); // Using the above local variables
-    #namespace > .touch-flag-skin-styles(); // Using the above local variables
     #namespace > .set-global-color-classes();
 
     .skin-element-padding();

--- a/src/css/skins/stormtrooper.less
+++ b/src/css/skins/stormtrooper.less
@@ -42,7 +42,6 @@
 
     #namespace > .controlbar-height();
     #namespace > .basic-skin-styles(); // Using the above local variables
-    #namespace > .touch-flag-skin-styles(); // Using the above local variables
     #namespace > .set-global-color-classes();
 
     .skin-element-padding();
@@ -59,12 +58,6 @@
     .jw-volume-tip,
     .jw-menu {
         bottom: .3em;
-    }
-
-    /* Playlist title */
-    .jw-tooltip-title {
-        border-bottom: 1px solid #5B697A;
-        background-color: @rail-color;
     }
 
     /* Rail/slider styles */

--- a/src/css/skins/vapor.less
+++ b/src/css/skins/vapor.less
@@ -41,7 +41,6 @@
 
     #namespace > .controlbar-height();
     #namespace > .basic-skin-styles(); // Using the above local variables
-		#namespace > .touch-flag-skin-styles(); // Using the above local variables
     #namespace > .set-global-color-classes();
 
     .skin-element-padding();
@@ -56,12 +55,6 @@
 
     .jw-skip {
         border-radius: @ui-padding;
-    }
-
-    /* Playlist title */
-    .jw-tooltip-title {
-        border-bottom: 1px solid #000;
-        background-color: #1E1E1E;
     }
 
     .jw-icon-inline,

--- a/src/css/states/complete.less
+++ b/src/css/states/complete.less
@@ -18,11 +18,7 @@
     }
 
     .jw-icon-playback {
-        .jw-icon-replay;
-
-        &:before {
-            font-size: 1.55em;
-        }
+        .jw-icon-play;
     }
 
     .jw-captions {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -396,7 +396,6 @@ define([
                 '.jw-button-color',
                 // toggle button
                 '.jw-toggle.jw-off',
-                '.jw-tooltip-title',
                 '.jw-skip .jw-skip-icon',
                 '.jw-nextup-body'
             ], 'color', inactiveColor);
@@ -411,8 +410,7 @@ define([
             // Apply background color
             addStyle([
                 // general background color
-                '.jw-background-color',
-                '.jw-tooltip-title'
+                '.jw-background-color'
             ], 'background', backgroundColor);
 
             addStyle([

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -417,16 +417,12 @@ define([
 
             addStyle([
                 // for small player, set the control bar gradient to the config background color
-                '.jw-breakpoint-0 .jw-background-color.jw-controlbar',
-                '.jw-breakpoint-1 .jw-background-color.jw-controlbar',
-                '.jw-flag-time-slider-above .jw-background-color.jw-controlbar',
+                '.jw-flag-time-slider-above .jw-background-color.jw-controlbar'
             ], 'background', backgroundColorGradient, true);
 
             addStyle([
-                // remove the config background color on time slider on small player
-                '.jw-breakpoint-0 .jw-background-color.jw-slider-time',
-                '.jw-breakpoint-1 .jw-background-color.jw-slider-time',
-                '.jw-flag-time-slider-above .jw-background-color.jw-slider-time',
+                // remove the config background color on time slider
+                '.jw-flag-time-slider-above .jw-background-color.jw-slider-time'
             ], 'background', 'none', true);
 
             insertGlobalColorClasses(activeColor, inactiveColor, id);


### PR DESCRIPTION
### Changes proposed in this pull request:

- Got rid of background rules where jw-background-color is used
- Added margin for `jw-slider-horizontal`
- Removed time slider styles being applied specifically to breakpoint 0-1
- Removed time slider css rules from mixin
- Removed unused touch flag mixin rules
- Removed references to unused class: `jw-tooltip-title`
- Reverted play button change for complete state from https://github.com/jwplayer/jwplayer/pull/1608
- Vertically center text in control bar center group

Fixes #
JW7-3836
