### PR TITLE
Bugfix/font smoothing

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -38,8 +38,7 @@
 
         "property-case": "lower",
         "property-no-unknown": [
-            true,
-            { "ignoreProperties": ["font-smoothing"] }
+            true
         ],
 
         "declaration-bang-space-after": "never",

--- a/src/css/controls/imports/icons.less
+++ b/src/css/controls/imports/icons.less
@@ -7,6 +7,19 @@
     src: url("../../../../assets/fonts/jw-icons.woff") format("woff"), url("../../../../assets/fonts/jw-icons.ttf") format("truetype");
 }
 
+.jw-icon {
+    font-family: "jw-icons";
+    font-style: normal;
+    font-weight: normal;
+    text-transform: none;
+    background-color: transparent;
+    font-variant: normal;
+    /* font-smoothing is a private setting not transformed by PostCSS */
+    -webkit-font-smoothing: antialiased;
+    /* OSX Firefox specific style for improving legibility */
+    -moz-osx-font-smoothing: grayscale;
+}
+
 /*** ICONS ***/
 .jw-icon-audio-tracks {
     &:before {

--- a/src/css/controls/imports/icons.less
+++ b/src/css/controls/imports/icons.less
@@ -5,15 +5,6 @@
 @font-face {
     font-family: "jw-icons";
     src: url("../../../../assets/fonts/jw-icons.woff") format("woff"), url("../../../../assets/fonts/jw-icons.ttf") format("truetype");
-    font-weight: normal;
-    font-style: normal;
-}
-
-.jw-icon-inline,
-.jw-icon-tooltip,
-.jw-icon-display,
-.jw-controlbar .jw-menu .jw-option:before {
-    .jw-icon;
 }
 
 /*** ICONS ***/

--- a/src/css/controls/imports/jwplayerlayout.less
+++ b/src/css/controls/imports/jwplayerlayout.less
@@ -50,6 +50,10 @@
     text-align: center;
     font-variant: normal;
     font-stretch: normal;
+    /* font-smoothing is a private setting not transformed by PostCSS */
+    -webkit-font-smoothing: antialiased;
+    /* OSX Firefox specific style for improving legibility */
+    -moz-osx-font-smoothing: grayscale;
 }
 
 /* These items can intercept pointer-events */

--- a/src/css/controls/imports/jwplayerlayout.less
+++ b/src/css/controls/imports/jwplayerlayout.less
@@ -50,10 +50,6 @@
     text-align: center;
     font-variant: normal;
     font-stretch: normal;
-    /* font-smoothing is a private setting not transformed by PostCSS */
-    -webkit-font-smoothing: antialiased;
-    /* OSX Firefox specific style for improving legibility */
-    -moz-osx-font-smoothing: grayscale;
 }
 
 /* These items can intercept pointer-events */

--- a/src/css/controls/imports/nextup.less
+++ b/src/css/controls/imports/nextup.less
@@ -2,9 +2,6 @@
 @import "icons";
 
 .jw-nextup-container {
-    font-smoothing: antialiased;
-    /* Firefox specific style for improving legibility on OSX */
-    -moz-osx-font-smoothing: grayscale;
     background-color: transparent;
     bottom: @controlbar-height;
     cursor: pointer;

--- a/src/css/controls/states.less
+++ b/src/css/controls/states.less
@@ -111,6 +111,10 @@ body .jwplayer.jw-state-error.jw-flag-audio-player {
         display: none;
     }
 
+    .jw-title {
+        padding-top: 4px;
+    }
+
     .jw-title-primary {
         width: auto;
         display: inline-block;

--- a/src/css/controls/states.less
+++ b/src/css/controls/states.less
@@ -92,7 +92,6 @@ body .jw-error,
 body .jwplayer.jw-state-error {
     .jw-icon-display {
         cursor: default;
-        .jw-icon;
         .jw-icon-error;
     }
 }

--- a/src/css/shared-imports/mixins.less
+++ b/src/css/shared-imports/mixins.less
@@ -1,19 +1,5 @@
 @import "vars";
 
-/* Mixin for icon default formatting */
-.jw-icon {
-    font-family: "jw-icons";
-    font-style: normal;
-    font-weight: normal;
-    text-transform: none;
-    background-color: transparent;
-    font-variant: normal;
-    /* font-smoothing is a private setting not transformed by PostCSS */
-    -webkit-font-smoothing: antialiased;
-    /* OSX Firefox specific style for improving legibility */
-    -moz-osx-font-smoothing: grayscale;
-}
-
 .inset-controlbar() {
     &:not(.jw-flag-time-slider-above):not(.jw-flag-audio-player) {
         &,

--- a/src/css/shared-imports/mixins.less
+++ b/src/css/shared-imports/mixins.less
@@ -3,14 +3,15 @@
 /* Mixin for icon default formatting */
 .jw-icon {
     font-family: "jw-icons";
-    font-smoothing: antialiased;
-    /* OSX Safari specific style for improving legibility */
-    -moz-osx-font-smoothing: grayscale;
     font-style: normal;
     font-weight: normal;
     text-transform: none;
     background-color: transparent;
     font-variant: normal;
+    /* font-smoothing is a private setting not transformed by PostCSS */
+    -webkit-font-smoothing: antialiased;
+    /* OSX Firefox specific style for improving legibility */
+    -moz-osx-font-smoothing: grayscale;
 }
 
 .inset-controlbar() {

--- a/src/css/skins/seven.less
+++ b/src/css/skins/seven.less
@@ -45,6 +45,10 @@
 
     .jw-text {
         text-rendering: optimizeLegibility;
+        /* font-smoothing is a private setting not transformed by PostCSS */
+        -webkit-font-smoothing: antialiased;
+        /* OSX Firefox specific style for improving legibility */
+        -moz-osx-font-smoothing: grayscale;
     }
 
     .jw-slider-container {

--- a/src/css/skins/seven.less
+++ b/src/css/skins/seven.less
@@ -45,9 +45,6 @@
 
     .jw-text {
         text-rendering: optimizeLegibility;
-        font-smoothing: antialiased;
-        /* OSX Safari specific style for improving legibility */
-        -moz-osx-font-smoothing: grayscale;
     }
 
     .jw-slider-container {


### PR DESCRIPTION
Remove "font-smoothing" and add private "-webkit-font-smoothing" style for icons and text. Remove some duplicate style definitions - mainly get rid of jw-icon font style duplication by moving it out of mixins.

JW7-4241