### PR TITLE
Exit fullscreen on IOS before firing playlist complete 

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -597,6 +597,9 @@ define([
                     } else {
                         // Autoplay/pause no longer needed since there's no more media to play
                         // This prevents media from replaying when a completed video scrolls into view
+                        if (utils.isIOS()) {
+                            _this.exitFullscreen();
+                        }
                         _model.set('playOnViewable', false);
                         _model.set('state', states.COMPLETE);
                         _this.trigger(events.JWPLAYER_PLAYLIST_COMPLETE, {});


### PR DESCRIPTION
### What does this Pull Request do?
Exits fullscreen on IOS before firing PLAYLIST_COMPLETE

### Why is this Pull Request needed?
IOS uses it's native rendering for videos in fullscreen and cannot show HTML overlays. For a better UX we want to exit fullscreen so that our overlays are displayed.

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW7-4377
