### PR TITLE
Only fire controls event when a change occurs after ready

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -177,20 +177,15 @@ define([
 
             // For onCaptionsList and onCaptionsChange
             _model.on('change:captionsList', function(model, captionsList) {
-                try {
-                    _this.triggerAfterReady(events.JWPLAYER_CAPTIONS_LIST, {
-                        tracks: captionsList,
-                        track: _getCurrentCaptions()
-                    });
-                } catch (e) {
-                    utils.log('Error with captionsList event:', e);
-                }
+                _this.triggerAfterReady(events.JWPLAYER_CAPTIONS_LIST, {
+                    tracks: captionsList,
+                    track: _model.get('captionsIndex') || 0
+                });
             });
 
             _model.on('change:mediaModel', function(model) {
                 model.mediaModel.on('change:state', function(mediaModel, state) {
-                    var modelState = normalizeState(state);
-                    model.set('state', modelState);
+                    model.set('state', normalizeState(state));
                 });
             });
 
@@ -222,7 +217,9 @@ define([
                 } else {
                     _view.removeControls();
                 }
+            }
 
+            function triggerControls(model, enable) {
                 _this.trigger(events.JWPLAYER_CONTROLS, {
                     controls: enable
                 });
@@ -265,6 +262,7 @@ define([
 
             function _playerReadyNotify() {
                 _model.change('visibility', _updateViewable);
+                _model.on('change:controls', triggerControls);
 
                 // Tell the api that we are loaded
                 _this.trigger(events.JWPLAYER_READY, {


### PR DESCRIPTION
### What does this Pull Request do?

Splits the part of `changeControls`that triggers a "controls" event into another function. The new function `triggerControls` is only fired when controls change after the player is ready.

### Why is this Pull Request needed?

This keeps the behavior of the "controls" event consistent with previous versions of the player. We do not want to fire a controls event for the initial configuration before the "ready" event (bug JW7-4306).

### Are there any points in the code the reviewer needs to double check?

I took the liberty of cleaning up the "captionsList" event adapter. There really isn't any reason we need a try catch, or need to use the controller method for getting the captions index when it is available on the model.

### Are there any Pull Requests open in other repos which need to be merged with this?

The captionsList player change was made to make a test pass that should not have. The change to test was to set `jwplayer.debug = false`:
https://github.com/jwplayer/jwplayer-commercial/pull/3370

#### Addresses Issue(s):

JW7-4306

