### PR TITLE
Put next-up properties on next-up instance rather than the model

### DIFF
--- a/src/css/controls/imports/nextup.less
+++ b/src/css/controls/imports/nextup.less
@@ -16,6 +16,7 @@
     transition: all 150ms ease;
     visibility: hidden;
     width: 100%;
+    pointer-events: none;
 
     .jw-flag-small-player & {
         display: none;
@@ -35,6 +36,7 @@
     position: relative;
     max-width: 300px;
     width: 100%;
+    pointer-events: all;
 }
 
 .jw-nextup-header {

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -87,10 +87,8 @@ define([
             this._model = _model;
             this._isMobile = utils.isMobile();
             this._localization = _model.get('localization');
-            this.setup(_api, _model);
-        }
 
-        setup(_api, _model) {
+            this.nextUpToolTip = null;
 
             const timeSlider = new TimeSlider(_model, _api);
             let volumeSlider;
@@ -118,13 +116,19 @@ define([
             if (_model.get('nextUpDisplay')) {
                 new UI(nextButton.element(), { useHover: true, directSelect: true })
                     .on('over', function () {
-                        this._model.set('nextUpVisible', true);
+                        const nextUpToolTip = this.nextUpToolTip;
+                        if (nextUpToolTip) {
+                            nextUpToolTip.toggle(true);
+                        }
                     }, this)
                     .on('out', function () {
-                        if (this._model.get('nextUpSticky')) {
-                            return;
+                        const nextUpToolTip = this.nextUpToolTip;
+                        if (nextUpToolTip) {
+                            if (nextUpToolTip.nextUpSticky) {
+                                return;
+                            }
+                            nextUpToolTip.toggle(false);
                         }
-                        this._model.set('nextUpVisible', false);
                     }, this);
             }
 

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -100,10 +100,8 @@ define([
             this.right = right;
 
             // Dock Area and Buttons
-            if (!this.dock) {
-                this.dock = new Dock(model);
-            }
-            this.right.appendChild(this.dock.element());
+            const dock = this.dock = new Dock(model);
+            this.right.appendChild(dock.element());
 
             // Touch UI mode when we're on mobile and we have a percentage height or we can fit the large UI in
             if (touchMode) {
@@ -119,23 +117,20 @@ define([
                 });
             }
 
+            // Controlbar
+            const controlbar = this.controlbar = new Controlbar(api, model);
+            controlbar.on(events.JWPLAYER_USER_ACTION, () => this.userActive());
             // Next Up Tooltip
-            if (model.get('nextUpDisplay') && !this.nextUpToolTip) {
+            if (model.get('nextUpDisplay') && !controlbar.nextUpToolTip) {
                 const nextUpToolTip = new NextUpToolTip(model, api, this.playerContainer);
                 nextUpToolTip.setup(this.context);
-                this.nextUpToolTip = nextUpToolTip;
+                controlbar.nextUpToolTip = nextUpToolTip;
 
                 // NextUp needs to be behind the controlbar to not block other tooltips
                 this.div.appendChild(nextUpToolTip.element());
             }
-
-            // Controlbar
-            if (!this.controlbar) {
-                this.controlbar = new Controlbar(api, model);
-                this.controlbar.on(events.JWPLAYER_USER_ACTION, () => this.userActive());
-            }
-            this.addActiveListeners(this.controlbar.element());
-            this.div.appendChild(this.controlbar.element());
+            this.addActiveListeners(controlbar.element());
+            this.div.appendChild(controlbar.element());
 
             // Unmute Autoplay Button. Ignore iOS9. Muted autoplay is supported in iOS 10+
             if (model.get('autostartMuted')) {
@@ -144,7 +139,7 @@ define([
                 this.mute.show();
                 this.div.appendChild(this.mute.element());
                 // Set mute state in the controlbar
-                this.controlbar.renderVolume(true, model.get('volume'));
+                controlbar.renderVolume(true, model.get('volume'));
                 // Hide the controlbar until the autostart flag is removed
                 utils.addClass(this.playerContainer, 'jw-flag-autostart');
 

--- a/src/js/view/controls/nextuptooltip.js
+++ b/src/js/view/controls/nextuptooltip.js
@@ -14,42 +14,40 @@ define([
             this.nextUpText = _model.get('localization').nextUp;
             this.nextUpClose = _model.get('localization').nextUpClose;
             this.state = 'tooltip';
+            this.enabled = false;
             this.reset();
         }
 
         setup(context) {
             this.container = context.createElement('div');
             this.container.className = 'jw-nextup-container jw-reset';
-            var element = utils.createElement(nextUpTemplate());
+            const element = utils.createElement(nextUpTemplate());
             this.addContent(element);
 
             this.closeButton = this.content.querySelector('.jw-nextup-close');
             this.closeButton.setAttribute('aria-label', this.nextUpClose);
             this.tooltip = this.content.querySelector('.jw-nextup-tooltip');
 
-            var model = this._model;
+            const model = this._model;
             // Next Up is hidden until we get a valid NextUp item from the nextUp event
-            model.set('nextUpEnabled', false);
+            this.enabled = false;
 
             // Events
-            model.on('change:mediaModel', this.onMediaModel, this);
-            model.on('change:streamType', this.onStreamType, this);
             model.on('change:nextUp', this.onNextUp, this);
-            model.on('change:nextUpVisible', this.toggle, this);
-            model.on('change:nextUpSticky', this.toggle, this);
 
             // Listen for duration changes to determine the offset from the end for when next up should be shown
-            model.on('change:duration', this.onDuration, this);
+            model.change('duration', this.onDuration, this);
             // Listen for position changes so we can show the tooltip when the offset has been crossed
-            model.on('change:position', this.onElapsed, this);
+            model.change('position', this.onElapsed, this);
 
-            this.onMediaModel(model, model.get('mediaModel'));
+            model.change('streamType', this.onStreamType, this);
+            model.change('mediaModel', this.onMediaModel, this);
 
             // Close button
             new UI(this.closeButton, { directSelect: true })
                 .on('click tap', function() {
-                    model.set('nextUpSticky', false);
-                    model.set('nextUpVisible', false);
+                    this.nextUpSticky = false;
+                    this.toggle(false);
                 }, this);
             // Tooltip
             new UI(this.tooltip)
@@ -73,16 +71,13 @@ define([
             this._api.next();
         }
 
-        toggle(model, show) {
-            show = !!show;
-
-            if (!model.get('nextUpEnabled')) {
+        toggle(show) {
+            if (!this.enabled) {
                 return;
             }
-
+            dom.toggleClass(this.container, 'jw-nextup-sticky', !!this.nextUpSticky);
             dom.toggleClass(this.container, 'jw-nextup-container-visible', show);
             dom.toggleClass(this._playerElement, 'jw-flag-nextup', show);
-            dom.toggleClass(this.container, 'jw-nextup-sticky', !!model.get('nextUpSticky'));
         }
 
         setNextUpItem(nextUpItem) {
@@ -92,7 +87,7 @@ define([
                 this.thumbnail = this.content.querySelector('.jw-nextup-thumbnail');
                 dom.toggleClass(this.thumbnail, 'jw-nextup-thumbnail-visible', !!nextUpItem.image);
                 if (nextUpItem.image) {
-                    var thumbnailStyle = this.loadThumbnail(nextUpItem.image);
+                    const thumbnailStyle = this.loadThumbnail(nextUpItem.image);
                     utils.style(this.thumbnail, thumbnailStyle);
                 }
 
@@ -102,7 +97,7 @@ define([
 
                 // Set title
                 this.title = this.content.querySelector('.jw-nextup-title');
-                var title = nextUpItem.title;
+                const title = nextUpItem.title;
                 this.title.innerText = title ? utils.createElement(title).textContent : '';
             }, 500);
         }
@@ -113,13 +108,13 @@ define([
                 return;
             }
 
-            var nextUpEnabled = !!(nextUp.title || nextUp.image);
-            model.set('nextUpEnabled', nextUpEnabled);
+            this.enabled = !!(nextUp.title || nextUp.image);
 
-            if (nextUpEnabled) {
+            if (this.enabled) {
                 if (!nextUp.showNextUp) {
                     // The related plugin will countdown the nextUp item
-                    model.set('nextUpSticky', false);
+                    this.nextUpSticky = false;
+                    this.toggle(false);
                 }
                 this.setNextUpItem(nextUp);
             }
@@ -131,7 +126,7 @@ define([
             }
 
             // Use nextupoffset if set or default to 10 seconds from the end of playback
-            var offset = utils.seconds(model.get('nextupoffset') || -10);
+            let offset = utils.seconds(model.get('nextupoffset') || -10);
             if (offset < 0) {
                 // Determine offset from the end. Duration may change.
                 offset += duration;
@@ -141,33 +136,34 @@ define([
         }
 
         onMediaModel(model, mediaModel) {
-            mediaModel.on('change:state', function(stateChangeMediaModel, state) {
+            mediaModel.change('state', function(stateChangeMediaModel, state) {
                 if (state === 'complete') {
-                    model.set('nextUpVisible', false);
+                    this.toggle(false);
                 }
-            });
+            }, this);
         }
 
         onElapsed(model, val) {
-            var nextUpSticky = model.get('nextUpSticky');
-            if (!model.get('nextUpEnabled') || nextUpSticky === false) {
+            const nextUpSticky = this.nextUpSticky;
+            if (!this.enabled || nextUpSticky === false) {
                 return;
             }
             // Show nextup during VOD streams if:
             // - in playlist mode but not playing an ad
             // - autoplaying in related mode and autoplaytimer is set to 0
-            var showTilEnd = val >= this.offset;
-            if (showTilEnd && nextUpSticky === undefined) { // show if nextUpSticky is unset
-                model.set('nextUpVisible', showTilEnd);
-                model.set('nextUpSticky', showTilEnd);
-            } else if (!showTilEnd && nextUpSticky === true) { // reset if there was a backward seek
+            const showUntilEnd = val >= this.offset;
+            if (showUntilEnd && nextUpSticky === undefined) { // show if nextUpSticky is unset
+                this.nextUpSticky = showUntilEnd;
+                this.toggle(showUntilEnd);
+            } else if (!showUntilEnd && nextUpSticky === false) { // reset if there was a backward seek
                 this.reset();
             }
         }
 
         onStreamType(model, streamType) {
             if (streamType !== 'VOD') {
-                model.set('nextUpSticky', false);
+                this.nextUpSticky = false;
+                this.toggle(false);
             }
         }
 
@@ -191,9 +187,8 @@ define([
         }
 
         reset() {
-            var model = this._model;
-            model.set('nextUpVisible', false);
-            model.set('nextUpSticky', undefined);
+            this.nextUpSticky = undefined;
+            this.toggle(false);
         }
     };
 });

--- a/src/js/view/controls/templates/nextup.js
+++ b/src/js/view/controls/templates/nextup.js
@@ -8,7 +8,7 @@ export default (header = '', title = '', closeAriaLabel = '') => {
                     `<div class="jw-nextup-title jw-reset">${title}</div>` +
                 `</div>` +
             `</div>` +
-            `<button class="jw-icon jw-nextup-close" aria-label="${closeAriaLabel}"></button>` +
+            `<button class="jw-icon jw-nextup-close jw-reset" aria-label="${closeAriaLabel}"></button>` +
         `</div>`
     );
 };


### PR DESCRIPTION
### What does this Pull Request do?

Adds next-up tooltip to controlbar and replaces model properties with instance properties.

### Why is this Pull Request needed?

'nextUpVisible', 'nextUpSticky' and 'nextUpEnabled' are not needed in the model.

These properties were only used in nextuptooltip.js an controlbar.js. 'nextUpVisible' was only used to trigger 'change:nextUpVisible' and could be removed completely once replaced with calls to `nextup.toggle(bool)`.
