### PR TITLE
[v7.11.1] Allow `resize()` to be used to update player bounds

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -588,21 +588,21 @@ define([
         };
 
         function _resizePlayer(playerWidth, playerHeight, resetAspectMode) {
+            const widthSet = utils.exists(playerWidth);
+            const heightSet = utils.exists(playerHeight);
             const playerStyle = {
                 width: playerWidth
             };
 
             // when jwResize is called remove aspectMode and force layout
-            resetAspectMode = !!resetAspectMode;
-            if (resetAspectMode) {
+            if (heightSet && resetAspectMode) {
                 _model.set('aspectratio', null);
-                // playerStyle.display = 'block';
             }
             if (!_model.get('aspectratio')) {
                 playerStyle.height = playerHeight;
             }
 
-            if (utils.exists(playerWidth) && utils.exists(playerHeight)) {
+            if (widthSet && heightSet) {
                 _model.set('width', playerWidth);
                 _model.set('height', playerHeight);
             }


### PR DESCRIPTION
### What does this Pull Request do?

This change prevents "aspect ratio" mode from being disabled when resize is called without a height argument.

### Why is this Pull Request needed?

While resize is expected to be called with a new width and height (ex: `jwplayer()resize('100%', 300)`), [we have demos](https://developer.jwplayer.com/jw-player/demos/advanced/minimize-and-float-video-on-scroll/) that use `player.resize()`to update the bounds of the player after the player container's dimensions have changed. This shouldn't have worked since the aspect ratio should be removed and width and height set to "auto" or 0, but [our code didn't actually remove the jw-flag-aspect-ratio properly](https://github.com/jwplayer/jwplayer/blob/v7.10.6/src/js/view/view.js#L760).

The reason the bounds need to be updated is that responsive players don't have any JavaScript event to trigger an update other than window resize and orientation change. In JW8 we'll think about using IntersectionObserver to tell when a player whose width or height uses percentages changes because of a layout change higher up in the DOM. We don't poll layout now because of the impact that would have on performance, but we need to update the bounds for the correct breakpoint class to be set on the player, and for `getWidth()` and `getHeight()` to return the correct values.

#### Addresses Issue(s):

JW7-4353