### PR TITLE
Run flash check in view’s media element

### DIFF
--- a/src/js/controller/setup-steps.js
+++ b/src/js/controller/setup-steps.js
@@ -30,7 +30,7 @@ define([
                 method: _loadIntersectionObserverPolyfill,
                 depends: []
             },
-            LOADED_POLYFILLS: {
+            LOAD_POLYFILLS: {
                 method: _loadedPolyfills,
                 depends: [
                     'LOAD_PROMISE_POLYFILL',
@@ -40,7 +40,10 @@ define([
             },
             LOAD_PLUGINS: {
                 method: _loadPlugins,
-                depends: ['LOAD_PROMISE_POLYFILL']
+                // Plugins require JavaScript Promises
+                depends: [
+                    'LOAD_PROMISE_POLYFILL'
+                ]
             },
             INIT_PLUGINS: {
                 method: _initPlugins,
@@ -56,15 +59,20 @@ define([
             },
             LOAD_PLAYLIST: {
                 method: _loadPlaylist,
-                depends: ['LOAD_PROMISE_POLYFILL']
+                depends: []
             },
             CHECK_FLASH: {
                 method: _checkFlash,
-                depends: []
+                depends: [
+                    'SETUP_VIEW'
+                ]
             },
             FILTER_PLAYLIST: {
                 method: _filterPlaylist,
-                depends: ['LOAD_PLAYLIST', 'CHECK_FLASH']
+                depends: [
+                    'LOAD_PLAYLIST',
+                    'CHECK_FLASH'
+                ]
             },
             SETUP_VIEW: {
                 method: _setupView,
@@ -82,7 +90,7 @@ define([
             SEND_READY: {
                 method: _sendReady,
                 depends: [
-                    'LOADED_POLYFILLS',
+                    'LOAD_POLYFILLS',
                     'INIT_PLUGINS',
                     'SET_ITEM',
                     'DEFERRED'
@@ -170,28 +178,19 @@ define([
         }
     }
 
-    function _checkFlash(resolve, _model, _api) {
+    function _checkFlash(resolve, _model, _api, _view) {
         var primaryFlash = _model.get('primary') === 'flash';
         var flashVersion = utils.flashVersion();
         if (primaryFlash && flashVersion) {
-            var originalContainer = _api.getContainer();
-            var parentElement = originalContainer.parentElement;
-            if (!parentElement) {
+            var viewContainer = _view.element();
+            var mediaContainer = viewContainer.querySelector('.jw-media');
+            if (!viewContainer.parentElement) {
                 // Cannot perform test when player container has no parent
                 resolve();
             }
-            var testContainer = document.createElement('div');
-            testContainer.id = _model.get('id');
-            var flashHealthCheckId = '' + testContainer.id + '-' + Math.random().toString(16).substr(2);
+            var flashHealthCheckId = '' + _model.get('id') + '-' + Math.random().toString(16).substr(2);
             var flashHealthCheckSwf = _model.get('flashloader');
-            var width = _model.get('width');
-            var height = _model.get('height');
-            utils.style(testContainer, {
-                position: 'relative',
-                width: width.toString().indexOf('%') > 0 ? width : (width + 'px'),
-                height: height.toString().indexOf('%') > 0 ? height : (height + 'px')
-            });
-            var swf = EmbedSwf.embed(flashHealthCheckSwf, testContainer, flashHealthCheckId, null);
+            var swf = EmbedSwf.embed(flashHealthCheckSwf, mediaContainer, flashHealthCheckId, null);
             var done = function() {
                 if (embedTimeout === -1) {
                     return;
@@ -215,7 +214,6 @@ define([
                 failed();
                 return;
             }
-            parentElement.replaceChild(testContainer, originalContainer);
             // If "flash.loader.swf" does not fire embedCallback in time, unset primary "flash" config option
             var embedTimeout = setTimeout(failed, 3000);
         } else {

--- a/src/js/providers/flash.js
+++ b/src/js/providers/flash.js
@@ -154,7 +154,10 @@ define([
                 var found = parent.getElementsByTagName('object')[0];
                 if (found) {
                     found.off(null, null, this);
-                    return found;
+                    if (!found.embedCallback) {
+                        return found;
+                    }
+                    parent.removeChild(found);
                 }
 
                 return EmbedSwf.embed(_playerConfig.flashplayer, parent, getObjectId(_playerId),


### PR DESCRIPTION
 Runs flash check in view’s media element. Loader swf is cleared by flash.js provider to avoid flicker from empty container and bugs that occur when removing/referencing swf inside the scope that ends the test task.

JW7-4064