### PR TITLE
Support player element out-of-DOM during setup

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -195,6 +195,11 @@ define([
             _model.on('change:viewSetup', function(model, viewSetup) {
                 if (viewSetup) {
                     _this.showView(_view.element());
+                }
+            });
+
+            _model.on('change:inDom', function(model, inDom) {
+                if (inDom) {
                     _observePlayerContainer(_view.element());
                 }
             });
@@ -968,12 +973,12 @@ define([
         },
 
         showView: function(viewElement) {
-            if (!document.documentElement.contains(this.currentContainer)) {
+            if (!document.body.contains(this.currentContainer)) {
                 // This implies the player was removed from the DOM before setup completed
                 //   or a player has been "re" setup after being removed from the DOM
-                this.currentContainer = document.getElementById(this._model.get('id'));
-                if (!this.currentContainer) {
-                    return;
+                var newContainer = document.getElementById(this._model.get('id'));
+                if (newContainer) {
+                    this.currentContainer = newContainer;
                 }
             }
 


### PR DESCRIPTION
This fixes setup for pages that remove the player element during setup. It also adds support for setting up the player with an element rather than an id and adding the player's container on or after the ready event.

Example 1 - element is removed during setup and added on or after ready:
```html
<body>
<div id="player-container">
    <div id="player"></div>
</div>
<script type="text/javascript">
    var container = document.body.querySelector('#player-container');
    jwplayer("player").setup({
        file: '//video.mp4'
    }).on('ready', function() {
        document.body.appendChild(container);
    });
    document.body.removeChild(container);
</script>
</body>
```

Example 2 - player is setup with element not in DOM, element is added afterwards
```html
<body>
<div id="player-container"></div>
<script type="text/javascript">
    var element = document.createElement('div');
    jwplayer(element).setup({
        file: '//video.mp4'
    }).on('ready', function() {
        document.body.appendChild(this.getContainer());
    });
</script>
</body>
```

Fixes JW7-4200 and #1136