### PR TITLE
Player API/View fixes

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -251,8 +251,6 @@ define([
 
                 _view.on('all', _triggerAfterReady, _this);
 
-                _model.change('visibility', _onVisibilityChange);
-
                 var related = _api.getPlugin('related');
                 if (related) {
                     related.on('nextUp', _model.setNextUp, _model);
@@ -266,6 +264,8 @@ define([
             }
 
             function _playerReadyNotify() {
+                _model.change('visibility', _onVisibilityChange);
+
                 // Tell the api that we are loaded
                 _this.trigger(events.JWPLAYER_READY, {
                     // this will be updated by Api

--- a/src/js/view/utils/views-manager.js
+++ b/src/js/view/utils/views-manager.js
@@ -15,6 +15,9 @@ function scheduleResponsiveRedraw() {
                 view.updateStyles();
             }
         });
+        views.forEach(view => {
+            view.checkResized();
+        });
     });
 }
 

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -87,12 +87,13 @@ define([
                 if (!_lastWidth || !_lastHeight) {
                     _responsiveListener();
                 }
-                _model.set('inDom', inDOM);
-                return;
             }
 
-            _model.set('containerWidth', containerWidth);
-            _model.set('containerHeight', containerHeight);
+            // Don't update container dimensions to 0, 0 when not in DOM
+            if (containerWidth || containerHeight || inDOM) {
+                _model.set('containerWidth', containerWidth);
+                _model.set('containerHeight', containerHeight);
+            }
             _model.set('inDom', inDOM);
 
             if (inDOM) {
@@ -540,8 +541,9 @@ define([
             resetAspectMode = !!resetAspectMode;
             if (resetAspectMode) {
                 _model.set('aspectratio', null);
-                playerStyle.display = 'block';
-            } else if (!_model.get('aspectratio')) {
+                // playerStyle.display = 'block';
+            }
+            if (!_model.get('aspectratio')) {
                 playerStyle.height = playerHeight;
             }
 

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -68,10 +68,6 @@ define([
         this.updateBounds = function () {
             cancelAnimationFrame(_resizeContainerRequestId);
             const inDOM = document.body.contains(_playerElement);
-            if (!inDOM) {
-                _model.set('inDom', inDOM);
-                return;
-            }
             const bounds = _bounds(_playerElement);
             const containerWidth = Math.round(bounds.width);
             const containerHeight = Math.round(bounds.height);
@@ -82,6 +78,7 @@ define([
                 if (!_lastWidth || !_lastHeight) {
                     _responsiveListener();
                 }
+                _model.set('inDom', inDOM);
                 return;
             }
             // If we have bad values for either dimension, return early


### PR DESCRIPTION
### What does this Pull Request do?

Address issues introduced by #1994 which led to JW7-4265 being rejected.

### Why is this Pull Request needed?

Fixes issues blocking release of 7.11.0-alpha.1:
- `player.resize()` not updating height
- `readyEvent.viewable` missing
- `player.setup(elementNotInDOM)` no longer firing 'ready' / completing setup

### Are there any points in the code the reviewer needs to double check?

Some of the regressions came from firing "resize" from within the `updateBounds` call. This has now been split out so there are three calls to fully update a player view: `updateBounds`, `updateStyles` and finally `checkResized` which will dispatch a "resize" event when player dimensions have changed. It's important that the view fire a "resize" event for setup to complete, and it's important for performance that these methods be split up.

Order of visibility/viewable calls in the controller have been updated to ensure that "viewable" is added to the ready event.

#### Addresses Issue(s):

JW7-4265


