### PR TITLE
Display Sliders & Menus on Hover

### DIFF
--- a/src/css/controls/imports/tooltip.less
+++ b/src/css/controls/imports/tooltip.less
@@ -51,7 +51,7 @@
     .jw-overlay {
         margin: 0;
         position: absolute;
-        bottom: @controlbar-height;
+        bottom: @mobile-touch-target;
         left: 50%;
         opacity: 0;
         visibility: hidden;


### PR DESCRIPTION
### This PR will...

Adjust overlay bottom padding for menus and sliders to match height of button touch target

### Why is this Pull Request needed?

This was a change that was lost when `time-slider-above.less` was removed

https://github.com/jwplayer/jwplayer/pull/2167/files#diff-f2ce3532c43eea857b27b2e792426d16L50

### Are there any points in the code the reviewer needs to double check?

@robwalch @johnBartos Do we still need the `:not(.jw-flag-ads-googleima)` selector that was in `time-slider-above.less` now that it is the only skin? I don't see that it was moved to another file

https://github.com/jwplayer/jwplayer/pull/2167/files#diff-f2ce3532c43eea857b27b2e792426d16L4

#### Addresses Issue(s):

JW8-229

