### PR TITLE
Horizontal position of non-native captions

### DIFF
--- a/src/js/polyfills/vtt.js
+++ b/src/js/polyfills/vtt.js
@@ -453,12 +453,15 @@ define([
         // value is applied.
         switch (cue.align) {
             case 'start':
+            case 'left':
                 textPos = cue.position;
                 break;
             case 'middle':
+            case 'center':
                 textPos = cue.position - (cue.size / 2);
                 break;
             case 'end':
+            case 'right':
                 textPos = cue.position - cue.size;
                 break;
             default:


### PR DESCRIPTION
### What does this Pull Request do?

This allows non-native captions to align horizontally by using default VTTCue enum values.

### Why is this Pull Request needed?

VTT position values were being ignored because we were not using all the align values that are standard for VTTCues.

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/hls.js/pull/87 is somewhat related.

