### PR TITLE
Bundle Promise and btoa polyfills in player embed

### DIFF
--- a/src/js/controller/setup-steps.js
+++ b/src/js/controller/setup-steps.js
@@ -7,7 +7,9 @@ define([
     'utils/underscore',
     'utils/helpers',
     'events/events',
-    'controller/controls-loader'
+    'controller/controls-loader',
+    'polyfills/promise',
+    'polyfills/base64'
 ], function(plugins, PlaylistLoader, ScriptLoader, EmbedSwf, Constants, _, utils, events, ControlsLoader) {
 
     var _pluginLoader;
@@ -15,20 +17,10 @@ define([
 
     function getQueue() {
         var Components = {
-            LOAD_PROMISE_POLYFILL: {
-                method: _loadPromisePolyfill,
-                depends: []
-            },
-            LOAD_BASE64_POLYFILL: {
-                method: _loadBase64Polyfill,
-                depends: []
-            },
             LOAD_PLUGINS: {
                 method: _loadPlugins,
                 // Plugins require JavaScript Promises
-                depends: [
-                    'LOAD_PROMISE_POLYFILL'
-                ]
+                depends: []
             },
             LOAD_XO_POLYFILL: {
                 method: _loadIntersectionObserverPolyfill,
@@ -44,16 +36,13 @@ define([
             },
             LOAD_CONTROLS: {
                 method: _loadControls,
-                depends: [
-                    'LOAD_PROMISE_POLYFILL'
-                ]
+                depends: []
             },
             SETUP_VIEW: {
                 method: _setupView,
                 depends: [
                     'LOAD_SKIN',
-                    'LOAD_XO_POLYFILL',
-                    'LOAD_PROMISE_POLYFILL'
+                    'LOAD_XO_POLYFILL'
                 ]
             },
             INIT_PLUGINS: {
@@ -103,28 +92,6 @@ define([
 
     function _deferred(resolve) {
         setTimeout(resolve, 0);
-    }
-
-    function _loadPromisePolyfill(resolve) {
-        if (!window.Promise) {
-            require.ensure(['polyfills/promise'], function (require) {
-                require('polyfills/promise');
-                resolve();
-            }, 'polyfills.promise');
-        } else {
-            resolve();
-        }
-    }
-
-    function _loadBase64Polyfill(resolve) {
-        if (!window.btoa || !window.atob) {
-            require.ensure(['polyfills/base64'], function(require) {
-                require('polyfills/base64');
-                resolve();
-            }, 'polyfills.base64');
-        } else {
-            resolve();
-        }
     }
 
     function _loadIntersectionObserverPolyfill(resolve) {

--- a/src/js/providers/flash.js
+++ b/src/js/providers/flash.js
@@ -188,7 +188,7 @@ define([
                         // After plugins load, then execute commandqueue
                     _swf.once('pluginsLoaded', function() {
                         _flashCommand('setupCommandQueue', _swf.__commandQueue);
-                        _swf.__commandQueue = [];
+                        _swf.__commandQueue.length = 0;
                     });
 
                         // setup flash player


### PR DESCRIPTION
The Promise and btoa base64 polyfills are 2.6K and 884 bytes respectively. Adding these to the code base put a tiny bit of overhead on Chrome, but this is essential to IE compatibility.

Also fixed a strict mode issue with flash.js. `_swf.__commandQueue` is created as a getter and cannot be overwritten. All we need to do is empty this array rather than replace it.

### Why is this Pull Request needed?

Webpack 2 boilerplate loaders depend on Promises, so we can't load polyfills for them with webpack. IE 11 and lower does not include Promises.

### Are there any points in the code the reviewer needs to double check?

No

### Are there any Pull Requests open in other repos which need to be merged with this?

[jwplayer-commercial] should be merged first, since this PR removes setup tasks currently required by commercial setup.

#### Addresses Issue(s):

JW8-118

