### PR TITLE
Set provider on model after calling init 

### DIFF
--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -222,8 +222,6 @@ define([
                 this.once('change:mediaContainer', this.onMediaContainer);
             }
 
-            this.set('provider', _provider.getName());
-
             if (_provider.getName().name.indexOf('flash') === -1) {
                 this.set('flashThrottle', undefined);
                 this.set('flashBlocked', false);
@@ -349,6 +347,9 @@ define([
             if (_provider.init) {
                 _provider.init(item);
             }
+
+            // Set the Provider after calling init because some Provider properties are only set afterwards
+            this.set('provider', _provider.getName());
 
             // Listening for change:item won't suffice when loading the same index or file
             // We also can't listen for change:mediaModel because it triggers whether or not


### PR DESCRIPTION
### This PR will...
Set `provider` after calling the Provider's `init` method

### Why is this Pull Request needed?
The Provider property `isPlaybackRateSupported` is set after init for the HTML5 Provider; in order to properly show/hide the Playback rate control, this PR set's `provider` after init, which triggers code checking `isPlaybackRateSupported`

### Are there any points in the code the reviewer needs to double check?
Is setting `provider` before `init` important? I want to see if the automated tests pass.

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW7-4430
