### PR TITLE
Add controls to DOM before “ready” event

### DIFF
--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -3,7 +3,7 @@ define(['utils/helpers',
     'controller/tracks-helper'
 ], function(utils, tracksLoader, tracksHelper) {
     /** Displays closed captions or subtitles on top of the video. **/
-    var Captions = function(_api, _model) {
+    var Captions = function(_model) {
         // Reset and load external captions on playlist item
         _model.on('change:playlistItem', _itemHandler, this);
 

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -17,11 +17,9 @@ define([
     'events/states',
     'events/events',
     'view/error',
-    'controller/events-middleware',
-    'controller/controls-loader'
+    'controller/events-middleware'
 ], function(Config, InstreamAdapter, _, Setup, Captions, Model, Storage,
-            Playlist, PlaylistLoader, utils, View, Events, changeStateEvent, states, events, error, eventsMiddleware,
-            ControlsLoader) {
+            Playlist, PlaylistLoader, utils, View, Events, changeStateEvent, states, events, error, eventsMiddleware) {
 
     function _queueCommand(command) {
         return function() {
@@ -192,33 +190,10 @@ define([
             });
 
             // Ensure captionsList event is raised after playlistItem
-            _captions = new Captions(_api, _model);
+            _captions = new Captions(_model);
 
             function _triggerAfterReady(type, e) {
                 _this.triggerAfterReady(type, e);
-            }
-
-            function changeControls(model, enable) {
-                if (enable) {
-                    ControlsLoader.load()
-                        .then(function (Controls) {
-                            if (!_view.isSetup) {
-                                return;
-                            }
-
-                            var controls = new Controls(document, _view.element());
-                            _view.addControls(controls);
-                            controls.on('all', _triggerAfterReady, _this);
-                        })
-                        .catch(function (reason) {
-                            _this.triggerError({
-                                message: 'Controls failed to load',
-                                reason: reason
-                            });
-                        });
-                } else {
-                    _view.removeControls();
-                }
             }
 
             function triggerControls(model, enable) {
@@ -237,13 +212,6 @@ define([
                     }
                 }
             }, this);
-
-            _model.on('change:inDom', function(model, inDom) {
-                if (inDom) {
-                    model.off('change:controls', changeControls);
-                    model.change('controls', changeControls);
-                }
-            });
 
             function _playerReady() {
                 _setup = null;

--- a/src/js/controller/controls-loader.js
+++ b/src/js/controller/controls-loader.js
@@ -1,19 +1,18 @@
 define([
 
 ], function() {
-    var controls = null;
+    let controlsPromise = null;
 
     function load() {
-        if (controls) {
-            return Promise.resolve(controls);
+        if (!controlsPromise) {
+            controlsPromise = new Promise(function (resolve) {
+                require.ensure(['view/controls/controls'], function (require) {
+                    const controls = require('view/controls/controls');
+                    resolve(controls);
+                }, 'jwplayer.controls');
+            });
         }
-
-        return new Promise(function (resolve) {
-            require.ensure(['view/controls/controls'], function (require) {
-                controls = require('view/controls/controls');
-                resolve(controls);
-            }, 'jwplayer.controls');
-        });
+        return controlsPromise;
     }
 
     return {

--- a/src/js/controller/setup-steps.js
+++ b/src/js/controller/setup-steps.js
@@ -308,14 +308,15 @@ define([
         });
     }
 
-    function _loadControls(resolve, _model) {
+    function _loadControls(resolve, _model, _api, _view) {
         if (!_model.get('controls')) {
             resolve();
             return;
         }
 
         ControlsLoader.load()
-            .then(function (/* Controls */) {
+            .then(function (Controls) {
+                _view.setControlsModule(Controls);
                 resolve();
             })
             .catch(function (reason) {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -6,6 +6,8 @@ import activeTab from 'utils/active-tab';
 import { requestAnimationFrame, cancelAnimationFrame } from 'utils/request-animation-frame';
 import { getBreakpoint, setBreakpoint } from 'view/utils/breakpoint';
 
+let ControlsModule;
+
 define([
     'events/events',
     'events/states',
@@ -19,8 +21,9 @@ define([
     'view/logo',
     'view/preview',
     'view/title',
+    'controller/controls-loader',
 ], function(events, states, Events, utils, _, requestFullscreenHelper, flagNoFocus,
-            ClickHandler, CaptionsRenderer, Logo, Preview, Title) {
+            ClickHandler, CaptionsRenderer, Logo, Preview, Title, ControlsLoader) {
 
     const _styles = utils.style;
     const _bounds = utils.bounds;
@@ -29,7 +32,7 @@ define([
 
     let stylesInjected = false;
 
-    return function View(_api, _model) {
+    function View(_api, _model) {
         const _this = _.extend(this, Events, {
             isSetup: false,
             api: _api,
@@ -395,7 +398,6 @@ define([
             itemReady(_model.get('playlistItem'));
             this.updateBounds();
 
-            _model.change('state', _stateHandler);
             _model.on('change:fullscreen', _fullscreen);
             _model.on('change:activeTab', updateVisibility);
             _model.on('change:fullscreen', updateVisibility);
@@ -410,10 +412,40 @@ define([
                 redraw(_model, 1, 0);
             }
 
+            _model.change('state', _stateHandler);
+            _model.change('controls', changeControls);
+
             // Triggering 'resize' resulting in player 'ready'
             _lastWidth = _lastHeight = null;
             this.checkResized();
         };
+
+        function changeControls(model, enable) {
+            if (enable) {
+                if (!ControlsModule) {
+                    ControlsLoader.load()
+                        .then(function (Controls) {
+                            ControlsModule = Controls;
+                            addControls();
+                        })
+                        .catch(function (reason) {
+                            _this.trigger('error', {
+                                message: 'Controls failed to load',
+                                reason: reason
+                            });
+                        });
+                } else {
+                    addControls();
+                }
+            } else {
+                _this.removeControls();
+            }
+        }
+
+        function addControls() {
+            const controls = new ControlsModule(document, _this.element());
+            _this.addControls(controls);
+        }
 
         function itemReady(item) {
             var videotag = _videoLayer.querySelector('video, audio');
@@ -545,6 +577,8 @@ define([
                     _captionsRenderer.renderCues(true);
                 }
             });
+
+            controls.on('all', _this.trigger, _this);
 
             const overlaysElement = _playerElement.querySelector('.jw-overlays');
             overlaysElement.addEventListener('mousemove', _userActivityCallback);
@@ -909,5 +943,11 @@ define([
             }
             utils.clearCss(_model.get('id'));
         };
+    }
+
+    View.prototype.setControlsModule = function(Controls) {
+        ControlsModule = Controls;
     };
+
+    return View;
 });


### PR DESCRIPTION
### What does this Pull Request do?

Load controls and add them to the view before the "ready" event is fired.

### Why is this Pull Request needed?

When the player is setup with controls, the controls should be available in the DOM on "ready".

### Are there any points in the code the reviewer needs to double check?

Controls loading is now done in setup or in the view. Not the controller. If controls failed to load on setup that would be fatal, but if they fail to load after setup the view would fire a non-fatal error event. 🤷‍♂️ 

In `view.init` I moved the call to `_model.change('state', _stateHandler)` until after `updateVisibility` so that there wouldn't be any DOM changes between the two bounds checks performed by `updateBounds` and `updateVisibility`;

### Are there any Pull Requests open in other repos which need to be merged with this?

No.

#### Addresses Issue(s):

JW7-4368
