### PR TITLE
Use the original colors for time sliders in timeSliderAbove mode

### DIFF
--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -282,7 +282,6 @@
       .jw-knob {
         border: none;
         box-shadow: none;
-        border-radius: 0;
       }
 
       .jw-knob {

--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -78,21 +78,15 @@
       padding: 0 10px;
     }
 
-    .jw-progress {
-      background: @fixed-time-slider-progress-color;
-    }
-
     /* do not show the controls background linear gradient when video is idle
     state (except when cast available and we show controls on idle state) or
     playing state when user inactive (the gradient in other scenarios blocks
     video from clashing with the video colors, making it easy to see/use) */
     &.jw-state-idle:not(.jw-flag-cast-available),
     &.jw-state-playing.jw-flag-user-inactive:not(.jw-flag-casting) {
-
       .jw-controls {
         background: none;
       }
-
     }
 
     /* by default, the control bar height is set to the height needed for live
@@ -286,9 +280,13 @@
       .jw-progress,
       .jw-buffer,
       .jw-knob {
-        background: none;
         border: none;
         box-shadow: none;
+        border-radius: 0;
+      }
+
+      .jw-knob {
+        background: none;
       }
 
       .jw-rail,

--- a/src/css/imports/vars.less
+++ b/src/css/imports/vars.less
@@ -99,7 +99,4 @@
 @nextup-close-button-color-inactive: @inactive-color;
 @nextup-close-button-color-active: @active-color;
 @nextup-close-button-color-hover: @hover-color;
-
-@fixed-time-slider-inactive-color: rgba(255, 255, 255, 0.8);
-@fixed-time-slider-hover-color: rgba(255, 255, 255, 1);
 @fixed-time-slider-progress-color: @progress-color;

--- a/src/css/skins/beelden.less
+++ b/src/css/skins/beelden.less
@@ -43,9 +43,6 @@
     @nextup-body-background: darken(fade(@controlbar-background-color, 90%), 20%);
     @nextup-body-text-color-overflow: darken(@controlbar-background-color, 20%);
 
-    @fixed-time-slider-inactive-color: @inactive-color;
-    @fixed-time-slider-hover-color: @hover-color;
-
     #namespace > .custom-skin-styles();
     #namespace > .basic-skin-styles(); // Using the above local variables
     #namespace > .set-global-color-classes();

--- a/src/css/skins/bekle.less
+++ b/src/css/skins/bekle.less
@@ -34,9 +34,6 @@
     @nextup-body-background: darken(@nextup-header-background, 5%);
     @nextup-body-text-color-overflow: darken(#182335, 5%);
 
-    @fixed-time-slider-inactive-color: @inactive-color;
-    @fixed-time-slider-hover-color: @active-color;
-
     #namespace > .custom-skin-styles();
     #namespace > .basic-skin-styles(); // Using the above local variables
     #namespace > .set-global-color-classes();

--- a/src/css/skins/five.less
+++ b/src/css/skins/five.less
@@ -35,8 +35,6 @@
     @nextup-body-text-color: @active-color;
     @nextup-body-text-color-overflow: darken(#eee, 10%);
 
-    @fixed-time-slider-inactive-color: @display-icon-color;
-    @fixed-time-slider-hover-color: @display-icon-hover-color;
     @fixed-time-slider-progress-color: #fff;
 
     @slider-fixed-knob-border-radius: 0px;
@@ -113,20 +111,23 @@
 
     // override control bar element colors that don't look good in time slider above mode
     &.jw-flag-time-slider-above {
-      .jw-controlbar .jw-group {
-        > .jw-text {
-          color: rgba(255, 255, 255, 0.6);
+        .jw-progress {
+            background: @fixed-time-slider-progress-color;
         }
-        > .jw-button-color {
-          color: rgba(255, 255, 255, 0.6);
-          &:hover {
-            color: rgba(255, 255, 255, 1);
-          }
-          &:focus {
-            color: rgba(255, 255, 255, 1);
-          }
-        }
-      }
-    }
 
+        .jw-controlbar .jw-group {
+            > .jw-text {
+                color: rgba(255, 255, 255, 0.6);
+            }
+            > .jw-button-color {
+                color: rgba(255, 255, 255, 0.6);
+                &:hover {
+                    color: rgba(255, 255, 255, 1);
+                }
+                &:focus {
+                    color: rgba(255, 255, 255, 1);
+                }
+            }
+        }
+    }
 }

--- a/src/css/skins/roundster.less
+++ b/src/css/skins/roundster.less
@@ -38,9 +38,6 @@
     @nextup-body-background: darken(@nextup-header-background, 20%);
     @nextup-body-text-color-overflow: darken(@controlbar-background, 20%);
 
-    @fixed-time-slider-inactive-color: @display-bkgd-color;
-    @fixed-time-slider-hover-color: @display-icon-hover-color;
-
     #namespace > .custom-skin-styles();
     #namespace > .basic-skin-styles(); // Using the above local variables
     #namespace > .set-global-color-classes();

--- a/src/css/skins/six.less
+++ b/src/css/skins/six.less
@@ -48,10 +48,6 @@
     @nextup-body-background: darken(@nextup-header-background, 20%);
     @nextup-body-text-color-overflow: darken(@def-background-color, 20%);
 
-    @fixed-time-slider-inactive-color: @inactive-color;
-    @fixed-time-slider-hover-color: @active-color;
-    @fixed-time-slider-progress-color: @rail-color;
-
     #namespace > .custom-skin-styles();
     #namespace > .basic-skin-styles(); // Using the above local variables
     #namespace > .set-global-color-classes();

--- a/src/css/skins/stormtrooper.less
+++ b/src/css/skins/stormtrooper.less
@@ -33,9 +33,6 @@
     @nextup-body-background: darken(@nextup-header-background, 20%);
     @nextup-body-text-color-overflow: darken(@controlbar-background, 20%);
 
-    @fixed-time-slider-inactive-color: @display-icon-color;
-    @fixed-time-slider-hover-color: @display-icon-hover-color;
-
     @slider-fixed-knob-border-radius: 0px;
     @slider-fixed-knob-height: 16px;
     @slider-fixed-knob-width: 4px;

--- a/src/css/skins/vapor.less
+++ b/src/css/skins/vapor.less
@@ -32,9 +32,6 @@
     @nextup-body-background: darken(@nextup-header-background, 20%);
     @nextup-body-text-color-overflow: darken(mix(white, black, 50%), 20%);
 
-    @fixed-time-slider-inactive-color: @display-icon-color;
-    @fixed-time-slider-hover-color: @display-icon-hover-color;
-
     @slider-fixed-knob-border-radius: 0px;
     @slider-fixed-knob-height: 16px;
     @slider-fixed-knob-width: 4px;


### PR DESCRIPTION
Remove some styles that set the background on the jw-progress to none.  It uses the colors defined in the skin instead.
Removed instances of some variables which were only ever set and not ever used.

JW7-3927