### PR TITLE
Add "nextShown" and "nextClick" events to the player for next button and tooltip

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -732,8 +732,18 @@ define([
             }
 
             function _nextUp() {
-                var related = _api.getPlugin('related');
+                const related = _api.getPlugin('related');
                 if (related) {
+                    const nextUp = _model.get('nextUp');
+                    if (nextUp) {
+                        _this.trigger('nextClick', {
+                            mode: nextUp.mode,
+                            ui: 'nextup',
+                            target: nextUp,
+                            itemsShown: [ nextUp ],
+                            feedData: nextUp.feedData,
+                        });
+                    }
                     related.next();
                 }
             }

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -250,9 +250,11 @@ define([
 
                 _view.on('all', _triggerAfterReady, _this);
 
-                var related = _api.getPlugin('related');
+                const related = _api.getPlugin('related');
                 if (related) {
-                    related.on('nextUp', _model.setNextUp, _model);
+                    related.on('nextUp', (nextUp) => {
+                        _model.set('nextUp', nextUp);
+                    });
                 }
 
                 // Fire 'ready' once the view has resized so that player width and height are available

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -436,10 +436,6 @@ define([
             this.persistCaptionsTrack();
         };
 
-        this.setNextUp = function (nextUp) {
-            this.set('nextUp', nextUp);
-        };
-
         function _autoStartSupportedIOS() {
             if (!utils.isIOS()) {
                 return false;

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -118,7 +118,7 @@ define([
                     .on('over', function () {
                         const nextUpToolTip = this.nextUpToolTip;
                         if (nextUpToolTip) {
-                            nextUpToolTip.toggle(true);
+                            nextUpToolTip.toggle(true, 'hover');
                         }
                     }, this)
                     .on('out', function () {

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -123,6 +123,7 @@ define([
             // Next Up Tooltip
             if (model.get('nextUpDisplay') && !controlbar.nextUpToolTip) {
                 const nextUpToolTip = new NextUpToolTip(model, api, this.playerContainer);
+                nextUpToolTip.on('all', this.trigger, this);
                 nextUpToolTip.setup(this.context);
                 controlbar.nextUpToolTip = nextUpToolTip;
 
@@ -250,12 +251,15 @@ define([
             }
             if (this.rightClickMenu) {
                 this.rightClickMenu.destroy();
-                this.rightClickMenu = null;
             }
 
             if (this.keydownCallback) {
                 this.playerContainer.removeEventListener('keydown', this.keydownCallback);
-                this.keydownCallback = null;
+            }
+
+            const nextUpToolTip = this.nextUpToolTip;
+            if (nextUpToolTip) {
+                nextUpToolTip.destroy();
             }
         }
 

--- a/src/js/view/controls/nextuptooltip.js
+++ b/src/js/view/controls/nextuptooltip.js
@@ -90,7 +90,6 @@ define([
                         mode: nextUp.mode,
                         ui: 'nextup',
                         itemsShown: [ nextUp ],
-                        page: 0,
                         feedData: nextUp.feedData,
                         reason: reason,
                     });

--- a/src/js/view/controls/nextuptooltip.js
+++ b/src/js/view/controls/nextuptooltip.js
@@ -172,7 +172,7 @@ define([
             if (showUntilEnd && nextUpSticky === undefined) { // show if nextUpSticky is unset
                 this.nextUpSticky = showUntilEnd;
                 this.toggle(showUntilEnd, 'time');
-            } else if (!showUntilEnd && nextUpSticky === false) { // reset if there was a backward seek
+            } else if (!showUntilEnd && nextUpSticky) { // reset if there was a backward seek
                 this.reset();
             }
         }


### PR DESCRIPTION
### What does this Pull Request do?

Fire a "nextShown" event when the next up tooltip is shown. "hover" and "time" reasons are added to calls that toggle on the tooltip.

Fire a "nextClick" event when the next button or next tooltip is clicked.

### Why is this Pull Request needed?

These events contain data needed to evaluate impressions and clicks of upcoming playlist items and recommendations.

### Are there any points in the code the reviewer needs to double check?

Model `setNextUp` method has been removed because it's not needed. And, a destroy method has been added to the nextup tooltip to clear model listeners registered to it's instance - we should do this for all control components that add listeners to the model OR reuse the same controls instance each time "controls" are toggled on and off.

### Are there any Pull Requests open in other repos which need to be merged with this?

This PR requires additional data in the `nextUp` object added in https://github.com/jwplayer/jwplayer-plugin-related/pull/147

#### Addresses Issue(s):

JW7-4347 JW7-4357