### PR TITLE
Handle playlist loader errors gracefully in setup-steps

### DIFF
--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -83,13 +83,11 @@ const Config = function(options, persisted) {
     config.height = _normalizeSize(config.height);
     const pathToFlash = (getScriptPath('jwplayer.js') || config.base);
     config.flashplayer = config.flashplayer || pathToFlash + 'jwplayer.flash.swf';
-    config.flashloader = config.flashloader || pathToFlash + 'jwplayer.loader.swf';
 
     // Non ssl pages can only communicate with flash when it is loaded
     //   from a non ssl location
     if (window.location.protocol === 'http:') {
         config.flashplayer = config.flashplayer.replace('https', 'http');
-        config.flashloader = config.flashloader.replace('https', 'http');
     }
 
     config.aspectratio = _evaluateAspectRatio(config.aspectratio, config.width);

--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -71,9 +71,6 @@ Object.assign(CoreShim.prototype, {
         Object.assign(model.attributes, configuration, INITIAL_PLAYER_STATE);
 
         Promise.resolve().then(() => {
-            if (configuration.error) {
-                throw configuration.error;
-            }
             model.getProviders = function() {
                 return new Providers(configuration);
             };

--- a/src/js/api/set-playlist.js
+++ b/src/js/api/set-playlist.js
@@ -1,18 +1,17 @@
-import Playlist, { filterPlaylist } from 'playlist/playlist';
+import { filterPlaylist } from 'playlist/playlist';
 
-const setPlaylist = function(model, array, feedData) {
+const setPlaylist = function(model, playlist, feedData = {}) {
 
     model.set('feedData', feedData);
     if (feedData.error instanceof Error) {
         throw feedData.error;
     }
 
-    let playlist = Playlist(array);
-    playlist = filterPlaylist(playlist, model, feedData);
+    const filteredPlaylist = filterPlaylist(playlist, model, feedData);
 
-    model.set('playlist', playlist);
+    model.set('playlist', filteredPlaylist);
 
-    if (!Array.isArray(playlist) || playlist.length === 0) {
+    if (!Array.isArray(filteredPlaylist) || filteredPlaylist.length === 0) {
         throw new Error('No playable sources found');
     }
 };

--- a/src/js/api/set-playlist.js
+++ b/src/js/api/set-playlist.js
@@ -1,7 +1,11 @@
 import Playlist, { filterPlaylist } from 'playlist/playlist';
 
 const setPlaylist = function(model, array, feedData) {
+
     model.set('feedData', feedData);
+    if (feedData.error instanceof Error) {
+        throw feedData.error;
+    }
 
     let playlist = Playlist(array);
     playlist = filterPlaylist(playlist, model, feedData);

--- a/src/js/controller/setup-steps.js
+++ b/src/js/controller/setup-steps.js
@@ -112,14 +112,10 @@ function setupView(_model, _view) {
 }
 
 function setPlaylistItem(_model) {
-    return filterPlaylist(_model).then(() => {
-        if (destroyed(_model)) {
-            return;
-        }
-        return new Promise(resolve => {
-            _model.once('itemReady', resolve);
-            _model.setItemIndex(_model.get('item'));
-        });
+
+    return new Promise(resolve => {
+        _model.once('itemReady', resolve);
+        _model.setItemIndex(_model.get('item'));
     });
 }
 
@@ -132,14 +128,20 @@ const startSetup = function(_api, _model, _view) {
         return Promise.reject();
     }
     return Promise.all([
-        setPlaylistItem(_model, _api, _view),
+        filterPlaylist(_model),
         // filterPlaylist -->
         // -- loadPlaylist,
         initPlugins(_model, _api, _view),
         // loadPlugins,
         // setupView -->
         // -- loadSkin
-    ]);
+    ]).then(() => {
+        if (destroyed(_model)) {
+            return;
+        }
+        // Set the active playlist item after plugins are loaded and the view is setup
+        return setPlaylistItem(_model);
+    });
 };
 
 export default startSetup;

--- a/src/js/controller/setup-steps.js
+++ b/src/js/controller/setup-steps.js
@@ -60,6 +60,8 @@ export function loadPlaylist(_model) {
             playlistLoader.load(playlist);
         });
     }
+    const normalizedPlaylist = Playlist(playlist);
+    _model.set('playlist', normalizedPlaylist);
     return resolved;
 }
 

--- a/src/js/controller/setup-steps.js
+++ b/src/js/controller/setup-steps.js
@@ -3,6 +3,7 @@ import { PLAYLIST_LOADED, MEDIA_COMPLETE, ERROR } from 'events/events';
 import Promise from 'polyfills/promise';
 import plugins from 'plugins/plugins';
 import PlaylistLoader from 'playlist/loader';
+import Playlist from 'playlist/playlist';
 import ScriptLoader from 'utils/scriptloader';
 import _ from 'utils/underscore';
 
@@ -41,30 +42,34 @@ function initPlugins(_model, _api, _view) {
 export function loadPlaylist(_model) {
     const playlist = _model.get('playlist');
     if (_.isString(playlist)) {
-        return new Promise((resolve, reject) => {
+        return new Promise(resolve => {
             const playlistLoader = new PlaylistLoader();
             playlistLoader.on(PLAYLIST_LOADED, function(data) {
-                resolve(data);
+                const loadedPlaylist = Playlist(data.playlist);
+                delete data.playlist;
+                _model.set('playlist', loadedPlaylist);
+                _model.set('feedData', data);
+                resolve();
             });
             playlistLoader.on(ERROR, err => {
-                reject(new Error(`Error loading playlist: ${err.message}`));
+                _model.set('feedData', {
+                    error: new Error(`Error loading playlist: ${err.message}`)
+                });
+                resolve();
             });
             playlistLoader.load(playlist);
         });
-
     }
-    const data = _model.get('feedData') || {};
-    data.playlist = playlist;
-    return Promise.resolve(data);
+    return resolved;
 }
 
 function filterPlaylist(_model) {
-    return loadPlaylist(_model).then(data => {
+    return loadPlaylist(_model).then(() => {
         if (destroyed(_model)) {
             return;
         }
         // `setPlaylist` performs filtering
-        setPlaylist(_model, data.playlist, data);
+        setPlaylist(_model, _model.get('playlist'), _model.get('feedData'));
         loadProvidersForPlaylist(_model);
     });
 }

--- a/src/js/playlist/loader.js
+++ b/src/js/playlist/loader.js
@@ -8,7 +8,7 @@ const PlaylistLoader = function() {
     var _this = Object.assign(this, Events);
 
     this.load = function(playlistfile) {
-        utils.ajax(playlistfile, playlistLoaded, playlistLoadError);
+        utils.ajax(playlistfile, playlistLoaded, playlistError);
     };
 
     this.destroy = function() {
@@ -58,10 +58,6 @@ const PlaylistLoader = function() {
         } catch (error) {
             playlistError(error);
         }
-    }
-
-    function playlistLoadError(err) {
-        playlistError('Error loading playlist: ' + err);
     }
 
     function playlistError(msg) {

--- a/src/js/utils/embedswf.js
+++ b/src/js/utils/embedswf.js
@@ -1,10 +1,9 @@
 import { Browser } from 'environment/environment';
 
 define([
-    'utils/helpers',
     'utils/backbone.events',
     'utils/underscore'
-], function(utils, Events, _) {
+], function(Events, _) {
 
     // Defaults
     var BGCOLOR = '#000000';
@@ -146,7 +145,7 @@ define([
             }
 
             var args = Array.prototype.slice.call(arguments, 1);
-            var status = utils.tryCatch(function() {
+            try {
                 if (args.length) {
                     // remove any nodes from arguments
                     // cyclical structures cannot be converted to JSON
@@ -160,13 +159,11 @@ define([
                 } else {
                     swf.__externalCall(name);
                 }
-            });
-
-            if (status instanceof utils.Error) {
-                console.error(name, status);
+            } catch (error) {
+                console.error(name, error);
                 if (name === 'setup') {
-                    status.name = 'Failed to setup flash';
-                    return status;
+                    error.name = 'Failed to setup flash';
+                    return error;
                 }
             }
             return swf;


### PR DESCRIPTION
### This PR will...

Make `loadPlaylist` in setup-steps update 'playlist' and 'feedData' on the model. On 'error', rather than breaking the promise chain by calling 'reject', store the error in 'feedData'.

### Why is this Pull Request needed?

The setup promises should not reject. Errors can be thrown which will be caught at the end of setup. This allows the view to load and display setup errors correctly.

### Are there any Pull Requests open in other repos which need to be merged with this?

jwplayer-commercial

#### Addresses Issue(s):

JW8-111

