### PR TITLE
Handle calls to resize() before "ready" gracefully

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -66,8 +66,8 @@ define([
 
         const _preview = new Preview(_model);
         const _title = new Title(_model);
+        const _captionsRenderer = new CaptionsRenderer(_model);
 
-        let _captionsRenderer;
         let _logo;
 
         let _playerState;
@@ -169,6 +169,9 @@ define([
         }
 
         function _responsiveUpdate() {
+            if (!_this.isSetup) {
+                return;
+            }
             _this.updateBounds();
             _this.updateStyles();
             _this.checkResized();
@@ -317,7 +320,6 @@ define([
             _logo.on(events.JWPLAYER_LOGO_CLICK, _logoClickHandler);
 
             // captions rendering
-            _captionsRenderer = new CaptionsRenderer(_model);
             _captionsRenderer.setup(_playerElement.id, _model.get('captions'));
 
             // captions should be place behind controls, and not hidden when controls are hidden


### PR DESCRIPTION
### What does this Pull Request do?

Prevents responsive update before view is setup and define captions render in view constructor

### Why is this Pull Request needed?

A call to `resize` while the player is setting up may attempt to access `_captionsRenderer` in the view before it's defined. It could also run `_responsiveUpdate` whose subroutines are run at "ready" in the optimal order.

While we recommend setting `width` and `height` in the player config, over changing `jwplayer().setup().resize()`, this shouldn't break.

#### Addresses Issue(s):

JW7-4376

