### PR TITLE
Adds browsers prefixes via PostCSS Autoprefixer

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -37,7 +37,10 @@
         "shorthand-property-no-redundant-values": true,
 
         "property-case": "lower",
-        "property-no-unknown": true,
+        "property-no-unknown": [
+            true,
+            { "ignoreProperties": ["font-smoothing"] }
+        ],
 
         "declaration-bang-space-after": "never",
         "declaration-bang-space-before": "always",

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -41,6 +41,20 @@ module.exports = function(grunt) {
         starttime: new Date(),
         pkg: packageInfo,
 
+        stylelint: {
+            options: {
+                configFile: '.stylelintrc',
+                formatter: 'string',
+                ignoreDisables: false,
+                failOnError: true,
+                reportNeedlessDisables: false,
+                syntax: 'less'
+            },
+            src: [
+                'src/**/*.less'
+            ]
+        },
+
         less: {
             options: {
                 compress: false,
@@ -82,18 +96,33 @@ module.exports = function(grunt) {
             }
         },
 
-        stylelint: {
+        postcss: {
             options: {
-                configFile: '.stylelintrc',
-                formatter: 'string',
-                ignoreDisables: false,
+                processors: [
+                    require('autoprefixer')
+                ],
+                map: true,
                 failOnError: true,
-                reportNeedlessDisables: false,
-                syntax: 'less'
+                writeDest: true
             },
-            src: [
-                'src/**/*.less'
-            ]
+            internal: {
+                src: [
+                    'bin-debug/reference/*.css',
+                    'bin-debug/skins/*.css',
+                ]
+            },
+            debug: {
+                src: [
+                    'bin-debug/reference/*.css',
+                    'bin-debug/skins/*.css',
+                    'bin-release/skins/*.css'
+                ]
+            },
+            release: {
+                src: [
+                    'bin-release/skins/*.css'
+                ]
+            }
         },
 
         watch : {
@@ -116,7 +145,7 @@ module.exports = function(grunt) {
             },
             css: {
                 files: ['src/css/{,*/}*.less'],
-                tasks: ['stylelint', 'webpack:debug', 'less:debug']
+                tasks: ['stylelint', 'webpack:debug', 'less:debug', 'postcss:debug']
             },
             tests: {
                 files : ['test/{,*/}*.js'],
@@ -311,7 +340,8 @@ module.exports = function(grunt) {
         'webpack',
         'lint:player',
         'stylelint',
-        'less'
+        'less',
+        'postcss'
     ]);
 
     grunt.registerTask('build-flash', [

--- a/browserslist
+++ b/browserslist
@@ -1,0 +1,16 @@
+> 1%
+Last 3 Chrome versions
+Last 3 ChromeAndroid versions
+Android >= 4
+Firefox >= 30
+Last 3 FirefoxAndroid versions
+Safari >= 9
+iOs >= 8
+Last 4 Edge versions
+Last 4 ExplorerMobile versions
+IE 9-11
+Last 2 Samsung versions
+Last 5 BlackBerry versions
+Last 5 OperaMobile versions
+Last 5 OperaMini versions
+Last 5 UCAndroid versions

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "dependencies": {},
   "devDependencies": {
     "async": "2.1.4",
+    "autoprefixer": "6.7.7",
     "autoprefixer-loader": "3.2.0",
     "babel-core": "^6.24.0",
     "babel-loader": "^6.4.0",
@@ -28,6 +29,7 @@
     "grunt-contrib-watch": "1.0.0",
     "grunt-flash-compiler": "0.3.5",
     "grunt-karma": "2.0.0",
+    "grunt-postcss": "0.8.0",
     "grunt-stylelint": "0.7.0",
     "handlebars": "4.0.5",
     "handlebars-loader": "1.2.0",
@@ -54,6 +56,7 @@
     "node-libs-browser": "1.0.0",
     "phantomjs-polyfill": "0.0.2",
     "phantomjs-prebuilt": "2.1.7",
+    "postcss-loader": "1.3.3",
     "qunitjs": "1.23.1",
     "raw-loader": "0.5.1",
     "requirejs": "2.3.3",

--- a/src/css/controls/flags/ads.less
+++ b/src/css/controls/flags/ads.less
@@ -10,6 +10,7 @@
         display: none;
     }
 
+    /* captions styles code specific to native text track rendering */
     video::-webkit-media-text-track-container {
         display: none;
     }

--- a/src/css/controls/flags/controls-hidden.less
+++ b/src/css/controls/flags/controls-hidden.less
@@ -17,6 +17,7 @@
         max-height: none;
     }
 
+    /* captions styles code specific to native text track rendering */
     video::-webkit-media-text-track-container {
         max-height: none;
     }

--- a/src/css/controls/flags/time-slider-above.less
+++ b/src/css/controls/flags/time-slider-above.less
@@ -385,6 +385,7 @@
         */
 
         .jw-captions,
+        /* captions styles code specific to native text track rendering */
         video:-webkit-media-text-track-container {
             max-height: ~"calc(100% - 64px)";
         }

--- a/src/css/controls/flags/touch.less
+++ b/src/css/controls/flags/touch.less
@@ -15,6 +15,7 @@
             bottom: 4.25em;
         }
 
+        /* captions styles code specific to native text track rendering */
         video::-webkit-media-text-track-container {
             /* need to compensate for the control bar being 3.75em on mobile */
             max-height: ~"calc(100% - 60px)";

--- a/src/css/controls/flags/user-inactive.less
+++ b/src/css/controls/flags/user-inactive.less
@@ -7,6 +7,7 @@
 
         .jw-media {
             cursor: none;
+            /* cursor hiding on media elements for Safari */
             -webkit-cursor-visibility: auto-hide;
         }
 

--- a/src/css/controls/imports/nextup.less
+++ b/src/css/controls/imports/nextup.less
@@ -2,8 +2,7 @@
 @import "icons";
 
 .jw-nextup-container {
-    -webkit-font-smoothing: antialiased;
-    -moz-font-smoothing: antialiased;
+    font-smoothing: antialiased;
     background-color: transparent;
     bottom: @controlbar-height;
     cursor: pointer;

--- a/src/css/controls/states.less
+++ b/src/css/controls/states.less
@@ -26,22 +26,9 @@
     .jw-display-icon-display .jw-icon {
         .jw-icon-buffer;
 
-        -webkit-animation: spin 2s linear infinite;
-        -moz-animation: spin 2s linear infinite;
         animation: spin 2s linear infinite;
-        @-moz-keyframes spin {
-            100% {
-                -moz-transform: rotate(360deg);
-            }
-        }
-        @-webkit-keyframes spin {
-            100% {
-                -webkit-transform: rotate(360deg);
-            }
-        }
         @keyframes spin {
             100% {
-                -webkit-transform: rotate(360deg);
                 transform: rotate(360deg);
             }
         }

--- a/src/css/jwplayer/imports/jwplayerlayout.less
+++ b/src/css/jwplayer/imports/jwplayerlayout.less
@@ -9,12 +9,8 @@
     font-family: Arial, Helvetica, sans-serif;
     background-color: #000;
 
-    // disallow text-select highlighting
+    /* disallow text-select highlighting.  Safari specific feature */
     -webkit-touch-callout: none;
-    -webkit-user-select: none;
-    -khtml-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
     user-select: none;
 
     * {

--- a/src/css/jwplayer/imports/reset.less
+++ b/src/css/jwplayer/imports/reset.less
@@ -15,5 +15,6 @@
     direction: ltr;
     font-variant: inherit;
     font-stretch: inherit;
+    /* non-standard prefixed style used in Chrome, Safari, and some MS browsers.  Not Autoprefixed */
     -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
 }

--- a/src/css/jwplayer/states.less
+++ b/src/css/jwplayer/states.less
@@ -50,6 +50,7 @@ body .jwplayer.jw-state-error {
         display: none;
     }
 
+    /* captions styles code specific to native text track rendering */
     video::-webkit-media-text-track-container {
         display: none;
     }

--- a/src/css/shared-imports/mixins.less
+++ b/src/css/shared-imports/mixins.less
@@ -3,7 +3,7 @@
 /* Mixin for icon default formatting */
 .jw-icon {
     font-family: "jw-icons";
-    -webkit-font-smoothing: antialiased;
+    font-smoothing: antialiased;
     font-style: normal;
     font-weight: normal;
     text-transform: none;
@@ -41,6 +41,7 @@
         }
 
         .jwplayer& {
+            /* captions styles code specific to native text track rendering */
             video::-webkit-media-text-track-container {
                 max-height: ~"calc(~'100%' - ~'46px')";
             }
@@ -357,6 +358,7 @@
             }
 
             .jwplayer& {
+                /* captions styles code specific to native text track rendering */
                 video::-webkit-media-text-track-container {
                     max-height: ~"calc(~'100%' - ~'38px')";
                 }

--- a/src/css/skins/seven.less
+++ b/src/css/skins/seven.less
@@ -44,7 +44,8 @@
 
     .jw-text {
         text-rendering: optimizeLegibility;
-        -webkit-font-smoothing: antialiased;
+        // OSX Safari specific style for improving legibility
         -moz-osx-font-smoothing: grayscale;
+        font-smoothing: antialiased;
     }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -123,7 +123,7 @@ var multiConfig = _.compact(_.map([
                     loaders: [
                         'simple-style-loader',
                         'css',
-                        'autoprefixer?browsers=' + encodeURIComponent('> 1%'),
+                        'postcss-loader',
                         'less?compress'
                     ]
                 },
@@ -144,6 +144,11 @@ var multiConfig = _.compact(_.map([
                     loader: 'babel-loader'
                 }
             ]
+        },
+        postcss: function() {
+            return [
+                require('autoprefixer')
+            ];
         }
     });
 }));


### PR DESCRIPTION
This adds PostCSS and its autoprefixer plugin to both the web pack and grunt build processes.  The prefixes added are based on the browsers present in the browserslist file.  Some nonstandard styles are retained for features specific to the platform.

JW7-4100
