### PR TITLE
Limit provider supports checks in core-loader

### DIFF
--- a/src/js/api/core-loader.js
+++ b/src/js/api/core-loader.js
@@ -1,4 +1,5 @@
 import Item from 'playlist/item';
+import ProvidersSupported from 'providers/providers-supported';
 
 let bundlePromise = null;
 
@@ -37,13 +38,13 @@ export function requiresPolyfills() {
 }
 
 export function requiresProvider(model, providerName) {
+    const providerSupports = ProvidersSupported.find(provider => provider.name === providerName);
     const providersManager = model.getProviders();
     const playlist = model.get('playlist');
     if (Array.isArray(playlist) && playlist.length) {
         const firstItem = Item(playlist[0]);
         if (firstItem) {
-            const providersNeeded = providersManager.required([firstItem]);
-            return providersNeeded.length && providersNeeded[0].name === providerName;
+            return providersManager.providerSupports(providerSupports, firstItem.sources[0]);
         }
     }
     return false;


### PR DESCRIPTION
### This PR will...

Prevent all provider.supports check from being called when testing for providers that should be bundled by core-loader.

### Why is this Pull Request needed?

We only bundle the html5 provider here, only we only need to call that provider's support method to see if it is required. Calling other provider supports methods is inefficient.

### Are there any points in the code the reviewer needs to double check?

This commercial test was calling shaka.supports for items with DRM before the supported DRM matrix was probed resulting in unexpected console warnings:

/test/squash/bootstrap.html?primary=html5&edition=ads&feature=drm/drm_with_ads&suite=DRM

### Are there any Pull Requests open in other repos which need to be merged with this?

No

#### Addresses Issue(s):

JW8-111