### PR TITLE
Set outline-color on dock buttons to remove focus ring

### DIFF
--- a/src/js/view/controls/templates/dock.js
+++ b/src/js/view/controls/templates/dock.js
@@ -17,7 +17,7 @@ const dockButton = (buttonClass = '', buttonId = '', image, tooltipText) => {
     const aria = tooltipText ? `aria-label="${tooltipText}" role="button" tabindex="0"` : '';
     return (
         `<div class="jw-dock-button jw-background-color jw-reset ${buttonClass}" button="${buttonId}">` +
-            `<div class="jw-icon jw-dock-image jw-reset" ${style} ${aria}></div>` +
+            `<div class="jw-icon jw-dock-image jw-button-color jw-reset" ${style} ${aria}></div>` +
             `<div class="jw-arrow jw-reset"></div>` +
             `${tooltipHtml}` +
         `</div>`


### PR DESCRIPTION
### What does this Pull Request do?

Adds the `. jw-button-color` class on dock button icons. This class is added to all icon buttons for custom foreground colors and resetting some default browser styles we do not want.

### Why is this Pull Request needed?

`outline-color` needs to be set on elements with `tabindex` so that focus rings are not drawn when clicking on buttons. The `. jw-button-color` class does this making the dock button icons more consistent with other UI buttons.

### Are there any points in the code the reviewer needs to double check?

No

### Are there any Pull Requests open in other repos which need to be merged with this?

no

#### Addresses Issue(s):

None

