### PR TITLE
Controls API cleanup

### DIFF
--- a/src/js/view/controls/components/chapters.mixin.js
+++ b/src/js/view/controls/components/chapters.mixin.js
@@ -49,9 +49,9 @@ define([
 
         drawCues: function () {
             // We won't want to draw them until we have a duration
-            const duration = this._model.mediaModel.get('duration');
+            const duration = this._model.get('duration');
             if (!duration || duration <= 0) {
-                this._model.mediaModel.once('change:duration', this.drawCues, this);
+                this._model.once('change:duration', this.drawCues, this);
                 return;
             }
 

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -66,18 +66,22 @@ define([
             this.rightClickMenu = null;
             this.showing = false;
             this.unmuteCallback = null;
-            this.element = null;
+            this.div = null;
             this.right = null;
             this.activeListeners = {
                 mousemove: () => clearTimeout(this.activeTimeout),
                 mouseout: () => this.userActive()
             };
+            this.dimensions = {};
         }
 
         enable(api, model) {
             const element = this.context.createElement('div');
             element.className = 'jw-controls jw-reset';
-            this.element = element;
+            this.div = element;
+
+            const height = model.get('height');
+            const touchMode = utils.isMobile() && (typeof height === 'string' || height >= CONTOLBAR_ONLY_HEIGHT);
 
             // Display Buttons
             if (!this.displayContainer) {
@@ -86,33 +90,23 @@ define([
                 const playDisplayIcon = new PlayDisplayIcon(model);
                 const nextDisplayIcon = new NextDisplayIcon(model, api);
 
-                // toggle playback
-                playDisplayIcon.on('click tap', () => {
-                    this.trigger(events.JWPLAYER_DISPLAY_CLICK);
-                    this.userActive(1000);
-                    api.play(reasonInteraction());
-                });
-                // make playDisplayIcon clickthrough on chrome for flash to avoid power safe throttle
-                if (utils.isChrome() && !utils.isMobile()) {
-                    playDisplayIcon.el.addEventListener('mousedown', () => {
-                        const provider = model.getVideo();
-                        const isFlash = (provider && provider.getName().name.indexOf('flash') === 0);
-                        if (!isFlash) {
-                            return;
-                        }
-                        const resetPointerEvents = () => {
-                            this.context.removeEventListener('mouseup', resetPointerEvents);
-                            playDisplayIcon.el.style.pointerEvents = 'auto';
-                        };
-                        this.style.pointerEvents = 'none';
-                        this.context.addEventListener('mouseup', resetPointerEvents);
+                // Toggle playback on mobile
+                if (touchMode) {
+                    playDisplayIcon.on('tap', () => {
+                        this.trigger(events.JWPLAYER_DISPLAY_CLICK);
+                        this.userActive(1000);
+                        api.play(reasonInteraction());
                     });
+                } else {
+                    // On desktop allow media element to capture all play/pause toggle clicks
+                    playDisplayIcon.el.style.pointerEvents = 'none';
                 }
+
                 displayContainer.addButton(rewindDisplayIcon);
                 displayContainer.addButton(playDisplayIcon);
                 displayContainer.addButton(nextDisplayIcon);
 
-                this.element.appendChild(displayContainer.element());
+                this.div.appendChild(displayContainer.element());
                 this.displayContainer = displayContainer;
             }
 
@@ -128,12 +122,17 @@ define([
             this.right.appendChild(this.dock.element());
 
             // Touch UI mode when we're on mobile and we have a percentage height or we can fit the large UI in
-            const height = model.get('height');
-            if (utils.isMobile() && (typeof height === 'string' || height >= CONTOLBAR_ONLY_HEIGHT)) {
+            if (touchMode) {
                 utils.addClass(this.playerContainer, 'jw-flag-touch');
             } else {
                 this.rightClickMenu = new RightClick();
-                this.rightClickMenu.setup(model, this.playerContainer, this.playerContainer);
+                model.change('flashBlocked', (modelChanged, isBlocked) => {
+                    if (isBlocked) {
+                        this.rightClickMenu.destroy();
+                    } else {
+                        this.rightClickMenu.setup(modelChanged, this.playerContainer, this.playerContainer);
+                    }
+                });
             }
 
             // Next Up Tooltip
@@ -143,7 +142,7 @@ define([
                 this.nextUpToolTip = nextUpToolTip;
 
                 // NextUp needs to be behind the controlbar to not block other tooltips
-                this.element.appendChild(nextUpToolTip.element());
+                this.div.appendChild(nextUpToolTip.element());
             }
 
             // Controlbar
@@ -152,14 +151,14 @@ define([
                 this.controlbar.on(events.JWPLAYER_USER_ACTION, () => this.userActive());
             }
             this.addActiveListeners(this.controlbar.element());
-            this.element.appendChild(this.controlbar.element());
+            this.div.appendChild(this.controlbar.element());
 
             // Unmute Autoplay Button. Ignore iOS9. Muted autoplay is supported in iOS 10+
             if (model.get('autostartMuted')) {
                 const unmuteCallback = () => this.unmuteAutoplay(api, model);
                 this.mute = button('jw-autostart-mute jw-off', unmuteCallback, model.get('localization').volume);
                 this.mute.show();
-                this.element.appendChild(this.mute.element());
+                this.div.appendChild(this.mute.element());
                 // Set mute state in the controlbar
                 this.controlbar.renderVolume(true, model.get('volume'));
                 // Hide the controlbar until the autostart flag is removed
@@ -256,15 +255,16 @@ define([
             // Show controls when enabled
             this.userActive();
 
-            this.playerContainer.appendChild(this.element);
+            this.playerContainer.appendChild(this.div);
         }
 
         disable() {
             this.off();
             clearTimeout(this.activeTimeout);
 
-            if (this.element.parentNode) {
-                this.playerContainer.removeChild(this.element);
+            if (this.div.parentNode) {
+                utils.removeClass(this.playerContainer, 'jw-flag-touch');
+                this.playerContainer.removeChild(this.div);
             }
             if (this.controlbar) {
                 this.removeActiveListeners(this.controlbar.element());
@@ -280,8 +280,19 @@ define([
             }
         }
 
-        getElement() {
-            return this.element;
+        controlbarHeight() {
+            if (!this.dimensions.cbHeight) {
+                this.dimensions.cbHeight = this.controlbar.element().clientHeight;
+            }
+            return this.dimensions.cbHeight;
+        }
+
+        element() {
+            return this.div;
+        }
+
+        logoContainer() {
+            return this.right;
         }
 
         resize(model, breakPoint) {
@@ -295,6 +306,7 @@ define([
             utils.toggleClass(this.playerContainer, 'jw-flag-small-player', smallPlayer);
             utils.toggleClass(this.playerContainer, 'jw-flag-audio-player', audioMode);
             utils.toggleClass(this.playerContainer, 'jw-flag-time-slider-above', timeSliderAbove);
+            this.dimensions = {};
 
             model.set('audioMode', audioMode);
         }

--- a/src/js/view/controls/dock.js
+++ b/src/js/view/controls/dock.js
@@ -6,7 +6,7 @@ define([
     'utils/ui'
 ], function(utils, _, UI) {
 
-    const getDockButton = function(evt) {
+    function getDockButton(evt) {
         if (utils.hasClass(evt.target, 'jw-dock-button')) {
             // Clicks on button container
             return evt.target;
@@ -17,23 +17,29 @@ define([
 
         // Clicks on any other children
         return evt.target.parentElement;
-    };
+    }
+
+    function getDockContainer(buttons) {
+        const html = dockTemplate(buttons);
+        return utils.createElement(html);
+    }
 
     return class Dock {
         constructor(_model) {
             this.model = _model;
 
-            this.setup();
-            this.model.on('change:dock', this.render, this);
-        }
-
-        setup() {
             const buttons = this.model.get('dock');
-            const clickHandler = this.click.bind(this);
 
-            const html = dockTemplate(buttons);
-            this.el = utils.createElement(html);
-            new UI(this.el).on('click tap', clickHandler);
+            this.el = getDockContainer(buttons);
+            new UI(this.el).on('click tap', this.click, this);
+
+            this.model.on('change:dock', (model, changedButtons) => {
+                const newEl = getDockContainer(changedButtons);
+                utils.emptyElement(this.el);
+                for (let i = newEl.childNodes.length; i--;) {
+                    this.el.appendChild(newEl.firstChild);
+                }
+            }, this);
         }
 
         click(evt) {
@@ -46,14 +52,6 @@ define([
             if (btn && btn.callback) {
                 btn.callback(evt);
             }
-        }
-
-        render() {
-            const buttons = this.model.get('dock');
-            const html = dockTemplate(buttons);
-            const newEl = utils.createElement(html);
-
-            this.el.innerHTML = newEl.innerHTML;
         }
 
         element() {

--- a/src/js/view/controls/play-display-icon.js
+++ b/src/js/view/controls/play-display-icon.js
@@ -10,38 +10,42 @@ define([
     return class PlayDisplayIcon {
         constructor(_model) {
             _.extend(this, Events);
-            this.model = _model;
 
-            this.el = utils.createElement(displayIconTemplate('display', this.model.get('localization').playback));
+            const localization = _model.get('localization');
+            const element = utils.createElement(displayIconTemplate('display', localization.playback));
+            const iconDisplay = element.getElementsByClassName('jw-icon-display')[0];
+            iconDisplay.style.pointerEvents = 'none';
+            element.style.cursor = 'pointer';
 
-            this.iconUI = new UI(this.el).on('click tap', (evt) => {
+            this.el = element;
+
+            this.iconUI = new UI(this.el).on('tap', (evt) => {
                 this.trigger(evt.type);
             });
 
-            this.model.on('change:state', (model, newstate) => {
-                var iconDisplay = this.el.getElementsByClassName('jw-icon-display');
-                if (iconDisplay.length) {
-                    var localization = this.model.get('localization');
-                    var newstateLabel = localization.playback;
-                    switch (newstate) {
-                        case 'buffering':
-                            newstateLabel = localization.buffer;
-                            break;
-                        case 'playing':
-                            newstateLabel = localization.pause;
-                            break;
-                        case 'complete':
-                            newstateLabel = localization.replay;
-                            break;
-                        default:
-                            newstateLabel = '';
-                            break;
-                    }
-                    if (newstateLabel === '') {
-                        iconDisplay[0].removeAttribute('aria-label');
-                    } else {
-                        iconDisplay[0].setAttribute('aria-label', newstateLabel);
-                    }
+            _model.on('change:state', (model, newstate) => {
+                let newstateLabel;
+                switch (newstate) {
+                    case 'buffering':
+                        newstateLabel = localization.buffer;
+                        break;
+                    case 'playing':
+                        newstateLabel = localization.pause;
+                        break;
+                    case 'paused':
+                        newstateLabel = localization.playback;
+                        break;
+                    case 'complete':
+                        newstateLabel = localization.replay;
+                        break;
+                    default:
+                        newstateLabel = '';
+                        break;
+                }
+                if (newstateLabel === '') {
+                    iconDisplay.removeAttribute('aria-label');
+                } else {
+                    iconDisplay.setAttribute('aria-label', newstateLabel);
                 }
             });
         }

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -395,17 +395,7 @@ define([
         }
 
         function onFlashBlockedChange(model, isBlocked) {
-            if (isBlocked) {
-                if (_controls && _controls.rightClickMenu) {
-                    _controls.rightClickMenu.destroy();
-                }
-                utils.addClass(_playerElement, 'jw-flag-flash-blocked');
-            } else {
-                if (_controls && _controls.rightClickMenu) {
-                    _controls.rightClickMenu.setup(_model, _playerElement, _playerElement);
-                }
-                utils.removeClass(_playerElement, 'jw-flag-flash-blocked');
-            }
+            utils.toggleClass(_playerElement, 'jw-flag-flash-blocked', isBlocked);
         }
 
         function _logoClickHandler(evt) {
@@ -443,7 +433,10 @@ define([
             controls.enable(_api, _model);
             controls.addActiveListeners(_logo.element());
 
-            _logo.setContainer(controls.right);
+            var logoContainer = controls.logoContainer();
+            if (logoContainer) {
+                _logo.setContainer(logoContainer);
+            }
 
             _model.on('change:scrubbing', _stateHandler);
             _model.change('streamType', _setLiveMode, this);
@@ -473,7 +466,6 @@ define([
                 overlay.removeEventListener('mousemove', _userActivityCallback);
             }
 
-            utils.removeClass(_playerElement, 'jw-flag-touch');
             utils.clearCss(_model.get('id'));
             _styles(_videoLayer, {
                 cursor: ''
@@ -717,7 +709,7 @@ define([
                     _resizeMedia();
                     break;
                 case states.PAUSED:
-                    if (_model.get('controls')) {
+                    if (_controls && !_controls.showing) {
                         _captionsRenderer.renderCues(true);
                     }
                     break;
@@ -785,7 +777,7 @@ define([
 
         this.controlsContainer = function() {
             if (_controls) {
-                return _controls.element;
+                return _controls.element();
             }
             // return controls stand-in element not in DOM
             return document.createElement('div');
@@ -800,17 +792,10 @@ define([
             };
 
             if (_controls) {
-                // If we are using a dock, subtract that from the top
-                var dockButtons = _model.get('dock');
-                if (dockButtons && dockButtons.length) {
-                    bounds.y = _controls.dock.element().clientHeight;
-                    bounds.height -= bounds.y;
-                }
-
                 // Subtract controlbar from the bottom when using one
                 includeCB = includeCB || !utils.exists(includeCB);
                 if (includeCB) {
-                    bounds.height -= _controls.controlbar.element().clientHeight;
+                    bounds.height -= _controls.controlbarHeight();
                 }
             }
 


### PR DESCRIPTION
JW7-4093

Controls API used by view after these changes:

**API properties**
- `instreamState` When the player is in ads mode, this property is updated to reflect the ads player state. Otherwise, it is null.
- `showing` boolean. Indicates the user activity state of controls

**API methods**
- `addActiveListeners(element)` Add mouse and touch listeners to toggle user activity over an element
- `controlbarHeight()` Returns the height of the control bar, used for placing ads correctly and calculating the bounds returned by jwplayer().getSafeRegion()
- `disable()` Tears down controls when removed from the view
- `element()` Return the controls DOM element
- `enable(api, model)` Setup and activate controls
- `logoContainer()` Return the DOM element container for the logo element. Return null if the logo should remain in the player's DOM element.
- `on(event, listener, context)` (backbone events)
- `once(event, listener, context)`
- `off(event, listener, context)`
- `removeActiveListeners(element)` Remove mouse and touch listeners to toggle user activity over an element
- `resize(model, breakpoint)` Handle player size state changes. Called on setup and whenever player dimensions change
- `unmuteAutoplay(api, model)` Called when exiting autoplay muted state; on fullscreen.
- `userActive(timeout)` Set user activity on controls
- `userInactive()` Set user inactivity on controls

**API events** (all controls events are forwarded by the controller to the public api)
- `"userActive"` Fires on user activity. Used to add CSS that shows controls while playing.
- `"userInactive"` Fires after after user in inactive. Used to remove CSS so controls are hidden while playing.

Other changes
- Removed dock buttons from `jwplayer().getSafeRegion()` calculation. We don't use the bounds offset for anything, and the impact it has on bounds height could negatively impact initialization of the IMA AdsManager.