### PR TITLE
Perf/use dom utils to modify classlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Check out an interactive example in this [JSFiddle](https://jsfiddle.net/Lgs0ou8
  We appreciate all contributions towards the player! Before submitting an issue or PR, please see our contributing docs [here](CONTRIBUTING.md).
 
 ## Building the Player
-We use `grunt` and a few `npm scripts` to build the player, lint code, and run tests. Debug code is built to `/bin-debug`, while minified & uglified code is built to `/bin-release`. Code is built with `webpack`, linted with `eslint` and `flow`, and tested with `karma` and `qunit`.
+We use `grunt` and a few `npm scripts` to build the player, lint code, and run tests. Debug code is built to `/bin-debug`, while minified & uglified code is built to `/bin-release`. Code is built with `webpack`, linted with `eslint`, and tested with `karma` and `qunit`.
 
 #### Requirements:
  1. [Node.js](https://nodejs.org/download)
@@ -102,7 +102,6 @@ We use `grunt` and a few `npm scripts` to build the player, lint code, and run t
 5. Lint your code:
  ````
  npm run lint
- npm run flow
  ````
 
 ## Software License

--- a/src/js/view/captionsrenderer.js
+++ b/src/js/view/captionsrenderer.js
@@ -1,9 +1,10 @@
 define([
     'utils/helpers',
     'utils/css',
+    'utils/dom',
     'events/states',
     'utils/underscore'
-], function (utils, cssUtils, states, _) {
+], function (utils, cssUtils, dom, states, _) {
     /** Component that renders the actual captions on screen. **/
     var CaptionsRenderer;
     var _style = cssUtils.style;
@@ -36,11 +37,11 @@ define([
         _display.className = 'jw-captions jw-reset';
 
         this.show = function () {
-            _display.className = 'jw-captions jw-captions-enabled jw-reset';
+            dom.addClass(_display, 'jw-captions-enabled');
         };
 
         this.hide = function () {
-            _display.className = 'jw-captions jw-reset';
+            dom.removeClass(_display, 'jw-captions-enabled');
         };
 
         // Assign list of captions to the renderer
@@ -101,7 +102,7 @@ define([
             if (!cues.length) {
                 _currentCues = [];
             } else if (_.difference(cues, _currentCues).length) {
-                _captionsWindow.className = 'jw-captions-window jw-reset jw-captions-window-active';
+                dom.addClass(_captionsWindow, 'jw-captions-window-active');
                 _currentCues = cues;
             }
 

--- a/test/unit/providers-test.js
+++ b/test/unit/providers-test.js
@@ -30,7 +30,7 @@ define([
         'hls_androidhls_true': { file: 'http://playertest.longtailvideo.com/adaptive/bipbop/bipbopall.hls', type: 'm3u8', androidhls: true },
 
         'hls_androidhls_false': { file: 'http://playertest.longtailvideo.com/adaptive/bipbop/bipbopall.hls', type: 'm3u8', androidhls: false },
-        'mov': { file: 'assets/os/bunny.mov' },
+        'mov': { file: 'http://playertest.longtailvideo.com/bunny.mov' },
         'youtube': { file: 'http://www.youtube.com/watch?v=YE7VzlLtp-4' }
     };
 


### PR DESCRIPTION
### What does this Pull Request do?

Uses our DOM utils to add and remove classes from cations renderer elements after setup.

### Why is this Pull Request needed?

Setting `element.className` to it's own value still marks the element for redraw. Our utils check this before setting className to avoid unnecessary repaints or layout invalidation.

### Are there any points in the code the reviewer needs to double check?

@egreaves shouldn't we remove ".jw-captions-window-active" when there are no captions?

### Are there any Pull Requests open in other repos which need to be merged with this?

#2042 for v7.12.0
