### PR TITLE
Do not call swf.off because swf.events is read-only 

### DIFF
--- a/src/js/providers/flash.js
+++ b/src/js/providers/flash.js
@@ -378,7 +378,6 @@ define([
                 removeBlockedCheck();
                 this.remove();
                 if (_swf) {
-                    _swf.off();
                     _swf = null;
                 }
                 _container = null;

--- a/src/js/providers/flash.js
+++ b/src/js/providers/flash.js
@@ -378,6 +378,7 @@ define([
                 removeBlockedCheck();
                 this.remove();
                 if (_swf) {
+                    _swf.off();
                     _swf = null;
                 }
                 _container = null;

--- a/src/js/utils/embedswf.js
+++ b/src/js/utils/embedswf.js
@@ -22,6 +22,14 @@ define([
         });
     }
 
+    function addSetter(obj, property, value) {
+        Object.defineProperty(obj, property, {
+            set: function() {
+                return value;
+            }
+        });
+    }
+
     function embed(swfUrl, container, id, wmode) {
         var swf;
         var queueCommands = true;
@@ -114,7 +122,16 @@ define([
                 }
             });
         });
-        addGetter(swf, '_events', {});
+
+        let events = {};
+        Object.defineProperty(swf, '_events', {
+            get: function () {
+                return events;
+            },
+            set: function (value) {
+                events = value;
+            }
+        });
 
         // javascript can trigger SwfEventRouter callbacks
         addGetter(swf, 'triggerFlash', function(name) {

--- a/src/js/utils/embedswf.js
+++ b/src/js/utils/embedswf.js
@@ -22,14 +22,6 @@ define([
         });
     }
 
-    function addSetter(obj, property, value) {
-        Object.defineProperty(obj, property, {
-            set: function() {
-                return value;
-            }
-        });
-    }
-
     function embed(swfUrl, container, id, wmode) {
         var swf;
         var queueCommands = true;


### PR DESCRIPTION
### This PR will...
Remove the call to `swf.off()` on Flash provider destroy

### Why is this Pull Request needed?
`.off()` sets the internal `_events` object to null; with the Flash provider, this object is read-only. Now that we operate in strict mode this throws an exception (previously it was swallowed).

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-119
