### PR TITLE
Downgrade css-loader to 0.26.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "babel-plugin-transform-es2015-modules-commonjs": "6.24.0",
     "babel-preset-es2015": "6.24.0",
     "babel-preset-es2015-loose": "8.0.0",
-    "css-loader": "0.28.0",
+    "css-loader": "0.26.4",
     "eslint": "3.19.0",
     "eslint-config-jwplayer-base": "7.1.0",
     "eslint-plugin-import": "2.2.0",


### PR DESCRIPTION
Saves us ~47k. See: https://github.com/webpack-contrib/css-loader/issues/454