### PR TITLE
Improve Flash memory usage and performance

### DIFF
--- a/src/flash/com/longtailvideo/jwplayer/player/SwfEventRouter.as
+++ b/src/flash/com/longtailvideo/jwplayer/player/SwfEventRouter.as
@@ -73,20 +73,12 @@ public class SwfEventRouter {
      */
 
     static private var _sendScript:XML = <script><![CDATA[
-function(id, name, data, lastTimeout) {
-    if (name === 'time' || name === 'bufferChange') {
-        clearTimeout(lastTimeout);
+function(id, name, data) {
+    var swf = document.getElementById(id);
+    if (swf && typeof swf.trigger === 'function') {
+        return swf.trigger(name, data);
     }
-    return setTimeout(function() {
-        var swf = document.getElementById(id);
-        if (swf && typeof swf.trigger === 'function') {
-            return swf.trigger(name, data);
-        }
-        // console.log('Unhandled event from "' + id +'":', name, json);
-    }, 0);
 }]]></script>;
-
-    static private var jsEventTimeouts:Object = {};
 
     static public function triggerJsEvent(name:String, data:Object = null):void {
         var id:String = ExternalInterface.objectID;
@@ -106,17 +98,12 @@ function(id, name, data, lastTimeout) {
                 } catch(err:Error) {
                     trace(err);
                 }
-                try {
-                    jsEventTimeouts[name] = ExternalInterface.call(_sendScript, id, name, data, jsEventTimeouts[name]);
-                } catch(err:Error) {
-                    trace(err);
-                }
-            } else {
-                try {
-                    ExternalInterface.call(_sendScript, id, name);
-                } catch(err:Error) {
-                    trace(err);
-                }
+            }
+
+            try {
+                ExternalInterface.call(_sendScript, id, name, data);
+            } catch(err:Error) {
+                trace(err);
             }
             return;
         }

--- a/src/flash/com/longtailvideo/jwplayer/player/SwfEventRouter.as
+++ b/src/flash/com/longtailvideo/jwplayer/player/SwfEventRouter.as
@@ -73,16 +73,17 @@ public class SwfEventRouter {
      */
 
     static private var _sendScript:XML = <script><![CDATA[
-function(id, name, data) {
+function(id, name, json) {
     var swf = document.getElementById(id);
     if (swf && typeof swf.trigger === 'function') {
-        return swf.trigger(name, data);
+        return swf.trigger(name, json);
     }
 }]]></script>;
 
     static public function triggerJsEvent(name:String, data:Object = null):void {
         var id:String = ExternalInterface.objectID;
         if (ExternalInterface.available) {
+            var json:String;
             if (data !== null) {
                 try {
                     if (data is String || data is Number) {
@@ -95,19 +96,19 @@ function(id, name, data) {
                         delete data.target;
                         delete data.currentTarget;
                     }
+                    json = encodeURIComponent(JSON.stringify(data));
                 } catch(err:Error) {
                     trace(err);
                 }
             }
-
             try {
-                ExternalInterface.call(_sendScript, id, name, data);
+                ExternalInterface.call(_sendScript, id, name, json);
             } catch(err:Error) {
                 trace(err);
             }
             return;
         }
-        trace('Could not dispatch event "' + id + '":', name, data);
+        trace('Could not dispatch event "' + id + '":', name, json);
     }
 
     static public function error(code:int, message:String):void {

--- a/src/js/providers/flash.js
+++ b/src/js/providers/flash.js
@@ -386,11 +386,6 @@ define([
             }
         });
 
-        // Overwrite the event dispatchers to block on certain occasions
-        this.trigger = function(type, args) {
-            return Events.trigger.call(this, type, args);
-        };
-
     }
 
     // Register provider

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -48,16 +48,6 @@ define([
 
         this.renderNatively = utils.isChrome() || utils.isIOS() || utils.isSafari() || utils.isEdge();
 
-        // Overwrite the event dispatchers to block on certain occasions
-        this.trigger = function(type, args) {
-            return Events.trigger.call(this, type, args);
-        };
-
-        this.setState = function(state) {
-            return DefaultProvider.setState.call(this, state);
-        };
-
-
         var _this = this;
         var _mediaEvents = {
             click: _clickHandler,

--- a/src/js/utils/embedswf.js
+++ b/src/js/utils/embedswf.js
@@ -94,9 +94,9 @@ define([
             }
             return Events.off.apply(swf, args);
         });
-        addGetter(swf, 'trigger', function(type, args) {
+        addGetter(swf, 'trigger', function(type, json) {
             var eventQueue = swf._eventQueue;
-            eventQueue.push({ type: type, args: args });
+            eventQueue.push({ type: type, json: json });
             if (processEventsTimeout > -1) {
                 return;
             }
@@ -105,7 +105,12 @@ define([
                 processEventsTimeout = -1;
                 while (length--) {
                     var event = eventQueue.shift();
-                    Events.trigger.call(swf, event.type, event.args);
+                    if (event.json) {
+                        var data = JSON.parse(decodeURIComponent(event.json));
+                        Events.trigger.call(swf, event.type, data);
+                    } else {
+                        Events.trigger.call(swf, event.type);
+                    }
                 }
             });
         });


### PR DESCRIPTION
Restore custom JSON encoding for Flash events. Flash's native JSON encoding does not handle object properties with special characters (like ".").

Async and JSON decoding logic has been moved out of ActionScript so that as little JS is evaluated by the browser for the Flash plugin.

Events are not queued and processed in groups to reduce the number of timeouts created and limit the pending number of timeouts needed to process data from Flash.

JW7-4165

---
PS. These lines should have been removed by @pajong when attach/detach logic was removed from providers:
```js
-        // Overwrite the event dispatchers to block on certain occasions
-        this.trigger = function(type, args) {
-            return Events.trigger.call(this, type, args);
-        };
-
-        this.setState = function(state) {
-            return DefaultProvider.setState.call(this, state);
-        };
```