### PR TITLE
Address Flash blocking in Chrome 57 with controlbar sized player and flash primary

### DIFF
--- a/src/css/jwplayer/flags/audioplayer.less
+++ b/src/css/jwplayer/flags/audioplayer.less
@@ -1,20 +1,14 @@
 .jw-flag-audio-player {
-    .jw-media {
+    &:not(.jw-flag-flash-blocked) .jw-media {
         visibility: hidden;
     }
 
-    &:not(.jw-ie) {
-        // small object tag prevents chrome Power Save throttle
-        object {
-            width: 1px;
-            height: 1px;
-        }
+    .jw-title {
+        background: none;
     }
 
-    .jw-ie {
-        // min 45px object tag prevents IE11 CORS Flash Blocking
-        object {
-            min-height: 45px;
-        }
+    // min 45px object tag prevents IE11 CORS Flash Blocking
+    object {
+        min-height: 45px;
     }
 }


### PR DESCRIPTION
Resizing the swf to 1px no longer prevents Flash throttling in Chrome. The swf must not be hidden when blocked so the user can click to play Flash.

While developers should no longer use primary flash, in case they are, this will help.

Player config:
```js
{
"file": "http://playertest.longtailvideo.com/adaptive/bbbfull/bbbfull.m3u8",
"flashloader": "//ssl.p.jwpcdn.com/player/v/7.10.5/jwplayer.loader.swf",
"flashplayer": "//ssl.p.jwpcdn.com/player/v/7.10.5/jwplayer.flash.swf",
"height": 40,
"primary" : "flash"
}
```

JW7-3632