### PR TITLE
Preloading: Trigger When Player is Viewable

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -285,7 +285,11 @@ define([
                     viewable: viewable
                 });
                 _checkPlayOnViewable(model, viewable);
-                _checkPreload(model, viewable);
+
+                if (shouldPreload(model.get('preloaded'), viewable)) {
+                    model.getVideo().preload();
+                    model.set('preloaded', true);
+                }
             }
 
             function _checkPlayOnViewable(model, viewable) {
@@ -298,15 +302,11 @@ define([
                 }
             }
 
-            function _checkPreload(model, viewable) {
-                const attemptPreload = (viewable === 1 || _api.uniqueId === 1);
-
-                if (model.get('preloaded') || !attemptPreload) {
-                    return;
-                }
-
-                model.getVideo().preload();
-                model.set('preloaded', true);
+            // Should only attempt to preload if the player is viewable.
+            // Otherwise, it should try to preload the first player on the page,
+            // which is the player that has a uniqueId of 1
+            function shouldPreload(preloaded, viewable) {
+                return !preloaded && (viewable === 1 || _api.uniqueId === 1);
             }
 
             this.triggerAfterReady = function(type, args) {

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -287,7 +287,7 @@ define([
                 _checkPlayOnViewable(model, viewable);
 
                 if (shouldPreload(model.get('preloaded'), viewable)) {
-                    model.getVideo().preload();
+                    model.getVideo().preload(model.get('playlistItem'));
                     model.set('preloaded', true);
                 }
             }

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -262,6 +262,8 @@ define([
                 }
 
                 _checkAutoStart();
+
+                _model.set('preloaded', false);
                 _model.change('viewable', viewableChange);
             }
 
@@ -283,16 +285,28 @@ define([
                     viewable: viewable
                 });
                 _checkPlayOnViewable(model, viewable);
+                _checkPreload(model, viewable);
             }
 
             function _checkPlayOnViewable(model, viewable) {
-                if (_model.get('playOnViewable')) {
+                if (model.get('playOnViewable')) {
                     if (viewable) {
                         _autoStart();
                     } else if (utils.isMobile()) {
                         _this.pause({ reason: 'autostart' });
                     }
                 }
+            }
+
+            function _checkPreload(model, viewable) {
+                const attemptPreload = (viewable === 1 || _api.uniqueId === 1);
+
+                if (model.get('preloaded') || !attemptPreload) {
+                    return;
+                }
+
+                model.getVideo().preload();
+                model.set('preloaded', true);
             }
 
             this.triggerAfterReady = function(type, args) {

--- a/src/js/providers/default.js
+++ b/src/js/providers/default.js
@@ -14,6 +14,7 @@ define([
 
         // Basic playback features
         play: noop,
+        preload: noop,
         load: noop,
         stop: noop,
         volume: noop,
@@ -53,6 +54,7 @@ define([
         setControls: noop,
         attachMedia: noop,
         detachMedia: noop,
+        init: noop,
 
         setState: function(state) {
             var oldState = this.state || states.IDLE;

--- a/src/js/providers/flash.js
+++ b/src/js/providers/flash.js
@@ -101,9 +101,8 @@ define([
             }
         }
 
-
         _.extend(this, Events, Tracks, {
-            init: function(item) {
+            preload: function(item) {
                 // if not preloading or autostart is true, do nothing
                 if (item.preload && item.preload !== 'none' && !_playerConfig.autostart) {
                     _item = item;

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -482,9 +482,6 @@ define([
                 // Playback rate is broken on Android HLS
                 _this.supportsPlaybackRate = false;
             }
-            if (source.preload && source.preload !== _videotag.getAttribute('preload')) {
-                _setAttribute('preload', source.preload);
-            }
 
             var sourceElement = document.createElement('source');
             sourceElement.src = source.file;
@@ -568,7 +565,16 @@ define([
             _duration = item.duration || 0;
             _visualQuality.reason = '';
             _setVideotagSource(_levels[_currentQuality]);
+            this.preloadSource = _levels[_currentQuality];
             this.setupSideloadedTracks(item.tracks);
+        };
+
+        this.preload = function() {
+            if (!this.preloadSource || this.preloadSource.preload === 'none') {
+                return;
+            }
+
+            _setAttribute('preload', this.preloadSource.preload);
         };
 
         this.load = function(item) {

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -565,16 +565,12 @@ define([
             _duration = item.duration || 0;
             _visualQuality.reason = '';
             _setVideotagSource(_levels[_currentQuality]);
-            this.preloadSource = _levels[_currentQuality];
             this.setupSideloadedTracks(item.tracks);
         };
 
-        this.preload = function() {
-            if (!this.preloadSource || this.preloadSource.preload === 'none') {
-                return;
-            }
-
-            _setAttribute('preload', this.preloadSource.preload);
+        this.preload = function(item) {
+            let preload = item.sources[_currentQuality] ? item.sources[_currentQuality].preload : 'metadata';
+            _setAttribute('preload', preload);
         };
 
         this.load = function(item) {


### PR DESCRIPTION
### This PR will...

- Trigger providers to preload when a player is viewable or if it's the first player on the page if no players are viewable
- Update the HTML5 provider to handle preloading when player is viewable

### Why is this Pull Request needed?

To allow providers, such as Shaka & hls.js, to know that they should begin preloading

### Are there any points in the code the reviewer needs to double check?

That any player should only ever have one provider triggered to preload

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-commercial/pull/3652
https://github.com/jwplayer/jwplayer-commercial/pull/2126

#### Addresses Issue(s):

JW8-23


