### PR TITLE
Chromeless UI Bugs

### DIFF
--- a/src/css/flags/controls-disabled.less
+++ b/src/css/flags/controls-disabled.less
@@ -1,6 +1,7 @@
 .jw-flag-controls-disabled {
-    .jw-controls {
+    .jw-controls, .jw-nextup-container {
         visibility: hidden;
+        opacity: 0;
     }
 
     .jw-logo {

--- a/src/css/flags/controls-disabled.less
+++ b/src/css/flags/controls-disabled.less
@@ -1,7 +1,6 @@
 .jw-flag-controls-disabled {
     .jw-controls, .jw-nextup-container {
         visibility: hidden;
-        opacity: 0;
     }
 
     .jw-logo {

--- a/src/css/flags/time-slider-above.less
+++ b/src/css/flags/time-slider-above.less
@@ -7,12 +7,6 @@
     display: table;
   }
 
-  &.jw-state-idle:not(.jw-flag-cast-available) {
-    .jw-display {
-      padding: 0;
-    }
-  }
-
   /* ==================================================
   display
   */
@@ -25,6 +19,12 @@
         padding-top: @mobile-touch-target;
         padding-bottom: @mobile-touch-target * 1.5;
       }
+  }
+
+  &.jw-state-idle:not(.jw-flag-cast-available), &.jw-state-error {
+    .jw-display {
+      padding: 0;
+    }
   }
 
   /* ==================================================

--- a/src/css/imports/title.less
+++ b/src/css/imports/title.less
@@ -47,5 +47,6 @@
 
   .jw-title-secondary {
     display: none;
+    margin-top: 5px;
   }
 }

--- a/src/css/imports/title.less
+++ b/src/css/imports/title.less
@@ -31,7 +31,7 @@
     margin-top: -.5em;
 }
 
-.jw-flag-small-player:not(.jw-flag-audio-player) {
+.jw-flag-small-player {
 
   .jw-title {
     background: linear-gradient(180deg, fade(mix(black, white, 80%), 75%), fade(mix(black, white, 80%), 0%));

--- a/src/css/imports/title.less
+++ b/src/css/imports/title.less
@@ -31,7 +31,7 @@
     margin-top: -.5em;
 }
 
-.jw-flag-small-player {
+.jw-flag-small-player:not(.jw-flag-audio-player) {
 
   .jw-title {
     background: linear-gradient(180deg, fade(mix(black, white, 80%), 75%), fade(mix(black, white, 80%), 0%));

--- a/src/css/imports/title.less
+++ b/src/css/imports/title.less
@@ -1,6 +1,5 @@
 @import "vars";
 
-
 .jw-title {
     display: none;
     position: absolute;
@@ -48,7 +47,5 @@
 
   .jw-title-secondary {
     display: none;
-    margin-top: 5px;
   }
-
 }

--- a/src/css/states/states.less
+++ b/src/css/states/states.less
@@ -103,7 +103,6 @@ body .jwplayer.jw-state-error {
     }
     .jw-title-secondary {
       display: block;
-      padding-top: 0.75em;
     }
   }
 
@@ -179,31 +178,21 @@ body .jwplayer.jw-state-error {
   }
 }
 
-.jw-state-idle,
-.jwplayer.jw-state-complete:not(.jw-flag-casting),
-body .jwplayer.jw-state-error {
-  &.jw-flag-audio-player {
-    .jw-preview {
-      display: none;
-    }
-
-    .jw-title-primary {
-      width: auto;
-      display: inline-block;
-      padding-right: 0;
-    }
-
-    .jw-title-secondary {
-      width: auto;
-      display: inline-block;
-      padding-left: 0;
-    }
-  }
-}
-
-body .jwplayer.jw-flag-audio-player .jw-error {
+body .jwplayer.jw-state-error.jw-flag-audio-player {
   .jw-preview {
     display: none;
+  }
+
+  .jw-title-primary {
+    width: auto;
+    display: inline-block;
+    padding-right: 0;
+  }
+
+  .jw-title-secondary {
+    width: auto;
+    display: inline-block;
+    padding-left: 0;
   }
 }
 

--- a/src/css/states/states.less
+++ b/src/css/states/states.less
@@ -97,8 +97,14 @@
 
 body .jw-error,
 body .jwplayer.jw-state-error {
-  .jw-title .jw-title-primary {
-    white-space: normal;
+  .jw-title {
+    .jw-title-primary {
+      white-space: normal;
+    }
+    .jw-title-secondary {
+      display: block;
+      padding-top: 0.75em;
+    }
   }
 
   .jw-icon-display {
@@ -163,10 +169,10 @@ body .jwplayer.jw-state-error {
 
 // Show preview
 
-.jw-state-idle,
+.jw-state-idle:not(.jw-flag-audio-player),
 .jwplayer.jw-state-complete:not(.jw-flag-casting):not(.jw-flag-audio-player),
-body .jw-error,
-body .jwplayer.jw-state-error {
+body .jw-error:not(.jw-flag-audio-player),
+body .jwplayer.jw-state-error:not(.jw-flag-audio-player) {
   .jw-preview {
     display: block;
   }

--- a/src/css/states/states.less
+++ b/src/css/states/states.less
@@ -169,12 +169,41 @@ body .jwplayer.jw-state-error {
 
 // Show preview
 
-.jw-state-idle:not(.jw-flag-audio-player),
+
+.jw-state-idle,
 .jwplayer.jw-state-complete:not(.jw-flag-casting):not(.jw-flag-audio-player),
-body .jw-error:not(.jw-flag-audio-player),
-body .jwplayer.jw-state-error:not(.jw-flag-audio-player) {
+body .jw-error,
+body .jwplayer.jw-state-error {
   .jw-preview {
     display: block;
+  }
+}
+
+.jw-state-idle,
+.jwplayer.jw-state-complete:not(.jw-flag-casting),
+body .jwplayer.jw-state-error {
+  &.jw-flag-audio-player {
+    .jw-preview {
+      display: none;
+    }
+
+    .jw-title-primary {
+      width: auto;
+      display: inline-block;
+      padding-right: 0;
+    }
+
+    .jw-title-secondary {
+      width: auto;
+      display: inline-block;
+      padding-left: 0;
+    }
+  }
+}
+
+body .jwplayer.jw-flag-audio-player .jw-error {
+  .jw-preview {
+    display: none;
   }
 }
 


### PR DESCRIPTION
- Error description displays for small players, padding adjusted so it
does not overlap with error title. Item description still stays hidden.
Affects with and without controls.

- Found another bug: Error display icon container now centered in
player for small players with controls.

- Poster image no longer show in controlbar only mode.

- Next Up container now hidden when controls are disabled.

JW7-4059