### PR TITLE
Add option to not pause when instream init

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -73,7 +73,7 @@ define([
 
         this.type = 'instream';
 
-        this.init = function() {
+        this.init = function(sharedVideoTag) {
 
             // Keep track of the original player state
             _oldProvider = _model.getVideo();
@@ -102,7 +102,7 @@ define([
 
             // If the player's currently playing, pause the video tag
             var currState = _model.get('state');
-            if (currState === states.PLAYING || currState === states.BUFFERING) {
+            if (!sharedVideoTag && (currState === states.PLAYING || currState === states.BUFFERING)) {
                 _oldProvider.pause();
             }
 


### PR DESCRIPTION
### What does this Pull Request do?
Add a flag to not pause the video tag on instream init.

### Why is this Pull Request needed?
Googima iOS pauses the ad when the video tag is paused on ad init,
because the same video tag is used to play the ad and the content.

### Are there any points in the code the reviewer needs to double check?
The same code was there but reverted after a fix, but a change from IMA SDK may have caused the problem to occur again.
The commit that reverted the change: https://github.com/jwplayer/jwplayer/commit/786dce1831810f24557831855eea04bfd86ca881

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-ads-googima/pull/211

#### Addresses Issue(s):

ADS-187

