### PR TITLE
Dont exit fullscreen on complete 

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -765,10 +765,6 @@ define([
             }
             utils.replaceClass(_playerElement, /jw-state-\S+/, 'jw-state-' + state);
 
-            if (state === states.COMPLETE) {
-                _api.setFullscreen(false);
-            }
-
             // Update captions renderer
             switch (state) {
                 case states.IDLE:


### PR DESCRIPTION
### What does this Pull Request do?
Allows the player to stay in fullscreen on complete by removing the exit fullscreen call on state update.

### Why is this Pull Request needed?
Since we only enter fullscreen on an explicit user interaction, we should only exit on an explicit interaction. This allows the user to stay in fullscreen mode between both playlist and related items.

### Are there any points in the code the reviewer needs to double check?
Is there any code or tests relying on the player being out of fullscreen on complete?

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):
JW7-4377
