### PR TITLE
Support setup options events with event names

### DIFF
--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -188,20 +188,12 @@ export default function Api(element) {
             resetPlayer(this, core);
             core = coreFactory(this, element);
 
-            // bind event listeners passed in to the config
-            utils.foreach(options.events, (evt, val) => {
-                // TODO: JW8-206 if 'evt' starts with 'on' convert to event name and register event with `on` method
-                const fn = this[evt];
-                if (typeof fn === 'function') {
-                    fn.call(this, val);
-                }
-            });
-
             options.id = playerId;
 
             core.init(options, this);
 
-            return this;
+            // bind event listeners passed in to the config
+            return this.on(options.events, null, this);
         },
 
         /** Asynchronously removes the player from the page.

--- a/src/js/compatibility.js
+++ b/src/js/compatibility.js
@@ -100,7 +100,7 @@
             playerInstance.setup = function(options) {
                 var eventMap = options.events;
                 if (eventMap) {
-                    Object.keys(options.events).forEach(eventKey => {
+                    Object.keys(eventMap).forEach(function(eventKey) {
                         var eventName = callbackMap[eventKey];
                         if (eventName) {
                             eventMap[eventName] = eventMap[eventKey];

--- a/src/js/compatibility.js
+++ b/src/js/compatibility.js
@@ -89,6 +89,28 @@
                 };
             });
 
+            /*
+             Event maps passed to the player on setup should use event names,
+             rather than onEventName. Here "onReady" is converted
+             to "ready" in the setup options events block. Ex:
+             `jwplayer().setup({ events: { onReady: fn } })` becomes
+             `jwplayer().setup({ events: { ready: fn } })`
+             */
+            var setup = playerInstance.setup;
+            playerInstance.setup = function(options) {
+                var eventMap = options.events;
+                if (eventMap) {
+                    Object.keys(options.events).forEach(eventKey => {
+                        var eventName = callbackMap[eventKey];
+                        if (eventName) {
+                            eventMap[eventName] = eventMap[eventKey];
+                            delete eventMap[eventKey];
+                        }
+                    });
+                }
+                return setup.call(this, options);
+            };
+
             return playerInstance;
         };
 
@@ -129,29 +151,9 @@
          */
         jwplayerCompatible._ = playerLibrary._;
         jwplayerCompatible.api = playerLibrary.api;
-        jwplayerCompatible.events = playerLibrary.events;
-        jwplayerCompatible.playlist = playerLibrary.playlist;
-        jwplayerCompatible.plugins = playerLibrary.plugins;
         jwplayerCompatible.utils = utils;
         jwplayerCompatible.version = playerLibrary.version;
         jwplayerCompatible.vid = playerLibrary.vid;
-
-        /*
-            In JW8 we've removed the jwplayer.touchEvents.* touchEvents; they've been replaced by ES6 constants.
-            The touchEvents names are unchanged.
-        */
-        var touchEvents = {
-            DRAG: 'drag',
-            DRAG_START: 'dragStart',
-            DRAG_END: 'dragEnd',
-            CLICK: 'click',
-            DOUBLE_CLICK: 'doubleClick',
-            TAP: 'tap',
-            DOUBLE_TAP: 'doubleTap',
-            OVER: 'over',
-            MOVE: 'move',
-            OUT: 'out'
-        };
 
         /*
             In JW8 we've removed the jwplayer.events.JWPLAYER_* events, as well as the jwplayer.events.states.* states.
@@ -237,9 +239,24 @@
             JWPLAYER_BREAKPOINT: 'breakpoint'
         };
 
-        events.touchEvents = touchEvents;
+        /*
+            In JW8 we've removed the jwplayer.touchEvents.* touchEvents; they've been replaced by ES6 constants.
+            The touchEvents names are unchanged.
+        */
+        events.touchEvents = {
+            DRAG: 'drag',
+            DRAG_START: 'dragStart',
+            DRAG_END: 'dragEnd',
+            CLICK: 'click',
+            DOUBLE_CLICK: 'doubleClick',
+            TAP: 'tap',
+            DOUBLE_TAP: 'doubleTap',
+            OVER: 'over',
+            MOVE: 'move',
+            OUT: 'out'
+        };
 
-        var states = {
+        events.state = {
             BUFFERING: 'buffering',
             IDLE: 'idle',
             COMPLETE: 'complete',
@@ -252,7 +269,6 @@
             STALLED: 'stalled'
         };
 
-        events.state = states;
         jwplayerCompatible.events = events;
 
         window.jwplayer = jwplayerCompatible;


### PR DESCRIPTION
### This PR will...

Support setup options `.events` with event names. Written this way, the `events` block is supported by the `on` method (`api.on(options.events, null, api)`).

```js
jwplayer().setup({
    events:  {
        ready: function() { this.play(); },
        play: function(e) { console.log('play event:', e); },
        levelsChanged: function(e) { console.log('levelsChanged:', e); },
    }
});
```
and add compatibility for deprecated event handler method keys...

### Why is this Pull Request needed?

JW7 and earlier used event listener registration method keys in the events block. These methods have been deprecated and are not compatible with the `on` method. The compatibility script will convert these to their corresponding method names.

```js
jwplayer().setup({
    events:  {
        onReady: function() { this.play(); },
        onPlay: function(e) { console.log('play event:', e); },
        onQualityChange: function(e) { console.log('levelsChanged:', e); },
    }
});
```

#### Addresses Issue(s):

JW8-206

