### PR TITLE
Position captions correctly in chrome less mode

### DIFF
--- a/src/css/controls/flags/controls-hidden.less
+++ b/src/css/controls/flags/controls-hidden.less
@@ -14,15 +14,6 @@
     .jw-nextup-container {
         bottom: 0.5em;
     }
-
-    .jw-captions {
-        max-height: none;
-    }
-
-    /* captions styles code specific to native text track rendering */
-    video::-webkit-media-text-track-container {
-        max-height: none;
-    }
 }
 
 .jw-flag-controls-hidden {

--- a/src/css/controls/flags/user-inactive.less
+++ b/src/css/controls/flags/user-inactive.less
@@ -5,6 +5,15 @@
     &.jw-state-playing {
         .jwplayer.jw-flag-controls-hidden;
 
+        .jw-captions {
+            max-height: none;
+        }
+
+        /* captions styles code specific to native text track rendering */
+        video::-webkit-media-text-track-container {
+            max-height: none;
+        }
+
         .jw-media {
             cursor: none;
             /* cursor hiding on media elements for Safari */

--- a/src/css/jwplayer.less
+++ b/src/css/jwplayer.less
@@ -27,5 +27,6 @@
 @import "jwplayer/flags/skinloading";            // Hides content until styles loaded.  Rename stylesloading.les
 @import "jwplayer/flags/fullscreen";
 @import "jwplayer/flags/flash-blocked";
+@import "jwplayer/flags/controls-hidden";
 
 @import "jwplayer/flags/audioplayer";

--- a/src/css/jwplayer/flags/controls-hidden.less
+++ b/src/css/jwplayer/flags/controls-hidden.less
@@ -1,0 +1,10 @@
+.jwplayer.jw-flag-controls-hidden { // Position captions correctly in Chromeless mode
+    .jw-captions {
+        max-height: none;
+    }
+
+    /* captions styles code specific to native text track rendering */
+    video::-webkit-media-text-track-container {
+        max-height: none;
+    }
+}

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -316,6 +316,8 @@ define([
             _resizePlayer(width, height);
             if (_model.get('controls')) {
                 updateContainerStyles(width, height);
+            } else {
+                utils.addClass(_playerElement, 'jw-flag-controls-hidden');
             }
 
             if (!stylesInjected) {
@@ -392,13 +394,14 @@ define([
                 tap: () => {
                     _this.trigger(events.JWPLAYER_DISPLAY_CLICK);
                     const state = model.get('state');
+                    const controls = _model.get('controls');
 
-                    if (_model.get('controls') &&
+                    if (controls &&
                         ((state === states.IDLE || state === states.COMPLETE) ||
                         (_instreamModel && _instreamModel.get('state') === states.PAUSED))) {
                         api.play(reasonInteraction());
                     }
-                    if (state === states.PAUSED) {
+                    if (controls && state === states.PAUSED) {
                         // Toggle visibility of the controls when tapping the media
                         // Do not add mobile toggle "jw-flag-controls-hidden" in these cases
                         if (_instreamModel ||
@@ -461,8 +464,6 @@ define([
                 // ignore model that triggered this event and use current state model
                 _stateHandler(_instreamModel || _model);
             }
-
-            utils.toggleClass(_playerElement, 'jw-flag-controls-disabled', !bool);
         };
 
         this.addControls = function (controls) {
@@ -484,6 +485,8 @@ define([
             if (logoContainer) {
                 _logo.setContainer(logoContainer);
             }
+
+            utils.removeClass(_playerElement, 'jw-flag-controls-hidden');
 
             _styles(_videoLayer, {
                 cursor: 'pointer'
@@ -511,6 +514,8 @@ define([
             if (overlay) {
                 overlay.removeEventListener('mousemove', _userActivityCallback);
             }
+
+            utils.addClass(_playerElement, 'jw-flag-controls-hidden');
 
             _styles(_videoLayer, {
                 cursor: ''
@@ -731,7 +736,7 @@ define([
                     _stateUpdate(model, _playerState);
                 });
             }
-            if (_playerState !== states.PAUSED && utils.hasClass(_playerElement, 'jw-flag-controls-hidden')) {
+            if (_model.get('controls') && _playerState !== states.PAUSED && utils.hasClass(_playerElement, 'jw-flag-controls-hidden')) {
                 utils.removeClass(_playerElement, 'jw-flag-controls-hidden');
             }
         }


### PR DESCRIPTION
### What does this Pull Request do?

Adds the ".jw-flag-controls-hidden" class to the player element in Chromeless mode for captions to be positioned correctly.

#### Addresses Issue(s):

JW7-4289

