### PR TITLE
Check for autostart only when a playlist is loaded

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -335,13 +335,16 @@ define([
                 _this.trigger('destroyPlugin', {});
                 _stop(true);
 
-                _model.once('itemReady', _checkAutoStart);
+                // Check for autostart only when loading a playlist, so that we don't autostart while progressing or using the API
+                _model.off('itemReady', _checkAutoStart);
 
                 switch (typeof item) {
                     case 'string':
+                        _model.once('itemReady', _checkAutoStart);
                         _loadPlaylist(item);
                         break;
                     case 'object':
+                        _model.once('itemReady', _checkAutoStart);
                         var success = _setPlaylist(item, feedData);
                         if (success) {
                             _setItem(0);
@@ -433,7 +436,6 @@ define([
 
             function _autoStart() {
                 var state = _model.get('state');
-                _model.set('autostart', false);
 
                 if (state === states.IDLE || state === states.PAUSED) {
                     _play({ reason: 'autostart' });


### PR DESCRIPTION
### This PR will...
Check autostart on `itemReady` only when a playlist is loaded

### Why is this Pull Request needed?
Subsequent playlists should be autostarted if `autostart: true`; however, playlist progression should not.

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

 JW7-4465
