### PR TITLE
Fix font resizing for browser-rendered captions

### DIFF
--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -401,7 +401,7 @@
 
     .jw-captions,
     video::-webkit-media-text-track-container {
-      max-height: calc(100% - 6.25em * (4.125em));
+      max-height:  ~"calc(100% - 72px)";
     }
 
     /* ==================================================

--- a/src/css/flags/touch.less
+++ b/src/css/flags/touch.less
@@ -17,7 +17,7 @@
         video::-webkit-media-text-track-container {
             // need to compensate for the control bar being 3.75em on mobile
             // 97% - 6.25 * 4.25em
-            max-height: 70%;
+            max-height:  ~"calc(100% - 66px)";
         }
 
     }

--- a/src/css/imports/captions.less
+++ b/src/css/imports/captions.less
@@ -6,7 +6,7 @@
     height: inherit;
     text-align: center;
     display: none;
-    max-height: calc(97% - 6.25 * (@controlbar-height));
+    max-height: ~"calc(100% - 46px)";
     line-height: 1.3em;
     letter-spacing: normal;
     word-spacing: normal;
@@ -58,7 +58,7 @@
     }
     video::-webkit-media-text-track-container {
         // With 16 lines of captions, 1em ~= 6.25% of height
-        max-height: calc(97% - 6.25 * (@controlbar-height));
+        max-height: ~"calc(100% - 46px)";
         line-height: 1.3em;
     }
     video::-webkit-media-text-track-display {

--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -45,6 +45,16 @@
     &.jw-flag-ads-googleima .jw-controlbar {
       bottom: 0;
     }
+
+    .jw-captions {
+      max-height: ~"calc(~'100%' - ~'46px')";
+    }
+
+    .jwplayer& {
+      video::-webkit-media-text-track-container {
+        max-height:  ~"calc(~'100%' - ~'46px')";
+      }
+    }
   }
 
   &:not(.jw-flag-time-slider-above):not(.jw-flag-audio-player):not(.jw-flag-small-player) {
@@ -357,12 +367,12 @@
         }
 
         .jw-captions {
-            max-height: calc(97% - 6.25 * (@controlbar-height));
+            max-height: ~"calc(~'100%' - ~'38px')";
         }
 
-        .jwplayer {
+        .jwplayer& {
             video::-webkit-media-text-track-container {
-                max-height: calc(97% - 6.25 * (@controlbar-height));
+                max-height:  ~"calc(~'100%' - ~'38px')";
             }
         }
 

--- a/src/js/view/captionsrenderer.js
+++ b/src/js/view/captionsrenderer.js
@@ -69,9 +69,15 @@ define([
                 scale = Math.pow(width / 400, 0.6);
             if (scale) {
                 var size = _options.fontSize * scale;
-                _style(_display, {
-                    fontSize: Math.floor(size*2)/2 + 'px'
-                });
+                var fontSize = Math.floor(size*2)/2;
+
+                if (_model.get('renderCaptionsNatively')) {
+                    _setShadowDOMFontSize(_model.get('id'), fontSize);
+                } else {
+                    _style(_display, {
+                        fontSize: fontSize + 'px'
+                    });
+                }
             }
             this.renderCues(true);
         };
@@ -204,10 +210,7 @@ define([
             // VTT.js DOM text styles
             cssUtils.css('#' + playerId + ' .jw-text-track-cue', textStyle, playerId);
 
-            // Set Shadow DOM font size (needs to be important to override browser's in line style)
-            var target = utils.isSafari() ? 'display' : 'container';
-            cssUtils.css('#' + playerId + ' .jw-video::-webkit-media-text-track-' + target,
-                '{font-size: ' + fontSize + 'px !important;}', playerId);
+            _setShadowDOMFontSize(playerId, fontSize);
 
             // Shadow DOM window styles
             cssUtils.css('#' + playerId + ' .jw-video::-webkit-media-text-track-display', windowStyle, playerId);
@@ -227,6 +230,13 @@ define([
                 cssUtils.css('#' + playerId + ' .jw-video::-webkit-media-text-track-display-backdrop',
                     backdropStyle, playerId);
             }
+        }
+
+        function _setShadowDOMFontSize(playerId, fontSize) {
+            // Set Shadow DOM font size (needs to be important to override browser's in line style)
+            var target = utils.isSafari() ? 'display' : 'container';
+            cssUtils.css('#' + playerId + ' .jw-video::-webkit-media-text-track-' + target,
+                '{font-size: ' + fontSize + 'px !important;}', playerId);
         }
 
         function _addEdgeStyle(option, style, fontOpacity) {


### PR DESCRIPTION
### Changes proposed in this pull request:

This also improves captions positioning by setting the text track container's height so that it's ~6px above the control bar.

Fixes #
JW7-4043
