### PR TITLE
Check for mute before pausing a player scrolled out of visibility

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -289,7 +289,7 @@ define([
                 if (_model.get('playOnViewable')) {
                     if (viewable) {
                         _autoStart();
-                    } else if (utils.isMobile() && model.get('mute')) {
+                    } else if (utils.isMobile()) {
                         _this.pause({ reason: 'autostart' });
                     }
                 }

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -263,6 +263,7 @@ define([
 
                 _checkAutoStart();
                 _model.change('viewable', viewableChange);
+                _model.change('viewable', _checkPlayOnViewable);
             }
 
             function _updateViewable(model, visibility) {
@@ -282,7 +283,6 @@ define([
                 _this.trigger('viewable', {
                     viewable: viewable
                 });
-                _checkPlayOnViewable(model, viewable);
             }
 
             function _checkPlayOnViewable(model, viewable) {

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -197,6 +197,10 @@ define([
                 });
             });
 
+            _model.on('change:autostartFailed change:autostartMuted change:mute', function(model) {
+                model.off('viewable', _checkPlayOnViewable);
+            });
+
             // Ensure captionsList event is raised after playlistItem
             _captions = new Captions(_model);
 

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -197,10 +197,6 @@ define([
                 });
             });
 
-            _model.on('change:autostartFailed change:autostartMuted change:mute', function(model) {
-                model.off('viewable', _checkPlayOnViewable);
-            });
-
             // Ensure captionsList event is raised after playlistItem
             _captions = new Captions(_model);
 
@@ -268,6 +264,9 @@ define([
                 _checkAutoStart();
                 _model.change('viewable', viewableChange);
                 _model.change('viewable', _checkPlayOnViewable);
+                _model.on('change:autostartFailed change:autostartMuted change:mute', function(model) {
+                    model.off('change:viewable', _checkPlayOnViewable);
+                });
             }
 
             function _updateViewable(model, visibility) {

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -264,7 +264,7 @@ define([
                 _checkAutoStart();
                 _model.change('viewable', viewableChange);
                 _model.change('viewable', _checkPlayOnViewable);
-                _model.on('change:autostartFailed change:autostartMuted change:mute', function(model) {
+                _model.once('change:autostartFailed change:autostartMuted change:mute', function(model) {
                     model.off('change:viewable', _checkPlayOnViewable);
                 });
             }

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -289,7 +289,7 @@ define([
                 if (_model.get('playOnViewable')) {
                     if (viewable) {
                         _autoStart();
-                    } else if (utils.isMobile()) {
+                    } else if (utils.isMobile() && model.get('mute')) {
                         _this.pause({ reason: 'autostart' });
                     }
                 }

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -296,7 +296,6 @@ define([
             }
             if (this.unmuteCallback) {
                 model.off('change:autostartFailed change:autostartMuted change:mute', this.unmuteCallback);
-                model.off('viewable', _checkPlayOnViewable);
                 this.unmuteCallback = null;
             }
             model.set('autostartFailed', undefined);

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -296,6 +296,7 @@ define([
             }
             if (this.unmuteCallback) {
                 model.off('change:autostartFailed change:autostartMuted change:mute', this.unmuteCallback);
+                model.off('viewable', _checkPlayOnViewable);
                 this.unmuteCallback = null;
             }
             model.set('autostartFailed', undefined);


### PR DESCRIPTION
### This PR will...
pause the video after being scrolled off only if it is currently muted

### Why is this Pull Request needed?
To prevent pausing unmuted videos when scrolled out of view

### Are there any points in the code the reviewer needs to double check?
n/a

### Are there any Pull Requests open in other repos which need to be merged with this?
n/a

#### Addresses Issue(s):

JW7-4442

