### PR TITLE
Update IntersectionObserver polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "grunt-postcss": "0.8.0",
     "grunt-stylelint": "0.8.0",
     "import-loader": "1.0.1",
-    "intersection-observer": "0.2.1",
+    "intersection-observer": "0.3.2",
     "istanbul-instrumenter-loader": "1.2.0",
     "jquery": "3.2.1",
     "jsdoc": "^3.4.3",


### PR DESCRIPTION
### This PR will...

Update IntersectionObserver polyfill to v0.3.2. Updates include changes made since the v0.2.1 release on Jan 18, 2017:

https://github.com/WICG/IntersectionObserver/commits/gh-pages

### Why is this Pull Request needed?

- Our IE11 fix https://github.com/WICG/IntersectionObserver/commit/6cd1bed6509793abb173a4e31c16f3a24f739c08
- Account for the body element clipping overflow https://github.com/WICG/IntersectionObserver/commit/5548372ee843574212a1018ca612e01508d7c09b
- Incorporate all the latest spec changes 
 https://github.com/WICG/IntersectionObserver/commit/c6e2d49fa81310530501a9afc99516bb125ae510

Probably the only change we don't need is "support for nodes in shadow DOM":
https://github.com/WICG/IntersectionObserver/commit/9cfde412e9eae7ffe2bdc371f480e1daf20adc5f