### PR TITLE
Fire 'nextHidden' when nextUp disappears

### DIFF
--- a/src/js/view/controls/nextuptooltip.js
+++ b/src/js/view/controls/nextuptooltip.js
@@ -93,6 +93,8 @@ define([
                         feedData: nextUp.feedData,
                         reason: reason,
                     });
+                } else if (!show && nextUp) {
+                    this.trigger('nextHidden');
                 }
             }
         }


### PR DESCRIPTION
### This PR will...
trigger 'nextHidden' when the nextUp mini pop-up disappears

### Why is this Pull Request needed?
in analytics we listen for nextHidden to reset the 'nextShownReason'.

### Are there any points in the code the reviewer needs to double check?
n/a

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-analytics/pull/291

#### Addresses Issue(s):

JW7-4434

