### PR TITLE
Bugfix/video resize on item

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -492,8 +492,10 @@ define([
                 _videotag.removeAttribute('src');
                 _videotag.removeAttribute('jw-loaded');
                 _videotag.removeAttribute('jw-played');
-
                 dom.emptyElement(_videotag);
+                cssUtils.style(_videotag, {
+                    objectFit: ''
+                });
                 _currentQuality = -1;
                 // Don't call load in iE9/10 and check for load in PhantomJS
                 if (!_isMSIE && 'load' in _videotag) {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -892,10 +892,6 @@ define([
                 fullscreenHelpers.destroy();
                 fullscreenHelpers = null;
             }
-            if (displayClickHandler) {
-                displayClickHandler.destroy();
-                displayClickHandler = null;
-            }
             if (_model.mediaController) {
                 _model.mediaController.off('fullscreenchange', _fullscreenChangeHandler);
             }
@@ -905,6 +901,10 @@ define([
 
             if (_instreamModel) {
                 this.destroyInstream();
+            }
+            if (displayClickHandler) {
+                displayClickHandler.destroy();
+                displayClickHandler = null;
             }
             if (_logo) {
                 _logo.destroy();

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -327,6 +327,7 @@ define([
 
             _model.change('mediaModel', (model, mediaModel) => {
                 mediaModel.change('mediaType', _onMediaTypeChange, this);
+                mediaModel.on('change:visualQuality', _resizeMedia, this);
             });
             _model.change('skin', onSkinChange, this);
             _model.change('stretching', onStretchChange);
@@ -606,29 +607,29 @@ define([
             _styles(_playerElement, playerStyle);
         }
 
-        function _resizeMedia(mediaWidth, mediaHeight) {
-            if (!mediaWidth || isNaN(1 * mediaWidth)) {
-                if (!_lastWidth) {
+        function _resizeMedia(containerWidth, containerHeight) {
+            if (!containerWidth || isNaN(1 * containerWidth)) {
+                containerWidth = _model.get('containerWidth');
+                if (!containerWidth) {
                     return;
                 }
-                mediaWidth = _lastWidth;
             }
-            if (!mediaHeight || isNaN(1 * mediaHeight)) {
-                if (!_lastHeight) {
+            if (!containerHeight || isNaN(1 * containerHeight)) {
+                containerHeight = _model.get('containerHeight');
+                if (!containerHeight) {
                     return;
                 }
-                mediaHeight = _lastHeight;
             }
 
             if (_preview) {
-                _preview.resize(mediaWidth, mediaHeight, _model.get('stretching'));
+                _preview.resize(containerWidth, containerHeight, _model.get('stretching'));
             }
 
             const provider = _model.getVideo();
             if (!provider) {
                 return;
             }
-            const transformScale = provider.resize(mediaWidth, mediaHeight, _model.get('stretching'));
+            const transformScale = provider.resize(containerWidth, containerHeight, _model.get('stretching'));
 
             // poll resizing if video is transformed
             if (transformScale) {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -327,7 +327,7 @@ define([
 
             _model.change('mediaModel', (model, mediaModel) => {
                 mediaModel.change('mediaType', _onMediaTypeChange, this);
-                mediaModel.on('change:visualQuality', _resizeMedia, this);
+                mediaModel.on('change:visualQuality', () => {_resizeMedia()}, this);
             });
             _model.change('skin', onSkinChange, this);
             _model.change('stretching', onStretchChange);

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -327,7 +327,9 @@ define([
 
             _model.change('mediaModel', (model, mediaModel) => {
                 mediaModel.change('mediaType', _onMediaTypeChange, this);
-                mediaModel.on('change:visualQuality', () => {_resizeMedia()}, this);
+                mediaModel.on('change:visualQuality', () => {
+                    _resizeMedia();
+                }, this);
             });
             _model.change('skin', onSkinChange, this);
             _model.change('stretching', onStretchChange);


### PR DESCRIPTION
### What does this Pull Request do?
This PR ensures that resize is called when the video tag's size is obtained. It also resets the video tag's style when a new item is loaded, and destroys the displayClickHandler after destroyInstream is called.

### Why is this Pull Request needed?
This PR is needed to fix a bug where the video size would not resize after skipping to the next item, and an issue where the next item would inherit the previous item's videoTag style.

### Are there any points in the code the reviewer needs to double check?
I don't believe so

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/3374

#### Addresses Issue(s):
Skipping to next playlist item does not resize video properly

JW7-4301

