### PR TITLE
Improve player controls usability at breakpoint 0

### DIFF
--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -7,12 +7,6 @@
     display: table;
   }
 
-  &.jw-state-idle:not(.jw-flag-cast-available) {
-    .jw-display {
-      padding: 0;
-    }
-  }
-
   /* ==================================================
   display
   */
@@ -20,18 +14,27 @@
 
   // Consistent padding for display icons so they don't interfere with the time slider touch target
   // and don't get repositioned when the timeslider is not visible
-  &.jw-flag-small-player {
-      .jw-display {
-        padding-top: @mobile-touch-target;
-        padding-bottom: @mobile-touch-target * 1.5;
-      }
+  &.jw-flag-small-player .jw-display {
+    padding-bottom: @mobile-touch-target * 1.25;
   }
+  &.jw-breakpoint-1 .jw-display {
+    padding-top: @mobile-touch-target;
+  }
+
+
 
   /* ==================================================
   to avoid overriding audio player on small size
   */
 
   &.jwplayer {
+
+    &.jw-state-idle:not(.jw-flag-cast-available),
+    &.jw-state-error {
+      .jw-display {
+        padding: 0;
+      }
+    }
 
     /* ==================================================
     control bar

--- a/src/css/imports/display.less
+++ b/src/css/imports/display.less
@@ -51,7 +51,6 @@ display icons
 */
 
 .jw-display {
-
   display: table;
   height: 100%;
   padding: @controlbar-height 0;
@@ -61,11 +60,13 @@ display icons
   .jw-flag-dragging & {
     display: none;
   }
+}
 
-  .jw-state-idle:not(.jw-flag-cast-available) & {
+.jw-state-idle:not(.jw-flag-cast-available),
+.jw-state-error {
+   .jw-display {
     padding: 0;
   }
-
 }
 
 .jw-display-container {
@@ -115,31 +116,38 @@ display icons
 
 }
 
-// hide next and rewind buttons on extra small player
 .jw-breakpoint-0 {
-  .jw-display-icon-next,
+  .jw-display-icon-container {
+    margin: 0 2px;
+  }
+
+  // hide rewind button since it can't fit
   .jw-display-icon-rewind {
     display: none;
   }
-    .jw-display .jw-icon {
-        height: @mobile-touch-target;
-        line-height: @mobile-touch-target;
-        width: @mobile-touch-target;
-        &::before {
-            font-size: @mobile-touch-target * 0.5;
-        }
+  .jw-display {
+    padding: 0 0 40px 0;
+
+    .jw-icon {
+      height: @mobile-touch-target;
+      line-height: @mobile-touch-target;
+      width: @mobile-touch-target;
+      &::before {
+        font-size: @mobile-touch-target * 0.5;
+      }
     }
+  }
 }
 
 .jw-breakpoint-1 {
-    .jw-display .jw-icon {
-        height: @mobile-touch-target * 1.25;
-        line-height: @mobile-touch-target * 1.25;
-        width: @mobile-touch-target * 1.25;
-        &::before {
-            font-size: @mobile-touch-target * 0.5;
-        }
+  .jw-display .jw-icon {
+    height: @mobile-touch-target * 1.25;
+    line-height: @mobile-touch-target * 1.25;
+    width: @mobile-touch-target * 1.25;
+    &::before {
+      font-size: @mobile-touch-target * 0.5;
     }
+  }
 }
 
 .jw-breakpoint-3 {

--- a/src/css/imports/dock.less
+++ b/src/css/imports/dock.less
@@ -79,3 +79,9 @@
         margin: 2% 1%;
     }
 }
+
+.jw-breakpoint-0 {
+    .jw-related-dock-btn {
+        display: none;
+    }
+}


### PR DESCRIPTION
### Changes proposed in this pull request:

- Center display icons between time slider and the top of the player when the control bar is visible
- Center display icons in the idle and error states
- Hide the related/playlist dock button and the rewind display button at breakpoint 0

Fixes #
JW7-3991
