### PR TITLE
Allow the reuse of text tracks 

### DIFF
--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -105,7 +105,7 @@ define(['utils/helpers',
                 _unknownCount = labelInfo.unknownCount;
             }
 
-            // During the same playlist we reuse tracks and add them with the same ID; allow the new track to replace the old
+            // During the same playlist we may reu and readd tracks with the same _id; allow the new track to replace the old
             _tracksById[track._id] = track;
             _tracks.push(track);
         }

--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -24,12 +24,12 @@ define(['utils/helpers',
 
             var tracks = e.tracks || [];
             for (var i = 0; i < tracks.length; i++) {
-                var track = tracks[i];
-                if (_tracksById[track._id]) {
-                    continue;
-                }
-                _addTrack(track);
+                _addTrack(tracks[i]);
             }
+
+            // To avoid duplicate tracks in the menu when we reuse an _id, regenerate the tracks array
+            _tracks = Object.keys(_tracksById).map(id => _tracksById[id]);
+
             var captionsMenu = _captionsMenu();
             _selectDefaultIndex();
             this.setCaptionsList(captionsMenu);
@@ -105,8 +105,9 @@ define(['utils/helpers',
                 _unknownCount = labelInfo.unknownCount;
             }
 
-            _tracks.push(track);
+            // During the same playlist we reuse tracks and add them with the same ID; allow the new track to replace the old
             _tracksById[track._id] = track;
+            _tracks.push(track);
         }
 
         function _captionsMenu() {


### PR DESCRIPTION
### This PR will...
- Allow new tracks with the same `_id` to replace the old
- Regenerate the `_tracks` array to remove potential duplicates

### Why is this Pull Request needed?
Shaka will emit duplicate `trackschanged` events during the same playlist item; we must use this new track in `captions.js` in order to display cues (otherwise, `captions.js` always points to the old track and never shows cues)

### Are there any points in the code the reviewer needs to double check?
No?

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW7-4313

