### PR TITLE
Casting Icon not positioned correctly

### DIFF
--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -126,7 +126,7 @@
         button {
           font-size: inherit;
           height: 36px;
-          margin-bottom: 8px;
+          margin-bottom: 0.5em;
           width: @mobile-touch-target;
         }
 


### PR DESCRIPTION
On an Android chrome, the bottom margin was too small when time slider
above was enabled. By switching from `px` to `em`, the issue was
resolved

JW7-3915