### PR TITLE
Add thumbstrip functionality to touch and PointerEvent devices

### DIFF
--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -33,7 +33,9 @@ define([
     }
 
     function normalizeUIEvent(type, srcEvent, target) {
-        var source;
+        var source,
+            sourceType;
+
         if (srcEvent instanceof MouseEvent || (!srcEvent.touches && !srcEvent.changedTouches)) {
             source = srcEvent;
         } else {
@@ -43,8 +45,19 @@ define([
                 source = srcEvent.changedTouches[0];
             }
         }
+
+        // Expose what the source of the event is so that we can ensure it's handled correctly.
+        if (_supportsPointerEvents && srcEvent instanceof window.PointerEvent) {
+            sourceType = (srcEvent.pointerType === 'touch') ? 'touch' : 'mouse';
+        } else if (_supportsTouchEvents && srcEvent instanceof window.TouchEvent) {
+            sourceType = 'touch';
+        } else {
+            sourceType = 'mouse';
+        }
+
         return {
             type: type,
+            sourceEventType: sourceType,
             target: srcEvent.target,
             currentTarget: target,
             pageX: source.pageX,

--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -33,8 +33,7 @@ define([
     }
 
     function normalizeUIEvent(type, srcEvent, target) {
-        var source,
-            sourceType;
+        var source;
 
         if (srcEvent instanceof MouseEvent || (!srcEvent.touches && !srcEvent.changedTouches)) {
             source = srcEvent;
@@ -46,18 +45,9 @@ define([
             }
         }
 
-        // Expose what the source of the event is so that we can ensure it's handled correctly.
-        if (_supportsPointerEvents && srcEvent instanceof window.PointerEvent) {
-            sourceType = (srcEvent.pointerType === 'touch') ? 'touch' : 'mouse';
-        } else if (_supportsTouchEvents && srcEvent instanceof window.TouchEvent) {
-            sourceType = 'touch';
-        } else {
-            sourceType = 'mouse';
-        }
-
         return {
             type: type,
-            sourceEventType: sourceType,
+            sourceEvent: srcEvent,
             target: srcEvent.target,
             currentTarget: target,
             pageX: source.pageX,
@@ -301,6 +291,17 @@ define([
         };
 
         return this;
+    };
+
+    UI.getEventSource = function (evt) {
+        // Expose what the source of the event is so that we can ensure it's handled correctly.
+        if (_supportsPointerEvents && evt instanceof window.PointerEvent) {
+            return (evt.pointerType === 'touch') ? 'touch' : 'mouse';
+        } else if (_supportsTouchEvents && evt instanceof window.TouchEvent) {
+            return 'touch';
+        }
+
+        return 'mouse';
     };
 
     _.extend(UI.prototype, Events);

--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -293,8 +293,9 @@ define([
         return this;
     };
 
-    UI.getEventSource = function (evt) {
-        // Expose what the source of the event is so that we can ensure it's handled correctly.
+    // Expose what the source of the event is so that we can ensure it's handled correctly.
+    // This returns only 'touch' or 'mouse'.  'pen' will be treated as a mouse.
+    UI.getPointerType = function (evt) {
         if (_supportsPointerEvents && evt instanceof window.PointerEvent) {
             return (evt.pointerType === 'touch') ? 'touch' : 'mouse';
         } else if (_supportsTouchEvents && evt instanceof window.TouchEvent) {

--- a/src/js/view/components/timeslider.js
+++ b/src/js/view/components/timeslider.js
@@ -214,7 +214,7 @@ define([
 
             // With touch events, we never will get the hover events on the cues that cause cues to be active.
             // Therefore use the info we about the scroll position to detect if there is a nearby cue to be active.
-            if (UI.getEventSource(evt.sourceEvent) === 'touch') {
+            if (UI.getPointerType(evt.sourceEvent) === 'touch') {
                 this.activeCue = _.reduce(this.cues, function(closeCue, cue) {
                     if (Math.abs(position - (parseInt(cue.pct) / 100 * _railBounds.width)) < this.mobileHoverDistance) {
                         return cue;

--- a/src/js/view/components/timeslider.js
+++ b/src/js/view/components/timeslider.js
@@ -214,7 +214,7 @@ define([
 
             // With touch events, we never will get the hover events on the cues that cause cues to be active.
             // Therefore use the info we about the scroll position to detect if there is a nearby cue to be active.
-            if (evt.sourceEventType === 'touch') {
+            if (UI.getEventSource(evt.sourceEvent) === 'touch') {
                 this.activeCue = _.reduce(this.cues, function(closeCue, cue) {
                     if (Math.abs(position - (parseInt(cue.pct) / 100 * _railBounds.width)) < this.mobileHoverDistance) {
                         return cue;


### PR DESCRIPTION
Adds thumbstrip functionality to touch and PointerEvent devices by activating listeners for touch and mouse events instead of just mouse events.  In order to support touch platforms which will not activate the mouseover handler that will set the this.activeCue property, we have to use javascript to check what the closest cue is in the hover/drag handler.  We will set a cue that is within 5 pixels away to be the active cue so that we can show the text for the cue if necessary.

Since the last time this was PR'd, I moved the instanceof checks for determining the original pointerType to a util so that we don't run the instanceof checks whenever we normalize an event, and so we can give out the source event for those who might be interested.  We check the pointerType from the evt.sourceEvent instead.

JW7-3167