### PR TITLE
Remove string escapes that causes errors in CSS

### DIFF
--- a/src/css/shared-imports/mixins.less
+++ b/src/css/shared-imports/mixins.less
@@ -26,13 +26,13 @@
         }
 
         .jw-captions {
-            max-height: ~"calc(~'100%' - ~'46px')";
+            max-height: ~"calc(100% - 46px)";
         }
 
         .jwplayer& {
             /* captions styles code specific to native text track rendering */
             video::-webkit-media-text-track-container {
-                max-height: ~"calc(~'100%' - ~'46px')";
+                max-height: ~"calc(100% - 46px)";
             }
         }
     }
@@ -342,13 +342,13 @@
             }
 
             .jw-captions {
-                max-height: ~"calc(~'100%' - ~'38px')";
+                max-height: ~"calc(100% - 38px)";
             }
 
             .jwplayer& {
                 /* captions styles code specific to native text track rendering */
                 video::-webkit-media-text-track-container {
-                    max-height: ~"calc(~'100%' - ~'38px')";
+                    max-height: ~"calc(100% - 38px)";
                 }
             }
 


### PR DESCRIPTION
### What does this Pull Request do?
This PR removes unnecessary escaping of calc properties in LESS that were causing errors in the CSS.  This was an oversight while switching from RECESS to LESS.

### Why is this Pull Request needed?
This is necessary because it causes the intended CSS to not be applied and creates errors in the outputted stylesheets.

#### Addresses Issue(s):
https://github.com/jwplayer/jwplayer/issues/2061

