### PR TITLE
Slice language string to a length of 2 when mapping 2-char ISO codes

### DIFF
--- a/src/js/utils/language.js
+++ b/src/js/utils/language.js
@@ -14,11 +14,15 @@ define([
         ja: 'Japanese',
         pt: 'Portuguese',
         ru: 'Russian',
-        es: 'Spanish'
+        es: 'Spanish',
+        el: 'Greek',
     };
 
     function getLabel(language) {
-        return twoCharMap[language] || language;
+        if (!language) {
+            return '';
+        }
+        return twoCharMap[language.slice(0, 2)] || language;
     }
 
     return {

--- a/src/js/utils/language.js
+++ b/src/js/utils/language.js
@@ -20,8 +20,14 @@ define([
 
     function getLabel(language) {
         if (!language) {
-            return '';
+            return;
         }
+
+        // We do not map ISO 639-2 (3-letter codes)
+        if (language.length === 3) {
+            return language;
+        }
+
         return twoCharMap[language.slice(0, 2)] || language;
     }
 

--- a/test/unit/language-test.js
+++ b/test/unit/language-test.js
@@ -73,6 +73,11 @@ define([
 
                     assert.equal(langUtils.getLabel('es'), expected);
                 });
+
+                it('should map based only on the first two characters', function () {
+                   var expected = 'Portuguese';
+                   assert.equal(langUtils.getLabel('pt-br'), expected);
+                });
             });
 
 
@@ -114,7 +119,7 @@ define([
                     assert.equal(langUtils.getLabel('ita'), 'ita');
                 });
 
-                it('should not change for its Russion codes', function() {
+                it('should not change for its Russian codes', function() {
                     assert.equal(langUtils.getLabel('rus'), 'rus');
                 });
 


### PR DESCRIPTION
### What does this Pull Request do?
Limits ISO language code to a length of 2

### Why is this Pull Request needed?
Some language codes (in my case, from a DASH stream) come instead as two hyphenated strings, with the first being the actual code:

`pt-br` (Brazilian Portuguese)

All we care about are the first two chars.

### Are there any points in the code the reviewer needs to double check?
Should we map twice, maybe, when the string is hyphenated? 

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/3466

#### Addresses Issue(s):
JW7-4313
