### PR TITLE
Remove sourcemaps from CSS files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -102,7 +102,6 @@ module.exports = function(grunt) {
                 processors: [
                     require('autoprefixer')
                 ],
-                map: true,
                 failOnError: true,
                 writeDest: true
             },


### PR DESCRIPTION
### Why is this Pull Request needed?

Release assets should not contain source maps. They aren't needed in CSS debug assets either.

#### Addresses Issue(s):

JW7-4435


