### PR TITLE
Globally inject !important for important styles 

### DIFF
--- a/src/js/utils/css.js
+++ b/src/js/utils/css.js
@@ -11,7 +11,7 @@ define([
             _style(el, styles);
             var styleCSSText = el.style.cssText;
             if (important && styleCSSText) {
-                styleCSSText = styleCSSText.replace(/;$/g, ' !important;');
+                styleCSSText = styleCSSText.replace(/;/g, ' !important;');
             }
             cssText = '{' + styleCSSText + '}';
         } else if (typeof styles === 'string') {


### PR DESCRIPTION
### What does this Pull Request do?
Replaces `;` with ` !important;` for all captions styles that are required to be important to override browser defaults.

### Why is this Pull Request needed?
In Safari, when both a font color and family are specified, `!important` was being applied to the `font-family` and not to the font `color`. This was due to the regex doing a replace at the end of the string and not globally.
### Are there any points in the code the reviewer needs to double check?
No.
### Are there any Pull Requests open in other repos which need to be merged with this?
No.
#### Addresses Issue(s):

JW7-4307

