### PR TITLE
Add support for html5 audio tag using useAudioTag config property

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -130,14 +130,15 @@ define([
 
         // Find video tag, or create it if it doesn't exist.  View may not be built yet.
         var element = document.getElementById(_playerId);
-        var _videotag = (element) ? element.querySelector('video') : undefined;
+        var tagType = _playerConfig.useAudioTag ? 'audio' : 'video';
+        var _videotag = (element) ? element.querySelector(tagType) : undefined;
 
         function _setAttribute(name, value) {
             _videotag.setAttribute(name, value || '');
         }
 
         if (!_videotag) {
-            _videotag = document.createElement('video');
+            _videotag = document.createElement(tagType);
 
             if (_isMobile) {
                 _setAttribute('jw-gesture-required');


### PR DESCRIPTION
### Changes proposed in this pull request:

On iOS (especially iPhone) media played in a video tag is always played fullscreen. This makes JW Player useless if you want to play audio while keeping the main page on the screen (i.e. for read along audio).  Also, using a video tag to play audio only content is questionable practice considering the intent of the video tag (evident by the name).

This PR adds a simple configuration property to which uses an audio tag instead of a video tag for the player. 