### PR TITLE
Remove Display Icon Hover from Error and Buffering States

### DIFF
--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -133,16 +133,6 @@
           }
         }
 
-        &:not(.jw-flag-touch):not(.jw-state-error) {
-            .jw-display-icon-container:hover {
-                background: @display-bkgd-hover-color;
-
-                .jw-icon {
-                    color: @display-icon-hover-color;
-                }
-            }
-        }
-
         /* Slider colors */
 
         .jw-rail {
@@ -376,10 +366,37 @@
     }
     // Set color classes in the skin so they can be reused in other parts of the player (i.e. the related overlay)
     .set-global-color-classes() {
+        // Set the highlight color of the center display icon when we are hovering the player.
+        &.jwplayer:not(.jw-flag-touch){
+            // When not in an error state or in a buffering state...
+            &:not(.jw-error):not(.jw-state-error):not(.jw-state-buffering) {
+                // Highlight the display icon's background when hovering the media container
+                .jw-media:hover ~ .jw-controls .jw-display-icon-display {
+                    background-color: @display-bkgd-hover-color;
+                 }
 
-        &.jwplayer:not(.jw-flag-touch):not(.jw-state-error) {
-            .jw-media:hover ~ .jw-controls .jw-display-icon-display {
-                background-color: @display-bkgd-hover-color;
+                // Highlight the display icon and the display icon's background
+                .jw-display-icon-container:hover {
+                    background-color: @display-bkgd-hover-color;
+
+                    .jw-icon {
+                        color: @display-icon-hover-color;
+                    }
+                }
+            }
+
+            // When we're in an error or buffering state...
+            &.jw-error,
+            &.jw-state-error,
+            &.jw-state-buffering {
+                // Show the normal state for the icons so we do not imply its clickable
+                .jw-display-icon-container {
+                    background-color: @display-bkgd-color;
+
+                    .jw-icon {
+                        color: @display-icon-color;
+                    }
+                }
             }
         }
 
@@ -424,5 +441,4 @@
             color: @hover-color;
         }
     }
-
 }

--- a/src/css/skins/beelden.less
+++ b/src/css/skins/beelden.less
@@ -180,6 +180,15 @@
         border-radius: .3em;
     }
 
+    // Remove the gradients used and show the hover styles
+    &:not(.jw-flag-touch) {
+        &:not(.jw-error):not(.jw-state-error):not(.jw-state-buffering) {
+            .jw-display-icon-container:hover {
+                background: none;
+            }
+        }
+    }
+
     /* Styles for play button on idle */
     .jw-display-icon-container {
         border: @volume-border;

--- a/src/css/skins/seven.less
+++ b/src/css/skins/seven.less
@@ -14,38 +14,33 @@
   #namespace > .basic-skin-styles();
   #namespace > .set-global-color-classes();
 
-  .jw-display-icon-container {
-    border-radius: 3.5em;
+    .jw-display-icon-container {
+      border-radius: 3.5em;
 
-    &:hover {
-      .jw-icon {
-        color: @accent-color;
+      & > .jw-icon {
+        color: rgba(255, 255, 255, 0.9);
       }
     }
-  }
 
-  .jw-display-icon-container > .jw-icon {
-    color: rgba(255, 255, 255, 0.9);
-  }
+    .jw-dock-button {
+      // Seven skin dock buttons do not highlight, they only show the tooltip
+      &:hover{
+        background: @controlbar-background;
+      }
 
-  .jw-dock-button {
-    // Seven skin dock buttons do not highlight, they only show the tooltip
-    &:hover{
-      background: @controlbar-background;
+      border-radius: 2.5em;
     }
-    
-    border-radius: 2.5em;
-  }
 
   .jw-menu {
-      padding: 0;
-    }
+    padding: 0;
+  }
 
   .jw-dock {
     .jw-overlay {
       border-radius: @ui-padding;
     }
   }
+
   .jw-skip {
     border-radius: @ui-padding;
   }
@@ -55,5 +50,4 @@
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }
-
 }

--- a/src/css/skins/six.less
+++ b/src/css/skins/six.less
@@ -164,10 +164,20 @@
         border: @def-border;
     }
 
-    &:hover {
-        .jw-display-icon-container {
-            background: @def-background-style;
-            background-size: @def-background-size;
+    // Matching mixin code because we need to use background instead of background-color...
+    &:not(.jw-flag-touch) {
+        // When not in an error state or in a buffering state...
+        &:not(.jw-error):not(.jw-state-error):not(.jw-state-buffering) {
+            // Highlight the display icon's background when hovering the media container
+            .jw-media:hover ~ .jw-controls .jw-display-icon-display
+            {
+                background: @def-background-style;
+                background-size: @def-background-size;
+            }
+
+            .jw-display-icon-container:hover {
+                background: rgba(0,0,0,0.8);
+            }
         }
     }
 

--- a/src/css/states/error.less
+++ b/src/css/states/error.less
@@ -21,20 +21,10 @@ body .jw-error, .jwplayer.jw-state-error {
         display: none;
     }
 
-    &:hover .jw-display-icon-container {
-        cursor: default;
-        color: #fff;
-        background: #000;
-    }
-
     .jw-icon-display {
         cursor: default;
         .jw-icon;
         .jw-icon-error;
-
-        &:hover {
-            color: #fff;
-        }
     }
 
     .jw-display-icon-next,


### PR DESCRIPTION
Removed hover states in the error state because we do not want to imply that clicking in these states has an action.
Ensures the display icon has a neutral, hover for the jw-media container, and a hover for display-icons styles defined.  The hover background color for the icon is applied when hovering the media container.  Both the hover background color for the icon and the active color for the icon are applied on hovering the display icon.
Seven style updated to be a bit more organized
Clears gradients in Beelden for buttons to display hover styles correctly.
Sets gradients for Six to show gradients and the black background when hovering the media container or the display icons, respectively.