### PR TITLE
Only set the video tag title in mobile browsers

### DIFF
--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -210,9 +210,11 @@ define([
             elem.removeEventListener('pointerup', interactEndHandler);
             document.removeEventListener('mousemove', interactDragHandler);
             document.removeEventListener('mouseup', interactEndHandler);
-            _touchListenerTarget.removeEventListener('touchmove', interactDragHandler);
-            _touchListenerTarget.removeEventListener('touchcancel', interactEndHandler);
-            _touchListenerTarget.removeEventListener('touchend', interactEndHandler);
+            if (_touchListenerTarget) {
+                _touchListenerTarget.removeEventListener('touchmove', interactDragHandler);
+                _touchListenerTarget.removeEventListener('touchcancel', interactEndHandler);
+                _touchListenerTarget.removeEventListener('touchend', interactEndHandler);
+            }
 
             if (_hasMoved) {
                 triggerEvent(JW_TOUCH_EVENTS.DRAG_END, evt);

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -397,7 +397,6 @@ define([
         }
 
         this.init = function() {
-            itemReady(_model.get('playlistItem'));
             this.updateBounds();
 
             _model.on('change:fullscreen', _fullscreen);
@@ -405,7 +404,6 @@ define([
             _model.on('change:fullscreen', updateVisibility);
             _model.on('change:intersectionRatio', updateVisibility);
             _model.on('change:visibility', redraw);
-            _model.on('itemReady', itemReady);
 
             updateVisibility();
 
@@ -416,6 +414,11 @@ define([
 
             _model.change('state', _stateHandler);
             _model.change('controls', changeControls);
+            // Set the title attribute of the video tag to display background media information on mobile devices
+            if (_isMobile) {
+                setMediaTitleAttribute(_model.get('playlistItem'));
+                _model.on('itemReady', setMediaTitleAttribute);
+            }
 
             // Triggering 'resize' resulting in player 'ready'
             _lastWidth = _lastHeight = null;
@@ -449,14 +452,15 @@ define([
             _this.addControls(controls);
         }
 
-        function itemReady(item) {
+        function setMediaTitleAttribute(item) {
             var videotag = _videoLayer.querySelector('video, audio');
             // Youtube, chromecast and flash providers do no support video tags
             if (!videotag) {
                 return;
             }
-            const dummyDiv = document.createElement('DIV');
+
             // Writing a string to innerHTML completely decodes multiple-encoded strings
+            const dummyDiv = document.createElement('div');
             dummyDiv.innerHTML = item.title || '';
             videotag.setAttribute('title', dummyDiv.textContent);
         }


### PR DESCRIPTION
### This PR will...

Only set the video tag title attribute in mobile browsers.

### Why is this Pull Request needed?

Setting element title attributes in desktop browsers causes a tooltip to display when the mouse hovers over the element for a period of time. This tooltip shows up in fullscreen mode even after controls and the mouse cursor are hidden.

### Are there any points in the code the reviewer needs to double check?
While testing on iOS I found an exception in utils/ui.js thrown on player remove - added a guard around access to `_touchListenerTarget ` to prevent it.

#### Addresses Issue(s):

JW7-4412


