### PR TITLE
Base Style Fixes for MAUI

### DIFF
--- a/src/css/flags/media-audio.less
+++ b/src/css/flags/media-audio.less
@@ -1,42 +1,4 @@
-@import "../imports/vars";
-
 .jwplayer.jw-flag-media-audio {
-
-    .jw-controlbar {
-        display: table;
-    }
-
-    // This has higher specificity to overwrite jw-flag-user-inactive in pause state
-    &.jw-flag-user-inactive {
-
-        .jw-controlbar {
-            display: table;
-        }
-
-        .jw-nextup-container {
-          bottom: calc(@controlbar-height + 0.5em);
-        }
-
-    }
-    // This has higher specificity to overwrite caption position when user inactive in playing state
-    &.jw-flag-user-inactive.jw-state-playing {
-        .jw-plugin {
-            bottom: 3em;
-        }
-
-        .jw-captions {
-            max-height: calc(97% - 6.25 * (@controlbar-height));
-        }
-        // Separate shadow dom style to prevent side effects in browsers where the element doesn't exist
-        video::-webkit-media-text-track-container {
-            max-height: calc(97% - 6.25 * (@controlbar-height));
-        }
-
-        &.jw-flag-touch video::-webkit-media-text-track-container {
-            // need to compensate for the control bar being 3.75em on mobile
-            max-height: 70%;  // 97% - 6.25 * 4.25em
-        }
-    }
 
     // Hide autostart mute button
     .jw-autostart-mute {

--- a/src/css/flags/user-inactive.less
+++ b/src/css/flags/user-inactive.less
@@ -1,7 +1,7 @@
 @import "../imports/vars";
 @import "controls-hidden";
 
-.jwplayer.jw-flag-user-inactive {
+.jwplayer.jw-flag-user-inactive:not(.jw-flag-media-audio) {
 
   &.jw-state-playing {
 

--- a/src/css/imports/autostartmute.less
+++ b/src/css/imports/autostartmute.less
@@ -15,7 +15,7 @@
   }
 }
 
-.jwplayer.jw-flag-autostart {
+.jwplayer.jw-flag-autostart:not(.jw-flag-media-audio) {
   .jw-controlbar,
   .jw-nextup,
   &:not(.jw-state-buffering):not(.jw-state-error):not(.jw-state-complete) .jw-display {

--- a/src/css/imports/controlbar.less
+++ b/src/css/imports/controlbar.less
@@ -2,7 +2,7 @@
 @import "vars";
 
 .jw-controlbar {
-  display: inline-block; // for correct display in IE browsers
+  display: table;
   position: absolute;
   bottom: 0;
   height: @controlbar-height;

--- a/src/css/imports/display.less
+++ b/src/css/imports/display.less
@@ -13,8 +13,7 @@
 }
 
 .jwplayer,
-.jw-error,
-.jw-stretch-uniform {
+.jw-error {
     .jw-preview {
         background-size: contain;
     }

--- a/src/css/imports/display.less
+++ b/src/css/imports/display.less
@@ -78,6 +78,11 @@ display icons
   display: inline-block;
 }
 
+.jwplayer .jw-display-icon-container {
+    // float in case custom skin tries to override inline-block
+    float: left;
+}
+
 .jw-display-icon-container {
   display: inline-block;
   margin: 0 (@ui-padding * 0.5);

--- a/src/css/imports/display.less
+++ b/src/css/imports/display.less
@@ -18,6 +18,11 @@
     .jw-preview {
         background-size: contain;
     }
+    /* Enforce auto container sizing to prevent custom skin errors in 7.9 */
+    .jw-display-icon-container {
+        width: auto;
+        height: auto;
+    }
 }
 
 .jw-stretch-none {

--- a/src/css/imports/display.less
+++ b/src/css/imports/display.less
@@ -74,19 +74,20 @@ display icons
 }
 
 .jw-display-icon-container {
-  border-radius: @ui-corner-round;
   display: inline-block;
   margin: 0 (@ui-padding * 0.5);
 
   .jw-icon {
     cursor: pointer;
-    height: @mobile-touch-target;
-    line-height: @mobile-touch-target;
+
+    // Default to .jw-breakpoint-2 to match pre 7.9 styles
+    width: 75px;
+    height: 75px;
+    line-height: 75px;
     text-align: center;
-    width: @mobile-touch-target;
 
     &::before {
-      font-size: @mobile-touch-target * 0.5;
+      font-size: @mobile-touch-target * 0.75;
       position: relative;
     }
 
@@ -109,18 +110,25 @@ display icons
   .jw-display-icon-rewind {
     display: none;
   }
+    .jw-display .jw-icon {
+        height: @mobile-touch-target;
+        line-height: @mobile-touch-target;
+        width: @mobile-touch-target;
+        &::before {
+            font-size: @mobile-touch-target * 0.5;
+        }
+    }
 }
 
-// scale display icon sizes on larger breakpoints
-.jw-breakpoint-2 {
-  .jw-display .jw-icon {
-    height: @mobile-touch-target * 1.5;
-    line-height: @mobile-touch-target * 1.5;
-    width: @mobile-touch-target * 1.5;
-    &::before {
-      font-size: @mobile-touch-target * 0.75;
+.jw-breakpoint-1 {
+    .jw-display .jw-icon {
+        height: @mobile-touch-target * 1.25;
+        line-height: @mobile-touch-target * 1.25;
+        width: @mobile-touch-target * 1.25;
+        &::before {
+            font-size: @mobile-touch-target * 0.5;
+        }
     }
-  }
 }
 
 .jw-breakpoint-3 {

--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -125,7 +125,6 @@
         /* Colors for display icons */
         .jw-display-icon-container {
           background-color: @display-bkgd-color;
-          border-radius: @ui-corner-round;
           margin: 0 (@ui-padding * 0.5);
 
           .jw-icon {
@@ -213,7 +212,6 @@
         /* Dock button styles */
         .jw-dock-button {
             background: @display-bkgd-color;
-            border-radius: @ui-corner-round;
         }
 
         &:not(.jw-flag-touch) .jw-dock-button:hover {
@@ -290,7 +288,15 @@
 
     }
 
-    .controlbar-height() {
+    .custom-skin-styles() {
+
+        .jw-display-icon-container {
+            border-radius: @ui-corner-round;
+        }
+
+        .jw-dock-button {
+            border-radius: @ui-corner-round;
+        }
 
       .jw-controlbar .jw-controlbar-center-group .jw-text-alt  {
         top: 50%;

--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -23,6 +23,10 @@
 
 .inset-controlbar() {
 
+    .jw-controlbar {
+        display: inline-block;
+    }
+
   &:not(.jw-flag-time-slider-above):not(.jw-flag-audio-player):not(.jw-flag-small-player) {
 
     .jw-controlbar {

--- a/src/css/jwplayer.less
+++ b/src/css/jwplayer.less
@@ -1,5 +1,19 @@
 @import "imports/reset";
 
+@import "imports/mixins";
+
+@accent-color: #FFF;
+@inactive-color: #cecece;
+
+@controlbar-background: rgba(33, 33, 33, 0.8);
+@display-bkgd-color: @controlbar-background;
+@display-bkgd-hover-color: rgba(33, 33, 33, 1);
+
+@controlbar-height: 2.5em;
+
+#namespace > .basic-skin-styles();
+#namespace > .set-global-color-classes();
+
 @import "imports/jwplayerelement";
 @import "imports/video";
 @import "imports/display";

--- a/src/css/skins/beelden.less
+++ b/src/css/skins/beelden.less
@@ -46,7 +46,7 @@
     @fixed-time-slider-inactive-color: @inactive-color;
     @fixed-time-slider-hover-color: @hover-color;
 
-    #namespace > .controlbar-height();
+    #namespace > .custom-skin-styles();
     #namespace > .basic-skin-styles(); // Using the above local variables
     #namespace > .set-global-color-classes();
 

--- a/src/css/skins/bekle.less
+++ b/src/css/skins/bekle.less
@@ -37,7 +37,7 @@
     @fixed-time-slider-inactive-color: @inactive-color;
     @fixed-time-slider-hover-color: @active-color;
 
-    #namespace > .controlbar-height();
+    #namespace > .custom-skin-styles();
     #namespace > .basic-skin-styles(); // Using the above local variables
     #namespace > .set-global-color-classes();
 

--- a/src/css/skins/five.less
+++ b/src/css/skins/five.less
@@ -43,7 +43,7 @@
     @slider-fixed-knob-height: 16px;
     @slider-fixed-knob-width: 4px;
 
-    #namespace > .controlbar-height();
+    #namespace > .custom-skin-styles();
     #namespace > .basic-skin-styles(); // Using the above local variables
     #namespace > .set-global-color-classes();
 

--- a/src/css/skins/glow.less
+++ b/src/css/skins/glow.less
@@ -20,7 +20,7 @@
     @nextup-body-background: darken(@nextup-header-background, 20%);
     @nextup-body-text-color-overflow: darken(#131415, 20%);
 
-    #namespace > .controlbar-height();
+    #namespace > .custom-skin-styles();
     #namespace > .basic-skin-styles(); // Using the above local variables
     #namespace > .set-global-color-classes();
 

--- a/src/css/skins/roundster.less
+++ b/src/css/skins/roundster.less
@@ -41,7 +41,7 @@
     @fixed-time-slider-inactive-color: @display-bkgd-color;
     @fixed-time-slider-hover-color: @display-icon-hover-color;
 
-    #namespace > .controlbar-height();
+    #namespace > .custom-skin-styles();
     #namespace > .basic-skin-styles(); // Using the above local variables
     #namespace > .set-global-color-classes();
 

--- a/src/css/skins/seven.less
+++ b/src/css/skins/seven.less
@@ -1,35 +1,33 @@
-@import "../imports/mixins";
+@import "../imports/vars";
 
 .jw-skin-seven {
 
-  @accent-color: #FFF;
-  @inactive-color: #cecece;
-
-  @controlbar-background: rgba(33, 33, 33, 0.8);
   @display-bkgd-color: @controlbar-background;
-  @display-bkgd-hover-color: rgba(33, 33, 33, 1);
 
-  @controlbar-height: 2.5em;
+  .jw-display-icon-container {
+    border-radius: 3.5em;
 
-  #namespace > .basic-skin-styles();
-  #namespace > .set-global-color-classes();
+    & > .jw-icon {
+      color: rgba(255, 255, 255, 0.9);
+    }
+  }
 
-    .jw-display-icon-container {
-      border-radius: 3.5em;
+  &.jw-breakpoint-2 {
+    .jw-display .jw-icon {
+      width: @mobile-touch-target * 1.5;
+      height: @mobile-touch-target * 1.5;
+      line-height: @mobile-touch-target * 1.5;
+    }
+  }
 
-      & > .jw-icon {
-        color: rgba(255, 255, 255, 0.9);
-      }
+  .jw-dock-button {
+    // Seven skin dock buttons do not highlight, they only show the tooltip
+    &:hover{
+      background: @controlbar-background;
     }
 
-    .jw-dock-button {
-      // Seven skin dock buttons do not highlight, they only show the tooltip
-      &:hover{
-        background: @controlbar-background;
-      }
-
-      border-radius: 2.5em;
-    }
+    border-radius: 2.5em;
+  }
 
   .jw-menu {
     padding: 0;

--- a/src/css/skins/six.less
+++ b/src/css/skins/six.less
@@ -52,7 +52,7 @@
     @fixed-time-slider-hover-color: @active-color;
     @fixed-time-slider-progress-color: @rail-color;
 
-    #namespace > .controlbar-height();
+    #namespace > .custom-skin-styles();
     #namespace > .basic-skin-styles(); // Using the above local variables
     #namespace > .set-global-color-classes();
 

--- a/src/css/skins/stormtrooper.less
+++ b/src/css/skins/stormtrooper.less
@@ -40,7 +40,7 @@
     @slider-fixed-knob-height: 16px;
     @slider-fixed-knob-width: 4px;
 
-    #namespace > .controlbar-height();
+    #namespace > .custom-skin-styles();
     #namespace > .basic-skin-styles(); // Using the above local variables
     #namespace > .set-global-color-classes();
 

--- a/src/css/skins/vapor.less
+++ b/src/css/skins/vapor.less
@@ -1,7 +1,7 @@
 @import "../imports/mixins";
 
 .jw-skin-vapor {
-		@active-color: #0f9e60;
+    @active-color: #0f9e60;
     @inactive-color: rgba(0, 0, 0, 0.5);
    	@hover-color: @active-color;
 
@@ -32,14 +32,14 @@
     @nextup-body-background: darken(@nextup-header-background, 20%);
     @nextup-body-text-color-overflow: darken(mix(white, black, 50%), 20%);
 
-		@fixed-time-slider-inactive-color: @display-icon-color;
+    @fixed-time-slider-inactive-color: @display-icon-color;
     @fixed-time-slider-hover-color: @display-icon-hover-color;
 
-		@slider-fixed-knob-border-radius: 0px;
+    @slider-fixed-knob-border-radius: 0px;
     @slider-fixed-knob-height: 16px;
     @slider-fixed-knob-width: 4px;
 
-    #namespace > .controlbar-height();
+    #namespace > .custom-skin-styles();
     #namespace > .basic-skin-styles(); // Using the above local variables
     #namespace > .set-global-color-classes();
 


### PR DESCRIPTION
- Set basic styles in player, not in seven skin so that custom skins without color and background-color styles are not broken.
- Don't apply any user-inactive rules when playing media-audio
- Set display-icon-container width and height to "auto" to prevent custom skins from turning them into ovals
- Float display-icon-container(s) left so that the 3 center button always show horizontally even when custom skins change the display mode to block or table
- Make controlbar display table by default and only inline-block for inset controlbar skins

JW7-3901