### PR TITLE
Allow autostart on iOS Chrome

### DIFF
--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -450,7 +450,7 @@ define([
 
         this.autoStartOnMobile = function() {
             return this.get('autostart') && !this.get('sdkplatform') &&
-                ((_autoStartSupportedIOS() && (utils.isSafari() || utils.isFacebook())) || (utils.isAndroid() && utils.isChrome())) &&
+                ((_autoStartSupportedIOS() && (utils.isSafari() || utils.isChrome() || utils.isFacebook())) || (utils.isAndroid() && utils.isChrome())) &&
                 (!this.get('advertising') || this.get('advertising').autoplayadsmuted);
         };
     };


### PR DESCRIPTION
Whitelists iOS Chrome to autostart on mobile in correct versions of iOS.  iOS firefox appears to already auto play in release.

JW7-4112