### PR TITLE
Limit places that set control bar display

### DIFF
--- a/src/css/flags/ads.less
+++ b/src/css/flags/ads.less
@@ -73,7 +73,6 @@
 .jwplayer.jw-flag-ads-googleima {
 
     .jw-controlbar {
-        display: table;
         bottom: 0;
     }
 
@@ -91,24 +90,21 @@
     &.jw-skin-seven .jw-controlbar {
         font-size: 0.9em;
     }
-
-    &.jw-flag-ads-vpaid.jw-flag-ads-vpaid-controls {
-        .jw-controlbar {
-            display: table;
-            bottom: 0;
-        }
-    }
 }
 
+// Control bar should always be visible during ads on touch devices
 .jwplayer.jw-flag-ads.jw-flag-touch {
-    .jw-controlbar {
-        display: table;
+    &,
+    &.jw-flag-autostart {
+        .jw-controls .jw-controlbar.jw-controlbar {
+            display: table;
+        }
     }
 }
 
 .jwplayer.jw-flag-ads-vpaid,
 .jwplayer.jw-flag-touch.jw-flag-ads-vpaid {
-    .jw-controlbar, .jw-display-container, .jw-skip {
+    .jw-display-container, .jw-skip {
         display: none;
     }
 }

--- a/src/css/flags/ads.less
+++ b/src/css/flags/ads.less
@@ -70,7 +70,8 @@
     }
 
     // Control bar should always be visible during ad playback on touch devices
-    &.jwplayer.jw-flag-ads.jw-flag-touch {
+    // except when jw-flag-ads-vpaid is set
+    &.jw-flag-ads.jw-flag-touch:not(.jw-flag-ads-vpaid) {
         &,
         &.jw-flag-autostart {
             .jw-controls .jw-controlbar {

--- a/src/css/flags/ads.less
+++ b/src/css/flags/ads.less
@@ -68,13 +68,19 @@
             }
         }
     }
+
+    // Control bar should always be visible during ad playback on touch devices
+    &.jwplayer.jw-flag-ads.jw-flag-touch {
+        &,
+        &.jw-flag-autostart {
+            .jw-controls .jw-controlbar {
+                display: table;
+            }
+        }
+    }
 }
 
 .jwplayer.jw-flag-ads-googleima {
-
-    .jw-controlbar {
-        bottom: 0;
-    }
 
     &.jw-flag-touch {
         .jw-controlbar {
@@ -89,16 +95,6 @@
 
     &.jw-skin-seven .jw-controlbar {
         font-size: 0.9em;
-    }
-}
-
-// Control bar should always be visible during ads on touch devices
-.jwplayer.jw-flag-ads.jw-flag-touch {
-    &,
-    &.jw-flag-autostart {
-        .jw-controls .jw-controlbar.jw-controlbar {
-            display: table;
-        }
     }
 }
 

--- a/src/css/flags/audioplayer.less
+++ b/src/css/flags/audioplayer.less
@@ -1,4 +1,4 @@
-.jwplayer.jw-flag-audio-player {
+.jw-flag-audio-player {
     background-color: transparent;
 
     .jw-media {

--- a/src/css/flags/controls-hidden.less
+++ b/src/css/flags/controls-hidden.less
@@ -1,5 +1,4 @@
 .jwplayer.jw-flag-controls-hidden { // Toggle mobile controls. Also used for user inactivity
-  .jw-controlbar,
   .jw-dock,
   .jw-logo.jw-hide {
     display: none;

--- a/src/css/flags/controls-hidden.less
+++ b/src/css/flags/controls-hidden.less
@@ -1,5 +1,4 @@
-.jwplayer.jw-flag-controls-hidden {
-  .jw-controlbar,
+.jwplayer.jw-flag-controls-hidden { // Toggle mobile controls and hide during user inactivity
   .jw-dock,
   .jw-logo.jw-hide {
     display: none;

--- a/src/css/flags/controls-hidden.less
+++ b/src/css/flags/controls-hidden.less
@@ -1,4 +1,5 @@
-.jwplayer.jw-flag-controls-hidden { // Toggle mobile controls and hide during user inactivity
+.jwplayer.jw-flag-controls-hidden { // Toggle mobile controls. Also used for user inactivity
+  .jw-controlbar,
   .jw-dock,
   .jw-logo.jw-hide {
     display: none;

--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -8,20 +8,10 @@
   }
 
   &.jw-state-idle:not(.jw-flag-cast-available) {
-    .jw-controlbar {
-      display: none;
-    }
-    
     .jw-display {
       padding: 0;
     }
   }
-
-  /* ==================================================
-  dock
-  */
-
-
 
   /* ==================================================
   display

--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -104,9 +104,8 @@
 
     .jw-group > .jw-icon {
       font-size: 20px;
-      padding: 0;
-      text-align: center;
-      width: @mobile-touch-target;
+      padding: 0 8px;
+      max-width: @mobile-touch-target;
 
       &::before {
         background-color: transparent;

--- a/src/css/flags/user-inactive.less
+++ b/src/css/flags/user-inactive.less
@@ -22,12 +22,6 @@
       }
   }
 
-  &.jw-state-buffering {
-      .jw-controlbar {
-          display: none;
-      }
-  }
-
   &.jw-flag-casting {
 
       .jw-nextup-container {
@@ -43,12 +37,5 @@
               display: none;
           }
       }
-  }
-
-  &.jw-flag-audio-player,
-  &.jw-flag-casting {
-    .jw-controlbar {
-        display: table;
-    }
   }
 }

--- a/src/css/imports/autostartmute.less
+++ b/src/css/imports/autostartmute.less
@@ -16,7 +16,6 @@
 }
 
 .jwplayer.jw-flag-autostart:not(.jw-flag-media-audio) {
-  .jw-controlbar,
   .jw-nextup,
   &:not(.jw-state-buffering):not(.jw-state-error):not(.jw-state-complete) .jw-display {
     display: none;

--- a/src/css/imports/controlbar.less
+++ b/src/css/imports/controlbar.less
@@ -4,6 +4,7 @@
 .jw-controlbar {
   display: table;
   position: absolute;
+  left: 0;
   bottom: 0;
   height: @controlbar-height;
   width: 100%;
@@ -138,11 +139,24 @@
   }
 }
 
-.jw-flag-small-player {
+.jw-flag-small-player:not(.jw-flag-audio-player) {
   .jw-group {
     > .jw-icon-rewind,
     > .jw-icon-next,
     > .jw-icon-playback {
+      display: none;
+    }
+  }
+}
+
+.jw-flag-ads-vpaid,
+.jw-flag-autostart,
+.jw-flag-user-inactive.jw-state-playing,
+.jw-flag-user-inactive.jw-state-buffering,
+.jw-flag-controls-hidden
+{
+  &:not(.jw-flag-media-audio):not(.jw-flag-audio-player):not(.jw-flag-ads-googleima):not(.jw-flag-casting) {
+    .jw-controlbar {
       display: none;
     }
   }

--- a/src/css/imports/controlbar.less
+++ b/src/css/imports/controlbar.less
@@ -155,7 +155,7 @@
 .jw-flag-user-inactive.jw-state-buffering,
 .jw-flag-controls-hidden
 {
-  &:not(.jw-flag-media-audio):not(.jw-flag-audio-player):not(.jw-flag-ads-googleima):not(.jw-flag-casting) {
+  &:not(.jw-flag-media-audio):not(.jw-flag-audio-player):not(.jw-flag-ads-vpaid-controls):not(.jw-flag-casting) {
     .jw-controlbar {
       display: none;
     }

--- a/src/css/imports/controlbar.less
+++ b/src/css/imports/controlbar.less
@@ -152,9 +152,7 @@
 .jw-flag-ads-vpaid,
 .jw-flag-autostart,
 .jw-flag-user-inactive.jw-state-playing,
-.jw-flag-user-inactive.jw-state-buffering,
-.jw-flag-controls-hidden
-{
+.jw-flag-user-inactive.jw-state-buffering {
   &:not(.jw-flag-media-audio):not(.jw-flag-audio-player):not(.jw-flag-ads-vpaid-controls):not(.jw-flag-casting) {
     .jw-controlbar {
       display: none;

--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -48,6 +48,9 @@
       right: 2%;
       width: 96%; // width assignment is required for IE11 to center correctly
     }
+    &.jw-flag-ads-googleima .jw-controlbar {
+      bottom: 0;
+    }
   }
 
   &:not(.jw-flag-time-slider-above):not(.jw-flag-audio-player):not(.jw-flag-small-player) {

--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -33,11 +33,6 @@
     }
   }
 
-  // Specificity needed for error mode
-  &.jw-state-error .jw-controls > .jw-controlbar {
-    display: none;
-  }
-
   &:not(.jw-flag-time-slider-above):not(.jw-flag-audio-player):not(.jw-breakpoint-0)  {
     .jw-controlbar {
       bottom: .7em;

--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -26,8 +26,7 @@
   &:not(.jw-flag-time-slider-above):not(.jw-flag-audio-player) {
     &,
     .jwplayer.jw-flag-ads.jw-flag-touch&,
-    .jwplayer.jw-flag-ads.jw-flag-touch.jw-flag-autostart&
-    {
+    .jwplayer.jw-flag-ads.jw-flag-touch.jw-flag-autostart& {
       .jw-controlbar {
         display: inline-block;
       }

--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -23,7 +23,7 @@
 
 .inset-controlbar() {
 
-  &:not(.jw-time-slider-above):not(.jw-flag-audio-player) {
+  &:not(.jw-flag-time-slider-above):not(.jw-flag-audio-player) {
     &,
     .jwplayer.jw-flag-ads.jw-flag-touch&,
     .jwplayer.jw-flag-ads.jw-flag-touch.jw-flag-autostart&

--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -25,8 +25,8 @@
 
   &:not(.jw-flag-time-slider-above):not(.jw-flag-audio-player) {
     &,
-    .jwplayer.jw-flag-ads.jw-flag-touch&,
-    .jwplayer.jw-flag-ads.jw-flag-touch.jw-flag-autostart& {
+    .jw-flag-ads.jw-flag-touch:not(.jw-flag-ads-vpaid)&,
+    .jw-flag-ads.jw-flag-touch.jw-flag-autostart:not(.jw-flag-ads-vpaid)& {
       .jw-controlbar {
         display: inline-block;
       }

--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -23,10 +23,20 @@
 
 .inset-controlbar() {
 
-  &:not(.jw-flag-small-player):not(.jw-flag-audio-player) {
-    .jw-controlbar {
-      display: inline-block;
+  &:not(.jw-time-slider-above):not(.jw-flag-audio-player) {
+    &,
+    .jwplayer.jw-flag-ads.jw-flag-touch&,
+    .jwplayer.jw-flag-ads.jw-flag-touch.jw-flag-autostart&
+    {
+      .jw-controlbar {
+        display: inline-block;
+      }
     }
+  }
+
+  // Specificity needed for error mode
+  &.jw-state-error .jw-controls > .jw-controlbar {
+    display: none;
   }
 
   &:not(.jw-flag-time-slider-above):not(.jw-flag-audio-player):not(.jw-breakpoint-0)  {

--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -48,7 +48,12 @@
   }
 
   &:not(.jw-flag-time-slider-above):not(.jw-flag-audio-player):not(.jw-flag-small-player) {
+    &.jw-ie.jw-flag-ads .jw-controlbar-center-group .jw-text-alt  {
+        top: 1px;
+    }
+  }
 
+  &:not(.jw-flag-time-slider-above) {
     .jw-nextup-container {
       bottom: @controlbar-height + .7em;
       padding-left: 0;
@@ -63,9 +68,6 @@
         padding-left: 2%;
         padding-right: 2%;
       }
-    }
-    &.jw-ie.jw-flag-ads .jw-controlbar-center-group .jw-text-alt  {
-        top: 1px;
     }
   }
 

--- a/src/css/states/error.less
+++ b/src/css/states/error.less
@@ -1,7 +1,8 @@
 @import "../imports/vars";
 @import "../imports/icons";
 
-body .jw-error, .jwplayer.jw-state-error {
+body .jw-error,
+body .jw-state-error {
     .jw-title {
         display: block;
         .jw-title-primary {
@@ -13,11 +14,8 @@ body .jw-error, .jwplayer.jw-state-error {
         display: block;
     }
 
-    &,
-    &.jw-flag-time-slider-above {
-        .jw-controlbar {
-            display : none;
-        }
+    .jw-controlbar {
+        display: none;
     }
 
     .jw-captions {
@@ -56,3 +54,4 @@ body .jw-error {
         right: 0;
     }
 }
+

--- a/src/css/states/error.less
+++ b/src/css/states/error.less
@@ -2,7 +2,7 @@
 @import "../imports/icons";
 
 body .jw-error,
-body .jw-state-error {
+body .jwplayer.jw-state-error {
     .jw-title {
         display: block;
         .jw-title-primary {
@@ -14,7 +14,7 @@ body .jw-state-error {
         display: block;
     }
 
-    .jw-controlbar {
+    .jw-controls .jw-controlbar {
         display: none;
     }
 

--- a/src/css/states/error.less
+++ b/src/css/states/error.less
@@ -13,8 +13,11 @@ body .jw-error, .jwplayer.jw-state-error {
         display: block;
     }
 
-    .jw-controlbar {
-        display : none;
+    &,
+    &.jw-flag-time-slider-above {
+        .jw-controlbar {
+            display : none;
+        }
     }
 
     .jw-captions {

--- a/src/css/states/idle.less
+++ b/src/css/states/idle.less
@@ -30,7 +30,7 @@
         padding: 0;
       }
     }
-    .jwplayer&:not(.jw-flag-audio-player):not(.jw-flag-casting) .jw-controlbar {
+    .jwplayer&:not(.jw-flag-audio-player):not(.jw-flag-casting):not(.jw-flag-cast-available) .jw-controlbar {
         display: none;
     }
 }

--- a/src/css/states/idle.less
+++ b/src/css/states/idle.less
@@ -26,15 +26,11 @@
     /* hide control bar and clear display container padding on idle state unless
     cast available flag is set */
     &:not(.jw-flag-cast-available) {
-
-      .jw-controlbar {
-        display: none;
-      }
-
       .jw-display {
         padding: 0;
       }
-
     }
-
+    .jwplayer&:not(.jw-flag-audio-player):not(.jw-flag-casting) .jw-controlbar {
+        display: none;
+    }
 }

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -960,6 +960,12 @@ define([
         }
 
         function _toggleControls() {
+            // Do not add mobile toggle "jw-flag-controls-hidden" in these cases
+            if  (_instreamModel ||
+                _model.get('castActive') ||
+                (_model.mediaModel && _model.mediaModel.get('mediaType') === 'audio')) {
+                return;
+            }
             utils.toggleClass(_playerElement, 'jw-flag-controls-hidden');
             _captionsRenderer.renderCues(true);
         }

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -302,20 +302,24 @@ define([
         // Set global colors, used by related plugin
         // If a color is undefined simple-style-loader won't add their styles to the dom
         function insertGlobalColorClasses(activeColor, inactiveColor, playerId) {
-            var activeColorSet = {
-                color: activeColor,
-                borderColor: activeColor,
-                stroke: activeColor
-            };
-            var inactiveColorSet = {
-                color: inactiveColor,
-                borderColor: inactiveColor,
-                stroke: inactiveColor
-            };
-            utils.css('#' + playerId + ' .jw-color-active', activeColorSet, playerId);
-            utils.css('#' + playerId + ' .jw-color-active-hover:hover', activeColorSet, playerId);
-            utils.css('#' + playerId + ' .jw-color-inactive', inactiveColorSet, playerId);
-            utils.css('#' + playerId + ' .jw-color-inactive-hover:hover', inactiveColorSet, playerId);
+            if (activeColor) {
+                var activeColorSet = {
+                    color: activeColor,
+                    borderColor: activeColor,
+                    stroke: activeColor
+                };
+                utils.css('#' + playerId + ' .jw-color-active', activeColorSet, playerId);
+                utils.css('#' + playerId + ' .jw-color-active-hover:hover', activeColorSet, playerId);
+            }
+            if (inactiveColor) {
+                var inactiveColorSet = {
+                    color: inactiveColor,
+                    borderColor: inactiveColor,
+                    stroke: inactiveColor
+                };
+                utils.css('#' + playerId + ' .jw-color-inactive', inactiveColorSet, playerId);
+                utils.css('#' + playerId + ' .jw-color-inactive-hover:hover', inactiveColorSet, playerId);
+            }
         }
 
 


### PR DESCRIPTION
### Changes proposed in this pull request:

- Set display for structure
- Override display to hide control bar only when necessary
- Don't hide play/pause/rewind/next buttons for players showing control bar only


## Control Bar Structure
- default: `table`
- inset control bars: `inline-block`
- time slider above: `table`

## Control Bar Visibility

### The control bar is always visible for:
- .jw-flag-media-audio
- .jw-flag-audio-player
- .jw-flag-ads-vpaid-controls
- .jw-flag-casting
- .jw-flag-cast-available
- .jw-flag-ads.jw-flag-touch

### The control bar is always hidden for:
- .jw-flag-ads-hide-controls
- .jw-flag-controls-hidden (toggling controls on mobile)
- .jw-state-error
- .jw-error

The error rules need more specificity to override the rules that govern structure.

### The control bar is _conditionally_ hidden for:
- .jw-state-idle
- .jw-state-playing.jw-state-user-inactive
- .jw-state-buffering.jw-state-user-inactive
- .jw-flag-ads-vpaid
- .jw-flag-touch.jw-flag-autostart

We can use the `:not` pseudo-class for conditionally hiding the control bar for the above flags except on mobile during ad playback. We handle this case separately since `:not(.jw-flag-touch.jw-flag-ads)` doesn't work.


## CSS Output:

### Default
```
.jw-controlbar { 
  display:table;
  position:absolute;
  left:0;
  bottom:0;
  height:2.5em;
  width:100%;
  padding:0 .5em
}
```

### Inset Control Bar
```
.jw-skin-bekle:not(.jw-flag-time-slider-above):not(.jw-flag-audio-player) .jw-controlbar, 
.jw-flag-ads.jw-flag-touch:not(.jw-flag-ads-vpaid).jw-skin-bekle:not(.jw-flag-time-slider-above):not(.jw-flag-audio-player) .jw-controlbar, // ads
.jw-flag-ads.jw-flag-touch.jw-flag-autostart:not(.jw-flag-ads-vpaid).jw-skin-bekle:not(.jw-flag-time-slider-above):not(.jw-flag-audio-player) .jw-controlbar { // ads
  display: inline-block;
}
```

### Timeslider above
```
.jw-flag-time-slider-above:not(.jw-flag-ads-googleima) .jw-controlbar {
    display:table
}
```

### Control bar hidden
```
.jw-flag-ads-vpaid:not(.jw-flag-media-audio):not(.jw-flag-audio-player):not(.jw-flag-ads-vpaid-controls):not(.jw-flag-casting) .jw-controlbar,
.jw-flag-autostart:not(.jw-flag-media-audio):not(.jw-flag-audio-player):not(.jw-flag-ads-vpaid-controls):not(.jw-flag-casting) .jw-controlbar,
.jw-flag-user-inactive.jw-state-playing:not(.jw-flag-media-audio):not(.jw-flag-audio-player):not(.jw-flag-ads-vpaid-controls):not(.jw-flag-casting) .jw-controlbar,
.jw-flag-user-inactive.jw-state-buffering:not(.jw-flag-media-audio):not(.jw-flag-audio-player):not(.jw-flag-ads-vpaid-controls):not(.jw-flag-casting) .jw-controlbar { 
    display:none
} 
```

### Idle state
```
.jwplayer.jw-state-idle:not(.jw-flag-audio-player):not(.jw-flag-casting):not(.jw-flag-cast-available) .jw-controlbar { 
    display: none 
}
```

### Error state
```
body .jw-error .jw-controlbar,
body .jwplayer.jw-state-error .jw-controls .jw-controlbar {
    display: none
}
```

### Control bar shown for ads on mobile
```
.jwplayer.jw-flag-ads.jw-flag-ads.jw-flag-touch:not(.jw-flag-ads-vpaid) .jw-controls .jw-controlbar,
.jwplayer.jw-flag-ads.jw-flag-ads.jw-flag-touch:not(.jw-flag-ads-vpaid).jw-flag-autostart .jw-controls .jw-controlbar {
    display: table 
}
```


Fixes #
JW7-3943, JW7-3948
