### PR TITLE
Apply active color to background of selected menu options

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -375,13 +375,12 @@ define([
                 '.jw-button-color.jw-toggle',
                 '.jw-button-color:hover',
                 '.jw-button-color.jw-toggle.jw-off:hover',
-                '.jw-option:hover',
-                '.jw-option.jw-active-option',
+                '.jw-option:not(.jw-active-option):hover',
                 '.jw-nextup-header'
             ], 'color', activeColor);
             addStyle([
                 // menu active option
-
+                '.jw-option.jw-active-option',
                 // slider fill color
                 '.jw-progress'
             ], 'background', activeColor);


### PR DESCRIPTION
Apply active color to background of selected menu options.  Additionally make sure that hovering the active option does not make it become the same color as the background.

JW7-3917