### PR TITLE
Fit jw-icon-rewind:before to the size of the icon

### DIFF
--- a/src/css/imports/controlbar.less
+++ b/src/css/imports/controlbar.less
@@ -96,9 +96,10 @@
   min-width: 2.25em;
 }
 
-// Sets the icon container size as it's font glyph does not fit in it's boundries correctly.
+// Ensure button highlight color spans the width of the rewind icon
 .jw-icon-rewind {
-  min-width: 2.25em;
+  min-width: 2em;
+  padding: 0 .25em;
 }
 
 .jw-icon-volume {

--- a/src/css/imports/controlbar.less
+++ b/src/css/imports/controlbar.less
@@ -96,6 +96,11 @@
   min-width: 2.25em;
 }
 
+// Sets the icon container size as it's font glyph does not fit in it's boundries correctly.
+.jw-icon-rewind {
+  min-width: 2.25em;
+}
+
 .jw-icon-volume {
   min-width: 1.75em;
   text-align: left;

--- a/src/css/imports/display.less
+++ b/src/css/imports/display.less
@@ -103,7 +103,7 @@ display icons
     }
 
     &.jw-icon-rewind::before {
-      padding: 0.2em 0.05em;
+      padding: 0.1em 0;
     }
 
     .jw-state-idle &.jw-icon-display::before,

--- a/src/css/imports/icons.less
+++ b/src/css/imports/icons.less
@@ -133,6 +133,10 @@
 
 .jw-icon-rewind {
     &:before {
+        // This icon expands beyond its icon bounds, so we fit it to its related element to :hover correctly
         content: "\e900";
+        display: inline-block;
+        height: 100%;
+        width: 100%;
     }
 }

