### PR TITLE
Hide Safari shadow dom media controls with css

### DIFF
--- a/src/css/imports/captions.less
+++ b/src/css/imports/captions.less
@@ -75,6 +75,10 @@
         &::cue {
             background-color: rgba(0, 0, 0, 0.5);
         }
+        &::-webkit-media-controls-panel-container {
+            // Safari's media controls should not show when not in fullscreen on iOS devices
+            display: none;
+        }
     }
 
 }


### PR DESCRIPTION
### Changes proposed in this pull request:

Safari sets an opacity value for its media controls which obscure the player upon exiting full screen on iOS devices. This hides it with CSS.

Fixes #
JW7-4148
