### PR TITLE
Player dispatches playbackRateChanged event only once

### DIFF
--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -81,6 +81,9 @@ define([
                         this.set(type, data[type]);
                     }
                     return;
+                case 'ratechange':
+                    this.set('playbackRate', data.playbackRate);
+                    return;
                 case events.JWPLAYER_MEDIA_TYPE:
                     if (mediaModel.get('mediaType') !== data.mediaType) {
                         mediaModel.set('mediaType', data.mediaType);
@@ -122,9 +125,6 @@ define([
                         mediaModel.set('duration', data.duration);
                         this.set('duration', data.duration);
                     }
-                    break;
-                case events.JWPLAYER_PLAYBACK_RATE_CHANGED:
-                    this.set('playbackRate', data.playbackRate);
                     break;
                 case events.JWPLAYER_PROVIDER_CHANGED:
                     this.set('provider', _provider.getName());

--- a/src/js/events/events.js
+++ b/src/js/events/events.js
@@ -70,7 +70,7 @@ define([], function() {
         JWPLAYER_PLAYLIST_LOADED: 'playlist',
         JWPLAYER_AUDIO_TRACKS: 'audioTracks',
         JWPLAYER_AUDIO_TRACK_CHANGED: 'audioTrackChanged',
-        JWPLAYER_PLAYBACK_RATE_CHANGED: 'ratechange',
+        JWPLAYER_PLAYBACK_RATE_CHANGED: 'playbackRateChanged',
 
         // View Component Actions
         JWPLAYER_LOGO_CLICK: 'logoClick',

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -189,9 +189,7 @@ define([
         }
 
         function _playbackRateHandler() {
-            _this.trigger(events.JWPLAYER_PLAYBACK_RATE_CHANGED, {
-                playbackRate: _videotag.playbackRate
-            });
+            _this.trigger('ratechange', { playbackRate: _videotag.playbackRate });
         }
 
         function _checkVisualQuality() {


### PR DESCRIPTION
### What does this Pull Request do?
This PR makes the names and numbers of events sent out by the player more consistent.

### Why is this Pull Request needed?
The 'ratechange' event is now only used internally.   “playbackRateChanged" is dispatched by the player for others to use.  This also ensure that the player only dispatches one event externally when playback rate changes.

#### Addresses Issue(s):
JW7-4319