### PR TITLE
Vertically center ad text for small players of inset control bar skins

### DIFF
--- a/src/css/flags/ads.less
+++ b/src/css/flags/ads.less
@@ -62,8 +62,9 @@
             .jw-text-alt {
                 display: table;
                 white-space: nowrap;
-                top: 0px;
+                top: 0;
                 transform: none;
+                margin: 0.5em 0;
             }
         }
     }


### PR DESCRIPTION
### Changes proposed in this pull request:

Fixes #
JW7-3946
