### PR TITLE
Disable doubleclick fullscreen for chromeless

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -372,7 +372,7 @@ define([
                         }
                     }
                 },
-                doubleClick: () => api.setFullscreen(),
+                doubleClick: () => _controls && api.setFullscreen(),
                 move: () => _controls && _controls.userActive(),
                 over: () => _controls && _controls.userActive()
             });


### PR DESCRIPTION
We were not checking if we had controls before triggering fullscreen

JW7-4243