### PR TITLE
Move aria label util into module

### DIFF
--- a/src/js/controller/aria.js
+++ b/src/js/controller/aria.js
@@ -1,0 +1,19 @@
+define([
+
+], function() {
+
+    const addLabel = function(element, ariaLabel) {
+        if (!element || !ariaLabel) {
+            return;
+        }
+
+        element.setAttribute('aria-label', ariaLabel);
+        element.setAttribute('role', 'button');
+        element.setAttribute('tabindex', '0');
+    };
+
+    return {
+        addLabel: addLabel
+    };
+});
+

--- a/src/js/utils/aria.js
+++ b/src/js/utils/aria.js
@@ -1,8 +1,7 @@
 define([
 
 ], function() {
-
-    const addLabel = function(element, ariaLabel) {
+    return function(element, ariaLabel) {
         if (!element || !ariaLabel) {
             return;
         }
@@ -10,9 +9,5 @@ define([
         element.setAttribute('aria-label', ariaLabel);
         element.setAttribute('role', 'button');
         element.setAttribute('tabindex', '0');
-    };
-
-    return {
-        addLabel: addLabel
     };
 });

--- a/src/js/utils/aria.js
+++ b/src/js/utils/aria.js
@@ -16,4 +16,3 @@ define([
         addLabel: addLabel
     };
 });
-

--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -143,16 +143,6 @@ define([
         return bounds;
     };
 
-    dom.addAriaLabel = function(element, ariaLabel) {
-        if (!element || !ariaLabel) {
-            return;
-        }
-
-        element.setAttribute('aria-label', ariaLabel);
-        element.setAttribute('role', 'button');
-        element.setAttribute('tabindex', '0');
-    };
-
     return dom;
 });
 

--- a/src/js/view/controls/components/tooltip.js
+++ b/src/js/view/controls/components/tooltip.js
@@ -3,7 +3,7 @@ define([
     'utils/aria',
     'utils/helpers',
     'utils/underscore',
-], function(Events, Aria, utils, _) {
+], function(Events, ariaLabel, utils, _) {
 
     return class Tooltip {
         constructor(name, ariaText, elementShown) {
@@ -14,7 +14,7 @@ define([
                 className += ' jw-hidden';
             }
 
-            Aria.addLabel(this.el, ariaText);
+            ariaLabel(this.el, ariaText);
 
             this.el.className = className;
             this.container = document.createElement('div');

--- a/src/js/view/controls/components/tooltip.js
+++ b/src/js/view/controls/components/tooltip.js
@@ -1,8 +1,9 @@
 define([
     'utils/backbone.events',
+    'controller/aria',
     'utils/helpers',
     'utils/underscore',
-], function(Events, utils, _) {
+], function(Events, Aria, utils, _) {
 
     return class Tooltip {
         constructor(name, ariaText, elementShown) {
@@ -12,7 +13,7 @@ define([
             if (!elementShown) {
                 className += ' jw-hidden';
             }
-            utils.addAriaLabel(this.el, ariaText);
+            Aria.addLabel(this.el, ariaText);
 
             this.el.className = className;
             this.container = document.createElement('div');

--- a/src/js/view/controls/components/tooltip.js
+++ b/src/js/view/controls/components/tooltip.js
@@ -1,6 +1,6 @@
 define([
     'utils/backbone.events',
-    'controller/aria',
+    'utils/aria',
     'utils/helpers',
     'utils/underscore',
 ], function(Events, Aria, utils, _) {

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -10,7 +10,7 @@ define([
     'view/controls/components/menu',
     'view/controls/components/volumetooltip',
     'view/controls/components/button',
-], function(utils, _, Events, Constants, UI, Aria, Slider, TimeSlider, Menu, VolumeTooltip, button) {
+], function(utils, _, Events, Constants, UI, ariaLabel, Slider, TimeSlider, Menu, VolumeTooltip, button) {
     function text(name, role) {
         const element = document.createElement('span');
         element.className = 'jw-text jw-reset ' + name;
@@ -33,7 +33,7 @@ define([
 
         const castButton = document.createElement('button', 'google-cast-button');
         castButton.className = 'jw-button-color jw-icon-inline';
-        Aria.addLabel(castButton, ariaText);
+        ariaLabel(castButton, ariaText);
 
         const element = document.createElement('div');
         element.className = 'jw-reset jw-icon-cast';

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -4,13 +4,13 @@ define([
     'utils/backbone.events',
     'utils/constants',
     'utils/ui',
+    'utils/aria',
     'view/controls/components/slider',
     'view/controls/components/timeslider',
     'view/controls/components/menu',
     'view/controls/components/volumetooltip',
     'view/controls/components/button',
-    'controller/aria'
-], function(utils, _, Events, Constants, UI, Slider, TimeSlider, Menu, VolumeTooltip, button, Aria) {
+], function(utils, _, Events, Constants, UI, Aria, Slider, TimeSlider, Menu, VolumeTooltip, button) {
     function text(name, role) {
         const element = document.createElement('span');
         element.className = 'jw-text jw-reset ' + name;

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -8,8 +8,9 @@ define([
     'view/controls/components/timeslider',
     'view/controls/components/menu',
     'view/controls/components/volumetooltip',
-    'view/controls/components/button'
-], function(utils, _, Events, Constants, UI, Slider, TimeSlider, Menu, VolumeTooltip, button) {
+    'view/controls/components/button',
+    'controller/aria'
+], function(utils, _, Events, Constants, UI, Slider, TimeSlider, Menu, VolumeTooltip, button, Aria) {
     function text(name, role) {
         const element = document.createElement('span');
         element.className = 'jw-text jw-reset ' + name;
@@ -32,7 +33,7 @@ define([
 
         const castButton = document.createElement('button', 'google-cast-button');
         castButton.className = 'jw-button-color jw-icon-inline';
-        utils.addAriaLabel(castButton, ariaText);
+        Aria.addLabel(castButton, ariaText);
 
         const element = document.createElement('div');
         element.className = 'jw-reset jw-icon-cast';


### PR DESCRIPTION
To better break up the UI logic from the rest of the player, move aria labels into its own module. 

JW7-4282