### PR TITLE
Vertically align time slider rails with time-slider-above in IE9

### DIFF
--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -295,6 +295,10 @@
       .jw-buffer,
       .jw-progress {
         height: @slider-fixed-rail-height;
+        // center in ie
+        margin: auto;
+        top: 0;
+        bottom: 0;
       }
 
       .jw-rail {


### PR DESCRIPTION
IE9 requires `margin: auto` and `top/bottom/left/right: 0` to vertically/horizontally center absolute positioned elements.

This puts the rail behind the scrubber knob in IE9 with time-slider-above.

JW7-3773
