### PR TITLE
Override config properties that must be reset on setup (viewSetup)

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -917,8 +917,8 @@ define([
 
             this.playerDestroy = function () {
                 this.stop();
-                this.showView(this.originalContainer);
                 _stopObserving();
+                this.showView(this.originalContainer);
 
                 if (_view) {
                     _view.destroy();

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -36,10 +36,10 @@ define([
                 flashBlocked: false,
                 fullscreen: false,
                 scrubbing: false,
+                viewSetup: false,
                 duration: 0,
                 position: 0,
-                buffer: 0,
-                visibility: 0
+                buffer: 0
             });
 
             this.updateProviders();


### PR DESCRIPTION
The new setup routine requires the model to fire 'change:viewSetup' for the controller to add the view to the DOM during setup. This makes sure that viewSetup is set to false even if a different value is passed to player setup (for example by resetting up the player with `jwplayer().setup(jwplayer().getConfig())` - try not to do that).
 
JW7-4135