### PR TITLE
Hide controls for mobile autostart

### DIFF
--- a/src/css/flags/audioplayer.less
+++ b/src/css/flags/audioplayer.less
@@ -21,7 +21,7 @@
 
     .jw-controlbar {
         vertical-align: middle;
-        display: table;  // This overrides 'none' from jw-state-idle
+        display: table;
         height: 100%;
         left: 0;
         bottom: 0;

--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -3,6 +3,9 @@
 /* time slider above or small player (both override player into same UI) */
 .jw-flag-time-slider-above {
 
+  .jw-controlbar {
+    display: table;
+  }
 
   /* ==================================================
   dock
@@ -61,7 +64,6 @@
       border: none;
       border-radius: 0;
       background-size: auto;
-      display: table;
       height: @mobile-touch-target;
       padding: 0 10px;
     }

--- a/src/css/imports/autostartmute.less
+++ b/src/css/imports/autostartmute.less
@@ -15,7 +15,7 @@
   }
 }
 
-.jw-flag-autostart {
+.jwplayer.jw-flag-touch.jw-flag-autostart {
   .jw-controlbar,
   .jw-nextup,
   &:not(.jw-state-buffering):not(.jw-state-error):not(.jw-state-complete) .jw-display {

--- a/src/css/imports/autostartmute.less
+++ b/src/css/imports/autostartmute.less
@@ -15,7 +15,7 @@
   }
 }
 
-.jwplayer.jw-flag-touch.jw-flag-autostart {
+.jwplayer.jw-flag-autostart {
   .jw-controlbar,
   .jw-nextup,
   &:not(.jw-state-buffering):not(.jw-state-error):not(.jw-state-complete) .jw-display {

--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -34,10 +34,6 @@
       width: 96%; // width assignment is required for IE11 to center correctly
     }
 
-    &.jw-state-idle .jw-controlbar {
-      display: none;
-    }
-
     .jw-nextup-container {
       bottom: @controlbar-height + .7em;
       padding-left: 0;

--- a/src/css/states/idle.less
+++ b/src/css/states/idle.less
@@ -25,7 +25,7 @@
 
     /* hide control bar and clear display container padding on idle state unless
     cast available flag is set */
-    &:not(.jw-flag-cast-available) {
+    .jwplayer&:not(.jw-flag-cast-available) {
 
       .jw-controlbar {
         display: none;

--- a/src/css/states/idle.less
+++ b/src/css/states/idle.less
@@ -25,7 +25,7 @@
 
     /* hide control bar and clear display container padding on idle state unless
     cast available flag is set */
-    .jwplayer&:not(.jw-flag-cast-available) {
+    .jwplayer&:not(.jw-flag-cast-available):not(.jw-flag-audio-player) {
 
       .jw-controlbar {
         display: none;

--- a/src/css/states/idle.less
+++ b/src/css/states/idle.less
@@ -25,7 +25,7 @@
 
     /* hide control bar and clear display container padding on idle state unless
     cast available flag is set */
-    .jwplayer&:not(.jw-flag-cast-available):not(.jw-flag-audio-player) {
+    &:not(.jw-flag-cast-available) {
 
       .jw-controlbar {
         display: none;


### PR DESCRIPTION
### Changes proposed in this pull request:

Reduce specificity of `display: table` in `time-slider-above` mode and increase specificity for `jw-flag-autostart` to hide controls during muted autostart on mobile.

Fixes #
JW7-3879, JW7-3883
