### PR TITLE
setPlaybackRate only works for numbers

### DIFF
--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -396,9 +396,7 @@ define([
         };
 
         this.setPlaybackRate = function(playbackRate) {
-            playbackRate = parseFloat(playbackRate);
-
-            if (!_attached || _.isNaN(playbackRate)) {
+            if (!_attached || !_.isNumber(playbackRate)) {
                 return;
             }
 


### PR DESCRIPTION
### What does this Pull Request do?
This PR makes it so that the player will only set playback rate via the API if the user sends in an actual number.

### Why is this Pull Request needed?
This is needed because we want the API to encourage best practices by being strict about what values we will accept.

