### PR TITLE
Autoplay visible videos on desktop when autoplay = viewable

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -83,6 +83,10 @@ define([
 
             _model.setup(config, storage);
             _view  = this._view = new View(_api, _model);
+
+            if(_model.get('autostart') === 'viewable' && (window.self !== window.top)) {
+                _model.set('autostart', true);
+            }
             _setup = new Setup(_api, _model, _view, _setPlaylist);
 
             _setup.on(events.JWPLAYER_READY, _playerReady, this);
@@ -225,7 +229,7 @@ define([
                 }
                 // Start playback on desktop and mobile browsers when allowed
                 if (_canAutoStart()) {
-                    if (utils.isMobile() && _video().video) {
+                    if (_video().video && (utils.isMobile() || _model.get('autostart') === 'viewable')) {
                         // Only play if the video is in the viewport
                         _observeVideo(_video().video);
                     } else {


### PR DESCRIPTION
### Changes proposed in this pull request:

Add a new config option - `"autoplay": "viewable"` - which plays the video when 50% or more of the video is visible and pauses it otherwise. 

Note: there's no need to check if the video is in the active tab. The intersection observer does this in `_monitorIntersections`:
```
/**
 * Starts polling for intersection changes if the polling is not already
 * happening, and if the page's visibilty state is visible.
 * @private
 */
```

Fixes #
JW7-2009
