### PR TITLE
Resize controls once added

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -451,7 +451,9 @@ define([
 
             // refresh breakpoint and timeslider classes
             if (_lastHeight) {
-                _setContainerDimensions();
+                var breakPoint = setBreakpoint(_playerElement, _lastWidth, _lastHeight);
+                controls.resize(_model, breakPoint);
+                _captionsRenderer.renderCues(true);
             }
         };
 


### PR DESCRIPTION
Call `controls.resize` if the view has resized when adding controls. This ensures all controls flags have been set on the player element (`.jw-flag-audio-player` `.jw-flag-small-player` and `.jw-flag-time-slider-above`).

JW7-4255