### PR TITLE
Use video or audio tag in setup container

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -231,9 +231,14 @@ define([
 
             _model.on('change:viewSetup', function(model, viewSetup) {
                 if (viewSetup) {
+                    const mediaElement = this.currentContainer.querySelector('video, audio');
                     _this.showView(_view.element());
+                    if (mediaElement) {
+                        const mediaContainer = _model.get('mediaContainer');
+                        mediaContainer.appendChild(mediaElement);
+                    }
                 }
-            });
+            }, this);
 
             _model.on('change:inDom', function(model, inDom) {
                 if (inDom) {

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -96,7 +96,7 @@ define([
 
         // Find video tag, or create it if it doesn't exist.  View may not be built yet.
         var element = document.getElementById(_playerId);
-        var _videotag = (element) ? element.querySelector('video') : undefined;
+        var _videotag = (element) ? element.querySelector('video, audio') : undefined;
 
         function _setAttribute(name, value) {
             _videotag.setAttribute(name, value || '');

--- a/test/unit/api-test.js
+++ b/test/unit/api-test.js
@@ -163,8 +163,26 @@ define([
 
         api.setup(_.extend({}, configSmall)).on('ready', function() {
 
-            var video = document.getElementById('player').querySelector('video');
-            assert.strictEqual(video.id, 'custom-video', 'video tag in setup container is used by player');
+            var media = document.getElementById('player').querySelector('video');
+            assert.strictEqual(media.id, 'custom-video', 'video tag in setup container is used by player');
+
+            done();
+        }).on('setupError', function() {
+            assert.ok(false, 'FAIL');
+            done();
+        });
+    });
+
+    test('uses audio tag in container', function(assert) {
+        var done = assert.async();
+
+        var originalContainer = createWithAudioContainer('player');
+        var api = new Api(originalContainer, _.noop);
+
+        api.setup(_.extend({}, configSmall)).on('ready', function() {
+
+            var media = document.getElementById('player').querySelector('audio');
+            assert.strictEqual(media.id, 'custom-audio', 'video tag in setup container is used by player');
 
             done();
         }).on('setupError', function() {
@@ -386,6 +404,12 @@ define([
 
     function createWithVideoContainer(id) {
         var container = $('<div id="' + id + '"><video id="custom-video"></video></div>')[0];
+        $('#qunit-fixture').append(container);
+        return container;
+    }
+
+    function createWithAudioContainer(id) {
+        var container = $('<div id="' + id + '"><audio id="custom-audio"></audio></div>')[0];
         $('#qunit-fixture').append(container);
         return container;
     }

--- a/test/unit/api-test.js
+++ b/test/unit/api-test.js
@@ -155,6 +155,24 @@ define([
         });
     });
 
+    test('uses video tag in container', function(assert) {
+        var done = assert.async();
+
+        var originalContainer = createWithVideoContainer('player');
+        var api = new Api(originalContainer, _.noop);
+
+        api.setup(_.extend({}, configSmall)).on('ready', function() {
+
+            var video = document.getElementById('player').querySelector('video');
+            assert.strictEqual(video.id, 'custom-video', 'video tag in setup container is used by player');
+
+            done();
+        }).on('setupError', function() {
+            assert.ok(false, 'FAIL');
+            done();
+        });
+    });
+
     test('event dispatching', function(assert) {
         var api = createApi('player');
         var originalEvent = {
@@ -362,6 +380,12 @@ define([
 
     function createContainer(id) {
         var container = $('<div id="' + id + '"></div>')[0];
+        $('#qunit-fixture').append(container);
+        return container;
+    }
+
+    function createWithVideoContainer(id) {
+        var container = $('<div id="' + id + '"><video id="custom-video"></video></div>')[0];
         $('#qunit-fixture').append(container);
         return container;
     }


### PR DESCRIPTION
In v7.10 we broke an undocumented feature where the first provider would grab the video element from the container used at setup. This would allow setting up the player with a video tag already in the DOM:

```js
<div id="player">
  <video autostart mute controls preload="auto" src="video.mp4"></video>
</div>
```
This change restores that feature and also allows for audio tags to be used with HTML5 playback. This is needed for trick start setups where a click on a media element sets up a player and starts on mobile within the click event.

JW7-4110
Replaces #1863
