### PR TITLE
Removing controls removes captions styling

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -489,7 +489,6 @@ define([
                 overlay.removeEventListener('mousemove', _userActivityCallback);
             }
 
-            utils.clearCss(_model.get('id'));
             _styles(_videoLayer, {
                 cursor: ''
             });


### PR DESCRIPTION
When controls are removed after being loaded, the captions styles were
also being reset.

JW7-4288