### PR TITLE
Simplify CSS rules for sharing tooltip

### DIFF
--- a/src/css/controls/flags/overlay.less
+++ b/src/css/controls/flags/overlay.less
@@ -15,12 +15,7 @@
         }
     }
 
-    &-sharing.jw-breakpoint-2,
-    &-sharing.jw-breakpoint-3,
-    &-sharing.jw-breakpoint-4,
-    &-sharing.jw-breakpoint-5,
-    &-sharing.jw-breakpoint-6,
-    &-sharing.jw-breakpoint-7 {
+    &-sharing:not(.jw-flag-small-player) {
         .jw-controls,
         .jw-title {
             display: block;

--- a/src/css/jwplayer/imports/reset.less
+++ b/src/css/jwplayer/imports/reset.less
@@ -17,6 +17,7 @@
     font-stretch: inherit;
     /* non-standard prefixed style used in Chrome, Safari, and some MS browsers.  Not Autoprefixed */
     -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+    
     &:focus {
         outline: none;
     }

--- a/src/css/jwplayer/imports/reset.less
+++ b/src/css/jwplayer/imports/reset.less
@@ -17,4 +17,7 @@
     font-stretch: inherit;
     /* non-standard prefixed style used in Chrome, Safari, and some MS browsers.  Not Autoprefixed */
     -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+    &:focus {
+        outline: none;
+    }
 }

--- a/src/css/jwplayer/imports/reset.less
+++ b/src/css/jwplayer/imports/reset.less
@@ -17,8 +17,4 @@
     font-stretch: inherit;
     /* non-standard prefixed style used in Chrome, Safari, and some MS browsers.  Not Autoprefixed */
     -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
-    
-    &:focus {
-        outline: none;
-    }
 }

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -733,8 +733,8 @@ define([
 
             if (fullscreenState && _controls) {
                 // When going into fullscreen, we want the control bar to fade after a few seconds
-                    _controls.userActive();
-                }
+                _controls.userActive();
+            }
 
             _resizeMedia();
             _responsiveListener();


### PR DESCRIPTION
### What does this Pull Request do?
This simplifies the css rules that show the controls and title when the sharing tooltip is showing, all while maintaining the same level of specificity. It also hides the focus ring when `jw-reset` is applied to clickable elements.
### Why is this Pull Request needed?
To reduce css output and to ensure close buttons don't have focus rings.
### Are there any points in the code the reviewer needs to double check?
No.
### Are there any Pull Requests open in other repos which need to be merged with this?
No.
#### Addresses Issue(s):
