### PR TITLE
Set jw-text-alt height in mixins for IE11

### DIFF
--- a/src/css/imports/controlbar.less
+++ b/src/css/imports/controlbar.less
@@ -35,7 +35,7 @@
     top: -1px;
     bottom: 0;
     width: 100%;
-    height: auto;
+    height: @controlbar-height;
     line-height: @controlbar-height;
     margin: 0.5em 0;
     padding-right: 0.5em;

--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -345,6 +345,7 @@
           }
         }
 
+        .jw-text-alt,
         .jw-icon-inline,
         .jw-icon-tooltip,
         .jw-text-elapsed,


### PR DESCRIPTION
Setting height to auto for the absolutely positioned elements causes height to be 0 in IE11.  Setting a default line height and height in the default skins and specifically sets the values later on for individual skins.

JW7-4034
