### PR TITLE
Center VAST/Googima ad text in IE11

### DIFF
--- a/src/css/flags/ads.less
+++ b/src/css/flags/ads.less
@@ -64,10 +64,6 @@
 
             .jw-text-alt {
                 display: table;
-                white-space: nowrap;
-                top: 0;
-                transform: none;
-                margin: 0.5em 0;
             }
         }
     }

--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -334,6 +334,10 @@
         line-height: @mobile-touch-target;
       }
 
+      &.jw-ie .jw-text-alt {
+        top: -1px;
+      }
+
       .jw-text-duration {
         display: none;
       }

--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -316,15 +316,17 @@
         .jw-dock-button {
             border-radius: @ui-corner-round;
         }
-
-      .jw-controlbar .jw-controlbar-center-group .jw-text-alt  {
-        top: 50%;
-        transform: translateY(-50%);
-        margin: auto;
-        bottom: auto;
+      &:not(.jw-ie) {
+        .jw-controlbar .jw-controlbar-center-group .jw-text-alt  {
+          top: 50%;
+          transform: translateY(-50%);
+          margin: auto;
+          bottom: auto;
+        }
       }
 
-      &:not(.jw-flag-time-slider-above) {
+      &:not(.jw-flag-time-slider-above),
+      &.jw-flag-ads-googleima {
         .jw-controlbar {
           height: @controlbar-height;
 
@@ -341,6 +343,11 @@
           height: @controlbar-height;
           line-height: @controlbar-height;
         }
+      }
+
+      &.jw-flag-ads.jw-ie .jw-text-alt {
+        top: 1px;
+        margin: 0;
       }
 
       &:not(.jw-flag-time-slider-above):not(.jw-flag-small-player) {


### PR DESCRIPTION
### Changes proposed in this pull request:

- Vertically center ad text in IE11
- Maintain skin values for control bar height at all breakpoints for googima ads

Fixes #
JW7-3969, JW7-3960
