### PR TITLE
Setting alt text to a specific position for IE 9 and IE 11

### DIFF
--- a/src/css/flags/ads.less
+++ b/src/css/flags/ads.less
@@ -59,11 +59,8 @@
         .jw-controlbar .jw-text-alt {
             display: table;
             white-space: normal;
-            top: 1px;
+            top: -2px;
             transform: none;
-        }
-        &.jw-flag-small-player .jw-controlbar .jw-text-alt {
-            top: 5px;
         }
     }
 }


### PR DESCRIPTION
Setting alt text to a specific position for IE 9 and IE 11.  This seems to make the ad text look vertically centered across IE 9 and 11.  Two styles not required.

JW7-3923