### PR TITLE
Improve Play Reason Tracking

### DIFF
--- a/src/js/api/api-actions.js
+++ b/src/js/api/api-actions.js
@@ -8,17 +8,17 @@ define([
         //   Ultimately they should be moved into this file
         var passthroughs = [
             // 'setup',
+            // 'remove',
             // 'load',
             // 'play',
             // 'pause',
-            // 'remove',
+            // 'playlistNext',
+            // 'playlistPrev',
+            // 'playlistItem',
+            // 'seek',
 
-            'seek',
             'skipAd',
             'stop',
-            'playlistNext',
-            'playlistPrev',
-            'playlistItem',
             'resize',
 
             'addButton',

--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -213,6 +213,26 @@ define([
             return this.play(meta);
         };
 
+        this.seek = function(pos, meta = { reason: 'external' }) {
+            _controller.seek(pos, meta);
+            return _this;
+        };
+
+        this.playlistNext = function(meta = { reason: 'external' }) {
+            _controller.playlistNext(meta);
+            return _this;
+        };
+
+        this.playlistPrev = function(meta = { reason: 'external' }) {
+            _controller.playlistPrev(meta);
+            return _this;
+        };
+
+        this.playlistItem = function(index, meta = { reason: 'external' }) {
+            _controller.playlistItem(index, meta);
+            return _this;
+        };
+
         this.createInstream = function () {
             return _controller.createInstream();
         };

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -395,10 +395,8 @@ define([
                 return _model.get('state');
             }
 
-            function _play(meta) {
-                if (meta) {
-                    _model.set('playReason', meta.reason);
-                }
+            function _play(meta = {}) {
+                _model.set('playReason', meta.reason);
 
                 if (_model.get('state') === states.ERROR) {
                     return;
@@ -484,15 +482,13 @@ define([
                 return true;
             }
 
-            function _pause(meta) {
+            function _pause(meta = {}) {
                 _actionOnAttach = null;
 
-                if (meta) {
-                    _model.set('pauseReason', meta.reason);
-                    // Stop autoplay behavior if the video is paused by the user or an api call
-                    if (meta.reason === 'interaction' || meta.reason === 'external') {
-                        _model.set('playOnViewable', false);
-                    }
+                _model.set('pauseReason', meta.reason);
+                // Stop autoplay behavior if the video is paused by the user or an api call
+                if (meta.reason === 'interaction' || meta.reason === 'external') {
+                    _model.set('playOnViewable', false);
                 }
 
                 var adState = _getAdState();
@@ -572,11 +568,11 @@ define([
             }
 
             function _prev(meta) {
-                _item(_model.get('item') - 1, meta || { reason: 'external' });
+                _item(_model.get('item') - 1, meta);
             }
 
             function _next(meta) {
-                _item(_model.get('item') + 1, meta || { reason: 'external' });
+                _item(_model.get('item') + 1, meta);
             }
 
             function _completeHandler() {


### PR DESCRIPTION
### What does this Pull Request do?

1. Prevent last play reason from being repeated
2. Set playReason to "external" for API calls that don’t set a reason

### Why is this Pull Request needed?

Play reasons are not tracked correctly for playlist navigation with related, and any case where a specific reason for seek, next, prev and setting the playlist item is not specified.

### Are there any points in the code the reviewer needs to double check?

It's important that the previous 'playReason' removed when a new play call with no reason is called. This was not happening before:
  
```js
function _play(meta) {
  if (meta) {
    _model.set('playReason', meta.reason);
  }
```

Now we will always update playReason - `undefined` is better than the previous reason which would be incorrect, because we'll track those events as "unknown".

```js
function _play(meta = {}) {
  _model.set('playReason', meta.reason);
```

### Are there any Pull Requests open in other repos which need to be merged with this?

Not yet. These changes should help support JW7-4270

#### Addresses Issue(s):

JW7-2537

