### PR TITLE
Share preload constants between providers

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -287,8 +287,9 @@ define([
                 });
                 _checkPlayOnViewable(model, viewable);
 
-                if (shouldPreload(_preloaded, viewable)) {
-                    model.getVideo().preload(model.get('playlistItem'));
+                const item = model.get('playlistItem');
+                if (shouldPreload(_preloaded, viewable) && item.preload !== 'none') {
+                    model.getVideo().preload(item);
                     _preloaded = true;
                 }
             }

--- a/src/js/providers/constants.js
+++ b/src/js/providers/constants.js
@@ -1,4 +1,2 @@
-export const BufferLengths = {
-    METADATA: 1,
-    MAX: 25
-};
+export const MetaBufferLength = 1;
+export const MaxBufferLength = 1;

--- a/src/js/providers/constants.js
+++ b/src/js/providers/constants.js
@@ -1,0 +1,4 @@
+export const BufferLengths = {
+    METADATA: 1,
+    MAX: 25
+};


### PR DESCRIPTION
### This PR will...

- Allow the buffer lengths to be shared between providers
- Block calling the `preload` provider method if preload is `none`

### Why is this Pull Request needed?

- So that hlsjs and shaka use the same buffer length values

### Are there any Pull Requests open in other repos which need to be merged with this?

Merge Order:
1. https://github.com/jwplayer/jwplayer/pull/2133 (Current)
2. https://github.com/jwplayer/jwplayer-commercial/pull/3672

#### Addresses Issue(s):

JW8-55

