### PR TITLE
Fix transitions regression on autostart mobile ads mute button  needs-review

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Check out an interactive example in this [JSFiddle](https://jsfiddle.net/Lgs0ou8
  We appreciate all contributions towards the player! Before submitting an issue or PR, please see our contributing docs [here](CONTRIBUTING.md).
 
 ## Building the Player
-We use `grunt` and a few `npm scripts` to build the player, lint code, and run tests. Debug code is built to `/bin-debug`, while minified & uglified code is built to `/bin-release`. Code is built with `webpack`, linted with `eslint` and `flow`, and tested with `karma` and `qunit`.
+We use `grunt` and a few `npm scripts` to build the player, lint code, and run tests. Debug code is built to `/bin-debug`, while minified & uglified code is built to `/bin-release`. Code is built with `webpack`, linted with `eslint`, and tested with `karma` and `qunit`.
 
 #### Requirements:
  1. [Node.js](https://nodejs.org/download)
@@ -102,7 +102,6 @@ We use `grunt` and a few `npm scripts` to build the player, lint code, and run t
 5. Lint your code:
  ````
  npm run lint
- npm run flow
  ````
 
 ## Software License

--- a/src/css/controls/flags/ads.less
+++ b/src/css/controls/flags/ads.less
@@ -78,6 +78,7 @@
         &.jw-flag-autostart {
             .jw-controls .jw-controlbar {
                 display: table;
+                pointer-events: all;
                 visibility: visible;
                 opacity: 1;
             }

--- a/test/unit/providers-test.js
+++ b/test/unit/providers-test.js
@@ -30,7 +30,7 @@ define([
         'hls_androidhls_true': { file: 'http://playertest.longtailvideo.com/adaptive/bipbop/bipbopall.hls', type: 'm3u8', androidhls: true },
 
         'hls_androidhls_false': { file: 'http://playertest.longtailvideo.com/adaptive/bipbop/bipbopall.hls', type: 'm3u8', androidhls: false },
-        'mov': { file: 'assets/os/bunny.mov' },
+        'mov': { file: 'http://playertest.longtailvideo.com/bunny.mov' },
         'youtube': { file: 'http://www.youtube.com/watch?v=YE7VzlLtp-4' }
     };
 


### PR DESCRIPTION
### What does this Pull Request do?

Sets 'point-events' to 'all' on the controlbar in autostart muted mode.

### Why is this Pull Request needed?

Transition rules set point-events to none when hidden so that controls are not clicked on when hidden. If you set opacity and visibility back on to show the controlbar, pointer-events need to be reenabled too. Without this, the 'tapend' event goes through the mute button, down to the media element, and triggers an ad click.

### Are there any Pull Requests open in other repos which need to be merged with this?

#2039 for development and v7.12.0

#### Addresses Issue(s):

JW7-4332