### PR TITLE
Don't show nextUp when nextUpDisplay: false

### DIFF
--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -45,7 +45,8 @@ define([
             nextUpClose: 'Next Up Close',
             related: 'Related'
         },
-        renderCaptionsNatively: false
+        renderCaptionsNatively: false,
+        nextUpDisplay: true
         //qualityLabel: '480p',     // specify a default quality
         //captionLabel: 'English',  // specify a default Caption
     };

--- a/src/js/view/components/nextuptooltip.js
+++ b/src/js/view/components/nextuptooltip.js
@@ -5,10 +5,9 @@ define([
     'utils/helpers',
     'templates/nextup.html'
 ], function(dom, UI, _, utils, nextUpTemplate) {
-    var NextUpTooltip = function(_model, _api, nextButton, playerElement) {
+    var NextUpTooltip = function(_model, _api, playerElement) {
         this._model = _model;
         this._api = _api;
-        this._nextButton = nextButton;
         this._playerElement = playerElement;
         this.nextUpText = _model.get('localization').nextUp;
         this.nextUpClose = _model.get('localization').nextUpClose;
@@ -26,35 +25,34 @@ define([
             this.closeButton.setAttribute('aria-label', this.nextUpClose);
             this.tooltip = this.content.querySelector('.jw-nextup-tooltip');
 
+            var model = this._model;
             // Next Up is hidden until we get a valid NextUp item from the nextUp event
-            this.showNextUp = false;
-            this.streamType = undefined;
+            model.set('nextUpEnabled', false);
 
             // Events
-            this._model.on('change:mediaModel', this.onMediaModel, this);
-            this._model.on('change:streamType', this.onStreamType, this);
-            this._model.on('change:nextUp', this.onNextUp, this);
+            model.on('change:mediaModel', this.onMediaModel, this);
+            model.on('change:streamType', this.onStreamType, this);
+            model.on('change:nextUp', this.onNextUp, this);
+            model.on('change:nextUpVisible', this.toggle, this);
+            model.on('change:nextUpSticky', this.toggle, this);
 
             // Listen for duration changes to determine the offset from the end for when next up should be shown
-            this._model.on('change:duration', this.onDuration, this);
+            model.on('change:duration', this.onDuration, this);
             // Listen for position changes so we can show the tooltip when the offset has been crossed
-            this._model.on('change:position', this.onElapsed, this);
+            model.on('change:position', this.onElapsed, this);
 
-            this.onMediaModel(this._model, this._model.get('mediaModel'));
+            this.onMediaModel(model, model.get('mediaModel'));
 
             // Close button
             new UI(this.closeButton, {'directSelect': true})
-                .on('click tap', this.hide, this);
+                .on('click tap', function() {
+                    model.set('nextUpSticky', false);
+                    model.set('nextUpVisible', false);
+                    this.toggle(model, false);
+                }, this);
             // Tooltip
             new UI(this.tooltip)
                 .on('click tap', this.click, this);
-            // Next button behavior:
-            // - click = go to next playlist or related item
-            // - hover = show NextUp tooltip without 'close' button
-            new UI(this._nextButton.element(), {'useHover': true, 'directSelect': true})
-                .on('click tap', this.click, this)
-                .on('over', this.show, this)
-                .on('out', this.hoverOut, this);
         },
         loadThumbnail : function(url) {
             this.nextUpImage = new Image();
@@ -68,53 +66,24 @@ define([
             };
         },
         click: function() {
-            this.state = 'tooltip';
+            this.reset();
             this._api.next();
-            this.hide();
         },
-        show: function() {
-            if(this.state === 'opened' || this.hideToolTip) {
-                return;
-            }
-            dom.addClass(this.container, 'jw-nextup-container-visible');
-            dom.addClass(this._playerElement, 'jw-flag-nextup');
-        },
-        hide: function() {
-            dom.removeClass(this.container, 'jw-nextup-container-visible');
-            dom.removeClass(this.container, 'jw-nextup-sticky');
-            dom.removeClass(this._playerElement, 'jw-flag-nextup');
+        toggle: function(model, show) {
+            show = !!show;
 
-            if (this.state === 'opened') {
-                this.state = 'closed';
-            }
-        },
-        hoverOut: function() {
-            if (this.state === 'opened') {
-                // Moving the pointer away from the next button should not show/hide NextUp if it is 'opened'
+            if (!model.get('nextUpEnabled')) {
                 return;
             }
-            this.hide();
-        },
-        showTilEnd: function() {
-            // Show next up til playback ends. Don't hide even when controlbar is idle
-            if (this.state === 'opened' || this.state === 'closed') {
-                return;
-            }
-            dom.addClass(this.container, 'jw-nextup-sticky');
-            this.show();
-            this.state = 'opened';
+
+            dom.toggleClass(this.container, 'jw-nextup-container-visible', show);
+            dom.toggleClass(this._playerElement, 'jw-flag-nextup', show);
+            dom.toggleClass(this.container, 'jw-nextup-sticky', !!model.get('nextUpSticky'));
         },
         setNextUpItem: function(nextUpItem) {
             var _this = this;
             // Give the previous item time to complete its animation
             setTimeout(function () {
-                // hide the tooltip if we don't have a title or a thumbnail image
-                _this.hideToolTip = !(nextUpItem.title || nextUpItem.image);
-
-                if(_this.hideToolTip) {
-                    return;
-                }
-                
                 // Set thumbnail
                 _this.thumbnail = _this.content.querySelector('.jw-nextup-thumbnail');
                 dom.toggleClass(_this.thumbnail, 'jw-nextup-thumbnail-visible', !!nextUpItem.image);
@@ -134,14 +103,21 @@ define([
             }, 500);
         },
         onNextUp: function(model, nextUp) {
+            this.reset();
             if (!nextUp) {
-                this._nextButton.toggle(false);
-                this.showNextUp = false;
                 return;
             }
-            this.showNextUp = nextUp.showNextUp;
-            this._nextButton.toggle(true);
-            this.setNextUpItem(nextUp);
+
+            var nextUpEnabled = !!(nextUp.title || nextUp.image);
+            model.set('nextUpEnabled', nextUpEnabled);
+
+            if (nextUpEnabled) {
+                if (!nextUp.showNextUp) {
+                    // The related plugin will countdown the nextUp item
+                    model.set('nextUpSticky', false);
+                }
+                this.setNextUpItem(nextUp);
+            }
         },
         onDuration: function(model, duration) {
             if (!duration) {
@@ -158,27 +134,30 @@ define([
             this.offset = offset;
         },
         onMediaModel: function(model, mediaModel) {
+            var _this = this;
             mediaModel.on('change:state', function(model, state) {
                 if (state === 'complete') {
-                    this.state = 'tooltip';
-                    this.hide();
+                    _this.reset();
                 }
-            }, this);
+            });
         },
         onElapsed: function(model, val) {
-            // Show nextup if:
+            if (!model.get('nextUpEnabled') || model.get('nextUpSticky') === false) {
+                return;
+            }
+            // Show nextup during VOD streams if:
             // - in playlist mode but not playing an ad
             // - autoplaying in related mode and autoplaytimer is set to 0
-            // - not a live stream ('Live' or 'DVR')
-            if (this.streamType === 'VOD' && this.showNextUp && (val >= this.offset)) {
-                this.showTilEnd();
-            } else if (this.state === 'opened' || this.state === 'closed') {
-                this.state = 'tooltip';
-                this.hide();
+            var showTilEnd = val >= this.offset;
+            if (showTilEnd) {
+                model.set('nextUpVisible', showTilEnd);
+                model.set('nextUpSticky', showTilEnd);
             }
         },
         onStreamType: function(model, streamType) {
-            this.streamType = streamType;
+            if (streamType !== 'VOD') {
+                model.set('nextUpSticky', false);
+            }
         },
         element: function() {
             return this.container;
@@ -195,6 +174,11 @@ define([
                 this.container.removeChild(this.content);
                 this.content = null;
             }
+        },
+        reset: function() {
+            var model = this._model;
+            model.set('nextUpVisible', false);
+            model.set('nextUpSticky', null);
         }
     });
 

--- a/src/js/view/components/nextuptooltip.js
+++ b/src/js/view/components/nextuptooltip.js
@@ -48,7 +48,6 @@ define([
                 .on('click tap', function() {
                     model.set('nextUpSticky', false);
                     model.set('nextUpVisible', false);
-                    this.toggle(model, false);
                 }, this);
             // Tooltip
             new UI(this.tooltip)

--- a/src/js/view/components/nextuptooltip.js
+++ b/src/js/view/components/nextuptooltip.js
@@ -141,16 +141,19 @@ define([
             });
         },
         onElapsed: function(model, val) {
-            if (!model.get('nextUpEnabled') || model.get('nextUpSticky') === false) {
+            var nextUpSticky = model.get('nextUpSticky');
+            if (!model.get('nextUpEnabled') || nextUpSticky === false) {
                 return;
             }
             // Show nextup during VOD streams if:
             // - in playlist mode but not playing an ad
             // - autoplaying in related mode and autoplaytimer is set to 0
             var showTilEnd = val >= this.offset;
-            if (showTilEnd) {
+            if (showTilEnd && nextUpSticky === undefined) { // show if nextUpSticky is unset
                 model.set('nextUpVisible', showTilEnd);
                 model.set('nextUpSticky', showTilEnd);
+            } else if (!showTilEnd && nextUpSticky === true) { // reset if there was a backward seek
+                this.reset();
             }
         },
         onStreamType: function(model, streamType) {
@@ -177,7 +180,7 @@ define([
         reset: function() {
             var model = this._model;
             model.set('nextUpVisible', false);
-            model.set('nextUpSticky', null);
+            model.set('nextUpSticky', undefined);
         }
     });
 

--- a/src/js/view/controlbar.js
+++ b/src/js/view/controlbar.js
@@ -119,11 +119,26 @@ define([
                 muteButton = button('jw-icon-volume', this._api.setMute, vol);
             }
 
+            var nextButton = button('jw-icon-next', this._api.next.bind(this), next);
+
+            if (this._model.get('nextUpDisplay')) {
+                new UI(nextButton.element(), {'useHover': true, 'directSelect': true})
+                    .on('over', function () {
+                        this._model.set('nextUpVisible', true);
+                    }, this)
+                    .on('out', function () {
+                        if (this._model.get('nextUpSticky')) {
+                            return;
+                        }
+                        this._model.set('nextUpVisible', false);
+                    }, this);
+            }
+
             this.elements = {
                 alt: text('jw-text-alt', 'status'),
                 play: button('jw-icon-playback', this._api.play.bind(this, reasonInteraction()), play),
                 rewind: button('jw-icon-rewind', this.rewind.bind(this), rewind),
-                next: button('jw-icon-next', null, next), // the click/tap event listener is in the nextup tooltip
+                next: nextButton,
                 elapsed: text('jw-text-elapsed', 'timer'),
                 countdown: text('jw-text-countdown', 'timer'),
                 time: timeSlider,
@@ -219,6 +234,7 @@ define([
             this._model.on('change:captionsList', this.onCaptionsList, this);
             this._model.on('change:captionsIndex', this.onCaptionsIndex, this);
             this._model.on('change:streamType', this.onStreamTypeChange, this);
+            this._model.on('change:nextUp', this.onNextUp, this);
 
             // Event listeners
 
@@ -422,6 +438,9 @@ define([
                 this.elements.duration.innerHTML = 'Live';
                 this.elements.durationLeft.innerHTML = 'Live';
             }
+        },
+        onNextUp: function(model, nextUp) {
+            this.elements.next.toggle(!!nextUp);
         }
     });
 

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -691,12 +691,14 @@ define([
                 _model.on('change:autostartMuted', _autoplayUnmute);
                 _model.on('change:mute', _autoplayUnmute);
             }
+            if (_model.get('nextUpDisplay')) {
+                _nextuptooltip = new NextUpToolTip(_model, _api, _playerElement);
+                _nextuptooltip.setup();
 
-            _nextuptooltip = new NextUpToolTip(_model, _api, _controlbar.elements.next, _playerElement);
-            _nextuptooltip.setup();
+                // NextUp needs to be behind the controlbar to not block other tooltips
+                _controlsLayer.appendChild(_nextuptooltip.element());
+            }
 
-            // NextUp needs to be behind the controlbar to not block other tooltips
-            _controlsLayer.appendChild(_nextuptooltip.element());
             _controlsLayer.appendChild(_controlbar.element());
 
             _playerElement.addEventListener('focus', handleFocus);


### PR DESCRIPTION
### Changes proposed in this pull request:

- Setup the next button in the control bar
- Don't instantiate `nextuptooltip` when `nextUpDisplay: false`
- Use the following model properties to control nextUp:
    - `nextUpEnabled` (bool) - Enables nextUp behavior when there is a next item containing a title or thumbnail
    - `nextUpVisible` (bool) - show/hide nextUp tooltip based on the next button's `hover` state
    - `nextUpSticky` (bool) - Initialized to `null` for each playlistItem and can be set to `true`. When `true`, the nextUp tooltip includes the close button and is visible until playback of the current item ends or if the user closes the tooltip. When set to `false`, nextUp only shows on hover and `nextUpSticky` cannot be set to `true`. 

Fixes #
JW7-3600
