### PR TITLE
Trigger subtitlesChanged in non-native mode; reset _id when reusing a track

### DIFF
--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -452,8 +452,7 @@ define(['utils/underscore',
             }
         }
 
-        // We can setup the captions menu now since we're not rendering textTracks natively
-        if (!this.renderNatively && this._textTracks && this._textTracks.length) {
+        if (this._textTracks && this._textTracks.length) {
             this.trigger('subtitlesTracks', { tracks: this._textTracks });
         }
     }
@@ -554,6 +553,7 @@ define(['utils/underscore',
             if (track) {
                 track.kind = itemTrack.kind;
                 track.language = itemTrack.language || '';
+                track._id = null;
             } else {
                 track = this.video.addTextTrack(itemTrack.kind, label, itemTrack.language || '');
             }


### PR DESCRIPTION
### This PR will...
- Trigger `subtitlesTracks` from the mixin when rendering natively
- Reset track `_id` when reusing a track

### Why is this Pull Request needed?
Shaka assumes a mapping based on track order when mapping between it's internal tracks and our internal tracks. When moving between playlist items, if we reuse a track, then this assumption is broken - resetting `_id` forces it to be remade with the current track ordering.

If we do not trigger `subtitlesTracks` immediately when rendering natively, we may add cues to the wrong track because we have not yet selected the correct one for the current playlist. 

### Are there any points in the code the reviewer needs to double check?
I tested the following cases:
- Changing tracks
- Preroll
- Midroll
- Changing to a playlist item with different tracks
- Changing back to the first playlist item after playing a second with different tracks

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW7-4313
