### PR TITLE
Apply colorization via overrides within the skins

### DIFF
--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -96,6 +96,10 @@
             background: @controlbar-background;
         }
 
+        &.jw-flag-color-override .jw-background-color {
+            background: none;
+        }
+
         .jw-text {
             color: @inactive-color;
         }
@@ -154,6 +158,10 @@
 
         .jw-progress {
             background: @progress-color;
+        }
+
+        &.jw-flag-color-override .jw-progress {
+            background: none;
         }
 
         .jw-slider-horizontal {
@@ -228,6 +236,14 @@
             background: @display-bkgd-hover-color;
         }
 
+        &.jw-flag-color-override .jw-dock {
+            &:hover,
+            .jw-dock-button,
+            .jw-overlay {
+                background: none;
+            }
+        }
+
         /*
         Chromecast
         */
@@ -282,6 +298,10 @@
             fade(@nextup-body-text-color-overflow, 0%) 0%,
             @nextup-body-text-color-overflow 100%
           );
+        }
+
+        &.jw-flag-color-override .jw-nextup-thumbnail-visible + .jw-nextup-title::after {
+            background: none;
         }
 
         .jw-nextup-close {

--- a/src/css/skins/beelden.less
+++ b/src/css/skins/beelden.less
@@ -82,6 +82,10 @@
         }
     }
 
+    & .jw-icon-playback:before{
+        background: none;
+    }
+
     /* Keep the play/pause container from collapsing on toggle */
     &.jw-state-playing {
         .jw-icon-playback {
@@ -206,4 +210,16 @@
         border-radius: @ui-padding;
     }
 
+    &.jw-flag-color-override {
+        .jw-display-icon-container,
+        .jw-controlbar,
+        .jw-skip {
+            box-shadow: none;
+            border: none;
+        }
+
+        .jw-progress {
+            background: none;
+        }
+    }
 }

--- a/src/css/skins/bekle.less
+++ b/src/css/skins/bekle.less
@@ -95,7 +95,6 @@
     }
 
     .jw-slider-vertical {
-
         .jw-rail,
         .jw-progress {
             width: @rail-height;
@@ -108,7 +107,13 @@
         .jw-progress {
             background: @progress-vert-gradient;
         }
-
     }
 
+    // Override inside the skin to not bloat other skins
+    &.jw-flag-color-override {
+        .jw-progress,
+        .jw-slider-vertical .jw-progress {
+            background: none;
+        }
+    }
 }

--- a/src/css/skins/roundster.less
+++ b/src/css/skins/roundster.less
@@ -72,6 +72,10 @@
         box-shadow: 0px 1px 5px 1px rgba(134,142,163,1);
     }
 
+    &.jw-flag-color-override .jw-knob {
+        box-shadow: none;
+    }
+
     /* Timeline and horizontal volume slider */
     .jw-slider-horizontal {
         background: none;

--- a/src/css/skins/six.less
+++ b/src/css/skins/six.less
@@ -239,4 +239,26 @@
         }
     }
 
+    // Override styles inside the skin to not bloat other skins
+    &.jw-flag-color-override {
+        .jw-display-icon-container {
+            background: none;
+            border: none;
+        }
+
+        .jw-progress,
+        .jw-knob,
+        .jw-slider-vertical .jw-progress,
+        .jw-slider-vertical .jw-knob {
+            background: none;
+        }
+
+        .jw-dock {
+            &:hover,
+            .jw-dock-button,
+            .jw-overlay {
+                background: none;
+            }
+        }
+    }
 }

--- a/src/css/skins/stormtrooper.less
+++ b/src/css/skins/stormtrooper.less
@@ -72,6 +72,16 @@
         background: @rail-color;
     }
 
+    // Override styles inside the skin to not bloat other skins
+    &.jw-flag-color-override {
+        .jw-slider-horizontal .jw-progress,
+        .jw-slider-horizontal .jw-knob,
+        .jw-slider-vertical .jw-progress,
+        .jw-slider-vertical .jw-knob {
+            background: none;
+        }
+    }
+
     /* Timeline and horizontal volume slider */
     .jw-slider-horizontal {
         .jw-progress {

--- a/src/css/skins/vapor.less
+++ b/src/css/skins/vapor.less
@@ -106,6 +106,7 @@
 					border: 1px solid #000;
 			}
 
+
 		}
 
 

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -363,6 +363,8 @@ define([
                 utils.css(elements.join(', '), o, id);
             }
 
+            utils.addClass(_playerElement, 'jw-flag-color-override');
+
             // We can assume that the user will define both an active and inactive color because otherwise it doesn't
             // look good.
             var activeColor = _model.get('skinColorActive'),


### PR DESCRIPTION
Fixes an issue with overriding styles by making skins responsible for cleaning up after themselves.  Skins which apply potentially hard to override styles via JS (background) now will clear out these styles by disabling them when the jw-flag-color-override is set.  This make any style bloat that exists in the skin which creates it instead of increasing the overall player size by adding more styles in the JS.  This also allow more granular rollbacks (such as removing box-shadows) to be done in the skin which creates them instead of making view.js responsible for cleaning them up.

JW7-3908