### PR TITLE
Update dragging CSS flag on scrubbing change

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -322,6 +322,9 @@ define([
             _model.on('change:hideAdsControls', function (model, val) {
                 utils.toggleClass(_playerElement, 'jw-flag-ads-hide-controls', val);
             });
+            _model.on('change:scrubbing', function (model, val) {
+                utils.toggleClass(_playerElement, 'jw-flag-dragging', val);
+            });
             // Native fullscreen (coming through from the provider)
             _model.mediaController.on('fullscreenchange', _fullscreenChangeHandler);
 
@@ -497,7 +500,6 @@ define([
                 cursor: 'pointer'
             });
 
-            _model.on('change:scrubbing', _stateHandler);
             _model.change('streamType', _setLiveMode, this);
 
             controls.enable(_api, _model);
@@ -766,7 +768,6 @@ define([
         }
 
         function _stateUpdate(model, state) {
-            utils.toggleClass(_playerElement, 'jw-flag-dragging', model.get('scrubbing'));
             utils.replaceClass(_playerElement, /jw-state-\S+/, 'jw-state-' + _playerState);
 
             if (state === states.COMPLETE) {


### PR DESCRIPTION
### What does this Pull Request do?

Fixes when we apply the `.jw-flag-dragging` class to the player element.

### Why is this Pull Request needed?

Earlier changes toggled this on when a view state update was using the instream ads model, preventing the buffering icon from showing while ads load.

#### Addresses Issue(s):

JW7-4304

