### PR TITLE
Ensure 608 captions tracks are added to the cc menu in Edge

### DIFF
--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -132,7 +132,7 @@ define(['utils/underscore',
             if (utils.isEdge() || utils.isFF() || utils.isSafari()) {
                 // Listen for TextTracks added to the videotag after the onloadeddata event in Edge and Firefox
                 this.addTrackHandler = this.addTrackHandler || addTrackHandler.bind(this);
-                this.addTracksListener(this.video, 'addtrack', this.addTrackHandler);
+                this.addTracksListener(this.video.textTracks, 'addtrack', this.addTrackHandler);
             }
         }
 


### PR DESCRIPTION
### What does this Pull Request do?
Listens to the `addtrack` event, which is needed in Edge for updating the cc menu when TextTracks are added after the `onLoadedData` event.
### Why is this Pull Request needed?
This bug was introduced while adding captions support for HLS streams in IE11 and broke 608 captions support in Edge.
### Are there any points in the code the reviewer needs to double check?
No - it's just reverting a change that was made.
### Are there any Pull Requests open in other repos which need to be merged with this?
No.
#### Addresses Issue(s):
JW7-4327

