### PR TITLE
Work around calls that throw exceptions in Edge 15

### DIFF
--- a/src/js/view/utils/views-manager.js
+++ b/src/js/view/utils/views-manager.js
@@ -77,7 +77,9 @@ export default {
     },
     observe(container) {
         lazyInitIntersectionObserver();
-        intersectionObserver.unobserve(container);
+        try {
+            intersectionObserver.unobserve(container);
+        } catch (e) {/* catch Exception thrown by Edge 15 browser */}
         intersectionObserver.observe(container);
     },
     unobserve(container) {


### PR DESCRIPTION
### What does this Pull Request do?

1. Use model "change:activeTab" events to capture tab "visiblechange" events in our QoE tracker. The `document.removeEventListener` call in qoe.js throws an exception in Edge when the function argument is undefined.
2. Wrap `intersectionObserver.unobserve` in a try catch. It throws an exception in Edge when the container is not being observed. 

### Why is this Pull Request needed?

These changes guard against exceptions thrown in Edge 15 that break player setup, QoE and view-ability.

#### Addresses Issue(s):

JW7-4324

