### PR TITLE
Convert ISO language codes to label for Dash audio tracks

### DIFF
--- a/src/js/utils/language.js
+++ b/src/js/utils/language.js
@@ -16,12 +16,8 @@ define([
         'ru': 'Russian',
         'es': 'Spanish'
     };
-
-    /**
-     * A map of 3-letter language codes (ISO 639-2) to 2-letter language codes (ISO 639-1)
-     * Commented out until needed
-     */
-    // var threeCharMap = {
+    
+    // If we decide to support the 3-letter language codes (ISO 639-2), the accepted codes would be
     //     'zho': 'zh',
     //     'chi': 'zh',
     //     'dut': 'nl',
@@ -37,11 +33,8 @@ define([
     //     'rus': 'ru',
     //     'esp': 'es',
     //     'spa': 'es'
-    // };
 
     function getLabel(language) {
-        // var code = threeCharMap[language] || language;
-
         return twoCharMap[language] || language;
     }
 

--- a/src/js/utils/language.js
+++ b/src/js/utils/language.js
@@ -1,0 +1,51 @@
+define([
+], function () {
+
+    /**
+     * A map of 2-letter language codes (ISO 639-1) to language name in English
+     */
+    var twoCharMap = {
+        'zh': 'Chinese',
+        'nl': 'Dutch',
+        'en': 'English',
+        'fr': 'French',
+        'de': 'German',
+        'it': 'Italian',
+        'ja': 'Japanese',
+        'pt': 'Portuguese',
+        'ru': 'Russian',
+        'es': 'Spanish'
+    };
+
+    /**
+     * A map of 3-letter language codes (ISO 639-2) to 2-letter language codes (ISO 639-1)
+     */
+    var threeCharMap = {
+        'zho': 'zh',
+        'chi': 'zh',
+        'dut': 'nl',
+        'nld': 'nl',
+        'eng': 'en',
+        'fra': 'fr',
+        'fre': 'fr',
+        'deu': 'de',
+        'ger': 'de',
+        'ita': 'it',
+        'jpn': 'ja',
+        'por': 'pt',
+        'rus': 'ru',
+        'esp': 'es',
+        'spa': 'es'
+    };
+
+    function getLabel(language) {
+        var code = threeCharMap[language] || language;
+
+        return twoCharMap[code] || language;
+    }
+
+    return {
+        getLabel: getLabel
+    };
+});
+

--- a/src/js/utils/language.js
+++ b/src/js/utils/language.js
@@ -19,29 +19,30 @@ define([
 
     /**
      * A map of 3-letter language codes (ISO 639-2) to 2-letter language codes (ISO 639-1)
+     * Commented out until needed
      */
-    var threeCharMap = {
-        'zho': 'zh',
-        'chi': 'zh',
-        'dut': 'nl',
-        'nld': 'nl',
-        'eng': 'en',
-        'fra': 'fr',
-        'fre': 'fr',
-        'deu': 'de',
-        'ger': 'de',
-        'ita': 'it',
-        'jpn': 'ja',
-        'por': 'pt',
-        'rus': 'ru',
-        'esp': 'es',
-        'spa': 'es'
-    };
+    // var threeCharMap = {
+    //     'zho': 'zh',
+    //     'chi': 'zh',
+    //     'dut': 'nl',
+    //     'nld': 'nl',
+    //     'eng': 'en',
+    //     'fra': 'fr',
+    //     'fre': 'fr',
+    //     'deu': 'de',
+    //     'ger': 'de',
+    //     'ita': 'it',
+    //     'jpn': 'ja',
+    //     'por': 'pt',
+    //     'rus': 'ru',
+    //     'esp': 'es',
+    //     'spa': 'es'
+    // };
 
     function getLabel(language) {
-        var code = threeCharMap[language] || language;
+        // var code = threeCharMap[language] || language;
 
-        return twoCharMap[code] || language;
+        return twoCharMap[language] || language;
     }
 
     return {

--- a/src/js/utils/language.js
+++ b/src/js/utils/language.js
@@ -16,23 +16,6 @@ define([
         'ru': 'Russian',
         'es': 'Spanish'
     };
-    
-    // If we decide to support the 3-letter language codes (ISO 639-2), the accepted codes would be
-    //     'zho': 'zh',
-    //     'chi': 'zh',
-    //     'dut': 'nl',
-    //     'nld': 'nl',
-    //     'eng': 'en',
-    //     'fra': 'fr',
-    //     'fre': 'fr',
-    //     'deu': 'de',
-    //     'ger': 'de',
-    //     'ita': 'it',
-    //     'jpn': 'ja',
-    //     'por': 'pt',
-    //     'rus': 'ru',
-    //     'esp': 'es',
-    //     'spa': 'es'
 
     function getLabel(language) {
         return twoCharMap[language] || language;

--- a/test/unit/language-test.js
+++ b/test/unit/language-test.js
@@ -5,86 +5,121 @@ define([
     QUnit.module('languageUtils');
     var test = QUnit.test.bind(QUnit);
 
-    QUnit.module('getLabel');
+    QUnit.module('getLabel from unsupported codes');
+
+    test('should not change value if there is no matching language code', function (assert) {
+        assert.equal(langUtils.getLabel(), undefined);
+        assert.equal(langUtils.getLabel(null), null);
+        assert.equal(langUtils.getLabel('po'), 'po');
+        assert.equal(langUtils.getLabel('pol'), 'pol');
+    });
+
+    QUnit.module('getLabel from ISO 639-1 codes');
 
     test('should be English for its codes', function (assert) {
         var expected = 'English';
 
         assert.equal(langUtils.getLabel('en'), expected);
-        assert.equal(langUtils.getLabel('eng'), expected);
     });
 
     test('should be Chinese for its codes', function (assert) {
         var expected = 'Chinese';
 
         assert.equal(langUtils.getLabel('zh'), expected);
-        assert.equal(langUtils.getLabel('zho'), expected);
-        assert.equal(langUtils.getLabel('chi'), expected);
     });
 
     test('should be Dutch for its codes', function (assert) {
         var expected = 'Dutch';
 
         assert.equal(langUtils.getLabel('nl'), expected);
-        assert.equal(langUtils.getLabel('nld'), expected);
-        assert.equal(langUtils.getLabel('dut'), expected);
     });
 
     test('should be French for its codes', function (assert) {
         var expected = 'French';
 
         assert.equal(langUtils.getLabel('fr'), expected);
-        assert.equal(langUtils.getLabel('fra'), expected);
-        assert.equal(langUtils.getLabel('fre'), expected);
     });
 
     test('should be German for its codes', function (assert) {
         var expected = 'German';
 
         assert.equal(langUtils.getLabel('de'), expected);
-        assert.equal(langUtils.getLabel('deu'), expected);
-        assert.equal(langUtils.getLabel('ger'), expected);
     });
 
     test('should be Japanese for its codes', function (assert) {
         var expected = 'Japanese';
 
         assert.equal(langUtils.getLabel('ja'), expected);
-        assert.equal(langUtils.getLabel('jpn'), expected);
     });
 
     test('should be Portuguese for its codes', function (assert) {
         var expected = 'Portuguese';
 
         assert.equal(langUtils.getLabel('pt'), expected);
-        assert.equal(langUtils.getLabel('por'), expected);
     });
 
     test('should be Italian for its codes', function (assert) {
         var expected = 'Italian';
 
         assert.equal(langUtils.getLabel('it'), expected);
-        assert.equal(langUtils.getLabel('ita'), expected);
     });
 
     test('should be Russian for its codes', function (assert) {
         var expected = 'Russian';
 
         assert.equal(langUtils.getLabel('ru'), expected);
-        assert.equal(langUtils.getLabel('rus'), expected);
     });
 
     test('should be Spanish for its codes', function (assert) {
         var expected = 'Spanish';
 
         assert.equal(langUtils.getLabel('es'), expected);
-        assert.equal(langUtils.getLabel('esp'), expected);
-        assert.equal(langUtils.getLabel('spa'), expected);
     });
 
-    test('should not change value if there is no matching language code', function (assert) {
-        assert.equal(langUtils.getLabel(), undefined);
-        assert.equal(langUtils.getLabel(null), null);
-        assert.equal(langUtils.getLabel('pol'), 'pol');
+    QUnit.module('getLabel from ISO 639-2 codes');
+
+    test('should not change for its English codes', function (assert) {
+        assert.equal(langUtils.getLabel('eng'), 'eng');
+    });
+
+    test('should not change for its Chinese codes', function (assert) {
+        assert.equal(langUtils.getLabel('zho'), 'zho');
+        assert.equal(langUtils.getLabel('chi'), 'chi');
+    });
+
+    test('should not change for its Dutch codes', function (assert) {
+        assert.equal(langUtils.getLabel('nld'), 'nld');
+        assert.equal(langUtils.getLabel('dut'), 'dut');
+    });
+
+    test('should not change for its French codes', function (assert) {
+        assert.equal(langUtils.getLabel('fra'), 'fra');
+        assert.equal(langUtils.getLabel('fre'), 'fre');
+    });
+
+    test('should not change for its Herman codes', function (assert) {
+        assert.equal(langUtils.getLabel('deu'), 'deu');
+        assert.equal(langUtils.getLabel('ger'), 'ger');
+    });
+
+    test('should not change for its Japanese codes', function (assert) {
+        assert.equal(langUtils.getLabel('jpn'), 'jpn');
+    });
+
+    test('should not change for its Portuguese codes', function (assert) {
+        assert.equal(langUtils.getLabel('por'), 'por');
+    });
+
+    test('should not change for its Italian codes', function (assert) {
+        assert.equal(langUtils.getLabel('ita'), 'ita');
+    });
+
+    test('should not change for its Russion codes', function (assert) {
+        assert.equal(langUtils.getLabel('rus'), 'rus');
+    });
+
+    test('should not change for its Spanish codes', function (assert) {
+        assert.equal(langUtils.getLabel('esp'), 'esp');
+        assert.equal(langUtils.getLabel('spa'), 'spa');
     });
 });

--- a/test/unit/language-test.js
+++ b/test/unit/language-test.js
@@ -1,0 +1,90 @@
+define([
+    'utils/language',
+], function (langUtils, _) {
+
+    QUnit.module('languageUtils');
+    var test = QUnit.test.bind(QUnit);
+
+    QUnit.module('getLabel');
+
+    test('should be English for its codes', function (assert) {
+        var expected = 'English';
+
+        assert.equal(langUtils.getLabel('en'), expected);
+        assert.equal(langUtils.getLabel('eng'), expected);
+    });
+
+    test('should be Chinese for its codes', function (assert) {
+        var expected = 'Chinese';
+
+        assert.equal(langUtils.getLabel('zh'), expected);
+        assert.equal(langUtils.getLabel('zho'), expected);
+        assert.equal(langUtils.getLabel('chi'), expected);
+    });
+
+    test('should be Dutch for its codes', function (assert) {
+        var expected = 'Dutch';
+
+        assert.equal(langUtils.getLabel('nl'), expected);
+        assert.equal(langUtils.getLabel('nld'), expected);
+        assert.equal(langUtils.getLabel('dut'), expected);
+    });
+
+    test('should be French for its codes', function (assert) {
+        var expected = 'French';
+
+        assert.equal(langUtils.getLabel('fr'), expected);
+        assert.equal(langUtils.getLabel('fra'), expected);
+        assert.equal(langUtils.getLabel('fre'), expected);
+    });
+
+    test('should be German for its codes', function (assert) {
+        var expected = 'German';
+
+        assert.equal(langUtils.getLabel('de'), expected);
+        assert.equal(langUtils.getLabel('deu'), expected);
+        assert.equal(langUtils.getLabel('ger'), expected);
+    });
+
+    test('should be Japanese for its codes', function (assert) {
+        var expected = 'Japanese';
+
+        assert.equal(langUtils.getLabel('ja'), expected);
+        assert.equal(langUtils.getLabel('jpn'), expected);
+    });
+
+    test('should be Portuguese for its codes', function (assert) {
+        var expected = 'Portuguese';
+
+        assert.equal(langUtils.getLabel('pt'), expected);
+        assert.equal(langUtils.getLabel('por'), expected);
+    });
+
+    test('should be Italian for its codes', function (assert) {
+        var expected = 'Italian';
+
+        assert.equal(langUtils.getLabel('it'), expected);
+        assert.equal(langUtils.getLabel('ita'), expected);
+    });
+
+    test('should be Russian for its codes', function (assert) {
+        var expected = 'Russian';
+
+        assert.equal(langUtils.getLabel('ru'), expected);
+        assert.equal(langUtils.getLabel('rus'), expected);
+    });
+
+    test('should be Spanish for its codes', function (assert) {
+        var expected = 'Spanish';
+
+        assert.equal(langUtils.getLabel('es'), expected);
+        assert.equal(langUtils.getLabel('esp'), expected);
+        assert.equal(langUtils.getLabel('spa'), expected);
+    });
+
+    test('should not change value if there is no matching language code', function (assert) {
+        assert.equal(langUtils.getLabel(), undefined);
+        assert.equal(langUtils.getLabel(null), null);
+        assert.equal(langUtils.getLabel('pol'), 'pol');
+    });
+});


### PR DESCRIPTION
If the language attribute from the tracks in the manifest are ISO 639-1
or ISO 639-2 language codes, convert to appropriate label name

JW7-3951

https://github.com/jwplayer/jwplayer-commercial/pull/2951