### PR TITLE
Update QoE timer

### DIFF
--- a/src/js/utils/clock.js
+++ b/src/js/utils/clock.js
@@ -1,24 +1,24 @@
 define([], function() {
 
-    var performance = window.performance;
+    const performance = window.performance;
 
-    var supportsPerformance = !!(performance && performance.now);
+    const supportsPerformance = !!(performance && performance.now);
     
-    var MAX_INTERVAL = 1000;
+    const MAX_INTERVAL = 10000;
 
-    var getTime = function() {
+    const getTime = function() {
         if (supportsPerformance) {
             return performance.now();
         }
         return new Date().getTime();
     };
 
-    var Clock = function() {
-        var started = getTime();
-        var updated = started;
+    const Clock = function() {
+        const started = getTime();
+        let updated = started;
 
-        var updateClock = function() {
-            var delta = getTime() - updated;
+        const updateClock = function() {
+            let delta = getTime() - updated;
             if (delta > MAX_INTERVAL) {
                 delta = MAX_INTERVAL;
             } else if (delta < 0) {
@@ -26,7 +26,7 @@ define([], function() {
             }
             updated += delta;
         };
-        setInterval(updateClock, 50);
+        setInterval(updateClock, 1000);
 
         Object.defineProperty(this, 'currentTime', {
             get: function() {

--- a/src/js/utils/helpers.js
+++ b/src/js/utils/helpers.js
@@ -9,10 +9,11 @@ define([
     'utils/ajax',
     'utils/validator',
     'utils/playerutils',
+    'utils/timer',
     'utils/trycatch',
     'utils/stream-type',
     'utils/quality-labels'
-], function(strings, _, browser, dom, css, parser, id3Parser, ajax, validator, playerutils, trycatch, streamType, qualityLabels) {
+], function(strings, _, browser, dom, css, parser, id3Parser, ajax, validator, playerutils, Timer, trycatch, streamType, qualityLabels) {
     var utils = {};
 
     utils.log = function () {
@@ -60,6 +61,8 @@ define([
     utils.seconds = strings.seconds;
     utils.prefix = strings.prefix;
     utils.suffix = strings.suffix;
+
+    utils.Timer = Timer;
 
     _.extend(utils, parser, id3Parser, validator, browser, ajax, dom, css, playerutils, trycatch, streamType, qualityLabels);
 

--- a/src/js/utils/timer.js
+++ b/src/js/utils/timer.js
@@ -3,17 +3,14 @@ define([
     'utils/underscore'
 ], function(clock, _) {
 
-    var Timer = function() {
-        var startTimes = {};
-        var sum = {};
-        var counts = {};
+    const Timer = function() {
+        const startTimes = {};
+        const sum = {};
+        const counts = {};
 
-        var ticks = {};
+        const ticks = {};
 
-        var started = new Date().getTime();
-        if (started < 1) {
-            started = 1;
-        }
+        const started = Math.max(1, new Date().getTime());
 
         return {
             // Profile methods
@@ -25,19 +22,19 @@ define([
                 if (!startTimes[methodName]) {
                     return;
                 }
-                var now = started + clock.now();
-                var e = now - startTimes[methodName];
+                const now = started + clock.now();
+                const e = now - startTimes[methodName];
                 delete startTimes[methodName];
                 sum[methodName] = sum[methodName] + e || e;
             },
             dump: function() {
                 // Add running sum of latest method
                 // This lets `jwplayer().qoe().item.sums` return a tally of running playing/paused time
-                var runningSums = _.extend({}, sum);
-                for (var methodName in startTimes) {
+                const runningSums = _.extend({}, sum);
+                for (const methodName in startTimes) {
                     if (Object.prototype.hasOwnProperty.call(startTimes, methodName)) {
-                        var now = started + clock.now();
-                        var e = now - startTimes[methodName];
+                        const now = started + clock.now();
+                        const e = now - startTimes[methodName];
                         runningSums[methodName] = runningSums[methodName] + e || e;
                     }
                 }


### PR DESCRIPTION
### What does this Pull Request do?

1. Adds the Timer object to utils so that it is exposed to ad plugins.
2. Updates the QoE timer's clock to use less frequent intervals for limiting the impact of device sleep.
3. ES6 syntax updates

### Why is this Pull Request needed?

Ads QoE measurement.

### Are there any Pull Requests open in other repos which need to be merged with this?

Google IMA https://github.com/jwplayer/jwplayer-ads-googima/pull/219, VAST and FreeWheel ads plugins will depend on utils.Timer to measure ads requests.

#### Addresses Issue(s):

ADS-149 ADS-264 ADS-265

