### PR TITLE
Don't attempt to set video tag title when using flash

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -416,6 +416,7 @@ define([
         };
 
         function itemReady() {
+            const provider = _model.getVideo();
             if (provider && provider.getName().name.indexOf('flash') === 0) {
                 return;
             }

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -416,6 +416,9 @@ define([
         };
 
         function itemReady() {
+            if (provider && provider.getName().name.indexOf('flash') === 0) {
+                return;
+            }
             const title = _model.get('playlistItem').title || '';
             var videotag = _videoLayer.querySelector('video, audio');
             videotag.setAttribute('title', title);

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -417,7 +417,7 @@ define([
 
         function itemReady(item) {
             const provider = _model.getVideo();
-            if (provider && provider.getName().name === 'flash') {
+            if (provider && provider.getName().name.indexOf('flash') === 0) {
                 return;
             }
             const title = item.title || '';
@@ -602,7 +602,7 @@ define([
             }
             // pass fullscreen state to Flash provider
             // provider.getName() is the same as _api.getProvider() or _model.get('provider')
-            if (provider && provider.getName().name === 'flash') {
+            if (provider && provider.getName().name.indexOf('flash') === 0) {
                 provider.setFullscreen(state);
             }
         };
@@ -717,7 +717,7 @@ define([
         function _onMediaTypeChange(model, val) {
             const isAudioFile = (val === 'audio');
             const provider = _model.getVideo();
-            const isFlash = provider && provider.getName().name === 'flash';
+            const isFlash = (provider && provider.getName().name.indexOf('flash') === 0);
 
             utils.toggleClass(_playerElement, 'jw-flag-media-audio', isAudioFile);
 

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -417,7 +417,7 @@ define([
 
         function itemReady() {
             const provider = _model.getVideo();
-            if (provider && provider.getName().name.indexOf('flash') === 0) {
+            if (provider && provider.getName().name === 'flash') {
                 return;
             }
             const title = _model.get('playlistItem').title || '';
@@ -602,7 +602,7 @@ define([
             }
             // pass fullscreen state to Flash provider
             // provider.getName() is the same as _api.getProvider() or _model.get('provider')
-            if (provider && provider.getName().name.indexOf('flash') === 0) {
+            if (provider && provider.getName().name === 'flash') {
                 provider.setFullscreen(state);
             }
         };
@@ -717,7 +717,7 @@ define([
         function _onMediaTypeChange(model, val) {
             const isAudioFile = (val === 'audio');
             const provider = _model.getVideo();
-            const isFlash = (provider && provider.getName().name.indexOf('flash') === 0);
+            const isFlash = provider && provider.getName().name === 'flash';
 
             utils.toggleClass(_playerElement, 'jw-flag-media-audio', isAudioFile);
 


### PR DESCRIPTION
### What does this Pull Request do?
It avoids setting the video tag title when using the flash provider

### Why is this Pull Request needed?
The 'Add title attribute to <video> tag' PR https://github.com/jwplayer/jwplayer/pull/2013 broke the flash provider

### Are there any points in the code the reviewer needs to double check?
Would it be best to check for flash before adding the event listener ? (on itemReady)

### Are there any Pull Requests open in other repos which need to be merged with this?
n/a

#### Addresses Issue(s):
Enables title to be displayed in the iOS lock screen, instead of video's URL (without breaking flash)
JW7-3410

