### PR TITLE
Change to buffering when loading an ad

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -208,6 +208,7 @@ define([
             var providersNeeded = providersManager.required(playlist, primary);
 
             _model.set('hideAdsControls', false);
+            _instream._adModel.set('state', states.BUFFERING);
             providersManager.load(providersNeeded)
                 .then(function() {
                     if (_instream === null) {


### PR DESCRIPTION
### This PR will...
change the player state to buffering when loading a new ad.

### Why is this Pull Request needed?
When vpaid ad is closed in ad pod, and the next ad is an instream, the previous and the new state is 'playing', which results the play event to not fire when the instream begins. Play event only fires when there is a change in state.

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-ads-vast/pull/203

#### Addresses Issue(s):
ADS-336
