### PR TITLE
Position Captions for timeSliderAbove

### DIFF
--- a/src/css/controls/flags/time-slider-above.less
+++ b/src/css/controls/flags/time-slider-above.less
@@ -386,7 +386,7 @@
 
         .jw-captions,
         /* captions styles code specific to native text track rendering */
-        video:-webkit-media-text-track-container {
+        video::-webkit-media-text-track-container {
             max-height: ~"calc(100% - 64px)";
         }
 


### PR DESCRIPTION
`:` was being used, which is only for pseudo-classes, instead of `::`
which are for pseudo-elements.

JW7-4284