### PR TITLE
Prevent the display icon from being tappable in IMA ads on mobile

### DIFF
--- a/src/css/flags/ads.less
+++ b/src/css/flags/ads.less
@@ -67,6 +67,13 @@
         .jw-controlbar {
             font-size: 1em;
         }
+
+        .jw-display-icon-display {
+            &,
+            .jw-icon-display {
+                pointer-events: none;
+            }
+        }
     }
 
     &.jw-skin-seven .jw-controlbar {

--- a/src/css/flags/ads.less
+++ b/src/css/flags/ads.less
@@ -68,11 +68,9 @@
             font-size: 1em;
         }
 
-        .jw-display-icon-display {
-            &,
-            .jw-icon-display {
-                pointer-events: none;
-            }
+        .jw-display-icon-display,
+        .jw-display-icon-display .jw-icon-display {
+            pointer-events: none;
         }
     }
 


### PR DESCRIPTION
Prevent the display icon from being tappable in IMA ads on mobile so that we do not receive two taps on the UI, which is interpretted as a quick pause and unpause action.

JW7-3888