### PR TITLE
Remove Playback Rate Persistence

### DIFF
--- a/src/js/controller/storage.js
+++ b/src/js/controller/storage.js
@@ -47,8 +47,7 @@ define([
             'volume',
             'mute',
             'captionLabel',
-            'qualityLabel',
-            'defaultPlaybackRate'
+            'qualityLabel'
         ];
     }
 


### PR DESCRIPTION
### What does this Pull Request do?
This PR removes tests which test the persistence of the playback rate selections between sessions on the site.  When refreshing the page, we will now no longer see the same playback rate that we had when we set it during the last session.

### Why is this Pull Request needed?
This feature is no longer considered desirable and is too niche for all players to receive.

### Are there any Pull Requests open in other repos which need to be merged with this?
There is a commercial PR that removes tests related to this feature.

#### Addresses Issue(s):
JW7-4397