### PR TITLE
Clear 608 captions cue data before ad playback

### DIFF
--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -20,6 +20,7 @@ define(['utils/underscore',
         _initTextTracks: _initTextTracks,
         addTracksListener: addTracksListener,
         clearTracks: clearTracks,
+        clearCueData: clearCueData,
         disableTextTrack: disableTextTrack,
         enableTextTrack: enableTextTrack,
         getSubtitlesTrack: getSubtitlesTrack,
@@ -364,6 +365,14 @@ define(['utils/underscore',
             // Removing listener first to ensure that removing cues does not trigger it unnecessarily
             this.removeTracksListener(this.video.textTracks, 'change', this.textTrackChangeHandler);
             _removeCues(this.renderNatively, this.video.textTracks);
+        }
+    }
+
+    // Clear track cues to prevent duplicates
+    function clearCueData(trackId) {
+        if (this._cachedVTTCues[trackId]) {
+            this._cachedVTTCues[trackId] = {};
+            this._tracksById[trackId].data = [];
         }
     }
 


### PR DESCRIPTION
### What does this Pull Request do?
This clears 608 captions data before ad playback to prevent the presence of duplicate captions when media playback resumes.

### Why is this Pull Request needed?
608 captions were being duplicated when playback of an HLS stream started after a preroll/midroll due to having negligibly different start and end times. Since the captions are re-parsed anyways, it's safe to clear them out and let the provider pass them along to the renderer again.

### Are there any points in the code the reviewer needs to double check?
No.
### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/3401
#### Addresses Issue(s):
JW7-4022