--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -306,81 +306,77 @@
     }
 
     .custom-skin-styles() {
-        .jw-display-icon-container {
-            border-radius: @ui-corner-round;
+      .jw-display-icon-container {
+        border-radius: @ui-corner-round;
+      }
+
+      .jw-dock-button {
+        border-radius: @ui-corner-round;
+      }
+
+      .jw-controlbar .jw-controlbar-center-group .jw-text-alt {
+        top: 50%;
+        transform: translateY(-50%);
+        margin: auto;
+        bottom: auto;
+      }
+
+      &:not(.jw-flag-time-slider-above):not(.jw-flag-audio-player) {
+        .jw-controlbar {
+          height: @controlbar-height;
+
+          .jw-overlay {
+            bottom: @controlbar-height;
+          }
         }
 
-        .jw-dock-button {
-            border-radius: @ui-corner-round;
+        .jw-icon-inline,
+        .jw-icon-tooltip,
+        .jw-text-elapsed,
+        .jw-text-duration,
+        .jw-text-countdown {
+          height: @controlbar-height;
+          line-height: @controlbar-height;
+        }
+      }
+
+      &:not(.jw-flag-time-slider-above):not(.jw-flag-small-player) {
+        .jw-time-tip {
+          bottom: (@controlbar-height / 2);
         }
 
-        .jw-controlbar .jw-controlbar-center-group .jw-text-alt  {
-            top: 50%;
-            transform: translateY(-50%);
-            margin: auto;
-            bottom: auto;
+        .jw-captions {
+          max-height: calc(97% - 6.25 * (@controlbar-height));
         }
 
-        &:not(.jw-flag-time-slider-above) {
-            .jw-controlbar {
-                height: @controlbar-height;
-
-                .jw-overlay {
-                    bottom: @controlbar-height;
-                }
-            }
-
-            .jw-icon-inline,
-            .jw-icon-tooltip,
-            .jw-text-elapsed,
-            .jw-text-duration,
-            .jw-text-countdown {
-                height: @controlbar-height;
-                line-height: @controlbar-height;
-            }
+        .jwplayer {
+          video::-webkit-media-text-track-container {
+            max-height: calc(97% - 6.25 * (@controlbar-height));
+          }
         }
 
-        &:not(.jw-flag-time-slider-above):not(.jw-flag-small-player) {
-            .jw-time-tip {
-                bottom: (@controlbar-height / 2);
-            }
-
-            .jw-captions {
-                max-height: calc(97% - 6.25 * (@controlbar-height));
-            }
-
-            .jwplayer {
-                video::-webkit-media-text-track-container {
-                    max-height: calc(97% - 6.25 * (@controlbar-height));
-                }
-            }
-
-            .jw-controls {
-                .jw-controls-right {
-                    bottom: @controlbar-height;
-                }
-            }
-
-            &.jw-flag-audio-player {
-                .jw-controlbar {
-                    height: 100%;
-                }
-
-                .jw-icon-inline,
-                .jw-icon-tooltip,
-                .jw-text-elapsed,
-                .jw-text-duration,
-                .jw-text-countdown {
-                    height: auto;
-                    line-height: normal;
-                }
-            }
-
-            .jw-icon-inline,
-            .jw-icon-tooltip {
-                min-width: @controlbar-height * 5/8;
-            }
+        .jw-controls {
+          .jw-controls-right {
+            bottom: @controlbar-height;
+          }
         }
+
+        .jw-icon-inline,
+        .jw-icon-tooltip {
+          min-width: @controlbar-height * 5/8;
+        }
+
+        .jw-icon-rewind {
+          min-width: @controlbar-height;
+          padding: 0 @ui-padding * 1/2;
+        }
+      }
+
+      &.jw-flag-audio-player {
+        .jw-controlbar {
+          height: 100%;
+        }
+      }
     }
 
     // Set color classes in the skin so they can be reused in other parts of the player (i.e. the related overlay)

--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -299,6 +299,10 @@
           color: @nextup-close-button-color-hover;
         }
 
+        // Fixes an issue that cuts off the icon in Safari.  Value must be calculated base on skin's values.
+        .jw-flag-audio-player .jw-controlbar .jw-icon-rewind {
+            line-height: @font-size * @controlbar-height;
+        }
     }
 
     .custom-skin-styles() {

--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -22,59 +22,57 @@
 }
 
 .inset-controlbar() {
-
-  &:not(.jw-flag-time-slider-above):not(.jw-flag-audio-player) {
-    &,
-    .jw-flag-ads.jw-flag-touch:not(.jw-flag-ads-vpaid)&,
-    .jw-flag-ads.jw-flag-touch.jw-flag-autostart:not(.jw-flag-ads-vpaid)& {
-      .jw-controlbar {
-        display: inline-block;
-      }
-    }
-  }
-
-  &:not(.jw-flag-time-slider-above):not(.jw-flag-audio-player):not(.jw-breakpoint-0)  {
-    .jw-controlbar {
-      bottom: .7em;
-      max-width: @min-breakpoint-5-width;
-      margin: 0 auto;
-      left: 2%;
-      right: 2%;
-      width: 96%; // width assignment is required for IE11 to center correctly
-    }
-    &.jw-flag-ads-googleima .jw-controlbar {
-      bottom: 0;
-    }
-  }
-
-  &:not(.jw-flag-time-slider-above):not(.jw-flag-audio-player):not(.jw-flag-small-player) {
-    &.jw-ie.jw-flag-ads .jw-controlbar-center-group .jw-text-alt  {
-        top: 1px;
-    }
-  }
-
-  &:not(.jw-flag-time-slider-above) {
-    .jw-nextup-container {
-      bottom: @controlbar-height + .7em;
-      padding-left: 0;
-      padding-right: 0;
-      max-width: @min-breakpoint-5-width;
+    &:not(.jw-flag-time-slider-above):not(.jw-flag-audio-player) {
+        &,
+        .jw-flag-ads.jw-flag-touch:not(.jw-flag-ads-vpaid)&,
+        .jw-flag-ads.jw-flag-touch.jw-flag-autostart:not(.jw-flag-ads-vpaid)& {
+            .jw-controlbar {
+                display: inline-block;
+            }
+        }
     }
 
-    &.jw-breakpoint-2,
-    &.jw-breakpoint-3,
-    &.jw-breakpoint-4 {
-      .jw-nextup-container {
-        padding-left: 2%;
-        padding-right: 2%;
-      }
+    &:not(.jw-flag-time-slider-above):not(.jw-flag-audio-player):not(.jw-breakpoint-0)  {
+        .jw-controlbar {
+            bottom: .7em;
+            max-width: @min-breakpoint-5-width;
+            margin: 0 auto;
+            left: 2%;
+            right: 2%;
+            width: 96%; // width assignment is required for IE11 to center correctly
+        }
+        &.jw-flag-ads-googleima .jw-controlbar {
+            bottom: 0;
+        }
     }
-  }
 
-  &.jw-flag-audio-player .jw-controlbar {
-    bottom: 0; // overwrite the inset-controlbar mixin
-  }
+    &:not(.jw-flag-time-slider-above):not(.jw-flag-audio-player):not(.jw-flag-small-player) {
+        &.jw-ie.jw-flag-ads .jw-controlbar-center-group .jw-text-alt {
+            top: 1px;
+        }
+    }
 
+    &:not(.jw-flag-time-slider-above) {
+        .jw-nextup-container {
+            bottom: @controlbar-height + .7em;
+            padding-left: 0;
+            padding-right: 0;
+            max-width: @min-breakpoint-5-width;
+        }
+
+        &.jw-breakpoint-2,
+        &.jw-breakpoint-3,
+        &.jw-breakpoint-4 {
+            .jw-nextup-container {
+                padding-left: 2%;
+                padding-right: 2%;
+            }
+        }
+    }
+
+    &.jw-flag-audio-player .jw-controlbar {
+        bottom: 0; // overwrite the inset-controlbar mixin
+    }
 }
 
 .vertically-centered-rail-element(@rail-height, @element-height) {
@@ -100,7 +98,6 @@
 /* Mixin for common skin styles with variable colors */
 #namespace() {
     .basic-skin-styles() {
-
         .jw-background-color {
             background: @controlbar-background;
         }
@@ -143,12 +140,12 @@
 
         /* Colors for display icons */
         .jw-display-icon-container {
-          background-color: @display-bkgd-color;
-          margin: 0 (@ui-padding * 0.5);
+            background-color: @display-bkgd-color;
+            margin: 0 (@ui-padding * 0.5);
 
-          .jw-icon {
-            color: @display-icon-color;
-          }
+            .jw-icon {
+                color: @display-icon-color;
+            }
         }
 
         /* Slider colors */
@@ -242,27 +239,24 @@
         */
 
         .jw-icon-cast {
+            button {
+                --connected-color: @active-color;
+                --disconnected-color: @inactive-color;
 
-          button {
-            --connected-color: @active-color;
-            --disconnected-color: @inactive-color;
+                &:focus {
+                    --connected-color: @active-color;
+                    --disconnected-color: @hover-color;
+                }
 
-            &:focus {
-              --connected-color: @active-color;
-              --disconnected-color: @hover-color;
+                &.jw-off {
+                    --connected-color: @inactive-color;
+                }
             }
 
-            &.jw-off {
-              --connected-color: @inactive-color;
+            &:hover button {
+                --connected-color: @hover-color;
+                --disconnected-color: @hover-color;
             }
-
-          }
-
-          &:hover button {
-            --connected-color: @hover-color;
-            --disconnected-color: @hover-color;
-          }
-
         }
 
         /* Next up display */
@@ -308,7 +302,6 @@
     }
 
     .custom-skin-styles() {
-
         .jw-display-icon-container {
             border-radius: @ui-corner-round;
         }
@@ -317,78 +310,75 @@
             border-radius: @ui-corner-round;
         }
 
-      .jw-controlbar .jw-controlbar-center-group .jw-text-alt  {
-        top: 50%;
-        transform: translateY(-50%);
-        margin: auto;
-        bottom: auto;
-      }
-
-      &:not(.jw-flag-time-slider-above) {
-        .jw-controlbar {
-          height: @controlbar-height;
-
-          .jw-overlay {
-            bottom: @controlbar-height;
-          }
+        .jw-controlbar .jw-controlbar-center-group .jw-text-alt  {
+            top: 50%;
+            transform: translateY(-50%);
+            margin: auto;
+            bottom: auto;
         }
 
-        .jw-icon-inline,
-        .jw-icon-tooltip,
-        .jw-text-elapsed,
-        .jw-text-duration,
-        .jw-text-countdown {
-          height: @controlbar-height;
-          line-height: @controlbar-height;
+        &:not(.jw-flag-time-slider-above) {
+            .jw-controlbar {
+                height: @controlbar-height;
+
+                .jw-overlay {
+                    bottom: @controlbar-height;
+                }
+            }
+
+            .jw-icon-inline,
+            .jw-icon-tooltip,
+            .jw-text-elapsed,
+            .jw-text-duration,
+            .jw-text-countdown {
+                height: @controlbar-height;
+                line-height: @controlbar-height;
+            }
         }
-      }
 
-      &:not(.jw-flag-time-slider-above):not(.jw-flag-small-player) {
+        &:not(.jw-flag-time-slider-above):not(.jw-flag-small-player) {
+            .jw-time-tip {
+                bottom: (@controlbar-height / 2);
+            }
 
-        .jw-time-tip {
-            bottom: (@controlbar-height / 2);
-        }
-
-        .jw-captions {
-            max-height: calc(97% - 6.25 * (@controlbar-height));
-        }
-
-        .jwplayer {
-            video::-webkit-media-text-track-container {
+            .jw-captions {
                 max-height: calc(97% - 6.25 * (@controlbar-height));
             }
-        }
 
-        .jw-controls {
-            .jw-controls-right {
-                bottom: @controlbar-height;
+            .jwplayer {
+                video::-webkit-media-text-track-container {
+                    max-height: calc(97% - 6.25 * (@controlbar-height));
+                }
+            }
+
+            .jw-controls {
+                .jw-controls-right {
+                    bottom: @controlbar-height;
+                }
+            }
+
+            &.jw-flag-audio-player {
+                .jw-controlbar {
+                    height: 100%;
+                }
+
+                .jw-icon-inline,
+                .jw-icon-tooltip,
+                .jw-text-elapsed,
+                .jw-text-duration,
+                .jw-text-countdown {
+                    height: auto;
+                    line-height: normal;
+                }
+            }
+
+            .jw-icon-inline,
+            .jw-icon-tooltip {
+                min-width: @controlbar-height * 5/8;
             }
         }
-
-        &.jw-flag-audio-player {
-
-          .jw-controlbar {
-            height: 100%;
-          }
-
-          .jw-icon-inline,
-          .jw-icon-tooltip,
-          .jw-text-elapsed,
-          .jw-text-duration,
-          .jw-text-countdown {
-              height: auto;
-              line-height: normal;
-          }
-        }
-
-        .jw-icon-inline,
-        .jw-icon-tooltip {
-            min-width: @controlbar-height * 5/8;
-        }
-
-      }
-
     }
+
     // Set color classes in the skin so they can be reused in other parts of the player (i.e. the related overlay)
     .set-global-color-classes() {
         // Set the highlight color of the center display icon when we are hovering the player.
@@ -440,12 +430,12 @@
         }
         /* Color for list item text in menu lists */
         .jw-option {
-          color: @option-inactive-color;
+            color: @option-inactive-color;
 
-          &.jw-active-option {
-            color: @option-active-color;
-            background-color: @option-active-bg-color;
-          }
+            &.jw-active-option {
+                color: @option-active-color;
+                background-color: @option-active-bg-color;
+            }
         }
 
         &:not(.jw-flag-touch) .jw-option:hover {


### PR DESCRIPTION
Fit jw-icon-rewind:before to the size of the icon for correct safari highlights and display

Sets the 10 second rewind button's before pseudo element to fill its associated element.  This makes it so Safari will allow the entire icon can highlight correctly because Safari will only set the color on the part of the glyph that exists in that container.  This also fixes the issue where part of the icon is cut off in the audio only mode because it does not have a large enough line-height set.

JW7-3912 JW7-3664