### PR TITLE
Exit fullscreen on IOS before firing playlist complete 

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -595,6 +595,10 @@ define([
                     if (_model.get('repeat')) {
                         _next({ reason: 'repeat' });
                     } else {
+                        // Exit fullscreen on IOS so that our overlays show to the user
+                        if (utils.isIOS()) {
+                            _setFullscreen(false);
+                        }
                         // Autoplay/pause no longer needed since there's no more media to play
                         // This prevents media from replaying when a completed video scrolls into view
                         if (utils.isIOS()) {


### PR DESCRIPTION
### What does this Pull Request do?
Exits fullscreen on IOS before firing PLAYLIST_COMPLETE

### Why is this Pull Request needed?
IOS uses it's native rendering for videos in fullscreen and cannot show HTML overlays. For a better UX we want to exit fullscreen so that our overlays are displayed.

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW7-4377
