### PR TITLE
CC menu in safari absent sometimes

### DIFF
--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -39,7 +39,6 @@ define(['utils/underscore',
 
     function setTextTracks(tracks) {
         this._currentTextTrackIndex = -1;
-
         if (!tracks) {
             return;
         }
@@ -129,7 +128,7 @@ define(['utils/underscore',
             this.textTrackChangeHandler = this.textTrackChangeHandler || textTrackChangeHandler.bind(this);
             this.addTracksListener(this.video.textTracks, 'change', this.textTrackChangeHandler);
 
-            if (utils.isEdge() || utils.isFF()) {
+            if (utils.isEdge() || utils.isFF() || utils.isSafari()) {
                 // Listen for TextTracks added to the videotag after the onloadeddata event in Edge and Firefox
                 this.addTrackHandler = this.addTrackHandler || addTrackHandler.bind(this);
                 this.addTracksListener(this.video.textTracks, 'addtrack', this.addTrackHandler);


### PR DESCRIPTION
Listens for changes in textTracks after onloadeddata

Occasionally the cc button will be absent when playing a stream containing in manifest vtt on safari

Fixes #
JW7-4050
