### PR TITLE
Add "viewable" event to the player API

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -262,7 +262,7 @@ define([
                 }
 
                 _checkAutoStart();
-                _model.on('change:viewable', _checkPlayOnViewable);
+                _model.change('viewable', viewableChange);
             }
 
             function _updateViewable(model, visibility) {
@@ -272,13 +272,17 @@ define([
             }
 
             function _checkAutoStart() {
-                var autostart = _model.get('autostart');
-                if (!utils.isMobile() && autostart === true) {
+                if (!utils.isMobile() && _model.get('autostart') === true) {
                     // Autostart immediately if we're not mobile and not waiting for the player to become viewable first
                     _autoStart();
-                } else {
-                    _checkPlayOnViewable(_model, _model.get('viewable'));
                 }
+            }
+
+            function viewableChange(model, viewable) {
+                _this.trigger('viewable', {
+                    viewable: viewable
+                });
+                _checkPlayOnViewable(model, viewable);
             }
 
             function _checkPlayOnViewable(model, viewable) {


### PR DESCRIPTION
### What does this Pull Request do?

Adds the "viewable" event to our public API. The event fires when:

- The active state of the browser tab containing the player changes, affecting a player's visibility (document "visibilitychange" event or `document.hidden`)
- %50 of the player area enters or exits the browser viewport

The event contains a `viewable` property that matches the value that would returned by `getViewable()`:

```js
{
    type: "viewable",
    viewable: 1 or 0
}
```

### Why is this Pull Request needed?

This allows developer to listen for a viewable change. Currently this is only available in the public API via `jwplayer().getViewable()`. This can be used to determine that the player is viewable to the user - for example: by scrolling into view or by switching browser tabs.

#### Addresses Issue(s):

JW7-4371

