### PR TITLE
Move Seven skin IE 11 style to the seven.less file

### DIFF
--- a/src/css/flags/ads.less
+++ b/src/css/flags/ads.less
@@ -64,7 +64,6 @@
                 white-space: nowrap;
                 top: 0;
                 transform: none;
-                margin: 0.5em 0;
             }
         }
     }

--- a/src/css/skins/seven.less
+++ b/src/css/skins/seven.less
@@ -48,4 +48,8 @@
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }
+
+  &.jw-ie .jw-text-alt {
+    margin: 0.5em 0;
+  }
 }


### PR DESCRIPTION
Moves a seven skin IE 11 style to the seven.less file instead of existing in the ads.less file.  This prevents alignment in all other skins in IE 11.

JW7-3969