### PR TITLE
Dont clear stale stream timeout on timeUpdate 

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -157,7 +157,7 @@ define([
         }
 
         function _timeUpdateHandler() {
-            clearTimeouts();
+            clearTimeout(_playbackTimeout);
 
             _canSeek = true;
             if (_this.state === states.STALLED) {


### PR DESCRIPTION
Clearing at the top of every time update caused EOS detection never to work. The timeout can still cleared in time update if the stream isn't stale anymore

JW7-3269
