### PR TITLE
Hide control bar in idle state time slider above

### DIFF
--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -7,6 +7,16 @@
     display: table;
   }
 
+  &.jw-state-idle:not(.jw-flag-cast-available) {
+    .jw-controlbar {
+      display: none;
+    }
+    
+    .jw-display {
+      padding: 0;
+    }
+  }
+
   /* ==================================================
   dock
   */


### PR DESCRIPTION
When casting is not available, hide the controlbar when idle state in time slider above.
JW7-3782