### PR TITLE
Viewability api

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,6 +24,7 @@
         "import/no-extraneous-dependencies": ["error", { "devDependencies": true }],
         "no-console": 0,
         "prefer-rest-params": 0,
-        "prefer-arrow-callback": 0
+        "prefer-arrow-callback": 0,
+        "import/no-amd": 0
     }
 }

--- a/src/js/api/api-mutators.js
+++ b/src/js/api/api-mutators.js
@@ -15,7 +15,8 @@ define([
             'item', // this was playlistindex
             'stretching',
             'playlist',
-            'captions'
+            'captions',
+            'visibility'
         ];
 
         // given a name "buffer", it adds to jwplayer api a function named getBuffer

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -732,8 +732,8 @@ define([
 
                 // Always autostart on mobile if we're viewable
                 // Only autostart if viewable on desktop if autostart is explicitly viewable and we're not already playing
-                var desktopViewableAutostart = _model.get('autostart') === 'viewable'
-                    && _model.getState() !== states.PLAYING;
+                var desktopViewableAutostart = _model.get('autostart') === 'viewable' &&
+                    _model.getState() !== states.PLAYING;
                 return viewable && (mobile || desktopViewableAutostart);
             }
 

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -193,7 +193,7 @@ define([
                     if (_shouldAutoStart(viewable)) {
                         _autoStart();
                     } else if (utils.isMobile()) {
-                        _this.pause({reason: 'autostart'});
+                        _this.pause({ reason: 'autostart' });
                     }
                 }
             });
@@ -323,7 +323,11 @@ define([
                 _this.trigger('destroyPlugin', {});
 
                 if (_canAutoStart()) {
-                    _model.once('itemReady', _autoStart);
+                    _model.once('itemReady', function () {
+                        if (_shouldAutoStart(_model.get('viewable'))) {
+                            _autoStart();
+                        }
+                    });
                 }
 
                 switch (typeof item) {
@@ -716,14 +720,16 @@ define([
             }
 
             function _shouldAutoStart(viewable) {
-                var mobileAutostart = utils.isMobile();
-
-                if (!mobileAutostart && _model.get('autostart') === true) {
+                var mobile = utils.isMobile();
+                // Immediately autostart if we're not mobile and autostart is explicitly true
+                if (!mobile && _model.get('autostart') === true) {
                     return true;
                 }
 
+                // Always autostart on mobile if we're viewable
+                // Only autostart if viewable on desktop if autostart is explicitly viewable
                 var desktopViewableAutostart = _model.get('autostart') === 'viewable';
-                return viewable && (mobileAutostart || desktopViewableAutostart);
+                return viewable && (mobile || desktopViewableAutostart);
             }
 
             /** Controller API / public methods **/

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -15,7 +15,7 @@ define([
     'events/states',
     'events/events',
     'view/error',
-    'controller/events-middleware',
+    'controller/events-middleware'
 ], function(Config, InstreamAdapter, _, Setup, Captions, Model, Storage,
             Playlist, PlaylistLoader, utils, View, Events, changeStateEvent, states, events, error, eventsMiddleware) {
 
@@ -186,7 +186,11 @@ define([
 
             _model.on('change:viewable', function(model, viewable) {
                 var meta = { reason: 'autostart' };
-                viewable ? _this.play(meta) : _this.pause(meta);
+                if (viewable) {
+                    _this.play(meta);
+                } else {
+                    _this.pause(meta);
+                }
             });
 
             // Ensure captionsList event is raised after playlistItem

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -188,7 +188,8 @@ define([
                 });
             });
 
-            _model.on('change:viewable', function(model, viewable) {
+            _model.on('change:visibility', function(model, visibility) {
+                var viewable = visibility >= 0.5;
                 if (viewable && _model.get('playOnViewable')) {
                     _autoStart();
                 } else if (!viewable && utils.isMobile()) {
@@ -268,22 +269,23 @@ define([
                 if (!window.IntersectionObserver) {
                     return;
                 }
-                _xo = new window.IntersectionObserver(_onIntersection, { threshold: 0.5 });
+                // Fire the callback every time 25% of the player comes in/out of view
+                _xo = new window.IntersectionObserver(_onIntersection, { threshold: [0, 0.25, 0.5, 0.75, 1] });
                 _xo.observe(container);
             }
 
             function _stopObserving() {
-                _xo.disconnect();
-                _xo = undefined;
+                if (_xo) {
+                    _xo.disconnect();
+                    _xo = undefined;
+                }
             }
 
             function _onIntersection(entries) {
                 if (entries && entries.length) {
                     var entry = entries[0];
-                    if (entry.target === _this.getContainer() && entry.intersectionRatio >= 0.5) {
-                        _model.set('viewable', 1);
-                    } else {
-                        _model.set('viewable', 0);
+                    if (entry.target === _this.getContainer()) {
+                        _model.set('visibility', entry.intersectionRatio);
                     }
                 }
             }

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -731,8 +731,9 @@ define([
                 }
 
                 // Always autostart on mobile if we're viewable
-                // Only autostart if viewable on desktop if autostart is explicitly viewable
-                var desktopViewableAutostart = _model.get('autostart') === 'viewable';
+                // Only autostart if viewable on desktop if autostart is explicitly viewable and we're not already playing
+                var desktopViewableAutostart = _model.get('autostart') === 'viewable'
+                    && _model.getState() !== states.PLAYING;
                 return viewable && (mobile || desktopViewableAutostart);
             }
 

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -248,6 +248,10 @@ define([
             }
 
             function _observePlayerContainer(container) {
+                if (!container) {
+                    return;
+                }
+
                 if ('IntersectionObserver' in window &&
                     'IntersectionObserverEntry' in window &&
                     'intersectionRatio' in window.IntersectionObserverEntry.prototype) {

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -183,6 +183,11 @@ define([
                 });
             });
 
+            _model.on('change:viewable', function(model, viewable) {
+                var meta = { reason: 'autostart' };
+                viewable ? _this.play(meta) : _this.pause(meta);
+            });
+
             // Ensure captionsList event is raised after playlistItem
             _captions = new Captions(_api, _model);
 
@@ -225,7 +230,7 @@ define([
                 }
                 // Start playback on desktop and mobile browsers when allowed
                 if (_canAutoStart()) {
-                    if (utils.isMobile() && _video().video) {
+                    if (_video().video) {
                         // Only play if the video is in the viewport
                         _observeVideo(_video().video);
                     } else {
@@ -251,7 +256,7 @@ define([
                 if (!window.IntersectionObserver) {
                     return;
                 }
-                _xo = new window.IntersectionObserver(_toggleVideoPlayback, { threshold: 0.5 });
+                _xo = new window.IntersectionObserver(_onIntersection, { threshold: 0.5 });
                 _xo.observe(video);
             }
 
@@ -260,16 +265,15 @@ define([
                 _xo = undefined;
             }
 
-            function _toggleVideoPlayback(entries) {
+            function _onIntersection(entries) {
                 if (entries && entries.length) {
                     var video = _video().video;
                     var entry = entries[0];
-                    var meta = { reason: 'autostart' };
 
                     if (entry.target === video && entry.intersectionRatio >= 0.5) {
-                        _this.play(meta);
+                        _model.set('viewable', true);
                     } else {
-                        _this.pause(meta);
+                        _model.set('viewable', false);
                     }
                 }
             }

--- a/src/js/controller/events-middleware.js
+++ b/src/js/controller/events-middleware.js
@@ -10,7 +10,7 @@ define([
             case Events.JWPLAYER_AD_IMPRESSION:
             case 'play':
             case 'pause': {
-                var viewable = model.get('viewable') || 0;
+                var viewable = Math.round(model.get('visibility') || 0);
                 newState = _.extend({}, currentState, { viewable: viewable });
                 break;
             }

--- a/src/js/controller/events-middleware.js
+++ b/src/js/controller/events-middleware.js
@@ -1,27 +1,17 @@
 define([
     'utils/underscore',
     'events/events',
-    'events/states',
-], function (_, Events, States) {
-    function eventsMiddleware(model, type, data) {
-        var viewable = model.get('viewable') || 0;
-        return transform(type, data, { viewable: viewable });
-    }
-
-    function statesMiddleware(model, state) {
-        var viewable = model.get('viewable') || 0;
-        return transform(state.type, state, { viewable: viewable });
-    }
-
-    function transform(type, currentState, data) {
+], function (_, Events) {
+    return function middleware(model, type, currentState) {
         var newState = {};
 
         switch (type) {
             case Events.JWPLAYER_MEDIA_TIME:
             case Events.JWPLAYER_AD_IMPRESSION:
-            case States.PLAYING:
-            case States.PAUSED: {
-                newState = _.extend({}, currentState, { viewable: data.viewable });
+            case 'play':
+            case 'pause': {
+                var viewable = model.get('viewable') || 0;
+                newState = _.extend({}, currentState, { viewable: viewable });
                 break;
             }
             default: {
@@ -31,10 +21,5 @@ define([
         }
 
         return newState;
-    }
-
-    return {
-        eventsMiddleware: eventsMiddleware,
-        statesMiddleware: statesMiddleware,
     };
 });

--- a/src/js/controller/events-middleware.js
+++ b/src/js/controller/events-middleware.js
@@ -7,7 +7,6 @@ define([
 
         switch (type) {
             case Events.JWPLAYER_MEDIA_TIME:
-            case Events.JWPLAYER_AD_IMPRESSION:
             case 'play':
             case 'pause': {
                 var viewable = Math.round(model.get('visibility') || 0);

--- a/src/js/controller/events-middleware.js
+++ b/src/js/controller/events-middleware.js
@@ -1,0 +1,40 @@
+define([
+    'utils/underscore',
+    'events/events',
+    'events/states',
+], function (_, Events, States) {
+    function eventsMiddleware(model, type, data) {
+        var viewable = model.get('viewable') || 0;
+        return transform(type, data, { viewable: viewable });
+    }
+
+    function statesMiddleware(model, state) {
+        var viewable = model.get('viewable') || 0;
+        return transform(state.type, state, { viewable: viewable });
+    }
+
+    function transform(type, currentState, data) {
+        var newState = {};
+
+        switch (type) {
+            case Events.JWPLAYER_MEDIA_TIME:
+            case Events.JWPLAYER_AD_IMPRESSION:
+            case States.PLAYING:
+            case States.PAUSED: {
+                newState = _.extend({}, currentState, { viewable: data.viewable });
+                break;
+            }
+            default: {
+                newState = currentState;
+                break;
+            }
+        }
+
+        return newState;
+    }
+
+    return {
+        eventsMiddleware: eventsMiddleware,
+        statesMiddleware: statesMiddleware,
+    };
+});

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -864,6 +864,9 @@ define([
             // so we should update the model, setting mute to false
             if (autostartSucceeded) {
                 mute = false;
+            } else {
+                // Don't try to play again when viewable since it will keep failing
+                _model.set('playOnViewable', false);
             }
 
             _model.off('change:autostartFailed', _autoplayUnmute);
@@ -871,7 +874,6 @@ define([
             _model.off('change:autostartMuted', _autoplayUnmute);
             _model.set('autostartFailed', undefined);
             _model.set('autostartMuted', undefined);
-            _model.set('playOnViewable', false);
             _api.setMute(mute);
             // the model's mute value may not have changed. ensure the controlbar's mute button is in the right state
             _controlbar.renderVolume(mute, _model.get('volume'));

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -865,11 +865,13 @@ define([
             if (autostartSucceeded) {
                 mute = false;
             }
+
             _model.off('change:autostartFailed', _autoplayUnmute);
             _model.off('change:mute', _autoplayUnmute);
             _model.off('change:autostartMuted', _autoplayUnmute);
             _model.set('autostartFailed', undefined);
             _model.set('autostartMuted', undefined);
+            _model.set('playOnViewable', false);
             _api.setMute(mute);
             // the model's mute value may not have changed. ensure the controlbar's mute button is in the right state
             _controlbar.renderVolume(mute, _model.get('volume'));

--- a/test/data/api-methods.js
+++ b/test/data/api-methods.js
@@ -44,6 +44,7 @@ define({
     getStretching: null,
     getVisualQuality: null,
     getVolume: null,
+    getVisibility: null,
     getWidth: null,
     isBeforeComplete: null,
     isBeforePlay: null,

--- a/test/unit/events-middleware-test.js
+++ b/test/unit/events-middleware-test.js
@@ -1,0 +1,47 @@
+define([
+    'utils/underscore',
+    'controller/events-middleware',
+], function (_, middleware) {
+    QUnit.module('events-middleware');
+    var test = QUnit.test.bind(QUnit);
+    var eventsMiddleware = middleware.eventsMiddleware;
+    var statesMiddleware = middleware.statesMiddleware;
+
+    var mockModel = function(attributes) {
+        var model = {
+            get: function (attribute) {
+                return this[attribute];
+            }
+        };
+
+        return _.extend({}, model, attributes);
+    }
+
+    test('should add viewable to the play event', function (assert) {
+        var model = mockModel({ viewable: true });
+        var expected = { type: 'playing', viewable: true };
+        var actual = statesMiddleware(model, { type: 'playing' });
+        assert.deepEqual(actual, expected);
+    });
+
+    test('should add viewable to the paused event', function (assert) {
+        var model = mockModel({ viewable: true });
+        var expected = { type: 'paused', viewable: true };
+        var actual = statesMiddleware(model, { type: 'paused' });
+        assert.deepEqual(actual, expected);
+    });
+
+    test('should add viewable to the time event', function (assert) {
+        var model = mockModel({ viewable: true });
+        var expected = { viewable: true };
+        var actual = eventsMiddleware(model, 'time', {});
+        assert.deepEqual(actual, expected);
+    });
+
+    test('should add viewable to the adImpression event', function (assert) {
+        var model = mockModel({ viewable: true });
+        var expected = { viewable: true };
+        var actual = eventsMiddleware(model, 'adImpression', {});
+        assert.deepEqual(actual, expected);
+    })
+});

--- a/test/unit/events-middleware-test.js
+++ b/test/unit/events-middleware-test.js
@@ -16,29 +16,29 @@ define([
     }
 
     test('should add viewable to the play event', function (assert) {
-        var model = mockModel({ viewable: true });
-        var expected = { viewable: true, foo: 'bar' };
+        var model = mockModel({ visibility: 0.5 });
+        var expected = { viewable: 1, foo: 'bar' };
         var actual = middleware(model, 'play', { foo: 'bar' });
         assert.deepEqual(actual, expected);
     });
 
     test('should add viewable to the paused event', function (assert) {
-        var model = mockModel({ viewable: true });
-        var expected = { viewable: true, foo: 'bar' };
+        var model = mockModel({ visibility: 0.5 });
+        var expected = { viewable: 1, foo: 'bar' };
         var actual = middleware(model, 'pause', { foo: 'bar' });
         assert.deepEqual(actual, expected);
     });
 
     test('should add viewable to the time event', function (assert) {
-        var model = mockModel({ viewable: true });
-        var expected = { viewable: true, foo: 'bar' };
+        var model = mockModel({ visibility: 0.5 });
+        var expected = { viewable: 1, foo: 'bar' };
         var actual = middleware(model, 'time', { foo: 'bar' });
         assert.deepEqual(actual, expected);
     });
 
     test('should add viewable to the adImpression event', function (assert) {
-        var model = mockModel({ viewable: true });
-        var expected = { viewable: true, foo: 'bar' };
+        var model = mockModel({ visibility: 0.5 });
+        var expected = { viewable: 1, foo: 'bar' };
         var actual = middleware(model, 'adImpression', { foo: 'bar' });
         assert.deepEqual(actual, expected);
     });

--- a/test/unit/events-middleware-test.js
+++ b/test/unit/events-middleware-test.js
@@ -36,13 +36,6 @@ define([
         assert.deepEqual(actual, expected);
     });
 
-    test('should add viewable to the adImpression event', function (assert) {
-        var model = mockModel({ visibility: 0.5 });
-        var expected = { viewable: 1, foo: 'bar' };
-        var actual = middleware(model, 'adImpression', { foo: 'bar' });
-        assert.deepEqual(actual, expected);
-    });
-
     test('does not modify original data when the type does not have a case', function (assert) {
         var expected = { foo: 'bar' };
         var actual = middleware(mockModel({}), 'cat', expected);

--- a/test/unit/events-middleware-test.js
+++ b/test/unit/events-middleware-test.js
@@ -4,8 +4,6 @@ define([
 ], function (_, middleware) {
     QUnit.module('events-middleware');
     var test = QUnit.test.bind(QUnit);
-    var eventsMiddleware = middleware.eventsMiddleware;
-    var statesMiddleware = middleware.statesMiddleware;
 
     var mockModel = function(attributes) {
         var model = {
@@ -19,29 +17,35 @@ define([
 
     test('should add viewable to the play event', function (assert) {
         var model = mockModel({ viewable: true });
-        var expected = { type: 'playing', viewable: true };
-        var actual = statesMiddleware(model, { type: 'playing' });
+        var expected = { viewable: true, foo: 'bar' };
+        var actual = middleware(model, 'play', { foo: 'bar' });
         assert.deepEqual(actual, expected);
     });
 
     test('should add viewable to the paused event', function (assert) {
         var model = mockModel({ viewable: true });
-        var expected = { type: 'paused', viewable: true };
-        var actual = statesMiddleware(model, { type: 'paused' });
+        var expected = { viewable: true, foo: 'bar' };
+        var actual = middleware(model, 'pause', { foo: 'bar' });
         assert.deepEqual(actual, expected);
     });
 
     test('should add viewable to the time event', function (assert) {
         var model = mockModel({ viewable: true });
-        var expected = { viewable: true };
-        var actual = eventsMiddleware(model, 'time', {});
+        var expected = { viewable: true, foo: 'bar' };
+        var actual = middleware(model, 'time', { foo: 'bar' });
         assert.deepEqual(actual, expected);
     });
 
     test('should add viewable to the adImpression event', function (assert) {
         var model = mockModel({ viewable: true });
-        var expected = { viewable: true };
-        var actual = eventsMiddleware(model, 'adImpression', {});
+        var expected = { viewable: true, foo: 'bar' };
+        var actual = middleware(model, 'adImpression', { foo: 'bar' });
         assert.deepEqual(actual, expected);
-    })
+    });
+
+    test('does not modify original data when the type does not have a case', function (assert) {
+        var expected = { foo: 'bar' };
+        var actual = middleware(mockModel({}), 'cat', expected);
+        assert.equal(actual, expected);
+    });
 });


### PR DESCRIPTION
- Add `visibility `to the model (number between `0` or `1`)
- Drive viewable play/pause off `change:visibility`
- Create a middleware function which is run on every event before bubbling to the public API
- Create `getVisibility` api method
- Add `viewable` to `play`, `pause`, `time` via middleware
- Fix annoying ESLint rules

JW7-3538
