### PR TITLE
Support Logo in Control Bar

### DIFF
--- a/src/css/controls/imports/controlbar.less
+++ b/src/css/controls/imports/controlbar.less
@@ -31,6 +31,7 @@
         height: 100%;
         background-position: 50% 50%;
         background-repeat: no-repeat;
+        background-size: 20px;
         opacity: 0.75;
     }
 

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -225,6 +225,11 @@ define([
             appendChildren(elements.buttonContainer, buttonLayout);
             appendChildren(this.el, layout);
 
+            const logo = _model.get('logo');
+            if (logo && logo.position === 'control-bar') {
+                this.addLogo(logo);
+            }
+
             // Initial State
             elements.play.show();
             elements.fullscreen.show();
@@ -502,9 +507,28 @@ define([
             this.elements.next.toggle(!!nextUp);
         }
 
-        updateButtons(model, newButtons = [], oldButtons = []) {
+        addLogo(logo) {
             const buttonContainer = this.elements.buttonContainer;
 
+            const logoButton = new CustomButton(
+                logo.file,
+                'Logo',
+                () => {
+                    if (logo.link) {
+                        window.open(logo.link, '_blank');
+                    }
+                },
+                'logo'
+            );
+
+            buttonContainer.insertBefore(
+                logoButton.element(),
+                buttonContainer.querySelector('.jw-spacer').nextSibling
+            );
+        }
+
+        updateButtons(model, newButtons = [], oldButtons = []) {
+            const buttonContainer = this.elements.buttonContainer;
             this.removeButtons(buttonContainer, oldButtons);
 
             for (let i = newButtons.length - 1; i >= 0; i--) {
@@ -516,9 +540,14 @@ define([
                     newButtons[i].btnClass
                 );
 
+                let firstButton = buttonContainer.querySelector('.jw-spacer').nextSibling;
+                if (firstButton.getAttribute('button') === 'logo') {
+                    firstButton = firstButton.nextSibling;
+                }
+
                 buttonContainer.insertBefore(
                     newButton.element(),
-                    buttonContainer.querySelector('.jw-spacer').nextSibling
+                    firstButton
                 );
             }
         }

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -541,7 +541,7 @@ define([
                 );
 
                 let firstButton = buttonContainer.querySelector('.jw-spacer').nextSibling;
-                if (firstButton.getAttribute('button') === 'logo') {
+                if (firstButton && firstButton.getAttribute('button') === 'logo') {
                     firstButton = firstButton.nextSibling;
                 }
 

--- a/src/js/view/logo.js
+++ b/src/js/view/logo.js
@@ -32,7 +32,7 @@ define([
             _settings.position = _settings.position || LogoDefaults.position;
             _settings.hide = (_settings.hide.toString() === 'true');
 
-            if (!_logo) {
+            if (!_logo || _settings.position !== 'control-bar') {
                 _logo = utils.createElement(logoTemplate(_settings.position, _settings.hide));
             }
 

--- a/test/unit/controlbar-test.js
+++ b/test/unit/controlbar-test.js
@@ -1,4 +1,5 @@
 import ControlBar from 'view/controls/controlbar';
+import CustomButton from 'view/controls/components/custom-button';
 import SimpleModel from 'model/simplemodel';
 import _ from 'test/underscore';
 import sinon from 'sinon';
@@ -47,10 +48,21 @@ describe('Control Bar', function() {
             expect(controlBar.removeButtons.calledBefore(container.insertBefore)).to.be.true;
         });
 
-        it('should add button to the container', function() {
+        it('should add button after spacer if there is no logo', function() {
             controlBar.updateButtons(model, [{ id: '1' }]);
 
             expect(children.length).to.equal(3);
+        });
+
+        it('should add button after logo if there is one', function() {
+            const logo = document.createElement('div');
+            logo.setAttribute('button', 'logo');
+
+            container.appendChild(logo);
+            controlBar.updateButtons(model, [{ id: '1' }]);
+
+            expect(children.length).to.equal(4);
+            expect(children[3].getAttribute('button')).to.equal('1');
         });
 
         it('should add buttons to the container in order', function() {
@@ -97,6 +109,20 @@ describe('Control Bar', function() {
 
             expect(children.length).to.equal(3);
             expect(children[2].getAttribute('button')).to.equal('3');
+        });
+    });
+
+    describe('addLogo', function() {
+
+        it('should add a logo after spacer', function() {
+            controlBar.addLogo({
+                file: 'logo.svg',
+                link: 'http://www.jwplayer.com'
+            });
+
+            expect(children.length).to.equal(3);
+            expect(children[2].getAttribute('button')).to.equal('logo');
+            expect(children[2].children[0].style.backgroundImage).to.equal('url(http://localhost:9877/logo.svg)');
         });
     });
 });

--- a/test/unit/controlbar-test.js
+++ b/test/unit/controlbar-test.js
@@ -1,5 +1,4 @@
 import ControlBar from 'view/controls/controlbar';
-import CustomButton from 'view/controls/components/custom-button';
 import SimpleModel from 'model/simplemodel';
 import _ from 'test/underscore';
 import sinon from 'sinon';

--- a/test/unit/controlbar-test.js
+++ b/test/unit/controlbar-test.js
@@ -113,7 +113,7 @@ describe('Control Bar', function() {
 
     describe('addLogo', function() {
 
-        it('should add a logo after spacer', function() {
+        it('should add a logo image after spacer', function() {
             controlBar.addLogo({
                 file: 'logo.svg',
                 link: 'http://www.jwplayer.com'
@@ -121,7 +121,7 @@ describe('Control Bar', function() {
 
             expect(children.length).to.equal(3);
             expect(children[2].getAttribute('button')).to.equal('logo');
-            expect(children[2].children[0].style.backgroundImage).to.equal('url(http://localhost:9877/logo.svg)');
+            expect(children[2].children[0].style.backgroundImage.indexOf('logo.svg')).to.not.equal(-1);
         });
     });
 });


### PR DESCRIPTION
### This PR will...

Add `control-bar` as a new config value for `logo.position`, which will set the given logo image as the rightmost button after the spacer

### Why is this Pull Request needed?

To give customers the ability to add their logo in the control bar with the new UI

#### Addresses Issue(s):

JW8-138

