### PR TITLE
Updated default width and height values

### DIFF
--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -19,8 +19,8 @@ define([
         stretching: 'uniform',
         mute: false,
         volume: 90,
-        width: 480,
-        height: 270,
+        width: 640,
+        height: 360,
         audioMode: false,
         localization: {
             player: 'Video Player',

--- a/test/unit/api-config-test.js
+++ b/test/unit/api-config-test.js
@@ -39,6 +39,13 @@ define([
                 return x;
             }
 
+            it('should have default width of 640 and height of 360', function() {
+                let x = testConfig();
+
+                expect(x.width).to.equal(640);
+                expect(x.height).to.equal(360);
+            });
+
             it('should accept widths in different formats', function () {
                 let x = testConfig({ width: '100px' });
                 expect(x.width, 'pixel').to.equal('100');

--- a/test/unit/api-config-test.js
+++ b/test/unit/api-config-test.js
@@ -39,8 +39,8 @@ define([
                 return x;
             }
 
-            it('should have default width of 640 and height of 360', function() {
-                let x = testConfig();
+            it('should have default width of 640 and height of 360', function () {
+                const x = testConfig();
 
                 expect(x.width).to.equal(640);
                 expect(x.height).to.equal(360);


### PR DESCRIPTION
### This PR will...
Change the default player size **from** 480 x 270 **to** 640 x 360.
### Why is this Pull Request needed?
Our default player size was not up to date with current standards of minimum resolutions. Updating this should lead to less resolution customization.
### Are there any points in the code the reviewer needs to double check?
No
### Are there any Pull Requests open in other repos which need to be merged with this?
No
#### Addresses Issue(s):

JW8-173

