### PR TITLE
Don’t setup/show nextUp tooltip if nextUpDisplay = false

### DIFF
--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -45,7 +45,8 @@ define([
             nextUpClose: 'Next Up Close',
             related: 'Related'
         },
-        renderCaptionsNatively: false
+        renderCaptionsNatively: false,
+        nextUpDisplay: true
         //qualityLabel: '480p',     // specify a default quality
         //captionLabel: 'English',  // specify a default Caption
     };

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -695,8 +695,10 @@ define([
             _nextuptooltip = new NextUpToolTip(_model, _api, _controlbar.elements.next, _playerElement);
             _nextuptooltip.setup();
 
-            // NextUp needs to be behind the controlbar to not block other tooltips
-            _controlsLayer.appendChild(_nextuptooltip.element());
+            if (_model.get('nextUpDisplay')) {
+                // NextUp needs to be behind the controlbar to not block other tooltips
+                _controlsLayer.appendChild(_nextuptooltip.element());
+            }
             _controlsLayer.appendChild(_controlbar.element());
 
             _playerElement.addEventListener('focus', handleFocus);


### PR DESCRIPTION
### Changes proposed in this pull request:

Do not setup the next button when `nextUpDisplay: false`. The nextUp tooltip should not show on hover or after crossing the nextUpOffset threshold.

Fixes #
JW7-3600
