### PR TITLE
Fix issue with setup-steps passing playlist feedData

### DIFF
--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -9,13 +9,13 @@ import { SETUP_ERROR } from 'events/events';
 import Events from 'utils/backbone.events';
 import loadCoreBundle from 'api/core-loader';
 
-const CoreModel = function() {};
-Object.assign(CoreModel.prototype, SimpleModel);
+const modelShim = function() {};
+Object.assign(modelShim.prototype, SimpleModel);
 
 const CoreShim = function(originalContainer) {
     this._events = {};
-    this._model = new CoreModel();
-    this._model._qoeItem = new Timer();
+    this.modelShim = new modelShim();
+    this.modelShim._qoeItem = new Timer();
     this.originalContainer = originalContainer;
     this.apiQueue = new ApiQueueDecorator(this, [
         // These commands require a provider instance to be available
@@ -56,7 +56,7 @@ Object.assign(CoreShim.prototype, {
     off: Events.off,
     trigger: Events.trigger,
     init(options, api) {
-        const model = this._model;
+        const model = this.modelShim;
         const storage = new Storage('jwplayer', [
             'volume',
             'mute',
@@ -83,7 +83,7 @@ Object.assign(CoreShim.prototype, {
                 // Exit if `playerDestroy` was called on CoreLoader clearing the config
                 return;
             }
-            const config = this._model.clone();
+            const config = this.modelShim.clone();
             // copy queued commands
             const commandQueue = this.apiQueue.queue.slice(0);
             this.apiQueue.destroy();
@@ -104,6 +104,7 @@ Object.assign(CoreShim.prototype, {
         this.off();
         this._events =
             this._model =
+            this.modelShim =
             this.originalContainer =
             this.apiQueue = null;
     },
@@ -113,13 +114,13 @@ Object.assign(CoreShim.prototype, {
 
     // These methods read from the model
     get(property) {
-        return this._model.get(property);
+        return this.modelShim.get(property);
     },
     getItemQoe() {
-        return this._model._qoeItem;
+        return this.modelShim._qoeItem;
     },
     getConfig() {
-        return Object.assign({}, this._model.attributes);
+        return Object.assign({}, this.modelShim.attributes);
     },
     getCurrentCaptions() {
         return this.get('captionsIndex');

--- a/src/js/controller/setup-steps.js
+++ b/src/js/controller/setup-steps.js
@@ -44,7 +44,7 @@ export function loadPlaylist(_model) {
         return new Promise((resolve, reject) => {
             const playlistLoader = new PlaylistLoader();
             playlistLoader.on(PLAYLIST_LOADED, function(data) {
-                resolve(data.playlist, data);
+                resolve(data);
             });
             playlistLoader.on(ERROR, err => {
                 reject(new Error(`Error loading playlist: ${err.message}`));
@@ -53,16 +53,18 @@ export function loadPlaylist(_model) {
         });
 
     }
-    return Promise.resolve(playlist, _model.attributes.feedData);
+    const data = _model.get('feedData') || {};
+    data.playlist = playlist;
+    return Promise.resolve(data);
 }
 
 function filterPlaylist(_model) {
-    return loadPlaylist(_model).then((playlist, feedData) => {
+    return loadPlaylist(_model).then(data => {
         if (destroyed(_model)) {
             return;
         }
         // `setPlaylist` performs filtering
-        setPlaylist(_model, playlist, feedData);
+        setPlaylist(_model, data.playlist, data);
         loadProvidersForPlaylist(_model);
     });
 }


### PR DESCRIPTION
### Why is this Pull Request needed?

Promise.resolve only passed one argument to thenable method. `loadPlaylist` was attempting to pass `playlist` and `feedData` as two arguments. The default behavior for feeds is to pass one `data` object for `feedData` with a `playlist` property.

### Are there any Pull Requests open in other repos which need to be merged with this?

jwplayer/jwplayer-commercial bugfix/filter-playlist-feeddata branch

#### Addresses Issue(s):

JW8-111

