### PR TITLE
Display icon fix for rewind icon

### DIFF
--- a/src/css/imports/display.less
+++ b/src/css/imports/display.less
@@ -17,6 +17,7 @@
     .jw-preview {
         background-size: contain;
     }
+
     .jw-display-icon-container {
         /* Enforce auto container sizing to prevent custom skin errors in 7.9 */
         width: auto;
@@ -51,32 +52,30 @@ display icons
 */
 
 .jw-display {
+    display: table;
+    height: 100%;
+    padding: @controlbar-height 0;
+    position: relative;
+    width: 100%;
 
-  display: table;
-  height: 100%;
-  padding: @controlbar-height 0;
-  position: relative;
-  width: 100%;
+    .jw-flag-dragging & {
+        display: none;
+    }
 
-  .jw-flag-dragging & {
-    display: none;
-  }
-
-  .jw-state-idle:not(.jw-flag-cast-available) & {
-    padding: 0;
-  }
-
+    .jw-state-idle:not(.jw-flag-cast-available) & {
+        padding: 0;
+    }
 }
 
 .jw-display-container {
-  display: table-cell;
-  height: 100%;
-  text-align: center;
-  vertical-align: middle;
+    display: table-cell;
+    height: 100%;
+    text-align: center;
+    vertical-align: middle;
 }
 
 .jw-display-controls {
-  display: inline-block;
+    display: inline-block;
 }
 
 .jwplayer .jw-display-icon-container {
@@ -85,42 +84,40 @@ display icons
 }
 
 .jw-display-icon-container {
-  display: inline-block;
-  margin: 0 (@ui-padding * 0.5);
+    display: inline-block;
+    margin: 0 (@ui-padding * 0.5);
 
-  .jw-icon {
-    cursor: pointer;
+    .jw-icon {
+        cursor: pointer;
 
-    // Default to .jw-breakpoint-2 to match pre 7.9 styles
-    width: 75px;
-    height: 75px;
-    line-height: 75px;
-    text-align: center;
+        // Default to .jw-breakpoint-2 to match pre 7.9 styles
+        width: 75px;
+        height: 75px;
+        line-height: 75px;
+        text-align: center;
 
-    &::before {
-      font-size: @mobile-touch-target * 0.75;
-      position: relative;
+        &::before {
+            font-size: @mobile-touch-target * 0.75;
+            position: relative;
+        }
+
+        &.jw-icon-rewind::before {
+            padding: 0.2em 0.05em;
+        }
+
+        .jw-state-idle &.jw-icon-display::before,
+        .jw-state-paused &.jw-icon-display::before {
+            left: 1px;
+        }
     }
-
-    &.jw-icon-rewind::before {
-      padding: 0.2em 0.05em;
-    }
-
-    .jw-state-idle &.jw-icon-display::before,
-    .jw-state-paused &.jw-icon-display::before {
-      left: 1px;
-    }
-
-  }
-
 }
 
 // hide next and rewind buttons on extra small player
 .jw-breakpoint-0 {
-  .jw-display-icon-next,
-  .jw-display-icon-rewind {
-    display: none;
-  }
+    .jw-display-icon-next,
+    .jw-display-icon-rewind {
+        display: none;
+    }
     .jw-display .jw-icon {
         height: @mobile-touch-target;
         line-height: @mobile-touch-target;
@@ -139,30 +136,33 @@ display icons
         &::before {
             font-size: @mobile-touch-target * 0.5;
         }
+        &.jw-icon-rewind:before {
+            font-size: @mobile-touch-target * 0.75;
+        }
     }
 }
 
 .jw-breakpoint-3 {
-  .jw-display .jw-icon {
-    height: @mobile-touch-target * 1.75;
-    line-height: @mobile-touch-target * 1.75;
-    width: @mobile-touch-target * 1.75;
-    &::before {
-      font-size: @mobile-touch-target * 0.875;
+    .jw-display .jw-icon {
+        height: @mobile-touch-target * 1.75;
+        line-height: @mobile-touch-target * 1.75;
+        width: @mobile-touch-target * 1.75;
+        &::before {
+            font-size: @mobile-touch-target * 0.875;
+        }
     }
-  }
 }
 
 .jw-breakpoint-4,
 .jw-breakpoint-5,
 .jw-breakpoint-6,
 .jw-breakpoint-7 {
-  .jw-display .jw-icon {
-    height: @mobile-touch-target * 2;
-    line-height: @mobile-touch-target * 2;
-    width: @mobile-touch-target * 2;
-    &::before {
-      font-size: @mobile-touch-target;
+    .jw-display .jw-icon {
+        height: @mobile-touch-target * 2;
+        line-height: @mobile-touch-target * 2;
+        width: @mobile-touch-target * 2;
+        &::before {
+            font-size: @mobile-touch-target;
+        }
     }
-  }
 }


### PR DESCRIPTION
Display icon fix for rewind that increases the size of the rewind icon at breakpoint 1 where it appears too small.
Also reformats the LESS in the display.less file

JW7-3912