### PR TITLE
Improve default styling of captions

### DIFF
--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -401,7 +401,7 @@
 
     .jw-captions,
     video::-webkit-media-text-track-container {
-      max-height:  ~"calc(100% - 72px)";
+      max-height:  ~"calc(100% - 55px)";
     }
 
     /* ==================================================

--- a/src/css/flags/touch.less
+++ b/src/css/flags/touch.less
@@ -16,8 +16,7 @@
         }
         video::-webkit-media-text-track-container {
             // need to compensate for the control bar being 3.75em on mobile
-            // 97% - 6.25 * 4.25em
-            max-height:  ~"calc(100% - 66px)";
+            max-height:  ~"calc(100% - 60px)";
         }
 
     }

--- a/src/css/imports/captions.less
+++ b/src/css/imports/captions.less
@@ -6,8 +6,7 @@
     height: inherit;
     text-align: center;
     display: none;
-    max-height: ~"calc(100% - 46px)";
-    line-height: 1.3em;
+    max-height: ~"calc(100% - 40px)";
     letter-spacing: normal;
     word-spacing: normal;
     text-transform: none;
@@ -43,27 +42,39 @@
     font-weight: normal;
     text-align: center;
     text-decoration: none;
-    line-height: 1.3em;
-    padding: 0.1em 0.8em;
 }
+
 .jw-text-track-display {
     // Override vtt.js font-size so text resizes as the player size changes
     font-size: inherit;
-    line-height: 1.3em;
+    line-height: 1.5em;
+}
+
+.jw-text-track-cue {
+    background-color: rgba(0, 0, 0, 0.498039);
+    color: #fff;
+    padding: .1em .3em;
 }
 
 .jwplayer {
-    video::-webkit-media-controls {
-        justify-content: flex-start;
+    video {
+        // Normalize the coordinate system to uniformly adjust the container height
+        // when the control bar is visible
+        &::-webkit-media-controls {
+            justify-content: flex-start;
+        }
+        &::-webkit-media-text-track-container {
+            max-height: ~"calc(100% - 40px)";
+            line-height: 1.5em;
+        }
+        &::-webkit-media-text-track-display {
+            // Ensure captions aren't cropped when the pseudo
+            // element's width cannot accommodate all the text
+            min-width: -webkit-min-content;
+        }
+        &::cue {
+            background-color: rgba(0, 0, 0, 0.498039);
+        }
     }
-    video::-webkit-media-text-track-container {
-        // With 16 lines of captions, 1em ~= 6.25% of height
-        max-height: ~"calc(100% - 46px)";
-        line-height: 1.3em;
-    }
-    video::-webkit-media-text-track-display {
-        // Ensure captions aren't cropped when the pseudo
-        // element's width cannot accommodate all the text
-        min-width: -webkit-min-content;
-    }
+
 }


### PR DESCRIPTION
### Changes proposed in this pull request:

- Move default captions styles to CSS
- Added padding and better spacing between caption lines
- Only apply custom styles when set in the config
- Adjust captions container size to sit flush with the control bar
- Don't attempt to populate or render captions with the player when rendering natively (ultimately shouldn't instantiate the renderer when captions are rendered by the browser)
- Fix a bug where captions still had the default background when `options.back === false`




Fixes #
JW7-2723
