### PR TITLE
Prevents setting video tag title in incompatible Providers, and handles double encoded titles

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -425,7 +425,8 @@ define([
             }
             const title = item.title || '';
             var videotag = _videoLayer.querySelector('video, audio');
-            videotag.setAttribute('title', title);
+            videotag.innerHTML = title;
+            videotag.setAttribute('title', videotag.innerHTML);
         }
 
         function redraw(model, visibility, lastVisibility) {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -417,15 +417,15 @@ define([
 
         function itemReady(item) {
             const provider = _model.getVideo();
+            var videotag = _videoLayer.querySelector('video, audio');
             // Youtube, chromecast and flash providers do no support video tags
-            if (provider && /^(youtube|chromecast|flash)/.test(provider.getName().name)) {
+            if (!videotag) {
                 return;
             }
-            var videotag = _videoLayer.querySelector('video, audio');
             const dummyDiv = document.createElement('DIV');
             // Writing a string to innerHTML completely decodes multiple-encoded strings
             dummyDiv.innerHTML = item.title || '';
-            videotag.setAttribute('title', dummyDiv.innerHTML);
+            videotag.setAttribute('title', dummyDiv.textContent);
         }
 
         function redraw(model, visibility, lastVisibility) {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -416,7 +416,6 @@ define([
         };
 
         function itemReady(item) {
-            const provider = _model.getVideo();
             var videotag = _videoLayer.querySelector('video, audio');
             // Youtube, chromecast and flash providers do no support video tags
             if (!videotag) {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -417,13 +417,15 @@ define([
 
         function itemReady(item) {
             const provider = _model.getVideo();
+            // Youtube, chromecast and flash providers do no support video tags
             if (provider && /^(youtube|chromecast|flash)/.test(provider.getName().name)) {
                 return;
             }
             const title = item.title || '';
             var videotag = _videoLayer.querySelector('video, audio');
-            videotag.innerHTML = title;
-            videotag.setAttribute('title', videotag.innerHTML);
+            const dummyDiv = document.createElement('DIV');
+            dummyDiv.innerHTML = title;
+            videotag.setAttribute('title', dummyDiv.innerHTML);
         }
 
         function redraw(model, visibility, lastVisibility) {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -423,7 +423,7 @@ define([
             }
             var videotag = _videoLayer.querySelector('video, audio');
             const dummyDiv = document.createElement('DIV');
-            // The item's title is set to the div's innerHTML to decrypt strings
+            // Writing a string to innerHTML completely decodes multiple-encoded strings
             dummyDiv.innerHTML = item.title || '';
             videotag.setAttribute('title', dummyDiv.innerHTML);
         }

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -421,10 +421,10 @@ define([
             if (provider && /^(youtube|chromecast|flash)/.test(provider.getName().name)) {
                 return;
             }
-            const title = item.title || '';
             var videotag = _videoLayer.querySelector('video, audio');
             const dummyDiv = document.createElement('DIV');
-            dummyDiv.innerHTML = title;
+            // The item's title is set to the div's innerHTML to decrypt strings
+            dummyDiv.innerHTML = item.title || '';
             videotag.setAttribute('title', dummyDiv.innerHTML);
         }
 

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -417,7 +417,10 @@ define([
 
         function itemReady(item) {
             const provider = _model.getVideo();
-            if (provider && provider.getName().name.indexOf('flash') === 0) {
+            if (provider &&
+                (provider.getName().name === 'youtube' ||
+                 provider.getName().name === 'chromecast' ||
+                 provider.getName().name.indexOf('flash') === 0 )) {
                 return;
             }
             const title = item.title || '';

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -417,10 +417,7 @@ define([
 
         function itemReady(item) {
             const provider = _model.getVideo();
-            if (provider &&
-                (provider.getName().name === 'youtube' ||
-                 provider.getName().name === 'chromecast' ||
-                 provider.getName().name.indexOf('flash') === 0 )) {
+            if (provider && /^(youtube|chromecast|flash)/.test(provider.getName().name)) {
                 return;
             }
             const title = item.title || '';


### PR DESCRIPTION
### What does this Pull Request do?
Checks that the provider is not youtube or chromecast when setting title, and handles double encoded titles.

### Why is this Pull Request needed?
Player will crash if an attempt to set a video tag title is done on providers that do not support it, and the iOS lock screen will display double encoded symbols if the title is not converted.

### Are there any points in the code the reviewer needs to double check?
is this the best way to decode double encoded strings? I mimicked what was done in title.js

### Are there any Pull Requests open in other repos which need to be merged with this?
n/a

#### Addresses Issue(s):

JW7-3410

