### PR TITLE
Normalize getQualityLevels across providers 

### DIFF
--- a/src/js/providers/data-normalizer.js
+++ b/src/js/providers/data-normalizer.js
@@ -1,0 +1,9 @@
+export function qualityLevel(level) {
+    return {
+        bitrate: level.bitrate,
+        label: level.label,
+        width: level.width,
+        height: level.height
+    };
+}
+

--- a/src/js/providers/flash.js
+++ b/src/js/providers/flash.js
@@ -1,3 +1,5 @@
+import { qualityLevel } from 'providers/data-normalizer';
+
 define([
     'utils/helpers',
     'utils/underscore',
@@ -362,7 +364,7 @@ define([
                 return { name: 'flash' };
             },
             getQualityLevels: function() {
-                return _qualityLevels || (_item && _item.sources);
+                return _.map(_qualityLevels || (_item && _item.sources), level => qualityLevel(level));
             },
             getAudioTracks: function() {
                 return _audioTracks;

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -1,3 +1,5 @@
+import { qualityLevel } from 'providers/data-normalizer';
+
 define([
     'providers/html5-android-hls',
     'utils/css',
@@ -899,7 +901,7 @@ define([
         };
 
         this.getQualityLevels = function() {
-            return _getPublicLevels(_levels);
+            return _.map(_levels, level => qualityLevel(level));
         };
 
         this.getName = function() {

--- a/src/js/utils/quality-labels.js
+++ b/src/js/utils/quality-labels.js
@@ -6,7 +6,7 @@ function generateLabel(level, qualityLabels, redundant) {
         return '';
     }
     // Flash uses bitrate instead of bandwidth
-    const bandwidth = level.bandwidth || level.bitrate;
+    const bandwidth = level.bitrate || level.bandwidth;
     // Flash, in some cases, will create its own label. Prefer it over creating a new label
     return getCustomLabel(qualityLabels, bandwidth) ||
         level.label ||
@@ -77,7 +77,7 @@ function hasRedundantLevels(levels) {
         return false;
     }
     return _.some(levels, function (level) {
-        const key = level.height || level.bandwidth;
+        const key = level.height || level.bitrate || level.bandwidth;
         const foundDuplicate = this[key];
         this[key] = 1;
         return foundDuplicate;


### PR DESCRIPTION
Map each level through a factory function to ensure each provider returns the same data structure for `getQualityLevels`. Returned data matches our API documents.

JW7-4179
