### PR TITLE
Autoplay visible videos on desktop when autoplay = viewable

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -83,6 +83,10 @@ define([
 
             _model.setup(config, storage);
             _view  = this._view = new View(_api, _model);
+
+            if(_model.get('autostart') === 'viewable' && (window.self !== window.top)) {
+                _model.set('autostart', true);
+            }
             _setup = new Setup(_api, _model, _view, _setPlaylist);
 
             _setup.on(events.JWPLAYER_READY, _playerReady, this);
@@ -225,7 +229,7 @@ define([
                 }
                 // Start playback on desktop and mobile browsers when allowed
                 if (_canAutoStart()) {
-                    if (utils.isMobile() && _video().video) {
+                    if (_video().video && (utils.isMobile() || _model.get('autostart') === 'viewable')) {
                         // Only play if the video is in the viewport
                         _observeVideo(_video().video);
                     } else {

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -229,34 +229,34 @@ define([
                 }
                 // Start playback on desktop and mobile browsers when allowed
                 if (_canAutoStart()) {
-                    if (_video().video && (utils.isMobile() || _model.get('autostart') === 'viewable')) {
-                        // Only play if the video is in the viewport
-                        _observeVideo(_video().video);
+                    if (utils.isMobile() || _model.get('autostart') === 'viewable') {
+                        // Only play if the player is in the viewport
+                        _observePlayerContainer(_this.getContainer());
                     } else {
                         _autoStart();
                     }
                 }
             }
 
-            function _observeVideo(video) {
+            function _observePlayerContainer(container) {
                 if ('IntersectionObserver' in window &&
                     'IntersectionObserverEntry' in window &&
                     'intersectionRatio' in window.IntersectionObserverEntry.prototype) {
-                    _startObserving(video);
+                    _startObserving(container);
                 } else {
                     require.ensure(['polyfills/intersection-observer'], function (require) {
                         require('polyfills/intersection-observer');
-                        _startObserving(video);
+                        _startObserving(container);
                     }, 'polyfills.intersection-observer');
                 }
             }
 
-            function _startObserving(video) {
+            function _startObserving(container) {
                 if (!window.IntersectionObserver) {
                     return;
                 }
                 _xo = new window.IntersectionObserver(_toggleVideoPlayback, { threshold: 0.5 });
-                _xo.observe(video);
+                _xo.observe(container);
             }
 
             function _stopObserving() {
@@ -266,11 +266,12 @@ define([
 
             function _toggleVideoPlayback(entries) {
                 if (entries && entries.length) {
-                    var video = _video().video;
+                    var container = _this.getContainer();
                     var entry = entries[0];
                     var meta = { reason: 'autostart' };
+                    var viewable = entry.target === container && entry.intersectionRatio >= 0.5;
 
-                    if (_model.get('state') !== 'playing' && entry.target === video && entry.intersectionRatio >= 0.5) {
+                    if (_model.get('state') !== 'playing' && viewable) {
                         _this.play(meta);
                     } else if (utils.isMobile()) {
                         _this.pause(meta);

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -270,9 +270,9 @@ define([
                     var entry = entries[0];
                     var meta = { reason: 'autostart' };
 
-                    if (entry.target === video && entry.intersectionRatio >= 0.5) {
+                    if (_model.get('state') !== 'playing' && entry.target === video && entry.intersectionRatio >= 0.5) {
                         _this.play(meta);
-                    } else {
+                    } else if (utils.isMobile()) {
                         _this.pause(meta);
                     }
                 }


### PR DESCRIPTION
### Changes proposed in this pull request:

Add a new config option - `"autoplay": "viewable"` - which plays the video when 50% or more of the video is visible and pauses it otherwise. 

Note: there's no need to check if the video is in the active tab. The intersection observer does this in `_monitorIntersections`:
```
/**
 * Starts polling for intersection changes if the polling is not already
 * happening, and if the page's visibilty state is visible.
 * @private
 */
```

Fixes #
JW7-2009
