### PR TITLE
Fixes for timeSliderAbove=false

### DIFF
--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -21,29 +21,7 @@
   dock
   */
 
-  .jw-dock {
-    margin: 0;
-  }
 
-  &:not(.jw-breakpoint-0) {
-
-    // give dock some padding
-    .jw-dock {
-      padding: 0 1%;
-    }
-
-    // give dock buttons some space between each other above smallest breakpoint
-    .jw-dock-button {
-      margin: 2% 1%;
-    }
-
-  }
-
-  .jw-dock-button {
-    margin: 1px;
-    height: @mobile-touch-target;
-    width: @mobile-touch-target;
-  }
 
   /* ==================================================
   display

--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -166,16 +166,6 @@
       }
     }
 
-    &.jw-flag-small-player {
-      .jw-group {
-        > .jw-icon-rewind,
-        > .jw-icon-next,
-        > .jw-icon-playback {
-          display: none;
-        }
-      }
-    }
-
     /* ==================================================
     control bar groups
     */
@@ -210,6 +200,11 @@
         }
         .jw-text-duration {
           padding: 0 0.5em 0 0;
+        }
+      }
+      &.jw-breakpoint-0 {
+        .jw-text-countdown {
+          display: inline-block;
         }
       }
     }

--- a/src/css/imports/controlbar.less
+++ b/src/css/imports/controlbar.less
@@ -124,13 +124,26 @@
   display: none;
 }
 
