### PR TITLE
Cleanup logo template and styles

### DIFF
--- a/src/css/controls/states.less
+++ b/src/css/controls/states.less
@@ -1,9 +1,9 @@
 @import "../shared-imports/vars";
 @import "imports/icons";
 
-// setup
+// controls are displayed but hidden during setup for font icons to load
 .jw-state-setup .jw-controls {
-    display: none;
+    visibility: hidden;
 }
 
 // idle

--- a/src/css/jwplayer/states.less
+++ b/src/css/jwplayer/states.less
@@ -3,6 +3,10 @@
 // setup
 .jw-state-setup {
     background-color: transparent;
+
+    .jw-logo {
+        visibility: hidden;
+    }
 }
 
 // errors

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -414,10 +414,6 @@ define([
             });
         }
 
-        hideComponents() {
-            this.closeMenus();
-        }
-
         rewind() {
             const currentPosition = this._model.get('position');
             const duration = this._model.get('duration');

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -353,7 +353,9 @@ define([
             clearTimeout(this.activeTimeout);
             this.showing = false;
             if (this.controlbar) {
-                this.controlbar.hideComponents();
+                this.controlbar.closeMenus({
+                    type: 'userInactive'
+                });
             }
             utils.addClass(this.playerContainer, 'jw-flag-user-inactive');
             this.trigger('userInactive', this.showing);

--- a/src/js/view/logo.js
+++ b/src/js/view/logo.js
@@ -17,31 +17,24 @@ define([
     };
 
     return function Logo(_model) {
+        _.extend(this, Events);
+
         var _logo;
         var _settings;
         var _img = new Image();
-        var _logoConfig = _.extend({}, _model.get('logo'));
-
-        _.extend(this, Events);
 
         this.setup = function() {
-            _settings = _.extend({}, LogoDefaults, _logoConfig);
-            _settings.hide = (_settings.hide.toString() === 'true');
-
+            _settings = _.extend({}, LogoDefaults, _model.get('logo'));
             if (!_settings.file) {
                 return;
             }
 
+            _settings.position = _settings.position || LogoDefaults.position;
+            _settings.hide = (_settings.hide.toString() === 'true');
+
             if (!_logo) {
-                _logo = utils.createElement(logoTemplate());
+                _logo = utils.createElement(logoTemplate(_settings.position, _settings.hide));
             }
-
-            if (_settings.hide) {
-                // This causes it to fade out when jw-flag-user-inactive
-                utils.addClass(_logo, 'jw-hide');
-            }
-
-            utils.addClass(_logo, 'jw-logo-' + (_settings.position || LogoDefaults.position));
 
             _model.set('logo', _settings);
 

--- a/src/templates/logo.js
+++ b/src/templates/logo.js
@@ -1,3 +1,4 @@
-export default () => {
-    return `<div class="jw-logo jw-reset"></div>`;
+export default (position, hide) => {
+    const jwhide = hide ? ' jw-hide' : '';
+    return `<div class="jw-logo jw-logo-${position}${jwhide} jw-reset"></div>`;
 };


### PR DESCRIPTION
...and remove alias method from controlbar.

- Logo should not appear before player is ready
- Change controls setup state display mode for fonts to load earlier
- Logo should not hide when player becomes inactive in Chromeless mode (deprecated logo.hide support when controls is false. Coded #1974 doesn't make sense: )

JW7-4237
