### PR TITLE
Show sharing overlay at larger breakpoints

### DIFF
--- a/src/css/controls/flags/overlay.less
+++ b/src/css/controls/flags/overlay.less
@@ -15,7 +15,12 @@
         }
     }
 
-    &-sharing.jw-breakpoint-2 {
+    &-sharing.jw-breakpoint-2,
+    &-sharing.jw-breakpoint-3,
+    &-sharing.jw-breakpoint-4,
+    &-sharing.jw-breakpoint-5,
+    &-sharing.jw-breakpoint-6,
+    &-sharing.jw-breakpoint-7 {
         .jw-controls,
         .jw-title {
             display: block;

--- a/src/css/controls/flags/overlay.less
+++ b/src/css/controls/flags/overlay.less
@@ -14,4 +14,11 @@
             display: none;
         }
     }
+
+    &-sharing.jw-breakpoint-2 {
+        .jw-controls,
+        .jw-title {
+            display: block;
+        }
+    }
 }

--- a/src/css/controls/imports/transitions.less
+++ b/src/css/controls/imports/transitions.less
@@ -1,4 +1,5 @@
 .jw-controls-right,
+.jw-plugin-sharing,
 .jw-display,
 .jw-overlay,
 .jw-dock {


### PR DESCRIPTION
### What does this Pull Request do? 
Turns sharing overlay into miniature tooltip.

### Why is this Pull Request needed? 
Allows sharing to social media without pausing the video or disrupting the playback experience.

### Are there any points in the code the reviewer needs to double check?


### Are there any Pull Requests open in other repos which need to be merged with this?
 
https://github.com/jwplayer/jwplayer-plugin-sharing/pull/32

#### Addresses Issue(s): 
Adds sharing overlay to transitions fading and enables the text bar at the bottom of the sharing icon to disappear when the overlay is opened. 

JW7-4105

