### PR TITLE
Display subtitles and captions from HLSJS in IE11

### DIFF
--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -46,7 +46,7 @@ define([
             related: 'Discover',
             close: 'Close',
         },
-        renderCaptionsNatively: false,
+        renderCaptionsNatively: true,
         nextUpDisplay: true
     };
 

--- a/src/js/polyfills/vtt.js
+++ b/src/js/polyfills/vtt.js
@@ -534,6 +534,9 @@ define([
         this.bottom = obj.bottom || (top + (obj.height || height));
         this.width = obj.width || width;
         this.lineHeight = lh !== undefined ? lh : obj.lineHeight;
+
+        // Sets the width to be slightly larger to prevent text wrapping in IE 11
+        this.width = Math.ceil(this.width + 1);
     }
 
     // Move the box along a particular axis. Optionally pass in an amount to move

--- a/src/js/polyfills/vtt.js
+++ b/src/js/polyfills/vtt.js
@@ -886,6 +886,7 @@ define([
 
         var boxPositions = [];
         var containerBox = BoxPosition.getSimpleBoxPosition(paddedOverlay);
+        var currentNumOfLines = cues.reduce(function(totalLines, cue) { return totalLines + cue.text.split('\n').length; }, 0);
 
         (function () {
             for (var j = 0; j < cues.length; j++) {
@@ -900,8 +901,8 @@ define([
                 // Move the cue div to it's correct line position.
                 // Added on 08/03/2016 by Evol Greaves: evol@jwplayer.com for determining the correct
                 // position to place the containerBox.
-                var numLinesOfText = cue.text.split('\n').length;
-                moveBoxToLinePosition(window, styleBox, containerBox, boxPositions, numLinesOfText);
+                moveBoxToLinePosition(window, styleBox, containerBox, boxPositions, currentNumOfLines);
+                currentNumOfLines -= cue.text.split('\n').length;
 
                 // Remember the computed div so that we don't have to recompute it later
                 // if we don't have too.

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -50,6 +50,16 @@ define([
 
         this.renderNatively = renderNatively(_playerConfig.renderCaptionsNatively);
 
+        // Always render natively in iOS, Safari and Edge, where HLS is supported.
+        // Otherwise, use native rendering when set in the config for browsers that have adequate support.
+        // FF and IE are excluded due to styling/positioning drawbacks.
+        function renderNatively (configRenderNatively) {
+            if (utils.isIOS() || utils.isSafari() || utils.isEdge()) {
+                return true;
+            }
+            return configRenderNatively && utils.isChrome();
+        }
+
         var _this = this;
         var _mediaEvents = {
             click: _clickHandler,
@@ -1029,14 +1039,6 @@ define([
 
     VideoProvider.getName = function() {
         return { name: 'html5' };
-    };
-
-    // Render natively if we have this is iOS or Desktop Safari OR we set renderCaptionsNatively and the platforms supports native rendering
-    const renderNatively = (configRenderNatively) => {
-        if (utils.isIOS() || utils.isSafari()) {
-            return true;
-        }
-        return configRenderNatively && (utils.isChrome() || utils.isEdge());
     };
 
     return VideoProvider;

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -48,7 +48,7 @@ define([
 
         _.extend(this, Events, Tracks);
 
-        this.renderNatively = utils.isChrome() || utils.isIOS() || utils.isSafari() || utils.isEdge();
+        this.renderNatively = renderNatively(_playerConfig.renderCaptionsNatively);
 
         var _this = this;
         var _mediaEvents = {
@@ -1029,6 +1029,14 @@ define([
 
     VideoProvider.getName = function() {
         return { name: 'html5' };
+    };
+
+    // Render natively if we have this is iOS or Desktop Safari OR we set renderCaptionsNatively and the platforms supports native rendering
+    const renderNatively = (configRenderNatively) => {
+        if (utils.isIOS() || utils.isSafari()) {
+            return true;
+        }
+        return configRenderNatively && (utils.isChrome() || utils.isEdge());
     };
 
     return VideoProvider;

--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -169,9 +169,8 @@ define(['utils/underscore',
 
     function setSubtitlesTrack(menuIndex) {
         if (!this.renderNatively) {
-            //this.trigger('textTrackChanged', { currentTrack: menuIndex + 1 });
             if (this.setCurrentSubtitleTrack) {
-                this.setCurrentSubtitleTrack(menuIndex-1);
+                this.setCurrentSubtitleTrack(menuIndex - 1);
             }
             return;
         }
@@ -208,14 +207,6 @@ define(['utils/underscore',
             currentTrack: this._currentTextTrackIndex + 1,
             tracks: this._textTracks
         });
-
-        // IE 11 does not sent a change event when changing text track properties, so we manually send it.
-        //if (utils.isIE(11)) {
-            var e = document.createEvent('Event');
-            e.initEvent('change', false, false);
-
-            this.video.textTracks.dispatchEvent(e);
-        //}
     }
 
     function addCaptionsCue(cueData) {

--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -123,21 +123,19 @@ define(['utils/underscore',
             }
         }
 
-        if (!(this.renderNatively && utils.isIOS())) {
-            // Only bind and set this.textTrackChangeHandler once so that removeEventListener works
-            this.textTrackChangeHandler = this.textTrackChangeHandler || textTrackChangeHandler.bind(this);
-            this.addTracksListener(this.video.textTracks, 'change', this.textTrackChangeHandler);
+        // Only bind and set this.textTrackChangeHandler once so that removeEventListener works
+        this.textTrackChangeHandler = this.textTrackChangeHandler || textTrackChangeHandler.bind(this);
+        this.addTracksListener(this.video.textTracks, 'change', this.textTrackChangeHandler);
 
-            if (utils.isEdge() || utils.isIE(11) || utils.isFF() || utils.isSafari()) {
-                // Listen for TextTracks added to the videotag after the onloadeddata event in Edge and Firefox
-                this.addTrackHandler = this.addTrackHandler || addTrackHandler.bind(this);
-                this.addTracksListener(this.video, 'addtrack', this.addTrackHandler);
-            }
+        if (!this.renderNatively || utils.isEdge() || utils.isIE(11) || utils.isFF() || utils.isSafari()) {
+            // Listen for TextTracks added to the videotag after the onloadeddata event in Edge and Firefox
+            this.addTrackHandler = this.addTrackHandler || addTrackHandler.bind(this);
+            this.addTracksListener(this.video, 'addtrack', this.addTrackHandler);
+        }
 
-            if (!this.renderNatively) {
-                this.addCueHandler = this.addCueHandler || addCueHandler.bind(this);
-                this.addTracksListener(this.video, 'addcue', this.addCueHandler);
-            }
+        if (!this.renderNatively) {
+            this.addCueHandler = this.addCueHandler || addCueHandler.bind(this);
+            this.addTracksListener(this.video, 'addcue', this.addCueHandler);
         }
 
         if (this._textTracks.length) {
@@ -196,23 +194,21 @@ define(['utils/underscore',
         // Set the provider's index to the model's index, then show the selected track if it exists
         this._currentTextTrackIndex = menuIndex - 1;
 
-        if (this.renderNatively || utils.isIE(11)) {
-            if (this._textTracks[this._currentTextTrackIndex]) {
-                this._textTracks[this._currentTextTrackIndex].mode = 'showing';
-            }
+        if (this._textTracks[this._currentTextTrackIndex]) {
+            this._textTracks[this._currentTextTrackIndex].mode = 'showing';
+        }
 
-            // Update the model index since the track change may have come from a browser event
-            this.trigger('subtitlesTrackChanged', {
-                currentTrack: this._currentTextTrackIndex + 1,
-                tracks: this._textTracks
-            });
+        // Update the model index since the track change may have come from a browser event
+        this.trigger('subtitlesTrackChanged', {
+            currentTrack: this._currentTextTrackIndex + 1,
+            tracks: this._textTracks
+        });
 
-            // IE 11 does not sent a change event when changing text track properties, so we manually send it.
-            if (utils.isIE(11)) {
-                var e = document.createEvent('Event');
-                e.initEvent('change', false, false);
-                this.video.textTracks.dispatchEvent(e);
-            }
+        // IE 11 does not sent a change event when changing text track properties, so we manually send it.
+        if (utils.isIE(11)) {
+            var e = document.createEvent('Event');
+            e.initEvent('change', false, false);
+            this.video.textTracks.dispatchEvent(e);
         }
     }
 

--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -123,7 +123,7 @@ define(['utils/underscore',
             }
         }
 
-        if (this.renderNatively || utils.isIE(11)) {
+        if (!(this.renderNatively && utils.isIOS())) {
             // Only bind and set this.textTrackChangeHandler once so that removeEventListener works
             this.textTrackChangeHandler = this.textTrackChangeHandler || textTrackChangeHandler.bind(this);
             this.addTracksListener(this.video.textTracks, 'change', this.textTrackChangeHandler);
@@ -132,11 +132,11 @@ define(['utils/underscore',
                 // Listen for TextTracks added to the videotag after the onloadeddata event in Edge and Firefox
                 this.addTrackHandler = this.addTrackHandler || addTrackHandler.bind(this);
                 this.addTracksListener(this.video, 'addtrack', this.addTrackHandler);
+            }
 
-                if (utils.isIE(11)) {
-                    this.addCueHandler = this.addCueHandler || addCueHandler.bind(this);
-                    this.addTracksListener(this.video, 'addcue', this.addCueHandler);
-                }
+            if (!this.renderNatively) {
+                this.addCueHandler = this.addCueHandler || addCueHandler.bind(this);
+                this.addTracksListener(this.video, 'addcue', this.addCueHandler);
             }
         }
 
@@ -207,6 +207,7 @@ define(['utils/underscore',
                 tracks: this._textTracks
             });
 
+            // IE 11 does not sent a change event when changing text track properties, so we manually send it.
             if (utils.isIE(11)) {
                 var e = document.createEvent('Event');
                 e.initEvent('change', false, false);
@@ -425,14 +426,6 @@ define(['utils/underscore',
     }
 
     function addCueHandler(event) {
-        event.cueData.cue.vertical = '';
-        event.cueData.cue.snapToLines = true;
-        event.cueData.cue.lineAlign = 'start';
-        event.cueData.cue.position = 50;
-        event.cueData.cue.positionAlign = 'middle';
-        event.cueData.cue.size = 50;
-        event.cueData.cue.align = 'middle';
-
         this.addVTTCue(event.cueData);
     }
 
@@ -657,7 +650,7 @@ define(['utils/underscore',
                 // Captions within .05s of each other are treated as unique to account for
                 // quality switches where start/end times are slightly different.
                 cacheKeyTime = Math.floor(vttCue.startTime * 20);
-                var cacheLine = "_" + vttCue.line;
+                var cacheLine = '_' + vttCue.line;
                 var cacheValue = Math.floor(vttCue.endTime * 20);
                 var cueExists = cachedCues[cacheKeyTime + cacheLine] || cachedCues[(cacheKeyTime + 1) + cacheLine] || cachedCues[(cacheKeyTime - 1) + cacheLine];
 


### PR DESCRIPTION
### What does this Pull Request do?
This pull request adds support for captions and subtitles to display from HLSJS in IE11 and other platforms which do not render captions natively.

### Why is this Pull Request needed?
This is needed because non-native rendering platforms need extra information from HLSJS to know when and where to display captions.

### Are there any points in the code the reviewer needs to double check?
Not specifically.

### Are there any Pull Requests open in other repos which need to be merged with this?
Yes, there will be PRs in Commercial and HLSJS that need to be merged.  There will be noted in comments.

#### Addresses Issue(s):

JW7-4022

