### PR TITLE
Ensure hexadecimal pairs are created for values less than 16

### DIFF
--- a/src/js/utils/id3Parser.js
+++ b/src/js/utils/id3Parser.js
@@ -80,6 +80,9 @@ define([
     id3Parser.arrayToInt = function(array) {
         var sizeString = '0x';
         for (var i = 0; i < array.length; i++) {
+            if (array[i] < 16) {
+                sizeString += '0';
+            }
             sizeString += array[i].toString(16);
         }
         return parseInt(sizeString);


### PR DESCRIPTION
This fixes an issue where arrayToInt will return incorrect hexadecimal values if parsing the number will result in one character instead of two.  This can end up omitting significant ‘0’ values and generate incorrect INT values.

JW7-4121