### PR TITLE
Fix api loads during an ad causing incorrect player state

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -424,8 +424,8 @@ define([
                 }
                 _model.set('preInstreamState', 'instream-idle');
 
-                _stop(true);
                 _this.trigger('destroyPlugin', {});
+                _stop(true);
 
                 _model.once('itemReady', _checkAutoStart);
 


### PR DESCRIPTION
Fixes the issue where the player would not end up in the idle state after using api.load during an ad.  It does this by ensuring that the provider is reattached by triggering destroyPlugin before the player is stopped.

JW7-4172