### PR TITLE
Make the html5 provider return 1 for playbackRate by default

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -924,7 +924,8 @@ define([
         };
 
         this.getPlaybackRate = function() {
-            return _videotag.playbackRate;
+            // playbackRate should never be 0 or undefined. By default it should return 1.
+            return _videotag.playbackRate || 1;
         };
 
         this.getCurrentQuality = function() {


### PR DESCRIPTION
### Why is this Pull Request needed?

In browsers that do not implement the `playbackRate` getter properly, `0` is being returned. This should default to `1`.

#### Addresses Issue(s):

JW7-4437

