### PR TITLE
Hide logo when player is inactive on chromeless player with logo.hide = true

### DIFF
--- a/src/css/controls/states.less
+++ b/src/css/controls/states.less
@@ -3,7 +3,7 @@
 
 // setup
 .jw-state-setup .jw-controls {
-    display: none;
+    visibility: hidden;
 }
 
 // idle

--- a/src/css/jwplayer.less
+++ b/src/css/jwplayer.less
@@ -27,5 +27,5 @@
 @import "jwplayer/flags/skinloading";            // Hides content until styles loaded.  Rename stylesloading.les
 @import "jwplayer/flags/fullscreen";
 @import "jwplayer/flags/flash-blocked";
-
+@import "jwplayer/flags/user-inactive";
 @import "jwplayer/flags/audioplayer";

--- a/src/css/jwplayer/flags/user-inactive.less
+++ b/src/css/jwplayer/flags/user-inactive.less
@@ -1,0 +1,11 @@
+@import "../../shared-imports/vars";
+
+.jwplayer.jw-flag-user-inactive:not(.jw-flag-media-audio) {
+    &.jw-state-playing {
+        .jw-logo.jw-hide {
+            visibility: hidden;
+            pointer-events: none;
+            opacity: 0;
+        }
+    }
+}

--- a/src/css/jwplayer/states.less
+++ b/src/css/jwplayer/states.less
@@ -3,6 +3,9 @@
 // setup
 .jw-state-setup {
     background-color: transparent;
+    .jw-logo {
+        visibility: hidden;
+    }
 }
 
 // errors

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -414,10 +414,6 @@ define([
             });
         }
 
