### PR TITLE
Fix vpaid controls not showing on mobile

### DIFF
--- a/src/css/flags/ads.less
+++ b/src/css/flags/ads.less
@@ -73,7 +73,7 @@
         font-size: 0.9em;
     }
 
-    &.jw-flag-ads-vpaid-controls {
+    &.jw-flag-ads-vpaid.jw-flag-ads-vpaid-controls {
         .jw-controlbar {
             display: table;
             bottom: 0;


### PR DESCRIPTION
Bump up the specificity of the vpaid-controls so that it overrides flag-touch.
JW7-3866
