### PR TITLE
Don't end tests before async assertions are run

### DIFF
--- a/test/unit/ajax-test.js
+++ b/test/unit/ajax-test.js
@@ -21,13 +21,14 @@ describe('ajax', function() {
                     'success callback expects the result to have responseXML for XML content');
                 assert.equal(xhrResult.status, 200,
                     'success callback expects that the result status was 200');
+                done();
             },
             function error(message, requestUrl, xhrResult) {
                 assert.isOk(false, message, requestUrl, xhrResult);
+                done();
             },
             true
         );
-        done();
         assert.isOk(validXHR(xhr),
             'ajax returns an XMLHttpRequest instance');
     });
@@ -38,13 +39,14 @@ describe('ajax', function() {
             oncomplete: function (xhrResult) {
                 assert.isOk(xhrResult.responseText,
                     'success callback expects the the result to have responseText');
+                done();
             },
             onerror: function (message, requestUrl, xhrResult) {
                 assert.isOk(false, message, requestUrl, xhrResult);
+                done();
             },
             responseType: 'text'
         });
-        done();
         assert.isOk(validXHR(xhr),
             'ajax returns an XMLHttpRequest instance');
     });
@@ -53,16 +55,16 @@ describe('ajax', function() {
         var xhr = ajax({
             url: '/base/test/files/playlist.json',
             oncomplete: function (xhrResult) {
-
                 assert.isOk(_.isArray(xhrResult.response) && xhrResult.response[0].file,
                     'xhr.response is parsed JSON');
+                done();
             },
             onerror: function (message, requestUrl, xhrResult) {
                 assert.isOk(false, message, requestUrl, xhrResult);
+                done();
             },
             responseType: 'json'
         });
-        done();
         assert.isOk(validXHR(xhr),
             'ajax returns an XMLHttpRequest instance');
     });
@@ -71,19 +73,21 @@ describe('ajax', function() {
         var nonce = Math.random().toFixed(20).substr(2);
 
         ajax({
-            url: 'http://playertest.longtailvideo.com/vast/preroll.xml?n=' + nonce,
+            url: '//playertest.longtailvideo.com/vast/preroll.xml?n=' + nonce,
             oncomplete: function (xhrResult) {
-                assert.isNotOk(xhrResult.responseText, 'What?');
+                assert.isNotOk(xhrResult.responseText,
+                'This XHR request did not time out and triggered ajax().on("complete") unexpectedly.');
                 assert.isOk(false, 'expected request to timeout immediately');
+                done();
             },
             onerror: function (message) {
                 assert.equal(message, 'Timeout',
                     '"Timeout" error message');
+                done();
             },
             timeout: 0.0001,
             responseType: 'text'
         });
-        done();
     });
 
     it('withCredentials', function (done) {
@@ -95,14 +99,15 @@ describe('ajax', function() {
                 } else {
                     assert.isOk(true, 'withCredentials is not available in this browser');
                 }
+                done();
             },
             onerror: function() {
                 assert.isOk(false, 'request failed withCredentials');
+                done();
             },
             withCredentials: true,
             responseType: 'text'
         });
-        done();
     });
 
     it('withCredentials crossdomain', function (done) {
@@ -118,15 +123,16 @@ describe('ajax', function() {
                 }
                 assert.isOk(xhrResult.responseXML.firstChild,
                     'xml was returned');
+                done();
             },
             onerror: function() {
                 assert.isOk(false, 'crossdomain request failed withCredentials and retryWithoutCredentials');
+                done();
             },
             withCredentials: true,
             retryWithoutCredentials: true,
             requireValidXML: true
         });
-        done();
     });
 
     it('error "Error loading file" (bad request)', function (done) {
@@ -144,14 +150,15 @@ describe('ajax', function() {
             oncomplete: function (xhrResult) {
                 assert.isNotOk(xhrResult.responseXML, 'What?');
                 assert.isOk(false, 'expected error callback with invalid "Invalid XML"');
+                done();
             },
             onerror: function (message) {
                 assert.equal(message, 'Invalid XML',
                     '"Invalid XML" error message');
+                done();
             },
             requireValidXML: true
         });
-        done();
     });
 
     it('error "Invalid JSON"', function (done) {
@@ -159,14 +166,15 @@ describe('ajax', function() {
             url: '/base/test/files/invalid.xml',
             oncomplete: function() {
                 assert.isOk(false, 'expected error callback with invalid "Invalid JSON"');
+                done();
             },
             onerror: function (message) {
                 assert.equal(message, 'Invalid JSON',
                     '"Invalid JSON" error message');
+                done();
             },
             responseType: 'json'
         });
-        done();
     });
 
     it('error "File not found" (404) - Integration Test', function (done) {
@@ -174,12 +182,13 @@ describe('ajax', function() {
             url: 'foobar',
             oncomplete: function() {
                 assert.isOk(false, 'expected error callback with invalid "File not found"');
+                done();
             },
             onerror: function (message) {
                 assert.equal(message, 'File not found',
                     '"File not found" error message');
+                done();
             }
         });
-        done();
     });
 });


### PR DESCRIPTION
### This PR will...

Put back the `done()` call back where it belongs in ajax tests.

### Why is this Pull Request needed?

Moving `done()` outside of the callback we're trying to test results in assertions from these tests being fired over other tests, or on "before each".

### Are there any points in the code the reviewer needs to double check?

Other tests that like this marked skipped or still containing async assertions whose callback to complete the test was moved.