### PR TITLE
Modify html5 supports to account for hls ads

### DIFF
--- a/src/js/providers/providers-supported.js
+++ b/src/js/providers/providers-supported.js
@@ -3,6 +3,26 @@ import { isAndroidHls } from 'providers/html5-android-hls';
 import { isYouTube, isRtmp } from 'utils/validator';
 import video from 'utils/video';
 
+const MimeTypes = {
+    aac: 'audio/mp4',
+    mp4: 'video/mp4',
+    f4v: 'video/mp4',
+    m4v: 'video/mp4',
+    mov: 'video/mp4',
+    mp3: 'audio/mpeg',
+    mpeg: 'audio/mpeg',
+    ogv: 'video/ogg',
+    ogg: 'video/ogg',
+    oga: 'video/ogg',
+    vorbis: 'video/ogg',
+    webm: 'video/webm',
+    // The following are not expected to work in Chrome
+    f4a: 'video/aac',
+    m3u8: 'application/vnd.apple.mpegurl',
+    m3u: 'application/vnd.apple.mpegurl',
+    hls: 'application/vnd.apple.mpegurl'
+};
+
 const SupportsMatrix = [
     {
         name: 'youtube',
@@ -13,83 +33,62 @@ const SupportsMatrix = [
     {
         name: 'html5',
         supports: function (source) {
-            var MimeTypes = {
-                aac: 'audio/mp4',
-                mp4: 'video/mp4',
-                f4v: 'video/mp4',
-                m4v: 'video/mp4',
-                mov: 'video/mp4',
-                mp3: 'audio/mpeg',
-                mpeg: 'audio/mpeg',
-                ogv: 'video/ogg',
-                ogg: 'video/ogg',
-                oga: 'video/ogg',
-                vorbis: 'video/ogg',
-                webm: 'video/webm',
-                // The following are not expected to work in Chrome
-                f4a: 'video/aac',
-                m3u8: 'application/vnd.apple.mpegurl',
-                m3u: 'application/vnd.apple.mpegurl',
-                hls: 'application/vnd.apple.mpegurl'
-            };
-
-            var file = source.file;
-            var type = source.type;
-            var mimeType = source.mimeType;
-
-            var isAndroidHLS = isAndroidHls(source);
+            const isAndroidHLS = isAndroidHls(source);
             if (isAndroidHLS !== null) {
                 return isAndroidHLS;
             }
+
+            if (!video.canPlayType) {
+                return false;
+            }
+
+            const file = source.file;
+            const type = source.type;
 
             // Ensure RTMP files are not seen as videos
             if (isRtmp(file, type)) {
                 return false;
             }
 
+            const mimeType = source.mimeType || MimeTypes[type];
+
             // Not OK to use HTML5 with no extension
-            if (!MimeTypes[type] && !mimeType) {
+            if (!mimeType) {
                 return false;
             }
 
             // Last, but not least, we ask the browser
             // (But only if it's a video with an extension known to work in HTML5)
-            if (video.canPlayType) {
-                var result = video.canPlayType(MimeTypes[type] || mimeType);
-                return !!result;
-            }
-            return false;
+            return !!video.canPlayType(mimeType);
         }
     },
     {
         name: 'flash',
         supports: function (source) {
-            var flashExtensions = {
-                flv: 'video',
-                f4v: 'video',
-                mov: 'video',
-                m4a: 'video',
-                m4v: 'video',
-                mp4: 'video',
-                aac: 'video',
-                f4a: 'video',
-                mp3: 'sound',
-                mpeg: 'sound',
-                smil: 'rtmp'
-            };
-            var PLAYABLE = Object.keys(flashExtensions);
             if (!Features.flash) {
                 return false;
             }
 
-            var file = source.file;
-            var type = source.type;
+            const file = source.file;
+            const type = source.type;
 
             if (isRtmp(file, type)) {
                 return true;
             }
 
-            return PLAYABLE.indexOf(type) > -1;
+            return ([
+                'flv',
+                'f4v',
+                'mov',
+                'm4a',
+                'm4v',
+                'mp4',
+                'aac',
+                'f4a',
+                'mp3',
+                'mpeg',
+                'smil'
+            ]).indexOf(type) > -1;
         }
     }
 ];

--- a/src/js/providers/providers-supported.js
+++ b/src/js/providers/providers-supported.js
@@ -35,6 +35,7 @@ const SupportsMatrix = [
 
             var file = source.file;
             var type = source.type;
+            var mimeType = source.mimeType;
 
             var isAndroidHLS = isAndroidHls(source);
             if (isAndroidHLS !== null) {
@@ -47,14 +48,14 @@ const SupportsMatrix = [
             }
 
             // Not OK to use HTML5 with no extension
-            if (!MimeTypes[type]) {
+            if (!MimeTypes[type] && !mimeType) {
                 return false;
             }
 
             // Last, but not least, we ask the browser
             // (But only if it's a video with an extension known to work in HTML5)
             if (video.canPlayType) {
-                var result = video.canPlayType(MimeTypes[type]);
+                var result = video.canPlayType(MimeTypes[type] || mimeType);
                 return !!result;
             }
             return false;


### PR DESCRIPTION
### This PR will...
check the "mimeType" of the source with video.canPlayType function.

### Why is this Pull Request needed?
HLS ads already have mimeType, so we need to check the mimeType with canPlayType function.

#### Addresses Issue(s):
ADS-423