### PR TITLE
Show Live text in IE 11 by matching ads display styles

### DIFF
--- a/src/css/flags/live.less
+++ b/src/css/flags/live.less
@@ -18,4 +18,13 @@
         }
     }
 
+    &.jw-ie {
+        .jw-controlbar-center-group {
+            overflow: hidden;
+
+            .jw-text-alt {
+                display: table;
+            }
+        }
+    }
 }

--- a/src/css/imports/mixins.less
+++ b/src/css/imports/mixins.less
@@ -355,7 +355,8 @@
         }
       }
 
-      &.jw-flag-ads.jw-ie .jw-text-alt {
+      &.jw-flag-ads.jw-ie .jw-text-alt,
+      &.jw-flag-live.jw-ie .jw-text-alt {
         top: 1px;
         margin: 0;
       }


### PR DESCRIPTION
This code ensures that the Live text is displayed for live players in IE11 by adding current ads display styles to live as well.

JW7-4034