### PR TITLE
Remove deprecated API added to the compatibility script

### DIFF
--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -1003,20 +1003,6 @@ define([
          * @param {boolean} toggle - Specifies whether ad playback should be paused or resumed.
          */
         pauseAd(/* eslint-disable no-unused-vars */toggle/* eslint-enable no-unused-vars */) {},
-
-        /**
-         * @deprecated TODO: in version 8.0.0-0
-         */
-        dispatchEvent() {
-            this.trigger.apply(this, arguments);
-        },
-
-        /**
-         * @deprecated TODO: in version 8.0.0-0
-         */
-        removeEventListener() {
-            this.off.apply(this, arguments);
-        }
     });
 
     return Api;

--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -372,27 +372,11 @@ define([
             },
 
             /**
-             * Alias of `getPlaylistIndex()`
-             * @deprecated TODO: in version 8.0.0-0
-             */
-            getItem() {
-                return this.getPlaylistIndex();
-            },
-
-            /**
              * Gets all metadata for the current playlist item.
              * @returns {object}
              */
             getItemMeta() {
                 return _controller.get('itemMeta') || {};
-            },
-
-            /**
-             * Alias of `getItemMeta()`
-             * @deprecated TODO: in version 8.0.0-0
-             */
-            getMeta() {
-                return this.getItemMeta();
             },
 
             /**
@@ -1019,13 +1003,6 @@ define([
          * @param {boolean} toggle - Specifies whether ad playback should be paused or resumed.
          */
         pauseAd(/* eslint-disable no-unused-vars */toggle/* eslint-enable no-unused-vars */) {},
-
-        /**
-         * @deprecated since version 7.0. TODO: remove in 8.0.0-0
-         */
-        getRenderingMode() {
-            return 'html5';
-        },
 
         /**
          * @deprecated TODO: in version 8.0.0-0

--- a/test/data/api-methods-deprecated.js
+++ b/test/data/api-methods-deprecated.js
@@ -39,5 +39,10 @@ define({
     onSeek: null,
     onSetupError: null,
     onTime: null,
-    onVolume: null
+    onVolume: null,
+    dispatchEvent: null,
+    getRenderingMode: null,
+    removeEventListener: null,
+    getMeta: null,
+    getItem: null
 });

--- a/test/data/api-methods.js
+++ b/test/data/api-methods.js
@@ -6,7 +6,6 @@ define({
     //   getPlaylistIndex: null,
     //   jw...: null,
 
-    dispatchEvent: null,
     removeEventListener: null,
     addButton: null,
     addPlugin: null,

--- a/test/data/api-methods.js
+++ b/test/data/api-methods.js
@@ -29,7 +29,6 @@ define({
     getDuration: null,
     getFullscreen: null,
     getHeight: null,
-    getItem: null,
     getItemMeta: null,
     getMute: null,
     getPlaybackRate: null,

--- a/test/data/api-methods.js
+++ b/test/data/api-methods.js
@@ -31,7 +31,6 @@ define({
     getHeight: null,
     getItem: null,
     getItemMeta: null,
-    getMeta: null,
     getMute: null,
     getPlaybackRate: null,
     getPlaylist: null,

--- a/test/data/api-methods.js
+++ b/test/data/api-methods.js
@@ -40,7 +40,6 @@ define({
     getPosition: null,
     getProvider: null,
     getQualityLevels: null,
-    getRenderingMode: null,
     getSafeRegion: null,
     getState: null,
     getStretching: null,

--- a/test/data/api-methods.js
+++ b/test/data/api-methods.js
@@ -6,7 +6,6 @@ define({
     //   getPlaylistIndex: null,
     //   jw...: null,
 
-    removeEventListener: null,
     addButton: null,
     addPlugin: null,
     getPlugin: null,

--- a/test/unit/api-test.js
+++ b/test/unit/api-test.js
@@ -109,12 +109,6 @@ define([
             delete window.jwplayer.debug;
         });
 
-        it('rendering mode is html5', function() {
-            var api = createApi('player');
-
-            assert.equal(api.getRenderingMode(), 'html5', 'api.getRenderingMode() returns "html5"');
-        });
-
         it('can be removed and reused', function() {
             var api = createApi('player');
 

--- a/test/unit/api-test.js
+++ b/test/unit/api-test.js
@@ -251,7 +251,7 @@ define([
             var result = api.registerPlugin('', '7.0', function() {});
             assert.strictEqual(result, undefined, 'registerPlugin returns undefined');
 
-            assert.deepEqual(api.getMeta(), {}, 'getMeta returns {}');
+            assert.deepEqual(api.getItemMeta(), {}, 'getItemMeta returns {}');
             assert.strictEqual(api.getItem(), undefined, 'getItem returns undefined');
             assert.strictEqual(api.getPlaylist(), undefined, 'getPlaylist returns undefined');
             assert.strictEqual(api.getPlaylistItem(), undefined, 'getPlaylistItem() returns undefined');
@@ -267,7 +267,7 @@ define([
         it('has methods that can only be called after setup', function (done) {
             var api = createApi('player');
 
-            var meta = api.getMeta();
+            var meta = api.getItemMeta();
 
             var config = _.extend({}, configSmall, {
                 events: {
@@ -287,7 +287,7 @@ define([
                 assert.equal(e.setupTime, qoe.setupTime,
                     'ready event setup time equals QOE setup time');
 
-                assert.notEqual(api.getMeta(), meta,
+                assert.notEqual(api.getItemMeta(), meta,
                     'it.skipem meta is reset on ready');
 
                 assert.strictEqual(api.getContainer(), document.getElementById('player'),

--- a/test/unit/api-test.js
+++ b/test/unit/api-test.js
@@ -252,7 +252,7 @@ define([
             assert.strictEqual(result, undefined, 'registerPlugin returns undefined');
 
             assert.deepEqual(api.getItemMeta(), {}, 'getItemMeta returns {}');
-            assert.strictEqual(api.getItem(), undefined, 'getItem returns undefined');
+            assert.strictEqual(api.getPlaylistIndex(), undefined, 'getPlaylistIndex returns undefined');
             assert.strictEqual(api.getPlaylist(), undefined, 'getPlaylist returns undefined');
             assert.strictEqual(api.getPlaylistItem(), undefined, 'getPlaylistItem() returns undefined');
             assert.strictEqual(api.getPlaylistItem(0), null, 'getPlaylistItem(0) returns null');


### PR DESCRIPTION
### This PR will...
remove all instances of deprecated API methods added to compatibility script.

### Why is this Pull Request needed?
To exclude deprecated methods from jw8

### Are there any points in the code the reviewer needs to double check?
n/a -> callbacks are removed in https://github.com/jwplayer/jwplayer/pull/2157/
### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-ads-vast/pull/210

#### Addresses Issue(s):

JW8-110

