### PR TITLE
Update Add/Remove Button API

### DIFF
--- a/src/css/controls/imports/controlbar.less
+++ b/src/css/controls/imports/controlbar.less
@@ -281,3 +281,11 @@
         display: none;
     }
 }
+
+.jw-button-image {
+    width: 100%;
+    height: 100%;
+    background: 50% 50% no-repeat;
+    background-size: contain;
+    opacity: 0.75;
+}

--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -832,7 +832,7 @@ export default function Api(element) {
             return this;
         },
 
-        /** Adds or updates a button in the player's dock. The button is only displayed when controls are active.
+        /** Adds or updates a button in the player's control bar. The button is only displayed when controls are active.
          * @param {string} img - An image URL to use as the button icon.
          * @param {string} tooltip - A tooltip label to display when the button is hovered.
          * @param {function} callback - A callback to invoke when the button is clicked.
@@ -846,7 +846,7 @@ export default function Api(element) {
         },
 
         /**
-         * Removes a button from the player's dock.
+         * Removes a button from the player's control bar.
          * @param {string} id - The id of the button to remove.
          * @returns {Api}
          */

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -798,7 +798,6 @@ define([
                     }
                 }
 
-                console.log('Adding Buttons:', _.pluck(customButtons, 'id'));
                 _model.set('customButtons', customButtons);
             };
             this.removeButton = function(id) {
@@ -812,9 +811,7 @@ define([
                     (button) => button.id !== id
                 );
 
-                console.log('Removing Buttons:', _.pluck(customButtons, 'id'));
                 _model.set('customButtons', customButtons);
-
             };
             // Delegate trigger so we can run a middleware function before any event is bubbled through the API
             this.trigger = function (type, args) {

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -770,6 +770,8 @@ define([
                 return _model.checkComplete();
             };
             this.addButton = function(img, tooltip, callback, id, btnClass) {
+                let customButtons = _model.get('customButtons') || [];
+                let added = false;
                 const newButton = {
                     img: img,
                     tooltip: tooltip,
@@ -777,32 +779,42 @@ define([
                     id: id,
                     btnClass: btnClass
                 };
-                let replaced = false;
-                const dock = _.map(_model.get('dock'), function(dockButton) {
-                    const replaceButton =
-                        dockButton !== newButton &&
-                        dockButton.id === newButton.id;
 
-                    // replace button if its of the same id/type,
-                    // but has different values
-                    if (replaceButton) {
-                        replaced = true;
-                        return newButton;
+                customButtons = _.reduce(customButtons, function(buttons, button) {
+                    if (button.id === newButton.id) {
+                        added = true;
+                        buttons.push(newButton);
+                    } else {
+                        buttons.push(button);
                     }
-                    return dockButton;
-                });
+                    return buttons;
+                }, []);
 
-                // add button if it has not been replaced
-                if (!replaced) {
-                    dock.push(newButton);
+                if (!added) {
+                    if (newButton.id === 'related') {
+                        customButtons.push(newButton);
+                    } else {
+                        customButtons.unshift(newButton);
+                    }
                 }
 
-                _model.set('dock', dock);
+                console.log('Adding Buttons:', _.pluck(customButtons, 'id'));
+                _model.set('customButtons', customButtons);
             };
             this.removeButton = function(id) {
-                let dock = _model.get('dock') || [];
-                dock = _.reject(dock, _.matches({ id: id }));
-                _model.set('dock', dock);
+                const pluginIds = ['cardboard', 'share', 'related'];
+                if (_.contains(pluginIds, id)) {
+                    return;
+                }
+
+                const customButtons = _.filter(
+                    _model.get('customButtons'),
+                    (button) => button.id !== id
+                );
+
+                console.log('Removing Buttons:', _.pluck(customButtons, 'id'));
+                _model.set('customButtons', customButtons);
+
             };
             // Delegate trigger so we can run a middleware function before any event is bubbled through the API
             this.trigger = function (type, args) {

--- a/src/js/view/controls/components/custom-button.js
+++ b/src/js/view/controls/components/custom-button.js
@@ -1,0 +1,41 @@
+import buttonTemplate from 'view/controls/templates/custom-button';
+
+const utils = require('utils/helpers');
+const UI = require('utils/ui');
+
+export default class CustomButton {
+
+    constructor(img, ariaText, callback, id, btnClass) {
+        const button = buttonTemplate(btnClass,
+            id,
+            img,
+            ariaText
+        );
+
+        const buttonElement = utils.createElement(button);
+
+        new UI(buttonElement).on('click tap', callback, this);
+
+        this.id = id;
+        this.buttonElement = buttonElement;
+    }
+
+    element() {
+        return this.buttonElement;
+    }
+
+    toggle(show) {
+        if (show) {
+            this.show();
+        } else {
+            this.hide();
+        }
+    }
+
+    show() {
+        this.buttonElement.style.display = '';
+    }
+    hide() {
+        this.buttonElement.style.display = 'none';
+    }
+}

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -1,6 +1,7 @@
 import { PLAYBACK_RATE_ICON } from 'assets/svg-markup';
 import { Browser, OS } from 'environment/environment';
 import { dvrSeekLimit } from 'view/constants';
+import CustomButton from 'view/controls/components/custom-button';
 
 define([
     'utils/helpers',
@@ -112,10 +113,14 @@ define([
             }
             // Do not show the volume toggle in the mobile SDKs or <iOS10
             if (!_model.get('sdkplatform') && !(OS.iOS && OS.version.major < 10)) {
-                muteButton = button('jw-icon-volume', () => { _api.setMute(); }, vol);
+                muteButton = button('jw-icon-volume', () => {
+                    _api.setMute();
+                }, vol);
             }
 
-            const nextButton = button('jw-icon-next', () => { _api.next(); }, next);
+            const nextButton = button('jw-icon-next', () => {
+                _api.next();
+            }, next);
 
             if (_model.get('nextUpDisplay')) {
                 new UI(nextButton.element(), { useHover: true, directSelect: true })
@@ -138,8 +143,12 @@ define([
 
             this.elements = {
                 alt: text('jw-text-alt', 'status'),
-                play: button('jw-icon-playback', () => { _api.play(null, reasonInteraction()); }, play),
-                rewind: button('jw-icon-rewind', () => { this.rewind(); }, rewind),
+                play: button('jw-icon-playback', () => {
+                    _api.play(null, reasonInteraction());
+                }, play),
+                rewind: button('jw-icon-rewind', () => {
+                    this.rewind();
+                }, rewind),
                 next: nextButton,
                 elapsed: text('jw-text-elapsed', 'timer'),
                 countdown: text('jw-text-countdown', 'timer'),
@@ -157,8 +166,12 @@ define([
                 mute: muteButton,
                 volume: volumeSlider,
                 volumetooltip: volumeTooltip,
-                cast: createCastButton(() => { _api.castToggle(); }, this._localization),
-                fullscreen: button('jw-icon-fullscreen', () => { _api.setFullscreen(); }, this._localization.fullscreen)
+                cast: createCastButton(() => {
+                    _api.castToggle();
+                }, this._localization),
+                fullscreen: button('jw-icon-fullscreen', () => {
+                    _api.setFullscreen();
+                }, this._localization.fullscreen)
             };
 
             this.layout = {
@@ -236,6 +249,7 @@ define([
             _model.change('nextUp', this.onNextUp, this);
             _model.change('cues', this.addCues, this);
             _model.change('altText', this.setAltText, this);
+            _model.change('customButtons', this.updateButtons, this);
 
             // Event listeners
 
@@ -497,6 +511,48 @@ define([
 
         onNextUp(model, nextUp) {
             this.elements.next.toggle(!!nextUp);
+        }
+
+        updateButtons(model, newButtons = [], oldButtons = []) {
+            // TODO: Change to controlbar container
+            const buttonContainer = this.elements.right;
+
+            this.removeButtons(buttonContainer, oldButtons);
+
+            for (let i = newButtons.length - 1; i >= 0; i--) {
+                const newButton = new CustomButton(
+                    newButtons[i].img,
+                    newButtons[i].tooltip,
+                    newButtons[i].callback,
+                    newButtons[i].id,
+                    newButtons[i].btnClass
+                );
+
+                buttonContainer.insertBefore(newButton.element(), buttonContainer.firstChild);
+            }
+        }
+
+        removeButtons(buttonContainer, oldButtons) {
+            const toRemove = {};
+            const buttonElements = _.clone(buttonContainer.children);
+
+            for (let i = 0; i < oldButtons.length; i++) {
+                const oldButton = oldButtons[i];
+                toRemove[oldButton.id] = oldButton;
+            }
+
+            for (let i = 0; i < buttonElements.length; i++) {
+                const buttonElement = buttonElements[i];
+                if (!buttonElement) {
+                    return;
+                }
+
+                const id = buttonElement.getAttribute('button');
+
+                if (toRemove[id]) {
+                    buttonContainer.removeChild(buttonElement);
+                }
+            }
         }
     };
 });

--- a/src/js/view/controls/templates/custom-button.js
+++ b/src/js/view/controls/templates/custom-button.js
@@ -1,0 +1,14 @@
+export default (buttonClass = '', buttonId = '', image, ariaText) => {
+
+    // TODO: Deprecate jw-dock-image
+    const style = image ? `style="background-image: url(${image})"` : '';
+    const imageClass = image ? 'jw-button-image' : 'jw-dock-image';
+
+    const aria = ariaText ? `aria-label="${ariaText}" role="button" tabindex="0"` : '';
+
+    return (
+        `<div class="jw-icon jw-icon-inline jw-button-color jw-reset ${buttonClass}" button="${buttonId}">
+            <div class="jw-icon ${imageClass} jw-button-color jw-reset" ${style} ${aria}></div>
+        </div>`
+    );
+};


### PR DESCRIPTION
### This PR will...

Update the `addButton` & `removeButton` APIs to no longer add button to the dock and icon, but will be added to the control bar.

### Why is this Pull Request needed?

To support the new JW8 Skins, where we will no longer have a dock container and buttons.

### Are there any points in the code the reviewer needs to double check?

- Removing dock html && classes will be handled in https://jwplayer.atlassian.net/browse/JW8-88
- Will need to move where the buttons are being added to the control bar in https://jwplayer.atlassian.net/browse/JW8-127
- Need to verify with Product on what should happen when button id is missing or image url is invalid or blank

#### Addresses Issue(s):

JW8-126

