### PR TITLE
Avoid setting read-only properties on the native Tracks object 

### DIFF
--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -509,7 +509,7 @@ define(['utils/underscore',
                 if (utils.isIE() && renderNatively && /^(native|subtitle|cc)/.test(track._id)) {
                     return;
                 }
-                
+
                 // Cues are inaccessible if the track is disabled. While hidden,
                 // we can remove cues while the track is in a non-visible state
                 // Set to disabled before hidden to ensure active cues disappear
@@ -551,10 +551,7 @@ define(['utils/underscore',
             // already have one with the same label
             track = _.findWhere(tracks, { label: label });
 
-            if (track) {
-                track.kind = itemTrack.kind;
-                track.language = itemTrack.language || '';
-            } else {
+            if (!track) {
                 track = this.video.addTextTrack(itemTrack.kind, label, itemTrack.language || '');
             }
 


### PR DESCRIPTION
### This PR will...
Avoid setting read-only properties on the native Tracks object 

### Why is this Pull Request needed?
For our webpack2 builds, which `use strict`, setting read-only properties throws exceptions. Language and kind area read-only: Avoid setting read-only properties on the native Tracks object 

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW7-4438
