### PR TITLE
Bugfix/autostart broken android sdk

### DIFF
--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -451,9 +451,11 @@ define([
         }
 
         this.autoStartOnMobile = function() {
-            return this.get('autostart') && !this.get('sdkplatform') &&
-                ((_autoStartSupportedIOS() && (utils.isSafari() || utils.isChrome() || utils.isFacebook())) || (utils.isAndroid() && utils.isChrome())) &&
-                (!this.get('advertising') || this.get('advertising').autoplayadsmuted);
+            var autostartIsConfigured = this.get('autostart') && (!this.get('advertising') || this.get('advertising').autoplayadsmuted);
+            var iosDeviceIsSupported = _autoStartSupportedIOS() && (utils.isSafari() || utils.isChrome() || utils.isFacebook());
+            var androidDeviceIsSupported = utils.isAndroid() && utils.isChrome();
+            var isAndroidSdk = this.get('sdkplatform') === 1;
+            return (!this.get('sdkplatform') && autostartIsConfigured && (iosDeviceIsSupported || androidDeviceIsSupported)) || isAndroidSdk;
         };
     };
 

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -451,11 +451,13 @@ define([
         }
 
         this.autoStartOnMobile = function() {
-            var autostartIsConfigured = this.get('autostart') && (!this.get('advertising') || this.get('advertising').autoplayadsmuted);
-            var iosDeviceIsSupported = _autoStartSupportedIOS() && (utils.isSafari() || utils.isChrome() || utils.isFacebook());
-            var androidDeviceIsSupported = utils.isAndroid() && utils.isChrome();
+            var autostartAdsIsEnabled = (!this.get('advertising') || this.get('advertising').autoplayadsmuted);
+            var iosBrowserIsSupported = _autoStartSupportedIOS() && (utils.isSafari() || utils.isChrome() || utils.isFacebook());
+            var androidBrowserIsSupported = utils.isAndroid() && utils.isChrome();
+            var mobileBrowserIsSupported = (iosBrowserIsSupported || androidBrowserIsSupported);
             var isAndroidSdk = this.get('sdkplatform') === 1;
-            return (!this.get('sdkplatform') && autostartIsConfigured && (iosDeviceIsSupported || androidDeviceIsSupported)) || isAndroidSdk;
+            var platformCanAutostart = (!this.get('sdkplatform') && autostartAdsIsEnabled && mobileBrowserIsSupported) || isAndroidSdk;
+            return this.get('autostart') && platformCanAutostart;
         };
     };
 


### PR DESCRIPTION
checks for autostart in android sdk and made autoStartOnMobile more readable:

Note to reviewer: review after [PR in Android SDK](https://github.com/jwplayer/jwplayer-android-sdk-bishop/pull/691) is accepted
enables autostart in android sdk

Fixes #
JW7-3825
