### PR TITLE
Maintain focus on a clicked element JW7-4450

### DIFF
--- a/src/js/view/utils/flag-no-focus.js
+++ b/src/js/view/utils/flag-no-focus.js
@@ -10,12 +10,6 @@ define([
             dom.removeClass(elementContext, 'jw-no-focus');
         };
 
-        const onMouseUp = function (e) {
-            if (e.target && e.target.blur) {
-                e.target.blur();
-            }
-        };
-
         const onMouseDown = function () {
             _focusFromClick = true;
             dom.addClass(elementContext, 'jw-no-focus');
@@ -30,14 +24,12 @@ define([
         elementContext.addEventListener('focus', onFocus);
         elementContext.addEventListener('blur', onBlur);
         elementContext.addEventListener('mousedown', onMouseDown);
-        elementContext.addEventListener('mouseup', onMouseUp);
 
         return {
             destroy: function() {
                 elementContext.removeEventListener('focus', onFocus);
                 elementContext.removeEventListener('blur', onBlur);
                 elementContext.removeEventListener('mousedown', onMouseDown);
-                elementContext.removeEventListener('mouseup', onMouseUp);
             }
         };
     };


### PR DESCRIPTION
### This PR will...
Remove the `mouseup` handler which calls `blur` on the clicked element.

### Why is this Pull Request needed?
In order to allow users to tab through the Player after clicking on it, we must maintain focus on that element. A previous bugfix (JW7-2703) called `blur` on every `mouseup` in order to achieve a cosmetic goal; functionality, however, is more important.

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

 JW7-4450
