### PR TITLE
Add autoplay on mobile to iOS Facebook

### DIFF
--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -450,7 +450,7 @@ define([
 
         this.autoStartOnMobile = function() {
             return this.get('autostart') && !this.get('sdkplatform') &&
-                ((_autoStartSupportedIOS() && (utils.isSafari() || utils.isFacebookBrowser())) || (utils.isAndroid() && utils.isChrome())) &&
+                ((_autoStartSupportedIOS() && (utils.isSafari() || utils.isFacebook())) || (utils.isAndroid() && utils.isChrome())) &&
                 (!this.get('advertising') || this.get('advertising').autoplayadsmuted);
         };
     };

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -450,7 +450,7 @@ define([
 
         this.autoStartOnMobile = function() {
             return this.get('autostart') && !this.get('sdkplatform') &&
-                ((_autoStartSupportedIOS() && utils.isSafari()) || (utils.isAndroid() && utils.isChrome())) &&
+                ((_autoStartSupportedIOS() && (utils.isSafari() || utils.isFacebookBrowser())) || (utils.isAndroid() && utils.isChrome())) &&
                 (!this.get('advertising') || this.get('advertising').autoplayadsmuted);
         };
     };

--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -28,6 +28,8 @@ define([
     browser.isIPad = _browserCheck(/iPad/i);
     browser.isSafari602 = _browserCheck(/Macintosh.*Mac OS X 10_8.*6\.0\.\d* Safari/i);
     browser.isOSX = _browserCheck(/Mac OS X/i);
+    // Check for Facebook App Version to see if it's Facebook
+    browser.isFacebookBrowser = _browserCheck(/FBAV/i);
 
     var _isEdge = browser.isEdge = function(browserVersion) {
         if (browserVersion) {

--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -29,7 +29,7 @@ define([
     browser.isSafari602 = _browserCheck(/Macintosh.*Mac OS X 10_8.*6\.0\.\d* Safari/i);
     browser.isOSX = _browserCheck(/Mac OS X/i);
     // Check for Facebook App Version to see if it's Facebook
-    browser.isFacebookBrowser = _browserCheck(/FBAV/i);
+    browser.isFacebook = _browserCheck(/FBAV/i);
 
     var _isEdge = browser.isEdge = function(browserVersion) {
         if (browserVersion) {


### PR DESCRIPTION
Adds autoplay on mobile to iOS Facebook by whitelisting the browser for using the feature.  Could be better if we knew what version of the Facebook app implements it, however there appears to be little Facebook app release documentation.

JW7-4107