### PR TITLE
Ensure captions display when replaying Dash streams

### DIFF
--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -503,7 +503,7 @@ define(['utils/underscore',
     }
 
     function _removeCues(renderNatively, tracks) {
-        if (tracks.length) {
+        if (tracks && tracks.length) {
             _.each(tracks, function(track) {
                 // Let IE & Edge handle cleanup of non-sideloaded text tracks for native rendering
                 if (utils.isIE() && renderNatively && /^(native|subtitle|cc)/.test(track._id)) {


### PR DESCRIPTION
What does this Pull Request do?

Checks for tracks before obtaining the length

Why is this Pull Request needed?

Prevents Commercial PR jwplayer/jwplayer-commercial#3434 from failing unit tests

Are there any points in the code the reviewer needs to double check?

n/a

Are there any Pull Requests open in other repos which need to be merged with this?

jwplayer/jwplayer-commercial#3434

Addresses Issue(s):

dash vtt disappear on replay
JW7-4298