### PR TITLE
QoE Enhancements

### DIFF
--- a/src/js/utils/clock.js
+++ b/src/js/utils/clock.js
@@ -1,39 +1,41 @@
 define([], function() {
 
-    var AudioClockPolyfill = function() {
-        var currentTime = 0;
-        var time = new Date().getTime();
+    var performance = window.performance;
+
+    var supportsPerformance = !!(performance && performance.now);
+
+    var getTime = function() {
+        if (supportsPerformance) {
+            return performance.now();
+        }
+        return new Date().getTime();
+    };
+
+    var Clock = function() {
+        var started = getTime();
+        var updated = started;
 
         var updateClock = function() {
-            var delta = new Date().getTime() - time;
+            var delta = getTime() - updated;
             if (delta > 250) {
                 delta = 250;
             } else if (delta < 0) {
                 delta = 0;
             }
-            time += delta;
-            currentTime += delta;
+            updated += delta;
         };
         setInterval(updateClock, 50);
 
         Object.defineProperty(this, 'currentTime', {
             get: function() {
                 updateClock();
-                return currentTime / 1000;
+                return updated - started;
             }
         });
     };
 
-    var Clock = function() {
-        if ('AudioContext' in window) {
-            this.timer = new AudioContext();
-        } else {
-            this.timer = new AudioClockPolyfill();
-        }
-    };
-
     Clock.prototype.now = function() {
-        return this.timer.currentTime * 1000;
+        return this.currentTime;
     };
 
     return new Clock();

--- a/src/js/utils/clock.js
+++ b/src/js/utils/clock.js
@@ -1,0 +1,40 @@
+define([], function() {
+
+    var AudioClockPolyfill = function() {
+        var currentTime = 0;
+        var time = new Date().getTime();
+
+        var updateClock = function() {
+            var delta = new Date().getTime() - time;
+            if (delta > 250) {
+                delta = 250;
+            } else if (delta < 0) {
+                delta = 0;
+            }
+            time += delta;
+            currentTime += delta;
+        };
+        setInterval(updateClock, 50);
+
+        Object.defineProperty(this, 'currentTime', {
+            get: function() {
+                updateClock();
+                return currentTime / 1000;
+            }
+        });
+    };
+
+    var Clock = function() {
+        if ('AudioContext' in window) {
+            this.timer = new AudioContext();
+        } else {
+            this.timer = new AudioClockPolyfill();
+        }
+    };
+
+    Clock.prototype.now = function() {
+        return this.timer.currentTime * 1000;
+    };
+
+    return new Clock();
+});

--- a/src/js/utils/clock.js
+++ b/src/js/utils/clock.js
@@ -3,6 +3,8 @@ define([], function() {
     var performance = window.performance;
 
     var supportsPerformance = !!(performance && performance.now);
+    
+    var MAX_INTERVAL = 1000;
 
     var getTime = function() {
         if (supportsPerformance) {
@@ -17,8 +19,8 @@ define([], function() {
 
         var updateClock = function() {
             var delta = getTime() - updated;
-            if (delta > 250) {
-                delta = 250;
+            if (delta > MAX_INTERVAL) {
+                delta = MAX_INTERVAL;
             } else if (delta < 0) {
                 delta = 0;
             }

--- a/test/unit/model-qoe-test.js
+++ b/test/unit/model-qoe-test.js
@@ -68,8 +68,12 @@ define([
         assert.ok(validateMeasurement(qoeDump.events.firstFrame, startTime), 'first frame event was fired');
 
         // test that listeners are removed by testing that tick events are no longer changed
-        qoeItem.tick('playAttempt', -1);
-        qoeItem.tick('firstFrame', -1);
+        qoeItem.tick('playAttempt');
+        qoeItem.tick('firstFrame');
+        qoeDump = qoeItem.dump();
+        var playAttemptTick = qoeDump.events.playAttempt;
+        var firstFrameTick = qoeDump.events.firstFrame;
+
         model.mediaController.trigger(events.JWPLAYER_MEDIA_PLAY_ATTEMPT);
         model.mediaController.trigger(events.JWPLAYER_MEDIA_TIME, {
             position: 2
@@ -77,8 +81,8 @@ define([
         model.mediaController.trigger(events.JWPLAYER_PROVIDER_FIRST_FRAME);
 
         qoeDump = qoeItem.dump();
-        assert.equal(qoeDump.events.playAttempt, -1, 'play attempt is unchanged after further media events');
-        assert.equal(qoeDump.events.firstFrame,  -1, 'first frame is unchanged after further media events');
+        assert.equal(qoeDump.events.playAttempt, playAttemptTick, 'play attempt is unchanged after further media events');
+        assert.equal(qoeDump.events.firstFrame, firstFrameTick, 'first frame is unchanged after further media events');
     });
 
     test('tracks stalled time', function(assert) {
@@ -135,18 +139,19 @@ define([
         assert.ok(validateMeasurement(loadTime), 'time to first frame is a valid number');
 
         var qoeDump = qoeItem.dump();
-        assert.equal(qoeDump.counts.idle, 1,       'one idle event');
+        assert.equal(qoeDump.counts.idle, 1, 'one idle event');
         assert.equal(qoeDump.counts.loading, 1, 'one loading event');
         assert.equal(qoeDump.counts.playing, 1, 'one playing event');
-        assert.ok(validateMeasurement(qoeDump.sums.idle),       'idle sum is a valid number');
+        assert.ok(validateMeasurement(qoeDump.sums.idle), 'idle sum is a valid number');
         assert.ok(validateMeasurement(qoeDump.sums.loading), 'loading sum is a valid number');
+        assert.ok(validateMeasurement(qoeDump.sums.playing), 'playing sum is a valid number');
         assert.ok(validateMeasurement(qoeDump.events.playlistItem, startTime), 'playlistItem epoch time is ok');
-        assert.ok(validateMeasurement(qoeDump.events.playAttempt, startTime),   'playAttempt epoch time is ok');
-        assert.ok(validateMeasurement(qoeDump.events.firstFrame, startTime),     'firstFrame epoch time is ok');
+        assert.ok(validateMeasurement(qoeDump.events.playAttempt, startTime), 'playAttempt epoch time is ok');
+        assert.ok(validateMeasurement(qoeDump.events.firstFrame, startTime), 'firstFrame epoch time is ok');
     }
 
     function validateMeasurement(value, min) {
-        return typeof value === 'number' && !isNaN(value) && value >= (min||0);
+        return typeof value === 'number' && !isNaN(value) && value >= (min || 0);
     }
 
 });

--- a/test/unit/timer-test.js
+++ b/test/unit/timer-test.js
@@ -20,16 +20,23 @@ define([
     });
 
     test('timer tick test', function(assert) {
+        var done = assert.async();
         var time = new timer();
 
-        time.tick('event1', 5);
-        time.tick('event2', 10);
+        time.tick('event1');
 
-        var between = time.between('event1', 'event2');
-        assert.equal(between, 5, 'between tick time is correctly calculated');
+        setTimeout(function() {
 
-        between = time.between('no', 'value');
-        assert.equal(between, -1, 'invalid tick events returns -1');
+            time.tick('event2');
+
+            var between = time.between('event1', 'event2');
+            assert.ok(between > 5 && between < 30000, 'between tick time is correctly calculated');
+
+            between = time.between('no', 'value');
+            assert.equal(between, null, 'invalid tick events returns null');
+
+            done();
+        }, 10);
     });
 
 });


### PR DESCRIPTION
Use a running timer that updates when the `currentTime` getter is called and on using setInterval. The interval is set to run 20 times a second, adding the delta to currentTime on each run with a maximum delta of 1000 milliseconds. Any period greater than a second that passes while the device or browser is inactive will not be added to the running clock.

Also added a running tally of active state in `qoe.dump()` to make the `qoe()` API method useful for developers who want to get an active running tally of all states for the current playlist item:

```js
// (Setup a player and begin playback)

// Before these changes you would only get a total of previous states:
console.log(jwplayer().qoe().item.sums);
{
    idle: 145,
    loading: 406
}

 // Now the current state is tallied with each call
console.log(jwplayer().qoe().item.sums);
{
    idle: 145,
    loading: 406,
    playing: 6989
}
```

States that the player has not entered are still not logged. The complete state would look like:
```js
{
    idle: 150, // idle time before attempting playback (includes some setup time with autostart)
    loading: 586, // time spent buffering
    playing: 3134, // time spent playing
    paused: 568, // time spent paused
    complete: 3094 // idle time after playback (replay/recommendations state)
}
```

JW7-4056