### PR TITLE
Disable time-slider-above with timeSliderAbove: false in setup config

### DIFF
--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -92,11 +92,6 @@ define([
 
         config.aspectratio = _evaluateAspectRatio(config.aspectratio, config.width);
 
-        // set time slider location (static or fixed) at top level
-        if (config.timeSliderAbove) {
-            config.timeSliderAbove = _.isBoolean(config.timeSliderAbove) ? config.timeSliderAbove : false;
-        }
-
         if (_.isObject(config.skin)) {
             config.skinUrl = config.skin.url;
             config.skinColorInactive = config.skin.inactive; // default icon color

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -279,7 +279,9 @@ define([
 
         function _setTimesliderFlags(breakPoint, audioMode) {
             var smallPlayer = breakPoint < 2;
-            var timeSliderAbove = !audioMode && (_model.get('timeSliderAbove') || smallPlayer);
+            var timeSliderAboveConfig = _model.get('timeSliderAbove');
+            var timeSliderAbove = !audioMode &&
+                (timeSliderAboveConfig !== false) && (timeSliderAboveConfig || smallPlayer);
             utils.toggleClass(_playerElement, 'jw-flag-small-player', smallPlayer);
             utils.toggleClass(_playerElement, 'jw-flag-audio-player', audioMode);
             utils.toggleClass(_playerElement, 'jw-flag-time-slider-above', timeSliderAbove);


### PR DESCRIPTION
There are three modes for the time slider based on the config value of `timeSliderAbove`:

- unset: time slider changes to "time-slider-above" at breakpoints 0-1 (default)
- true: "time-slider-above" is always on
- false: "time-slider-above" is always off

JW7-3683
