### PR TITLE
Don’t show preview image during complete state for control bar only player

### DIFF
--- a/src/css/states/complete.less
+++ b/src/css/states/complete.less
@@ -1,8 +1,10 @@
 @import "../imports/icons";
 
 .jwplayer.jw-state-complete {
-    .jw-preview:not(.jw-flag-casting) {
-        display: block;
+    &:not(.jw-flag-casting):not(.jw-flag-audio-player) {
+        .jw-preview {
+            display: block;
+        }
     }
 
     .jw-display {


### PR DESCRIPTION
### Changes proposed in this pull request:

Fixes #
JW7-3961
