### PR TITLE
Hide nextUp on complete

### DIFF
--- a/src/js/view/components/nextuptooltip.js
+++ b/src/js/view/components/nextuptooltip.js
@@ -133,10 +133,9 @@ define([
             this.offset = offset;
         },
         onMediaModel: function(model, mediaModel) {
-            var _this = this;
             mediaModel.on('change:state', function(model, state) {
                 if (state === 'complete') {
-                    _this.reset();
+                    model.set('nextUpVisible', false);
                 }
             });
         },


### PR DESCRIPTION
### Changes proposed in this pull request:

The nextUp event handles resetting the tooltip when the item changes. This fixes an issue where nextUp should not be displayed, but does when a playlist item is repeated.

Fixes #
JW7-3600