-        hideComponents() {
-            this.closeMenus();
-        }
-
         rewind() {
             const currentPosition = this._model.get('position');
             const duration = this._model.get('duration');

--- a/src/js/view/logo.js
+++ b/src/js/view/logo.js
@@ -25,23 +25,16 @@ define([
         _.extend(this, Events);
 
         this.setup = function() {
-            _settings = _.extend({}, LogoDefaults, _logoConfig);
-            _settings.hide = (_settings.hide.toString() === 'true');
-
-            if (!_settings.file) {
+            if (!_logoConfig.file) {
                 return;
             }
+            _settings = _.extend({}, LogoDefaults, _logoConfig);
+            _settings.position = _settings.position || LogoDefaults.position;
+            _settings.hide = (_settings.hide.toString() === 'true');
 
             if (!_logo) {
-                _logo = utils.createElement(logoTemplate());
+                _logo = utils.createElement(logoTemplate(_settings));
             }
-
-            if (_settings.hide) {
-                // This causes it to fade out when jw-flag-user-inactive
-                utils.addClass(_logo, 'jw-hide');
-            }
-
-            utils.addClass(_logo, 'jw-logo-' + (_settings.position || LogoDefaults.position));
 
             _model.set('logo', _settings);
 

--- a/src/js/view/logo.js
+++ b/src/js/view/logo.js
@@ -17,23 +17,22 @@ define([
     };
 
     return function Logo(_model) {
+        _.extend(this, Events);
+
         var _logo;
         var _settings;
         var _img = new Image();
-        var _logoConfig = _.extend({}, _model.get('logo'));
-
-        _.extend(this, Events);
 
         this.setup = function() {
-            if (!_logoConfig.file) {
+            _settings = _.extend({}, LogoDefaults, _model.get('logo'));
+            if (!_settings.file) {
                 return;
             }
-            _settings = _.extend({}, LogoDefaults, _logoConfig);
             _settings.position = _settings.position || LogoDefaults.position;
             _settings.hide = (_settings.hide.toString() === 'true');
 
             if (!_logo) {
-                _logo = utils.createElement(logoTemplate(_settings));
+                _logo = utils.createElement(logoTemplate(_settings.position, _settings.hide));
             }
 
             _model.set('logo', _settings);

--- a/src/js/view/utils/user-activity.js
+++ b/src/js/view/utils/user-activity.js
@@ -1,0 +1,53 @@
+define([
+    'utils/backbone.events',
+    'utils/helpers',
+    'utils/underscore',
+], function (Events, utils, _) {
+
+    const ACTIVE_TIMEOUT = utils.isMobile() ? 4000 : 2000;
+
+    return class UserActivity {
+        constructor() {
+            _.extend(this, Events);
+
+            // Alphabetic order
+            // Any property on the prototype should be initialized here first
+            this.activeTimeout = -1;
+            this.showing = false;
+            this.activeListeners = {
+                mousemove: () => clearTimeout(this.activeTimeout),
+                mouseout: () => this.userActive()
+            };
+        }
+
+        addActiveListeners(element) {
+            if (element && !utils.isMobile()) {
+                element.addEventListener('mousemove', this.activeListeners.mousemove);
+                element.addEventListener('mouseout', this.activeListeners.mouseout);
+            }
+        }
+
+        removeActiveListeners(element) {
+            if (element) {
+                element.removeEventListener('mousemove', this.activeListeners.mousemove);
+                element.removeEventListener('mouseout', this.activeListeners.mouseout);
+            }
+        }
+
+        userActive(timeout) {
+            clearTimeout(this.activeTimeout);
+            this.activeTimeout = setTimeout(() => this.userInactive(),
+                timeout || ACTIVE_TIMEOUT);
+            if (!this.showing) {
+                this.showing = true;
+                this.trigger('userActive');
+            }
+        }
+
+        userInactive() {
+            clearTimeout(this.activeTimeout);
+            this.showing = false;
+            this.trigger('userInactive');
+        }
+    };
+});

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -1,4 +1,5 @@
 import playerTemplate from 'templates/player';
+import UserActivity from 'view/utils/user-activity';
 
 define([
     'events/events',
@@ -12,13 +13,12 @@ define([
     'view/utils/breakpoint',
     'view/utils/flag-no-focus',
     'view/utils/clickhandler',
-    'view/utils/user-activity',
     'view/captionsrenderer',
     'view/logo',
     'view/preview',
     'view/title',
 ], function(events, states, Events, utils, _, activeTab, raf, requestFullscreenHelper, setBreakpoint, flagNoFocus,
-            ClickHandler, UserActivity, CaptionsRenderer, Logo, Preview, Title) {
+            ClickHandler, CaptionsRenderer, Logo, Preview, Title) {
 
     var _styles = utils.style;
     var _bounds = utils.bounds;

--- a/src/templates/logo.js
+++ b/src/templates/logo.js
@@ -1,5 +1,5 @@
-export default (config) => {
+export default (position, hide) => {
     // jw-hide causes the logo to fade out when jw-flag-user-inactive
-    const jwhide = config.hide ? ' jw-hide' : '';
-    return `<div class="jw-logo jw-logo-${config.position}${jwhide} jw-reset"></div>`;
+    const jwhide = hide ? ' jw-hide' : '';
+    return `<div class="jw-logo jw-logo-${position}${jwhide} jw-reset"></div>`;
 };

--- a/src/templates/logo.js
+++ b/src/templates/logo.js
@@ -1,3 +1,5 @@
-export default () => {
-    return `<div class="jw-logo jw-reset"></div>`;
+export default (config) => {
+    // jw-hide causes the logo to fade out when jw-flag-user-inactive
+    const jwhide = config.hide ? ' jw-hide' : '';
+    return `<div class="jw-logo jw-logo-${config.position}${jwhide} jw-reset"></div>`;
 };


### PR DESCRIPTION
Move user active/inactive css logic back into the player view to support logo hiding functionality that is enabled in custom logo config options:

```
    "logo": {
        "hide": true, // huzza!
        "file": "logo.png"
    }
```

I'm not a fan of these changes, and seriously think, as part of chromeless this feature should be deprecated; The feature should still be there so that the logo hides with controls, but when controls are disabled, logo hiding should also be disabled.