### PR TITLE
Add thumbstrip functionality to touch and PointerEvent devices

### DIFF
--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -34,6 +34,7 @@ define([
 
     function normalizeUIEvent(type, srcEvent, target) {
         var source;
+
         if (srcEvent instanceof MouseEvent || (!srcEvent.touches && !srcEvent.changedTouches)) {
             source = srcEvent;
         } else {
@@ -43,8 +44,10 @@ define([
                 source = srcEvent.changedTouches[0];
             }
         }
+
         return {
             type: type,
+            sourceEvent: srcEvent,
             target: srcEvent.target,
             currentTarget: target,
             pageX: source.pageX,
@@ -288,6 +291,18 @@ define([
         };
 
         return this;
+    };
+
+    // Expose what the source of the event is so that we can ensure it's handled correctly.
+    // This returns only 'touch' or 'mouse'.  'pen' will be treated as a mouse.
+    UI.getPointerType = function (evt) {
+        if (_supportsPointerEvents && evt instanceof window.PointerEvent) {
+            return (evt.pointerType === 'touch') ? 'touch' : 'mouse';
+        } else if (_supportsTouchEvents && evt instanceof window.TouchEvent) {
+            return 'touch';
+        }
+
+        return 'mouse';
     };
 
     _.extend(UI.prototype, Events);

--- a/src/js/view/components/timeslider.js
+++ b/src/js/view/components/timeslider.js
@@ -2,11 +2,12 @@ define([
     'utils/underscore',
     'utils/helpers',
     'utils/constants',
+    'utils/ui',
     'view/components/slider',
     'view/components/tooltip',
     'view/components/chapters.mixin',
     'view/components/thumbnails.mixin'
-], function(_, utils, Constants, Slider, Tooltip, ChaptersMixin, ThumbnailsMixin) {
+], function(_, utils, Constants, UI, Slider, Tooltip, ChaptersMixin, ThumbnailsMixin) {
 
     var TimeTip = Tooltip.extend({
         setup : function() {
@@ -75,6 +76,7 @@ define([
 
             // Store the attempted seek, until the previous one completes
             this.seekThrottled = _.throttle(this.performSeek, 400);
+            this.mobileHoverDistance = 5;
 
             this._model
                 .on('change:playlistItem', this.onPlaylistItem, this)
@@ -95,9 +97,11 @@ define([
 
             this.elementRail.appendChild(this.timeTip.element());
 
-            // mousemove/mouseout because this currently mouse specific functionality.
-            this.el.addEventListener('mousemove', this.showTimeTooltip.bind(this), false);
-            this.el.addEventListener('mouseout', this.hideTimeTooltip.bind(this), false);
+            // Show the tooltip on while dragging (touch) moving(mouse), or moving over(mouse)
+            this.elementUI = new UI(this.el, {'useHover': true, 'useMove': true})
+                .on('drag move over', this.showTimeTooltip.bind(this), this)
+                .on('dragEnd out', this.hideTimeTooltip.bind(this), this);
+
         },
         limit: function(percent) {
             if (this.activeCue && _.isNumber(this.activeCue.pct)) {
@@ -207,6 +211,18 @@ define([
             }
 
             var timetipText;
+
+            // With touch events, we never will get the hover events on the cues that cause cues to be active.
+            // Therefore use the info we about the scroll position to detect if there is a nearby cue to be active.
+            if (UI.getPointerType(evt.sourceEvent) === 'touch') {
+                this.activeCue = _.reduce(this.cues, function(closeCue, cue) {
+                    if (Math.abs(position - (parseInt(cue.pct) / 100 * _railBounds.width)) < this.mobileHoverDistance) {
+                        return cue;
+                    }
+                    return closeCue;
+                }.bind(this), undefined);
+            }
+
             if (this.activeCue) {
                 timetipText = this.activeCue.text;
             } else {


### PR DESCRIPTION
Adds thumbstrip functionality to TouchEvent and PointerEvent devices by activating time slider listeners for touch and mouse events instead of just mouse events.  In order to support touch platforms which will not activate the mouseover handler that will set the this.activeCue property, we have to use javascript to check what the closest cue is in the hover/drag handler.  We will set a cue that is within 5 pixels away to be the active cue so that we can show the text for the cue if necessary.
UI.getPointerType() static function added so we can get the pointer type that triggered the original event.  Events return the sourceEvent for probing as necessary.

JW7-3167