### PR TITLE
Fix transitions regression on autostart mobile ads mute button

### DIFF
--- a/src/css/controls/flags/ads.less
+++ b/src/css/controls/flags/ads.less
@@ -78,6 +78,7 @@
         &.jw-flag-autostart {
             .jw-controls .jw-controlbar {
                 display: table;
+                pointer-events: all;
                 visibility: visible;
                 opacity: 1;
             }


### PR DESCRIPTION
### What does this Pull Request do?

Sets 'point-events' to 'all' on the controlbar in autostart muted mode.

### Why is this Pull Request needed?

Transition rules set point-events to none when hidden so that controls are not clicked on when hidden. If you set opacity and visibility back on to show the controlbar, pointer-events need to be reenabled too. Without this, the 'tapend' event goes through the mute button, down to the media element, and triggers an ad click.

### Are there any Pull Requests open in other repos which need to be merged with this?

#2040 for v7.11.0

#### Addresses Issue(s):

JW7-4332