### PR TITLE
Add thumbstrip functionality to touch and PointerEvent devices

### DIFF
--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -33,7 +33,9 @@ define([
     }
 
     function normalizeUIEvent(type, srcEvent, target) {
-        var source;
+        var source,
+            sourceType;
+
         if (srcEvent instanceof MouseEvent || (!srcEvent.touches && !srcEvent.changedTouches)) {
             source = srcEvent;
         } else {
@@ -43,8 +45,19 @@ define([
                 source = srcEvent.changedTouches[0];
             }
         }
+
+        // Expose what the source of the event is so that we can ensure it's handled correctly.
+        if (_supportsPointerEvents && srcEvent instanceof window.PointerEvent) {
+            sourceType = (srcEvent.pointerType === 'touch') ? 'touch' : 'mouse';
+        } else if (_supportsTouchEvents && srcEvent instanceof window.TouchEvent) {
+            sourceType = 'touch';
+        } else {
+            sourceType = 'mouse';
+        }
+
         return {
             type: type,
+            sourceEventType: sourceType,
             target: srcEvent.target,
             currentTarget: target,
             pageX: source.pageX,


### PR DESCRIPTION
Adds thumbstrip functionality to touch and PointerEvent devices by activating listeners for touch and mouse events instead of just mouse events.  In order to support touch platforms which will not activate the mouseover handler that will set the this.activeCue property, we have to use javascript to check what the closest cue is in the hover/drag handler.  We will set a cue that is within 5 pixels away to be the active cue so that we can show the text for the cue if necessary.

JW7-3167