### PR TITLE
Only use timeout param when it’s a number

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -935,6 +935,10 @@ define([
         }
 
         function _userActivity(timeout) {
+            if (isNaN(timeout)) {
+                timeout = 0;
+            }
+
             if(!_showing){
                 utils.removeClass(_playerElement, 'jw-flag-user-inactive');
                 _captionsRenderer.renderCues(true);


### PR DESCRIPTION
### Changes proposed in this pull request:

`_userActivity` is called with args for mouse events. This ensures we only use the `timeout` param when it's a number.

Fixes #
JW7-3898
