### PR TITLE
Set model autostart to false after autostarting JW7-4465

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -435,6 +435,7 @@ define([
                 var state = _model.get('state');
                 if (state === states.IDLE || state === states.PAUSED) {
                     _play({ reason: 'autostart' });
+                    _model.set('autostart', false);
                 }
             }
 

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -433,9 +433,10 @@ define([
 
             function _autoStart() {
                 var state = _model.get('state');
+                _model.set('autostart', false);
+
                 if (state === states.IDLE || state === states.PAUSED) {
                     _play({ reason: 'autostart' });
-                    _model.set('autostart', false);
                 }
             }
 


### PR DESCRIPTION
### This PR will...
Set the model's `autostart` property to `false` after successfully autostarting

### Why is this Pull Request needed?
If `autostart` is true in the config, every `reason` in the `playAttempt` event will be `autostart` - technically, we always have been autostarting for every item in the playlist, regardless of how it was selected. By setting the model's `autostart` property to false after an autostart, we avoid doing it for subsequent items, allowing the correct `reason` to be emitted.

### Are there any points in the code the reviewer needs to double check?
- Are we relying on `autostart` being true after the first autostart?
- Verify `load` api with autostart config

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW7-4465
