### PR TITLE
Check null for applyProviderListeners

### DIFF
--- a/src/js/controller/instream-flash.js
+++ b/src/js/controller/instream-flash.js
@@ -67,6 +67,9 @@ define([
             this.swf.triggerFlash('instream:init');
 
             this.applyProviderListeners = function(provider) {
+                if (!provider) {
+                    return;
+                }
                 this.model.on('change:volume', function(data, value) {
                     provider.volume(value);
                 }, this);

--- a/src/js/controller/instream-html5.js
+++ b/src/js/controller/instream-html5.js
@@ -60,6 +60,10 @@ define([
             // check provider after item change
             _checkProvider(provider);
 
+            if (!provider) {
+                return;
+            }
+
             // Match the main player's controls state
             provider.off(events.JWPLAYER_ERROR);
             provider.on(events.JWPLAYER_ERROR, function(data) {


### PR DESCRIPTION
Allow for `applyProviderListeners` t be called from ads plugins without a provider to reset the current ads provider event listeners (html5 only). Return early when `applyProviderListeners` is called without a provider.

ADS-218