### PR TITLE
Let Edge handle cleanup for non-sideloaded tracks in HLS streams

### DIFF
--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -490,6 +490,11 @@ define(['utils/underscore',
     function _removeCues(tracks) {
         if (tracks.length) {
             _.each(tracks, function(track) {
+                // Let Edge handle cleanup of non-sideloaded text tracks in HLS streams
+                if (utils.isEdge() && /^(native|subtitle)/.test(track._id)) {
+                    return;
+                }
+                
                 // Cues are inaccessible if the track is disabled. While hidden,
                 // we can remove cues while the track is in a non-visible state
                 // Set to disabled before hidden to ensure active cues disappear


### PR DESCRIPTION
### Changes proposed in this pull request:
We don't need to and shouldn't attempt to remove cues from tracks added by Edge during native HLS playback.

Fixes #
JW7-3926
