### PR TITLE
Improve view updates

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -76,7 +76,6 @@ define([
 
         let _resizeMediaTimeout = -1;
         let _resizeContainerRequestId = -1;
-        let _previewDisplayStateTimeout = -1;
 
         let displayClickHandler;
         let fullscreenHelpers;
@@ -555,9 +554,6 @@ define([
             _styles(_videoLayer, {
                 cursor: ''
             });
-
-            cancelAnimationFrame(_previewDisplayStateTimeout);
-            clearTimeout(_resizeMediaTimeout);
         };
 
         // Perform the switch to fullscreen
@@ -761,23 +757,14 @@ define([
                 _controls.instreamState = instreamState;
             }
 
-            // Throttle all state change UI updates except for play to prevent iOS 10 animation bug
-            cancelAnimationFrame(_previewDisplayStateTimeout);
-
-            if (_playerState === states.PLAYING) {
-                _stateUpdate(model, _playerState);
-            } else {
-                _previewDisplayStateTimeout = requestAnimationFrame(function () {
-                    _stateUpdate(model, _playerState);
-                });
-            }
-            if (_model.get('controls') && _playerState !== states.PAUSED && utils.hasClass(_playerElement, 'jw-flag-controls-hidden')) {
-                utils.removeClass(_playerElement, 'jw-flag-controls-hidden');
-            }
+            _stateUpdate(_playerState);
         }
 
-        function _stateUpdate(model, state) {
-            utils.replaceClass(_playerElement, /jw-state-\S+/, 'jw-state-' + _playerState);
+        function _stateUpdate(state) {
+            if (_model.get('controls') && state !== states.PAUSED && utils.hasClass(_playerElement, 'jw-flag-controls-hidden')) {
+                utils.removeClass(_playerElement, 'jw-flag-controls-hidden');
+            }
+            utils.replaceClass(_playerElement, /jw-state-\S+/, 'jw-state-' + state);
 
             if (state === states.COMPLETE) {
                 _api.setFullscreen(false);
@@ -889,7 +876,6 @@ define([
             viewsManager.remove(this);
             this.isSetup = false;
             this.off();
-            cancelAnimationFrame(_previewDisplayStateTimeout);
             cancelAnimationFrame(_resizeContainerRequestId);
             clearTimeout(_resizeMediaTimeout);
             _playerElement.removeEventListener('focus', onFocus);

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -81,6 +81,7 @@ define([
         let fullscreenHelpers;
         let focusHelper;
 
+        let _breakpoint = null;
         let _controls;
 
         function reasonInteraction() {
@@ -149,9 +150,13 @@ define([
                     width: containerWidth,
                     height: containerHeight
                 });
-                _this.trigger(events.JWPLAYER_BREAKPOINT, {
-                    breakpoint: getBreakpoint(containerWidth)
-                });
+                const breakpoint = getBreakpoint(containerWidth);
+                if (_breakpoint !== breakpoint) {
+                    _breakpoint = breakpoint;
+                    _this.trigger(events.JWPLAYER_BREAKPOINT, {
+                        breakpoint: _breakpoint
+                    });
+                }
             }
         };
 


### PR DESCRIPTION
### What does this Pull Request do?

Removes request animation frame deferral of player state class updates on the player element, and prevents breakpoint events from being dispatched when the breakpoint has not changed on resize.
 
### Why is this Pull Request needed?

The player state deferral is an old optimization to prevent posters from loading that is no longer needed. The breakpoint event is new and should only fire when there is a change.

### Are there any points in the code the reviewer needs to double check?

There were also a couple of timeout/request animation frame calls cancelled when controls are disabled. These are not related to controls so shouldn't be cancelled when controls are disabled.

This should help with intermittent issues with the player view not updating noticed by @dannyfinks  and @msiddique.