### PR TITLE
Split breakpoint get/set logic into separate functions & dispatch a breakpoint event separate of updating the class

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -105,7 +105,7 @@
         "indent": [1, 4, {"SwitchCase":1}],
         "brace-style": 1,
         "camelcase": 1,
-        "comma-spacing": [1, {"before": false, "after": true}],
+        "comma-spacing": [2, {"before": false, "after": true}],
         "comma-style": [1, "last"],
         "consistent-this": [0, "_this"],
         "eol-last": 1,

--- a/src/js/events/events.js
+++ b/src/js/events/events.js
@@ -87,7 +87,8 @@ define([], function() {
         JWPLAYER_PROVIDER_CLICK: 'providerClick',
         JWPLAYER_VIEW_TAB_FOCUS: 'tabFocus',
         JWPLAYER_CONTROLBAR_DRAGGING: 'scrubbing',
-        JWPLAYER_INSTREAM_CLICK: 'instreamClick'
+        JWPLAYER_INSTREAM_CLICK: 'instreamClick',
+        JWPLAYER_BREAKPOINT: 'breakpoint'
     };
 
     events.touchEvents = touchEvents;

--- a/src/js/view/utils/breakpoint.js
+++ b/src/js/view/utils/breakpoint.js
@@ -1,4 +1,4 @@
-const utils = require('utils/helpers');
+const domUtils = require('utils/dom');
 
 export function getBreakpoint(width) {
     let breakpoint = 0;
@@ -24,5 +24,5 @@ export function getBreakpoint(width) {
 
 export function setBreakpoint(playerElement, breakpointNumber) {
     const breakpointClass = 'jw-breakpoint-' + breakpointNumber;
-    utils.replaceClass(playerElement, /jw-breakpoint-\d+/, breakpointClass);
+    domUtils.replaceClass(playerElement, /jw-breakpoint-\d+/, breakpointClass);
 }

--- a/src/js/view/utils/breakpoint.js
+++ b/src/js/view/utils/breakpoint.js
@@ -1,31 +1,28 @@
-define([
-    'utils/helpers'
-], function (utils) {
-    return function setBreakpoint(playerElement, playerWidth, playerHeight) {
-        var width = playerWidth;
-        var height = playerHeight;
+const utils = require('utils/helpers');
 
-        var breakPoint = 0;
-        if (width >= 1280) {
-            breakPoint = 7;
-        } else if (width >= 960) {
-            breakPoint = 6;
-        } else if (width >= 800) {
-            breakPoint = 5;
-        } else if (width >= 640) {
-            breakPoint = 4;
-        } else if (width >= 540) {
-            breakPoint = 3;
-        } else if (width >= 420) {
-            breakPoint = 2;
-        } else if (width >= 320) {
-            breakPoint = 1;
-        }
+export function getBreakpoint(width) {
+    let breakpoint = 0;
 
-        var className = 'jw-breakpoint-' + breakPoint;
-        utils.replaceClass(playerElement, /jw-breakpoint-\d+/, className);
-        utils.toggleClass(playerElement, 'jw-orientation-portrait', (height > width));
+    if (width >= 1280) {
+        breakpoint = 7;
+    } else if (width >= 960) {
+        breakpoint = 6;
+    } else if (width >= 800) {
+        breakpoint = 5;
+    } else if (width >= 640) {
+        breakpoint = 4;
+    } else if (width >= 540) {
+        breakpoint = 3;
+    } else if (width >= 420) {
+        breakpoint = 2;
+    } else if (width >= 320) {
+        breakpoint = 1;
+    }
 
-        return breakPoint;
-    };
-});
+    return breakpoint;
+}
+
+export function setBreakpoint(playerElement, breakpointNumber) {
+    const breakpointClass = 'jw-breakpoint-' + breakpointNumber;
+    utils.replaceClass(playerElement, /jw-breakpoint-\d+/, breakpointClass);
+}

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -150,7 +150,9 @@ define([
                     width: containerWidth,
                     height: containerHeight
                 });
-                _this.trigger(events.JWPLAYER_BREAKPOINT,{ breakpoint: getBreakpoint(containerWidth) });
+                _this.trigger(events.JWPLAYER_BREAKPOINT, {
+                    breakpoint: getBreakpoint(containerWidth)
+                });
             }
         };
 

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -4,6 +4,7 @@ import viewsManager from 'view/utils/views-manager';
 import getVisibility from 'view/utils/visibility';
 import activeTab from 'utils/active-tab';
 import { requestAnimationFrame, cancelAnimationFrame } from 'utils/request-animation-frame';
+import { getBreakpoint, setBreakpoint } from 'view/utils/breakpoint';
 
 define([
     'events/events',
@@ -12,14 +13,13 @@ define([
     'utils/helpers',
     'utils/underscore',
     'view/utils/request-fullscreen-helper',
-    'view/utils/breakpoint',
     'view/utils/flag-no-focus',
     'view/utils/clickhandler',
     'view/captionsrenderer',
     'view/logo',
     'view/preview',
     'view/title',
-], function(events, states, Events, utils, _, requestFullscreenHelper, setBreakpoint, flagNoFocus,
+], function(events, states, Events, utils, _, requestFullscreenHelper, flagNoFocus,
             ClickHandler, CaptionsRenderer, Logo, Preview, Title) {
 
     const _styles = utils.style;
@@ -150,6 +150,7 @@ define([
                     width: containerWidth,
                     height: containerHeight
                 });
+                _this.trigger(events.JWPLAYER_BREAKPOINT,{ breakpoint: getBreakpoint(containerWidth) });
             }
         };
 
@@ -168,13 +169,16 @@ define([
             const audioMode = isAudioMode(_model);
             // Set timeslider flags
             if (_.isNumber(width) && _.isNumber(height)) {
-                const breakPoint = setBreakpoint(_playerElement, width, height);
-                const smallPlayer = breakPoint < 2;
+                const breakpoint = getBreakpoint(width);
+                setBreakpoint(_playerElement, breakpoint);
+
+                const smallPlayer = breakpoint < 2;
                 const timeSliderAboveConfig = _model.get('timeSliderAbove');
                 const timeSliderAbove = !audioMode &&
                     (timeSliderAboveConfig !== false) && (timeSliderAboveConfig || smallPlayer);
                 utils.toggleClass(_playerElement, 'jw-flag-small-player', smallPlayer);
                 utils.toggleClass(_playerElement, 'jw-flag-time-slider-above', timeSliderAbove);
+                utils.toggleClass(_playerElement, 'jw-orientation-portrait', (height > width));
             }
             utils.toggleClass(_playerElement, 'jw-flag-audio-player', audioMode);
             _model.set('audioMode', audioMode);

--- a/test/unit/breakpoint-test.js
+++ b/test/unit/breakpoint-test.js
@@ -1,59 +1,48 @@
+import { getBreakpoint, setBreakpoint } from 'view/utils/breakpoint';
+
 define([
     'utils/helpers',
-    'view/utils/breakpoint'
-], function (utils, breakpoint) {
-    /* jshint qunit: true */
+], function (utils) {
     QUnit.module('browser');
     var test = QUnit.test.bind(QUnit);
 
-    function breakpointClassname(width, height) {
-        var mockPlayer = utils.createElement();
-        breakpoint(mockPlayer, width, height);
-        return mockPlayer.className;
-    }
-
-    test('width >= 1280 sets jw-breakpoint-7', function (assert) {
+    test('width >= 1280 returns breakpoint 7', function (assert) {
         assert.expect(1);
-        assert.equal(breakpointClassname(1280), 'jw-breakpoint-7');
+        assert.equal(getBreakpoint(1280), 7);
     });
 
-    test('width >= 960 sets jw-breakpoint-6', function (assert) {
+    test('width >= 960 returns breakpoint 6', function (assert) {
         assert.expect(1);
-        assert.equal(breakpointClassname(960), 'jw-breakpoint-6');
+        assert.equal(getBreakpoint(960), 6);
     });
 
-    test('width >= 800 sets jw-breakpoint-5', function (assert) {
+    test('width >= 800 returns breakpoint 5', function (assert) {
         assert.expect(1);
-        assert.equal(breakpointClassname(800), 'jw-breakpoint-5');
+        assert.equal(getBreakpoint(800), 5);
     });
 
-    test('width >= 640 sets jw-breakpoint-4', function (assert) {
+    test('width >= 640 returns breakpoint 4', function (assert) {
         assert.expect(1);
-        assert.equal(breakpointClassname(640), 'jw-breakpoint-4');
+        assert.equal(getBreakpoint(640), 4);
     });
 
-    test('width >= 540 sets jw-breakpoint-3', function (assert) {
+    test('width >= 540 returns breakpoint 3', function (assert) {
         assert.expect(1);
-        assert.equal(breakpointClassname(540), 'jw-breakpoint-3');
+        assert.equal(getBreakpoint(540), 3);
     });
 
-    test('width >= 420 sets jw-breakpoint-2', function (assert) {
+    test('width >= 420 returns breakpoint 2', function (assert) {
         assert.expect(1);
-        assert.equal(breakpointClassname(420), 'jw-breakpoint-2');
+        assert.equal(getBreakpoint(420), 2);
     });
 
-    test('width >= 320 sets jw-breakpoint-1', function (assert) {
+    test('width >= 320 returns breakpoint 1', function (assert) {
         assert.expect(1);
-        assert.equal(breakpointClassname(320), 'jw-breakpoint-1');
+        assert.equal(getBreakpoint(320), 1);
     });
 
-    test('width < 320 sets jw-breakpoint-0', function (assert) {
+    test('width < 320 returns breakpoint 0', function (assert) {
         assert.expect(1);
-        assert.equal(breakpointClassname(319), 'jw-breakpoint-0');
+        assert.equal(getBreakpoint(319), 0);
     });
-
-    test('if height > width jw-orientation-portrait is set', function (assert) {
-        assert.expect(1);
-        assert.equal(breakpointClassname(319, 320), 'jw-breakpoint-0 jw-orientation-portrait');
-    })
 });


### PR DESCRIPTION
### What does this Pull Request do?
1) Split the getting & setting of breakpoints into separate functions
2) Dispatches a breakpoint event when the player is resized
3) Sets the breakpoint class only when updating container styles

### Why is this Pull Request needed?
Plugins previously relied on the assumption that when a resize event is received, a breakpoint will set on the player className. This assumption is not true anymore with viewability.

### Are there any points in the code the reviewer needs to double check?
I'd like @robwalch to check that my breakpoints are being dispatched & set in the correct handlers. 

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-plugin-related/pull/139

#### Addresses Issue(s):

JW7-4311
