### PR TITLE
Make swf a minimum of 45px on IE11 to prevent Flash block behavior

### DIFF
--- a/src/css/jwplayer/flags/audioplayer.less
+++ b/src/css/jwplayer/flags/audioplayer.less
@@ -1,12 +1,20 @@
 .jw-flag-audio-player {
-    // Hack may not currently work
     .jw-media {
         visibility: hidden;
+    }
 
+    &:not(.jw-ie) {
         // small object tag prevents chrome Power Save throttle
         object {
             width: 1px;
             height: 1px;
+        }
+    }
+
+    .jw-ie {
+        // min 45px object tag prevents IE11 CORS Flash Blocking
+        object {
+            min-height: 45px;
         }
     }
 }


### PR DESCRIPTION
Attempt to avoid IE11 Flash blocking of CORS swf by enforcing a minimum embed size on the object element.

JW7-3632