### PR TITLE
Create util to check if levels are redundant 

### DIFF
--- a/src/js/utils/quality-labels.js
+++ b/src/js/utils/quality-labels.js
@@ -69,11 +69,25 @@ define([
         return Math.floor(bandwidth / 1000);
     }
 
+    // Use an empty object as the context and populate it like a hash map
+    function hasRedundantLevels(levels) {
+        if (!_.isArray(levels)) {
+            return false;
+        }
+        return _.some(levels, function (level) {
+            var key = level.height || level.bandwidth;
+            var foundDuplicate = this[key];
+            this[key] = 1;
+            return foundDuplicate;
+        }, {});
+    }
+
     return {
         generateLabel: generateLabel,
         createLabel: createLabel,
         getCustomLabel: getCustomLabel,
         findClosestBandwidth: findClosestBandwidth,
         toKbps: toKbps,
+        hasRedundantLevels: hasRedundantLevels,
     };
 });

--- a/test/unit/quality-labels-test.js
+++ b/test/unit/quality-labels-test.js
@@ -130,4 +130,47 @@ define([
         var actual = qualityLabels.toKbps(3000);
         assert.equal(actual, expected);
     });
+
+    QUnit.module('hasRedundantLevels');
+    test('should return true if at least two levels share the same height', function (assert) {
+        var levels = [{ height: 100 }, { height: 50 }, { height: 100 }];
+        var actual = qualityLabels.hasRedundantLevels(levels);
+        assert.equal(actual, true);
+    });
+
+    test('should return false if no levels share the same height', function (assert) {
+        var levels = [{ height: 100 }, { height: 50 }, { height: 200 }];
+        var actual = qualityLabels.hasRedundantLevels(levels);
+        assert.equal(actual, false);
+    });
+
+    test('should return true if at least two have no height and share the same bandwidth', function (assert) {
+        var levels = [{ bandwidth: 10000 }, { height: 50 }, { bandwidth: 10000 }];
+        var actual = qualityLabels.hasRedundantLevels(levels);
+        assert.equal(actual, true);
+    });
+
+    test('should return false if at least two have no height and do not share the same bandwidth', function (assert) {
+        var levels = [{ bandwidth: 10000 }, { height: 50 }, { bandwidth: 20000 }];
+        var actual = qualityLabels.hasRedundantLevels(levels);
+        assert.equal(actual, false);
+    });
+
+    test('should return false if there are no levels', function (assert) {
+        var levels = [];
+        var actual = qualityLabels.hasRedundantLevels(levels);
+        assert.equal(actual, false);
+    });
+
+    test('should return false if levels are undefined', function (assert) {
+        var levels = undefined;
+        var actual = qualityLabels.hasRedundantLevels(levels);
+        assert.equal(actual, false);
+    });
+
+    test('should return false if levels are not an array', function (assert) {
+        var levels = { height: 100, notHeight: 100 };
+        var actual = qualityLabels.hasRedundantLevels(levels);
+        assert.equal(actual, false);
+    });
 });


### PR DESCRIPTION
Break function previously used just in just hlsjs into a util so shaka can use it too. Maybe this should go into a new `level-utils` file?

JW7-2476

(1/2) https://github.com/jwplayer/jwplayer-commercial/pull/2954