### PR TITLE
Fix controls not displaying when logo exists on player

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -440,10 +440,10 @@ define([
                 _captionsRenderer.renderCues(true);
             });
 
-            _logo.setContainer(controls.right);
-
             controls.enable(_api, _model);
             controls.addActiveListeners(_logo.element());
+
+            _logo.setContainer(controls.right);
 
             _model.on('change:scrubbing', _stateHandler);
             _model.change('streamType', _setLiveMode, this);


### PR DESCRIPTION
Fixes controls not displaying when a logo exists on player.  Previously, we would be trying to add the logo to a container that won’t necessarily exist.  placing _logo.setContainer after the controls.enable() ensures that it exists.