### PR TITLE
Fixes for alignment of control bar elements for ads and time-slider-above

### DIFF
--- a/src/css/flags/ads.less
+++ b/src/css/flags/ads.less
@@ -16,14 +16,17 @@
     }
 
     &.jw-flag-small-player {
-      .jw-display-icon-rewind,
-      .jw-display-icon-next,
-      .jw-display-icon-display {
-        display: none;
-      }
-      &.jw-state-buffering .jw-display-icon-display {
-        display: inline-block;
-      }
+        .jw-display-icon-rewind,
+        .jw-display-icon-next,
+        .jw-display-icon-display {
+            display: none;
+        }
+        &.jw-state-buffering .jw-display-icon-display {
+            display: inline-block;
+        }
+        .jw-controlbar-center-group {
+            padding: 0;
+        }
     }
 
     .jw-controlbar {

--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -159,7 +159,7 @@
         }
       }
       .jw-controlbar-left-group {
-        margin-left: -5px;
+        padding-left: 0;
 
         .jw-text-elapsed,
         .jw-text-countdown {
@@ -172,6 +172,12 @@
       &.jw-breakpoint-0 {
         .jw-text-countdown {
           display: inline-block;
+        }
+      }
+      &.jw-flag-small-player {
+        .jw-text-elapsed,
+        .jw-text-countdown {
+          padding-left: 15px;
         }
       }
     }
@@ -188,7 +194,7 @@
     }
 
     .jw-controlbar-right-group {
-      margin-right: -5px;
+      padding-right: 6px;
       text-align: right;
 
       .jw-text-duration {
@@ -320,7 +326,6 @@
 
       .jw-controlbar-center-group {
         height: auto;
-        padding: 0;
       }
 
       .jw-group > .jw-text-alt {


### PR DESCRIPTION
### Changes proposed in this pull request:

- Align left-most and right-most control bar elements with the time slider above them
- Remove padding on ad text at small breakpoints so it’s closer to the play/pause button

Fixes #
JW7-3895, JW7-3964, JW7-3970, JW7-3979
