### PR TITLE
Fix logo position when there are no dock buttons

### DIFF
--- a/src/css/imports/dock.less
+++ b/src/css/imports/dock.less
@@ -11,9 +11,6 @@
         clear: both;
         display: block;
     }
-    & + .jw-logo-top-right {
-        top: 3.5em;
-    }
 }
 
 .jw-dock-button {
@@ -48,7 +45,6 @@
     &:hover .jw-arrow {
         display: block;
     }
-
 }
 
 .jw-dock-image {

--- a/src/css/imports/logo.less
+++ b/src/css/imports/logo.less
@@ -23,6 +23,10 @@
 .jw-logo-top-right {
     top: 0;
     right: 0;
+
+    &.below {
+        top: 3.5em;
+    }
 }
 
 .jw-logo-top-left {

--- a/src/js/view/logo.js
+++ b/src/js/view/logo.js
@@ -42,6 +42,9 @@ define([
 
             _model.set('logo', _settings);
 
+            accommodateDock();
+            _model.on('change:dock', accommodateDock);
+
             // apply styles onload when image width and height are known
             _img.onload = function() {
                 // update logo style
@@ -90,8 +93,16 @@ define([
         };
 
         this.destroy = function() {
+            _model.off('change:dock', accommodateDock);
             _img.onload = null;
         };
+
+        function accommodateDock() {
+            // When positioned in the top right, the logo needs to be shifted down to accommodate dock buttons
+            var dockButtons = _model.get('dock');
+            var belowDock = !!(dockButtons && dockButtons.length && _settings.position === 'top-right');
+            utils.toggleClass(_logo, 'below', belowDock);
+        }
 
         return this;
     };


### PR DESCRIPTION
### Changes proposed in this pull request:

Shift the logo down only when positioned in the top right and dock buttons exist.

Fixes #
JW7-3637
