### PR TITLE
Reset model view state on view instantiation

### DIFF
--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -31,13 +31,12 @@ define([
                 // always start on first playlist item
                 item: 0,
                 itemMeta: {},
+                playlistItem: undefined,
                 // Initial state, upon setup
                 state: states.IDLE,
                 // Initially we don't assume Flash is needed
                 flashBlocked: false,
-                fullscreen: false,
-                scrubbing: false,
-                viewSetup: false,
+                provider: undefined,
                 duration: 0,
                 position: 0,
                 buffer: 0

--- a/src/js/view/controls/nextuptooltip.js
+++ b/src/js/view/controls/nextuptooltip.js
@@ -14,6 +14,7 @@ define([
             this.nextUpText = _model.get('localization').nextUp;
             this.nextUpClose = _model.get('localization').nextUpClose;
             this.state = 'tooltip';
+            this.reset();
         }
 
         setup(context) {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -58,7 +58,6 @@ define([
             logoWidth: 0,
         });
 
-
         const _playerElement = utils.createElement(playerTemplate(_model.get('id'), _model.get('localization').player));
         const _videoLayer = _playerElement.querySelector('.jw-media');
 

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -36,6 +36,29 @@ define([
             model: _model
         });
 
+        // init/reset view model properties
+        _.extend(_model.attributes, {
+            containerWidth: undefined,
+            containerHeight: undefined,
+            mediaContainer: undefined,
+            fullscreen: false,
+            inDom: undefined,
+            iFrame: undefined,
+            activeTab: undefined,
+            intersectionRatio: undefined,
+            visibility: undefined,
+            viewable: undefined,
+            viewSetup: false,
+            audioMode: undefined,
+            touchMode: undefined,
+            altText: '',
+            cues: undefined,
+            castClicked: false,
+            scrubbing: false,
+            logoWidth: 0,
+        });
+
+
         const _playerElement = utils.createElement(playerTemplate(_model.get('id'), _model.get('localization').player));
         const _videoLayer = _playerElement.querySelector('.jw-media');
 
@@ -308,12 +331,12 @@ define([
             });
             _model.change('skin', onSkinChange, this);
             _model.change('stretching', onStretchChange);
-            _model.change('aspectratio', onAspectRatioChange);
             _model.change('flashBlocked', onFlashBlockedChange);
 
             const width = _model.get('width');
             const height = _model.get('height');
             _resizePlayer(width, height);
+            _model.change('aspectratio', onAspectRatioChange);
             if (_model.get('controls')) {
                 updateContainerStyles(width, height);
             } else {


### PR DESCRIPTION
### What does this Pull Request do?

Sets the default value of view state model properties directly on the model at view instantiation.

### Why is this Pull Request needed?

Prevents override of default view state in player setup config. While `jwplayer().setup(jwplayer().getConfig())` is not a supported way to 'reset' the player, it should work. `getConfig` is an undocumented method for internal use that allows us to inspect the player model. It returns properties that the view and player use for setup and these must default to undefined for proper setup. Other properties are also reset here that are not set in their sub-modules on instantiation.

### Are there any points in the code the reviewer needs to double check?

For the nextup tooltip, I just call `reset` since that will set the default nextup state on setup. The way the model is used to communicate state between view and player modules is not ideal, but this will keep things clean until the view's state is separated from player and media state.

This is a follow up to #1901 which fixed a symptom of the same issue in the same test that calls `setup` with properties that should only be set internally.

#### Addresses Issue(s):

JW7-4299
