### PR TITLE
Align slider knobs for Seven, Roundster and Stormtrooper skins

### DIFF
--- a/src/css/imports/vars.less
+++ b/src/css/imports/vars.less
@@ -64,7 +64,7 @@
 
 
 // Rails and sliders
-@rail-height: 0.25em;
+@rail-height: 0.3em;
 @slider-height: @rail-height;
 @def-rail-width: @rail-height;
 @def-rail-width-padding: 0.6em;

--- a/src/css/skins/roundster.less
+++ b/src/css/skins/roundster.less
@@ -26,7 +26,7 @@
     @volume-background: #5c6373;
 
     @cue-size: .25em;
-    @thumb-size: .9em;
+    @thumb-size: 1em;
     @def-rail-width: 0.75em;
     @slider-height: @rail-height;
     @rail-height: 0.4em;
@@ -105,7 +105,13 @@
         .jw-slider-container{
             width: @def-rail-width;
         }
+    }
 
+    // Adjusts the volume slider container width to allow the slider to be centered
+    &.jw-flag-time-slider-above {
+        .jw-slider-vertical .jw-slider-container {
+            width: 0.8em;
+        }
     }
 
     /* For the overlay containers */

--- a/src/css/skins/stormtrooper.less
+++ b/src/css/skins/stormtrooper.less
@@ -20,8 +20,8 @@
     @cc-inactive: @buffer-color;
     @cc-active: @active-color;
     @volume-background: #333;
-
-    @rail-height: .3em;
+    
+    @rail-height: 0.375em;
     @thumb-size: .1em;
     @thumb-width: @thumb-size;
     @thumb-height: .5em;
@@ -79,7 +79,7 @@
         }
 
         .jw-knob {
-            .vertically-centered-rail-element(.3em,.5em);
+            .vertically-centered-rail-element(@rail-height,.5em);
 
             background: @vertical-rail-gradient;
             width: .3em;
@@ -89,7 +89,7 @@
         }
 
         .jw-cue {
-            .vertically-centered-rail-element(.3em,.4em);
+            .vertically-centered-rail-element(@rail-height,.4em);
             background-color: @inactive-color;
             border: 1px solid #000;
         }


### PR DESCRIPTION
Align slider knobs for Seven, Roundster and Stormtrooper skins by setting the heights and widths of the slider elements to display correctly.

JW7-3793