### PR TITLE
Hide Logo on Related Overlay

### DIFF
--- a/src/css/controls/flags/overlay.less
+++ b/src/css/controls/flags/overlay.less
@@ -7,8 +7,8 @@
         }
     }
 
-    &-sharing:not(.jw-flag-small-player) {
-        .jw-logo-top-right {
+    &-related {
+        .jw-logo {
             display: none;
         }
     }

--- a/src/css/controls/flags/overlay.less
+++ b/src/css/controls/flags/overlay.less
@@ -2,12 +2,7 @@
     &-sharing.jw-flag-small-player,
     &-related {
         .jw-controls,
-        .jw-title {
-            display: none;
-        }
-    }
-
-    &-related {
+        .jw-title,
         .jw-logo {
             display: none;
         }


### PR DESCRIPTION
### This PR will...

- When the logo is in the display container, hide it when the related overlay is opened 
- When the logo is in the display container, only hide it when the sharing over is opened in a small player

### Why is this Pull Request needed?

It is not being hidden when it is hidden. Especially bad when it is in the top right corner and covering up the close button

#### Addresses Issue(s):

JW8-262