### PR TITLE
Hide logo placed top-right when opening sharing tooltip

### DIFF
--- a/src/css/controls/flags/overlay.less
+++ b/src/css/controls/flags/overlay.less
@@ -12,5 +12,9 @@
         .jw-title {
             display: block;
         }
+
+        .jw-controls-right .jw-logo.jw-logo-top-right {
+            display: none;
+        }
     }
 }

--- a/src/css/controls/flags/overlay.less
+++ b/src/css/controls/flags/overlay.less
@@ -12,9 +12,5 @@
         .jw-title {
             display: block;
         }
-
-        .jw-controls-right .jw-logo.jw-logo-top-right {
-            display: none;
-        }
     }
 }

--- a/src/css/controls/flags/overlay.less
+++ b/src/css/controls/flags/overlay.less
@@ -6,13 +6,7 @@
             display: none;
         }
     }
-
     &-sharing:not(.jw-flag-small-player) {
-        .jw-controls,
-        .jw-title {
-            display: block;
-        }
-
         .jw-logo-top-right {
             display: none;
         }

--- a/src/css/controls/flags/overlay.less
+++ b/src/css/controls/flags/overlay.less
@@ -6,4 +6,15 @@
             display: none;
         }
     }
+
+    &-sharing:not(.jw-flag-small-player) {
+        .jw-controls,
+        .jw-title {
+            display: block;
+        }
+
+        .jw-controls-right .jw-logo.jw-logo-top-right {
+            display: none;
+        }
+    }
 }

--- a/src/css/controls/flags/overlay.less
+++ b/src/css/controls/flags/overlay.less
@@ -13,7 +13,7 @@
             display: block;
         }
 
-        .jw-controls-right .jw-logo.jw-logo-top-right {
+        .jw-logo-top-right {
             display: none;
         }
     }

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -234,8 +234,8 @@ define([
 
             // Show controls when enabled
             this.userActive();
-
-            this.playerContainer.appendChild(this.div);
+            const overlaysElement = this.playerContainer.querySelector('.jw-overlays');
+            this.playerContainer.insertBefore(this.div, overlaysElement);
         }
 
         disable() {

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -234,8 +234,8 @@ define([
 
             // Show controls when enabled
             this.userActive();
-            const overlaysElement = this.playerContainer.querySelector('.jw-overlays');
-            this.playerContainer.insertBefore(this.div, overlaysElement);
+
+            this.playerContainer.appendChild(this.div);
         }
 
         disable() {

--- a/src/js/view/logo.js
+++ b/src/js/view/logo.js
@@ -80,7 +80,12 @@ define([
 
         this.setContainer = function(container) {
             if (_logo) {
-                container.appendChild(_logo);
+                const dock = container.querySelector('.jw-dock');
+                if (dock) {
+                    container.insertBefore(_logo, dock);
+                } else {
+                    container.appendChild(_logo);
+                }
             }
         };
 

--- a/src/js/view/logo.js
+++ b/src/js/view/logo.js
@@ -80,12 +80,7 @@ define([
 
         this.setContainer = function(container) {
             if (_logo) {
-                const dock = container.querySelector('.jw-dock');
-                if (dock) {
-                    container.insertBefore(_logo, dock);
-                } else {
-                    container.appendChild(_logo);
-                }
+                container.appendChild(_logo);
             }
         };
 


### PR DESCRIPTION
### This PR will...
Positions jw-logo underneath the dock title seen when hovered over, and hides the logo with CSS when the mini sharing-overlay is opened

### Why is this Pull Request needed?
the logo blocks the sharing tooltip when it is opened

### Are there any points in the code the reviewer needs to double check?
n/a

### Are there any Pull Requests open in other repos which need to be merged with this?
n/a

#### Addresses Issue(s):
JW7-4416

