### PR TITLE
Center ad text and hide overflow in IE

### DIFF
--- a/src/css/flags/ads.less
+++ b/src/css/flags/ads.less
@@ -54,6 +54,18 @@
             display: none;
         }
     }
+
+    &.jw-ie {
+        .jw-controlbar .jw-text-alt {
+            display: table;
+            white-space: normal;
+            top: 1px;
+            transform: none;
+        }
+        &.jw-flag-small-player .jw-controlbar .jw-text-alt {
+            top: 5px;
+        }
+    }
 }
 
 .jwplayer.jw-flag-ads-googleima {


### PR DESCRIPTION
### Changes proposed in this pull request:

Fixes #
JW7-3923, JW7-3925
