### PR TITLE
Only fire complete if the state is not complete

### DIFF
--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -134,7 +134,8 @@ define([
                 case events.JWPLAYER_MEDIA_COMPLETE:
                     _beforecompleted = true;
                     this.mediaController.trigger(events.JWPLAYER_MEDIA_BEFORECOMPLETE, evt);
-                    if (_attached) {
+                    if (_attached && mediaModel.get('state') !== states.COMPLETE &&
+                        mediaModel.get('state') !== states.IDLE) {
                         this.playbackComplete();
                     }
                     return;


### PR DESCRIPTION
### What does this Pull Request do?
Check the state before firing complete, so that complete is not fired when the state is idle or complete.
### Why is this Pull Request needed?
When ad ad start and stop immediately, attachMedia calls complete event, then _attached flag is set to true. Then the complete event is fired again, resulting complete event to fire twice.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):
ADS-175
