### PR TITLE
Control bar display fixes

### DIFF
--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -3,10 +3,6 @@
 /* time slider above or small player (both override player into same UI) */
 .jw-flag-time-slider-above:not(.jw-flag-ads-googleima) {
 
-  .jw-controlbar {
-    display: table;
-  }
-
   &.jw-state-idle:not(.jw-flag-cast-available) {
     .jw-controlbar {
       display: none;
@@ -16,12 +12,6 @@
       padding: 0;
     }
   }
-
-  /* ==================================================
-  dock
-  */
-
-
 
   /* ==================================================
   display
@@ -48,6 +38,7 @@
     */
 
     .jw-controlbar {
+      display: table; // Ensure inset control bars have the right layout
       background: linear-gradient(180deg, rgba(0,0,0,0) 0, rgba(0,0,0,0.25) 30%, rgba(0,0,0,0.4) 70%, rgba(0,0,0,0.5) 100%);
       border: none;
       border-radius: 0;

--- a/src/css/flags/user-inactive.less
+++ b/src/css/flags/user-inactive.less
@@ -1,7 +1,7 @@
 @import "../imports/vars";
 @import "controls-hidden";
 
-.jwplayer.jw-flag-user-inactive:not(.jw-flag-media-audio) {
+.jw-flag-user-inactive:not(.jw-flag-media-audio) {
 
   &.jw-state-playing {
 

--- a/src/css/imports/autostartmute.less
+++ b/src/css/imports/autostartmute.less
@@ -15,7 +15,7 @@
   }
 }
 
-.jwplayer.jw-flag-autostart:not(.jw-flag-media-audio) {
+.jwplayer.jw-flag-touch.jw-flag-autostart:not(.jw-flag-media-audio) {
   .jw-controlbar,
   .jw-nextup,
   &:not(.jw-state-buffering):not(.jw-state-error):not(.jw-state-complete) .jw-display {

--- a/src/css/states/idle.less
+++ b/src/css/states/idle.less
@@ -23,9 +23,10 @@
         display: block;
     }
 
-    /* hide control bar and clear display container padding on idle state unless
-    cast available flag is set */
-    &:not(.jw-flag-cast-available) {
+    // Hide control bar and clear display container padding on idle state unless
+    // cast available flag is set
+    // Specificity needed for inset control bar
+    .jwplayer&:not(.jw-flag-cast-available) {
 
       .jw-controlbar {
         display: none;


### PR DESCRIPTION
### Changes proposed in this pull request:

- Fix control bar layout for inset skins in timeSliderAbove mode
- Ensure control bar is visible during ad playback on touch devices
- Ensure controls are hidden during muted autostart on touch devices

Specificity is added in cases where `:not(.class)` rules broke player states.

Fixes #
JW7-3943, JW7-3948
