### PR TITLE
Playback Rate Menu Does Not Appear As A Toggle

### DIFF
--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -294,7 +294,7 @@ define([
                 this.elements.playbackrates.setup(
                     playbackRateLabels,
                     selectedIndex,
-                    { defaultIndex: playbackRateControls.indexOf(1) }
+                    { defaultIndex: playbackRateControls.indexOf(1), isToggle: false }
                 );
 
                 _model.change('streamType provider', this.togglePlaybackRateControls, this);


### PR DESCRIPTION
### What does this Pull Request do?
This PR forces the playback rate menu to always appear as a menu.  It will not be a toggle.

### Why is this Pull Request needed?
It helps the user more immediately understand what the playback rate menu does.

### Are there any Pull Requests open in other repos which need to be merged with this?
Yes, there is a commercial PR: https://github.com/jwplayer/jwplayer-commercial/pull/3572

#### Addresses Issue(s):
JW7-4395

