### PR TITLE
Hide mouse pointer with CSS when controls aren’t visible

### DIFF
--- a/src/css/jwplayer/flags/controls-hidden.less
+++ b/src/css/jwplayer/flags/controls-hidden.less
@@ -7,4 +7,8 @@
     video::-webkit-media-text-track-container {
         max-height: none;
     }
+
+    .jw-media {
+        cursor: default;
+    }
 }

--- a/src/css/jwplayer/imports/jwplayerlayout.less
+++ b/src/css/jwplayer/imports/jwplayerlayout.less
@@ -55,6 +55,7 @@
 
 .jw-media {
     overflow: hidden;
+    cursor: pointer;
 }
 
 .jw-plugin {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -509,10 +509,6 @@ define([
 
             utils.removeClass(_playerElement, 'jw-flag-controls-hidden');
 
-            _styles(_videoLayer, {
-                cursor: 'pointer'
-            });
-
             _model.change('streamType', _setLiveMode, this);
 
             controls.enable(_api, _model);
@@ -555,10 +551,6 @@ define([
             }
 
             utils.addClass(_playerElement, 'jw-flag-controls-hidden');
-
-            _styles(_videoLayer, {
-                cursor: ''
-            });
         };
 
         // Perform the switch to fullscreen


### PR DESCRIPTION
### What does this Pull Request do?
Use CSS to hide the mouse pointer when `controls: false` or when the `user-inactive` flag is applied. 
### Why is this Pull Request needed?
The specificity of in-line styles caused the pointer to not disappear when controls are hidden, even in fullscreen mode. 
### Are there any points in the code the reviewer needs to double check?
No, but it's useful to note that Chrome does not behave the same way Safari does. In Safari, the pointer hides immediately when the controls are hidden. In Chrome, the behavior is inconsistent, even in fullscreen mode. I also observed this with youtube's player in Chrome and Safari. Chrome has repeatedly closed reported issues with `#wontfix` (See: [#102508](https://bugs.chromium.org/p/chromium/issues/detail?id=102508) & [#181005](https://bugs.chromium.org/p/chromium/issues/detail?id=181005)) because it is a non-standard feature.
### Are there any Pull Requests open in other repos which need to be merged with this?
No
#### Addresses Issue(s):
JW7-4341


