### PR TITLE
Use less fallbacks when creating track._id

### DIFF
--- a/src/js/controller/tracks-helper.js
+++ b/src/js/controller/tracks-helper.js
@@ -7,7 +7,7 @@ define([
             if (track.default || track.defaulttrack) {
                 trackId = 'default';
             } else {
-                trackId = track._id || track.file || track.name || track.label || (prefix + tracksCount);
+                trackId = track._id || track.file || (prefix + tracksCount);
             }
             return trackId;
         },

--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -491,7 +491,7 @@ define(['utils/underscore',
         if (tracks.length) {
             _.each(tracks, function(track) {
                 // Let Edge handle cleanup of non-sideloaded text tracks in HLS streams
-                if (utils.isEdge() && /^(native|subtitle)/.test(track._id)) {
+                if (utils.isEdge() && /^(native|subtitle|cc)/.test(track._id)) {
                     return;
                 }
                 

--- a/test/unit/tracks-helper-test.js
+++ b/test/unit/tracks-helper-test.js
@@ -45,18 +45,16 @@ define([
         func = 'createId';
         count = 0;
 
-        assert.expect(8);
+        assert.expect(6);
 
         assertProperty(assert, '', 'default', 'track.default is 1st priority even if other properties are set');
         assertProperty(assert, 'default', 'default',
             'track.defaulttrack is 2nd priority even if other properties are set');
         assertProperty(assert, 'defaulttrack', '_id', 'track._id is used if track.default is undefined');
         assertProperty(assert, '_id', 'file', 'track.file is used if track.default or track._id is undefined');
-        assertProperty(assert, 'file', 'name',
-            'track.name is prioritized over track.label if other properties are undefined.');
-        assertProperty(assert, 'name', 'label', 'track.label only has a higher priority than track.kind');
         setCount();
-        assertProperty(assert, 'label', 'kind' + count, 'track.kind is lowest priority');
+        assertProperty(assert, 'file',  'kind' + count,
+            'track.kind is used if other properties are undefined.');
         setCount();
         assertProperty(assert, 'kind', 'cc' + count, 'cc is used as the prefix if no other properties are set');
     });


### PR DESCRIPTION
### Changes proposed in this pull request:

Reduce the number of properties used to create `track._id`. This makes it predictable to determine tracks added by the browser during HLS playback in Edge.

Fixes #
JW7-3926
