### PR TITLE
Fix chromeless title, cursor, and captions renderer position

### DIFF
--- a/src/css/controls/states.less
+++ b/src/css/controls/states.less
@@ -8,10 +8,6 @@
 
 // idle
 .jw-state-idle {
-    // Show the title
-    .jw-title {
-        display: block;
-    }
 
     /* hide control bar and clear display container padding on idle state unless cast available flag is set */
     &:not(.jw-flag-cast-available) {

--- a/src/css/jwplayer/imports/jwplayerlayout.less
+++ b/src/css/jwplayer/imports/jwplayerlayout.less
@@ -55,7 +55,6 @@
 
 .jw-media {
     overflow: hidden;
-    cursor: pointer;
 }
 
 .jw-plugin {

--- a/src/css/jwplayer/states.less
+++ b/src/css/jwplayer/states.less
@@ -41,6 +41,11 @@ body .jwplayer.jw-state-error,
 body .jw-error,
 .jw-state-idle,
 .jwplayer.jw-state-complete:not(.jw-flag-casting):not(.jw-flag-audio-player) {
+    // Show the title
+    .jw-title {
+        display: block;
+    }
+
     .jw-preview {
         display: block;
     }

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -345,7 +345,7 @@ define([
             if (!this.showing) {
                 utils.removeClass(this.playerContainer, 'jw-flag-user-inactive');
                 this.showing = true;
-                this.trigger('userActive', this.showing);
+                this.trigger('userActive');
             }
         }
 
@@ -358,7 +358,7 @@ define([
                 });
             }
             utils.addClass(this.playerContainer, 'jw-flag-user-inactive');
-            this.trigger('userInactive', this.showing);
+            this.trigger('userInactive');
         }
     };
 });

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -437,7 +437,7 @@ define([
             var overlaysElement = _playerElement.querySelector('.jw-overlays');
             overlaysElement.addEventListener('mousemove', _userActivityCallback);
 
-            controls.on('uiActivity', function(/* showing */) {
+            controls.on('userActive userInactive', function() {
                 _captionsRenderer.renderCues(true);
             });
 
@@ -454,6 +454,9 @@ define([
                 var breakPoint = setBreakpoint(_playerElement, _lastWidth, _lastHeight);
                 controls.resize(_model, breakPoint);
                 _captionsRenderer.renderCues(true);
+                _styles(_videoLayer, {
+                    cursor: 'pointer'
+                });
             }
         };
 
@@ -473,6 +476,9 @@ define([
 
             utils.removeClass(_playerElement, 'jw-flag-touch');
             utils.clearCss(_model.get('id'));
+            _styles(_videoLayer, {
+                cursor: ''
+            });
 
             cancelAnimationFrame(_previewDisplayStateTimeout);
             clearTimeout(_resizeMediaTimeout);
@@ -610,7 +616,7 @@ define([
             if (fullscreenState) {
                 utils.addClass(playerElement, 'jw-flag-fullscreen');
                 _styles(document.body, {
-                    'overflow-y': 'hidden'
+                    overflowY: 'hidden'
                 });
 
                 // On going fullscreen we want the control bar to fade after a few seconds
@@ -620,7 +626,7 @@ define([
             } else {
                 utils.removeClass(playerElement, 'jw-flag-fullscreen');
                 _styles(document.body, {
-                    'overflow-y': ''
+                    overflowY: ''
                 });
             }
 


### PR DESCRIPTION
Title group is part of the player, not controls so display rules go in src/css/jwplayer.

JW7-4239

**Other fixes:**

By default we don't show a pointer cursor of the media layer (.jw-media). The cursor style is not toggled with controls by the view.

Fixed user activity listener on controls used to redraw vertical position of captions with captions renderer.

Use camelCase with style util (`overflowY`).
