### PR TITLE
Lazy instantiate intersection observer and set container classes in view

### DIFF
--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -19,26 +19,6 @@ define([
              NextUpToolTip, RightClick) {
 
     const ACTIVE_TIMEOUT = utils.isMobile() ? 4000 : 2000;
-    const CONTOLBAR_ONLY_HEIGHT = 44;
-
-    const isAudioMode = function(model) {
-        const playerHeight = model.get('height');
-        if (model.get('aspectratio')) {
-            return false;
-        }
-        if (typeof playerHeight === 'string' && playerHeight.indexOf('%') > -1) {
-            return false;
-        }
-
-        // Coerce into Number (don't parse out CSS units)
-        let verticalPixels = (playerHeight * 1) || NaN;
-        verticalPixels = (!isNaN(verticalPixels) ? verticalPixels : model.get('containerHeight'));
-        if (!verticalPixels) {
-            return false;
-        }
-
-        return verticalPixels && verticalPixels <= CONTOLBAR_ONLY_HEIGHT;
-    };
 
     const reasonInteraction = function() {
         return { reason: 'interaction' };
@@ -84,8 +64,7 @@ define([
             element.className = 'jw-controls jw-reset';
             this.div = element;
 
-            const height = model.get('height');
-            const touchMode = utils.isMobile() && (typeof height === 'string' || height >= CONTOLBAR_ONLY_HEIGHT);
+            const touchMode = model.get('touchMode');
 
             // Display Buttons
             if (!this.displayContainer) {
@@ -300,20 +279,8 @@ define([
             return this.right;
         }
 
-        resize(model, breakPoint) {
-            const audioMode = isAudioMode(model);
-
-            // Set timeslider flags
-            const smallPlayer = breakPoint < 2;
-            const timeSliderAboveConfig = model.get('timeSliderAbove');
-            const timeSliderAbove = !audioMode &&
-                (timeSliderAboveConfig !== false) && (timeSliderAboveConfig || smallPlayer);
-            utils.toggleClass(this.playerContainer, 'jw-flag-small-player', smallPlayer);
-            utils.toggleClass(this.playerContainer, 'jw-flag-audio-player', audioMode);
-            utils.toggleClass(this.playerContainer, 'jw-flag-time-slider-above', timeSliderAbove);
+        resize() {
             this.dimensions = {};
-
-            model.set('audioMode', audioMode);
         }
 
         unmuteAutoplay(api, model) {

--- a/src/js/view/utils/audio-mode.js
+++ b/src/js/view/utils/audio-mode.js
@@ -1,0 +1,20 @@
+export const CONTOLBAR_ONLY_HEIGHT = 44;
+
+export const isAudioMode = function(model) {
+    const playerHeight = model.get('height');
+    if (model.get('aspectratio')) {
+        return false;
+    }
+    if (typeof playerHeight === 'string' && playerHeight.indexOf('%') > -1) {
+        return false;
+    }
+
+    // Coerce into Number (don't parse out CSS units)
+    let verticalPixels = (playerHeight * 1) || NaN;
+    verticalPixels = (!isNaN(verticalPixels) ? verticalPixels : model.get('containerHeight'));
+    if (!verticalPixels) {
+        return false;
+    }
+
+    return verticalPixels && verticalPixels <= CONTOLBAR_ONLY_HEIGHT;
+};

--- a/src/js/view/utils/audio-mode.js
+++ b/src/js/view/utils/audio-mode.js
@@ -1,4 +1,4 @@
-export const CONTOLBAR_ONLY_HEIGHT = 44;
+export const CONTROLBAR_ONLY_HEIGHT = 44;
 
 export const isAudioMode = function(model) {
     const playerHeight = model.get('height');
@@ -16,5 +16,5 @@ export const isAudioMode = function(model) {
         return false;
     }
 
-    return verticalPixels && verticalPixels <= CONTOLBAR_ONLY_HEIGHT;
+    return verticalPixels && verticalPixels <= CONTROLBAR_ONLY_HEIGHT;
 };

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -1,5 +1,5 @@
 import playerTemplate from 'templates/player';
-import { isAudioMode, CONTOLBAR_ONLY_HEIGHT } from 'view/utils/audio-mode';
+import { isAudioMode, CONTROLBAR_ONLY_HEIGHT } from 'view/utils/audio-mode';
 import viewsManager from 'view/utils/views-manager';
 import getVisibility from 'view/utils/visibility';
 import activeTab from 'utils/active-tab';
@@ -338,7 +338,7 @@ define([
             _model.set('mediaContainer', _videoLayer);
             _model.set('iFrame', utils.isIframe());
             _model.set('activeTab', activeTab());
-            _model.set('touchMode', _isMobile && (typeof height === 'string' || height >= CONTOLBAR_ONLY_HEIGHT));
+            _model.set('touchMode', _isMobile && (typeof height === 'string' || height >= CONTROLBAR_ONLY_HEIGHT));
 
             viewsManager.add(this);
 

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -1,4 +1,5 @@
 import playerTemplate from 'templates/player';
+import { isAudioMode, CONTOLBAR_ONLY_HEIGHT } from 'view/utils/audio-mode';
 import viewsManager from 'view/utils/views-manager';
 import getVisibility from 'view/utils/visibility';
 import activeTab from 'utils/active-tab';
@@ -104,11 +105,15 @@ define([
         this.updateStyles = function() {
             const containerWidth = _model.get('containerWidth');
             const containerHeight = _model.get('containerHeight');
-            const breakPoint = setBreakpoint(_playerElement, containerWidth, containerHeight);
+
+            if (_model.get('controls')) {
+                updateContainerStyles(containerWidth, containerHeight);
+            }
 
             if (_controls) {
-                _controls.resize(_model, breakPoint);
+                _controls.resize(containerWidth, containerHeight);
             }
+
             _resizeMedia(containerWidth, containerHeight);
             _captionsRenderer.resize();
         };
@@ -135,6 +140,22 @@ define([
             _this.updateBounds();
             _this.updateStyles();
             _this.checkResized();
+        }
+
+        function updateContainerStyles(width, height) {
+            const audioMode = isAudioMode(_model);
+            // Set timeslider flags
+            if (_.isNumber(width) && _.isNumber(height)) {
+                const breakPoint = setBreakpoint(_playerElement, width, height);
+                const smallPlayer = breakPoint < 2;
+                const timeSliderAboveConfig = _model.get('timeSliderAbove');
+                const timeSliderAbove = !audioMode &&
+                    (timeSliderAboveConfig !== false) && (timeSliderAboveConfig || smallPlayer);
+                utils.toggleClass(_playerElement, 'jw-flag-small-player', smallPlayer);
+                utils.toggleClass(_playerElement, 'jw-flag-time-slider-above', timeSliderAbove);
+            }
+            utils.toggleClass(_playerElement, 'jw-flag-audio-player', audioMode);
+            _model.set('audioMode', audioMode);
         }
 
         // Set global colors, used by related plugin
@@ -293,6 +314,9 @@ define([
             const width = _model.get('width');
             const height = _model.get('height');
             _resizePlayer(width, height);
+            if (_model.get('controls')) {
+                updateContainerStyles(width, height);
+            }
 
             if (!stylesInjected) {
                 stylesInjected = true;
@@ -314,6 +338,7 @@ define([
             _model.set('mediaContainer', _videoLayer);
             _model.set('iFrame', utils.isIframe());
             _model.set('activeTab', activeTab());
+            _model.set('touchMode', _isMobile && (typeof height === 'string' || height >= CONTOLBAR_ONLY_HEIGHT));
 
             viewsManager.add(this);
 
@@ -360,7 +385,7 @@ define([
             clickHandler.on({
                 click: () => {
                     _this.trigger(events.JWPLAYER_DISPLAY_CLICK);
-                    if (_controls) {
+                    if (_model.get('controls')) {
                         api.play(reasonInteraction());
                     }
                 },
@@ -368,7 +393,7 @@ define([
                     _this.trigger(events.JWPLAYER_DISPLAY_CLICK);
                     const state = model.get('state');
 
-                    if (_controls &&
+                    if (_model.get('controls') &&
                         ((state === states.IDLE || state === states.COMPLETE) ||
                         (_instreamModel && _instreamModel.get('state') === states.PAUSED))) {
                         api.play(reasonInteraction());
@@ -469,8 +494,6 @@ define([
 
             // refresh breakpoint and timeslider classes
             if (_lastHeight) {
-                const breakPoint = setBreakpoint(_playerElement, _lastWidth, _lastHeight);
-                controls.resize(_model, breakPoint);
                 _captionsRenderer.renderCues(true);
             }
         };
@@ -795,8 +818,7 @@ define([
             if (_controls) {
                 return _controls.element();
             }
-            // return controls stand-in element not in DOM
-            return document.createElement('div');
+            return null;
         };
 
         this.getSafeRegion = function (includeCB) {


### PR DESCRIPTION
### What does this Pull Request do?

1. Makes sure that the IntersectionObserver is instantiated when needed after the polyfill has been loaded. Moving the instantiation to a modules top level scope meant we tried creating it before the polyfill was available.
2. Move code that adds flag classes to the player view so that for players with fixed dimensions, classes can be added before the view is added to the DOM / before controls are loaded. This avoids some layout invalidation when controls are loaded, and allows controlbar-only audio players to render correctly on embed.

### Why is this Pull Request needed?

Fixes UI update issues in browser that rely on the IntersectionObserver polyfill, as well as improves the view DOM state at setup.

### Are there any points in the code the reviewer needs to double check?

If the intersection observer is not instantiated an error will be thrown. This is intentional. We need view-ability to work for the player's UI and analytics to function correctly.

#### Addresses Issue(s):

JW7-4280 JW7-4281 JW7-4265

