### PR TITLE
Use DOM utils to modify CSS classes

### DIFF
--- a/src/js/view/captionsrenderer.js
+++ b/src/js/view/captionsrenderer.js
@@ -1,9 +1,10 @@
 define([
     'utils/helpers',
     'utils/css',
+    'utils/dom',
     'events/states',
     'utils/underscore'
-], function (utils, cssUtils, states, _) {
+], function (utils, cssUtils, dom, states, _) {
     /** Component that renders the actual captions on screen. **/
     var CaptionsRenderer;
     var _style = cssUtils.style;
@@ -36,11 +37,11 @@ define([
         _display.className = 'jw-captions jw-reset';
 
         this.show = function () {
-            _display.className = 'jw-captions jw-captions-enabled jw-reset';
+            dom.addClass(_display, 'jw-captions-enabled');
         };
 
         this.hide = function () {
-            _display.className = 'jw-captions jw-reset';
+            dom.removeClass(_display, 'jw-captions-enabled');
         };
 
         // Assign list of captions to the renderer
@@ -101,7 +102,7 @@ define([
             if (!cues.length) {
                 _currentCues = [];
             } else if (_.difference(cues, _currentCues).length) {
-                _captionsWindow.className = 'jw-captions-window jw-reset jw-captions-window-active';
+                dom.addClass(_captionsWindow, 'jw-captions-window-active');
                 _currentCues = cues;
             }
 


### PR DESCRIPTION
### What does this Pull Request do?

Uses our DOM utils to add and remove classes from cations renderer elements after setup.

### Why is this Pull Request needed?

Setting `element.className` to it's own value still marks the element for redraw. Our utils check this before setting className to avoid unnecessary repaints or layout invalidation.

### Are there any points in the code the reviewer needs to double check?

@egreaves shouldn't we remove ".jw-captions-window-active" when there are no captions?

