### PR TITLE
Fix fading out of controls on mobile when toggling with tap on mobile

### DIFF
--- a/src/css/controls/flags/controls-hidden.less
+++ b/src/css/controls/flags/controls-hidden.less
@@ -17,8 +17,11 @@
 }
 
 .jw-flag-controls-hidden {
-    .jw-controls {
+    .jw-controlbar,
+    .jw-display {
         visibility: hidden;
+        pointer-events: none;
+        opacity: 0;
     }
 
     .jw-logo {


### PR DESCRIPTION
### What does this Pull Request do?

Fixes an issue where the hiding of controls is not animated when toggling off controls on mobile while paused with a tap.

### Why is this Pull Request needed?

`opacity` and `pointer-events` must be set to `0` and `none` respectively, along with `visibility: hidden` when hiding elements meant be transitioned.

#### Addresses Issue(s):

JW7-4304
