### PR TITLE
Update player css flags when adding controls

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -469,23 +469,6 @@ define([
         this.addControls = function (controls) {
             _controls = controls;
 
-            const overlaysElement = _playerElement.querySelector('.jw-overlays');
-            overlaysElement.addEventListener('mousemove', _userActivityCallback);
-
-            controls.on('userActive userInactive', function() {
-                if (_playerState === states.PLAYING || _playerState === states.BUFFERING) {
-                    _captionsRenderer.renderCues(true);
-                }
-            });
-
-            controls.enable(_api, _model);
-            controls.addActiveListeners(_logo.element());
-
-            const logoContainer = controls.logoContainer();
-            if (logoContainer) {
-                _logo.setContainer(logoContainer);
-            }
-
             utils.removeClass(_playerElement, 'jw-flag-controls-hidden');
 
             _styles(_videoLayer, {
@@ -495,10 +478,29 @@ define([
             _model.on('change:scrubbing', _stateHandler);
             _model.change('streamType', _setLiveMode, this);
 
+            controls.enable(_api, _model);
+            controls.addActiveListeners(_logo.element());
+
+            const logoContainer = controls.logoContainer();
+            if (logoContainer) {
+                _logo.setContainer(logoContainer);
+            }
+
             // refresh breakpoint and timeslider classes
             if (_lastHeight) {
+                updateContainerStyles(_lastWidth, _lastHeight);
+                controls.resize(_lastWidth, _lastHeight);
                 _captionsRenderer.renderCues(true);
             }
+
+            controls.on('userActive userInactive', function() {
+                if (_playerState === states.PLAYING || _playerState === states.BUFFERING) {
+                    _captionsRenderer.renderCues(true);
+                }
+            });
+
+            const overlaysElement = _playerElement.querySelector('.jw-overlays');
+            overlaysElement.addEventListener('mousemove', _userActivityCallback);
         };
 
         this.removeControls = function () {


### PR DESCRIPTION
### What does this Pull Request do?

Update container classes when controls are added to the player.

### Why is this Pull Request needed?

These classes are not added when controls are false. When turning on controls these flags need to be added for controls to render correctly (.jw-flag-small-player, .jw-flag-time-slider-above, .jw-flag-audio-player).

### Are there any points in the code the reviewer needs to double check?

The order of execution of some calls in `View.addControls` has changed to prioritize writing class and style attribute before adding event listeners. `_captionsRenderer.renderCues` is always last to apply styles because it writes styles and reads layout.

#### Addresses Issue(s):

JW7-4292