### PR TITLE
Build docs when cutting a release

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -144,8 +144,7 @@ module.exports = function(grunt) {
                 tasks: [
                     'webpack:debug',
                     'lint:player',
-                    'karma:local',
-                    'docs'
+                    'karma:local'
                 ]
             },
             css: {
@@ -343,8 +342,7 @@ module.exports = function(grunt) {
         'lint:player',
         'stylelint',
         'less',
-        'postcss',
-        'docs'
+        'postcss'
     ]);
 
     grunt.registerTask('build-flash', [

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "lint:js": "eslint './src/js'",
     "lint:styles": "stylelint './src/css/**/*.less'",
     "lint:tests": "eslint './test/*.js'",
+    "preversion": "grunt && npm run docs && git add docs",
     "test": "karma start"
   },
   "engines": {


### PR DESCRIPTION
### This PR will...

Stop generating docs with every build. Build the player and generate docs in an npm `preversion` hook. Running `npm version` will build the player, generate docs and include the updated docs in the version update commit.

### Are there any points in the code the reviewer needs to double check?

This is a workflow optimization for builds that do not modify the api or doc comments. Ideally any commit that changes the api or doc comments includes changes to the docs.

If you are using npm 5, you need npm version 5.1.0 or higher to version this project. This avoids an error with the package-lock file being ignored https://github.com/npm/npm/pull/17505.

### Are there any Pull Requests open in other repos which need to be merged with this?

No
