### PR TITLE
Fix intermittent view setup Promise error in IE11

### DIFF
--- a/src/js/controller/setup-steps.js
+++ b/src/js/controller/setup-steps.js
@@ -52,7 +52,8 @@ define([
                 method: _setupView,
                 depends: [
                     'LOAD_SKIN',
-                    'LOAD_XO_POLYFILL'
+                    'LOAD_XO_POLYFILL',
+                    'LOAD_PROMISE_POLYFILL'
                 ]
             },
             INIT_PLUGINS: {

--- a/test/unit/api-test.js
+++ b/test/unit/api-test.js
@@ -132,19 +132,27 @@ define([
     });
 
     test('replaces and restores container', function(assert) {
+        var done = assert.async();
+
         var originalContainer = createContainer('player');
         var api = new Api(originalContainer, _.noop);
 
         var elementInDom = document.getElementById('player');
         assert.strictEqual(elementInDom, originalContainer, 'container is not replaced before setup');
 
-        api.setup({});
-        elementInDom = document.getElementById('player');
-        assert.notEqual(elementInDom, originalContainer, 'container is replaced after setup');
+        api.setup(_.extend({}, configSmall)).on('ready', function() {
+            elementInDom = document.getElementById('player');
+            assert.notEqual(elementInDom, originalContainer, 'container is replaced after setup');
 
-        api.remove();
-        elementInDom = document.getElementById('player');
-        assert.strictEqual(elementInDom, originalContainer, 'container is restored after remove');
+            api.remove();
+            elementInDom = document.getElementById('player');
+            assert.strictEqual(elementInDom, originalContainer, 'container is restored after remove');
+
+            done();
+        }).on('setupError', function() {
+            assert.ok(false, 'FAIL');
+            done();
+        });
     });
 
     test('event dispatching', function(assert) {


### PR DESCRIPTION
Also updated the api test since view setup is not guaranteed to be synchronous. Skin or polyfill loading means the player container won't be added to the DOM until later, so the 'replaces and restores container' test is now async.

Fixes #1969 in development