### PR TITLE
Set/Clear requestAnimationFrame & setTimeout correctly

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -1039,7 +1039,7 @@ define([
 
             _currentState = model.get('state');
             // Throttle all state change UI updates except for play to prevent iOS 10 animation bug
-            clearTimeout(_previewDisplayStateTimeout);
+            _cancelDelayResize(_previewDisplayStateTimeout);
 
             if (_currentState === states.PLAYING) {
                 _stateUpdate(model, _currentState);


### PR DESCRIPTION
This bug was causing us to clear the timeout id using the
requestAnimationFrame id, which affected casting

JW7-4207