### PR TITLE
Add title to video tag

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -571,6 +571,9 @@ define([
                 // don't change state on mobile before user initiates playback
                 _this.setState(states.LOADING);
             }
+            if (item.title) {
+                _videotag.setAttribute('title', item.title);
+            }
             _completeLoad(item.starttime || 0, item.duration || 0);
         };
 

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -571,9 +571,6 @@ define([
                 // don't change state on mobile before user initiates playback
                 _this.setState(states.LOADING);
             }
-            if (item.title) {
-                _videotag.setAttribute('title', item.title);
-            }
             _completeLoad(item.starttime || 0, item.duration || 0);
         };
 

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -400,8 +400,10 @@ define([
             _model.on('change:fullscreen', updateVisibility);
             _model.on('change:intersectionRatio', updateVisibility);
             _model.on('change:visibility', redraw);
+            _model.on('itemReady', itemReady);
 
             updateVisibility();
+            itemReady();
 
             // Always draw first player for icons to load
             if (viewsManager.size() === 1 && !_model.get('visibility')) {
@@ -412,6 +414,12 @@ define([
             _lastWidth = _lastHeight = null;
             this.checkResized();
         };
+
+        function itemReady() {
+            var title = _model.get('playlistItem').title || '';
+            var videotag = _videoLayer.querySelector('video, audio');
+            videotag.setAttribute('title', title);
+        }
 
         function redraw(model, visibility, lastVisibility) {
             if (visibility && !lastVisibility) {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -416,7 +416,7 @@ define([
         };
 
         function itemReady() {
-            var title = _model.get('playlistItem').title || '';
+            const title = _model.get('playlistItem').title || '';
             var videotag = _videoLayer.querySelector('video, audio');
             videotag.setAttribute('title', title);
         }


### PR DESCRIPTION
Adds the item's title to the video tag.

This allows the video's title to appear on iOS device's lock-screens.

Suggesting potential edge case scenarios would be greatly appreciated. Explored playlist with ads where some items don't have titles. 

Enables title to be displayed in the iOS lock screen, instead of video's URL

JW7-3410