-.jwplayer:not(.jw-breakpoint-0) .jw-text-countdown {
+.jwplayer .jw-text-countdown {
   display: none;
 }
 
-.jw-breakpoint-0 .jw-controlbar {
-  .jw-text-duration,
-  .jw-text-elapsed {
-    display: none;
+.jw-breakpoint-0,
+.jw-breakpoint-1:not(.jw-flag-time-slider-above) {
+  .jw-controlbar {
+    .jw-text-duration,
+    .jw-text-elapsed {
+      display: none;
+    }
+  }
+}
+
+.jw-flag-small-player {
+  .jw-group {
+    > .jw-icon-rewind,
+    > .jw-icon-next,
+    > .jw-icon-playback {
+      display: none;
+    }
   }
 }

--- a/src/css/imports/dock.less
+++ b/src/css/imports/dock.less
@@ -55,3 +55,27 @@
     background-repeat: no-repeat;
     opacity: 0.75;
 }
+
+
+.jw-flag-small-player {
+    .jw-dock {
+        margin: 0;
+    }
+    .jw-dock-button {
+        margin: 1px;
+        height: @mobile-touch-target;
+        width: @mobile-touch-target;
+    }
+}
+
+.jw-breakpoint-1 {
+    // give dock some padding
+    .jw-dock {
+        padding: 0 1%;
+    }
+
+    // give dock buttons some space between each other above smallest breakpoint
+    .jw-dock-button {
+        margin: 2% 1%;
+    }
+}

--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -23,12 +23,13 @@
 
 .inset-controlbar() {
 
+  &:not(.jw-flag-small-player) {
     .jw-controlbar {
-        display: inline-block;
+      display: inline-block;
     }
+  }
 
-  &:not(.jw-flag-time-slider-above):not(.jw-flag-audio-player):not(.jw-flag-small-player) {
-
+  &:not(.jw-flag-time-slider-above):not(.jw-flag-audio-player):not(.jw-breakpoint-0)  {
     .jw-controlbar {
       bottom: .7em;
       max-width: @min-breakpoint-5-width;
@@ -37,6 +38,9 @@
       right: 2%;
       width: 96%; // width assignment is required for IE11 to center correctly
     }
+  }
+
+  &:not(.jw-flag-time-slider-above):not(.jw-flag-audio-player):not(.jw-flag-small-player) {
 
     .jw-nextup-container {
       bottom: @controlbar-height + .7em;
@@ -311,17 +315,26 @@
         bottom: auto;
       }
 
-      &:not(.jw-flag-time-slider-above):not(.jw-flag-small-player) {
-
+      &:not(.jw-flag-time-slider-above) {
         .jw-controlbar {
-
           height: @controlbar-height;
 
           .jw-overlay {
             bottom: @controlbar-height;
           }
-
         }
+
+        .jw-icon-inline,
+        .jw-icon-tooltip,
+        .jw-text-elapsed,
+        .jw-text-duration,
+        .jw-text-countdown {
+          height: @controlbar-height;
+          line-height: @controlbar-height;
+        }
+      }
+
+      &:not(.jw-flag-time-slider-above):not(.jw-flag-small-player) {
 
         .jw-time-tip {
             bottom: (@controlbar-height / 2);
@@ -341,15 +354,6 @@
             .jw-controls-right {
                 bottom: @controlbar-height;
             }
-        }
-
-        .jw-icon-inline,
-        .jw-icon-tooltip,
-        .jw-text-elapsed,
-        .jw-text-duration,
-        .jw-text-countdown {
-            height: @controlbar-height;
-            line-height: @controlbar-height;
         }
 
         &.jw-flag-audio-player {

--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -23,7 +23,7 @@
 
 .inset-controlbar() {
 
-  &:not(.jw-flag-small-player) {
+  &:not(.jw-flag-small-player):not(.jw-flag-audio-player) {
     .jw-controlbar {
       display: inline-block;
     }
@@ -397,20 +397,6 @@
 
                     .jw-icon {
                         color: @display-icon-hover-color;
-                    }
-                }
-            }
-
-            // When we're in an error or buffering state...
-            &.jw-error,
-            &.jw-state-error,
-            &.jw-state-buffering {
-                // Show the normal state for the icons so we do not imply its clickable
-                .jw-display-icon-container {
-                    background-color: @display-bkgd-color;
-
-                    .jw-icon {
-                        color: @display-icon-color;
                     }
                 }
             }

--- a/src/css/skins/beelden.less
+++ b/src/css/skins/beelden.less
@@ -52,7 +52,12 @@
 
     .jw-controlbar {
         box-shadow: inset 0px 7px 1px -5px rgba(128,128,128,1);
-        border-radius: .3em;
+    }
+
+    &:not(.jw-breakpoint-0) {
+        .jw-controlbar {
+            border-radius: .3em;
+        }
     }
 
     /* Container styles for controlbar play/pause button */

--- a/src/css/skins/bekle.less
+++ b/src/css/skins/bekle.less
@@ -41,8 +41,10 @@
     .skin-element-padding();
     .inset-controlbar();
 
-    .jw-controlbar {
-        border-radius: .3em;
+    &:not(.jw-breakpoint-0) {
+        .jw-controlbar {
+            border-radius: .3em;
+        }
     }
 
     .jw-time-tip,

--- a/src/css/skins/roundster.less
+++ b/src/css/skins/roundster.less
@@ -46,9 +46,11 @@
 
     /* Controlbar styles */
     .inset-controlbar();
-    .jw-controlbar {
-        border-radius: @roundster-corners;
-        padding: 0 @roundster-corners;
+    &:not(.jw-breakpoint-0) {
+        .jw-controlbar {
+            border-radius: @roundster-corners;
+            padding: 0 @roundster-corners;
+        }
     }
 
     /* Rail/slider styles */

--- a/src/css/skins/six.less
+++ b/src/css/skins/six.less
@@ -63,12 +63,17 @@
 
     .jw-controlbar {
         border: @def-border;
-        border-radius: .3em;
         background-size: @def-background-size;
 
         .jw-overlay {
             bottom: 2em;
             padding-bottom: .25em;
+        }
+    }
+
+    &:not(.jw-breakpoint-0) {
+        .jw-controlbar {
+            border-radius: .3em;
         }
     }
 


### PR DESCRIPTION
### Changes proposed in this pull request:
- Fix inset control bar at small breakpoints for custom skins
- Show display icons on view even when `timeSliderAbove = false`

Fixes #
JW7-3943
