### PR TITLE
Load plugins in parallel with core

### DIFF
--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -1,6 +1,7 @@
 import ApiQueueDecorator from 'api/api-queue';
 import Config from 'api/config';
 import Providers from 'providers/providers';
+import loadPlugins from 'plugins/plugins';
 import Timer from 'api/timer';
 import Storage from 'model/storage';
 import SimpleModel from 'model/simplemodel';
@@ -79,8 +80,13 @@ Object.assign(CoreShim.prototype, {
             model.getProviders = function() {
                 return new Providers(configuration);
             };
-            return model;
-        }).then(loadCoreBundle).then(CoreMixin => {
+        }).then(() => {
+            return Promise.all([
+                loadCoreBundle(model),
+                loadPlugins(model, api)
+            ]);
+        }).then(allPromises => {
+            const CoreMixin = allPromises[0];
             if (!this.apiQueue) {
                 // Exit if `playerDestroy` was called on CoreLoader clearing the config
                 return;

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -54,7 +54,7 @@ Object.assign(Controller.prototype, {
         _view = this._view = new View(_api, _model);
         _view.on('all', _triggerAfterReady, _this);
 
-        _setup = new Setup(_api, _model, _view);
+        _setup = new Setup(_api, _model);
 
         _model.mediaController.on('all', _triggerAfterReady, _this);
         _model.mediaController.on(MEDIA_COMPLETE, function() {
@@ -858,6 +858,8 @@ Object.assign(Controller.prototype, {
         ], () => !_model.getVideo());
         // Add commands from CoreLoader to queue
         apiQueue.queue.push.apply(apiQueue.queue, commandQueue);
+        
+        _view.setup();
 
         return _setup.start();
     },

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -30,6 +30,7 @@ const Model = function() {
         Object.assign(this.attributes, config, INITIAL_PLAYER_STATE);
 
         this.updateProviders();
+        this.setAutoStart();
 
         return this;
     };
@@ -506,7 +507,7 @@ const Model = function() {
     // Mobile players always wait to become viewable.
     // Desktop players must have autostart set to viewable
     this.setAutoStart = function(autoStart) {
-        if (!_.isUndefined(autoStart)) {
+        if (autoStart !== undefined) {
             this.set('autostart', autoStart);
         }
 

--- a/src/js/controller/setup-steps.js
+++ b/src/js/controller/setup-steps.js
@@ -93,7 +93,6 @@ function setupView(_model, _view) {
         if (destroyed(_model)) {
             return;
         }
-        _model.setAutoStart();
         _view.setup();
     });
 

--- a/src/js/controller/setup-steps.js
+++ b/src/js/controller/setup-steps.js
@@ -9,10 +9,10 @@ import { log } from 'utils/helpers';
 
 const resolved = Promise.resolve();
 
-function loadPlugins(_model) {
+function loadPlugins(_model, _api) {
     window.jwplayerPluginJsonp = registerPlugin;
     const pluginLoader = pluginsLoadPlugins(_model.get('id'), _model.get('plugins'));
-    return pluginLoader.load().then(events => {
+    return pluginLoader.load(_api).then(events => {
         if (events) {
             events.forEach(object => {
                 if (object instanceof Error) {
@@ -20,21 +20,15 @@ function loadPlugins(_model) {
                 }
             });
         }
-        return pluginLoader;
     });
 }
 
 function initPlugins(_model, _api, _view) {
     return Promise.all([
         setupView(_model, _view),
-        loadPlugins(_model)
-    ]).then(all => {
-        const pluginLoader = all[1];
+        loadPlugins(_model, _api)
+    ]).then(() => {
         delete window.jwplayerPluginJsonp;
-        if (destroyed(_model)) {
-            return;
-        }
-        pluginLoader.setupPlugins(_api, _model);
     });
 }
 

--- a/src/js/plugins/loader.js
+++ b/src/js/plugins/loader.js
@@ -1,68 +1,21 @@
 import Promise from 'polyfills/promise';
-import utils from 'utils/helpers';
 
-function addToPlayerGenerator(_api, pluginInstance, div) {
-    return function() {
-        const overlaysElement = _api.getContainer().querySelector('.jw-overlays');
-        if (!overlaysElement) {
-            return;
-        }
-        div.left = overlaysElement.style.left;
-        div.top = overlaysElement.style.top;
-        overlaysElement.appendChild(div);
-        pluginInstance.displayArea = overlaysElement;
-    };
-}
+function configurePlugin(pluginObj, api) {
+    const pluginName = pluginObj.name;
+    const config = pluginObj.config;
 
-function pluginResizeGenerator(pluginInstance) {
-    function resize() {
-        var displayarea = pluginInstance.displayArea;
-        if (displayarea) {
-            pluginInstance.resize(displayarea.clientWidth, displayarea.clientHeight);
-        }
-    }
-    return function() {
-        resize();
-        // Sometimes a mobile device may trigger resize before the new sizes are finalized
-        setTimeout(resize, 400);
-    };
-}
+    const div = document.createElement('div');
+    div.id = api.id + '_' + pluginName;
+    div.className = 'jw-plugin jw-reset';
 
-function configurePlugins(plugins, api) {
-    Object.keys(plugins).forEach(pluginKey => {
-        var pluginObj = plugins[pluginKey];
-        const pluginName = pluginObj.name;
-        const config = pluginObj.config;
+    const pluginOptions = Object.assign({}, config);
+    const pluginInstance = pluginObj.getNewInstance(api, pluginOptions, div);
 
-        const status = utils.tryCatch(function() {
-
-            const div = document.createElement('div');
-            div.id = api.id + '_' + pluginName;
-            div.className = 'jw-plugin jw-reset';
-
-            const pluginOptions = Object.assign({}, config);
-            const pluginInstance = pluginObj.getNewInstance(api, pluginOptions, div);
-
-            pluginInstance.addToPlayer = addToPlayerGenerator(api, pluginInstance, div);
-            pluginInstance.resizeHandler = pluginResizeGenerator(pluginInstance);
-
-            api.addPlugin(pluginName, pluginInstance, div);
-        });
-
-        if (status instanceof utils.Error) {
-            utils.log('ERROR: Failed to load ' + pluginName + '.');
-        }
-    });
+    api.addPlugin(pluginName, pluginInstance, div);
 }
 
 const PluginLoader = function (pluginsModel, _config) {
-    const _this = this;
-
-    _this.setupPlugins = function (api) {
-        configurePlugins(pluginsModel.getPlugins(), api);
-    };
-
-    _this.load = function () {
+    this.load = function (api) {
         // Must be a hash map
         if (!_config || typeof _config !== 'object') {
             return Promise.resolve();
@@ -80,7 +33,10 @@ const PluginLoader = function (pluginsModel, _config) {
         /** Second pass to actually load the plugins **/
         const pluginPromises = Object.keys(plugins).map(name => {
             // Plugin object ensures that it's only loaded once
-            return plugins[name].load().catch(error => error);
+            const plugin = plugins[name];
+            return plugin.load().then(() => {
+                configurePlugin(plugin, api);
+            }).catch(error => error);
         });
 
         return Promise.all(pluginPromises);

--- a/src/js/plugins/plugin.js
+++ b/src/js/plugins/plugin.js
@@ -58,7 +58,27 @@ Object.assign(Plugin.prototype, {
 
     getNewInstance(api, config, div) {
         const PluginClass = this.js;
-        return new PluginClass(api, config, div);
+        const pluginInstance = new PluginClass(api, config, div);
+
+        pluginInstance.addToPlayer = function() {
+            const overlaysElement = api.getContainer().querySelector('.jw-overlays');
+            if (!overlaysElement) {
+                return;
+            }
+            div.left = overlaysElement.style.left;
+            div.top = overlaysElement.style.top;
+            overlaysElement.appendChild(div);
+            pluginInstance.displayArea = overlaysElement;
+        };
+
+        pluginInstance.resizeHandler = function() {
+            const displayarea = pluginInstance.displayArea;
+            if (displayarea) {
+                pluginInstance.resize(displayarea.clientWidth, displayarea.clientHeight);
+            }
+        };
+
+        return pluginInstance;
     }
 });
 

--- a/src/js/plugins/plugins.js
+++ b/src/js/plugins/plugins.js
@@ -1,15 +1,15 @@
 import PluginsLoader from 'plugins/loader';
 import PluginsModel from 'plugins/model';
 import Plugin from 'plugins/plugin';
-import utils from 'utils/helpers';
+import { log } from 'utils/helpers';
 
 const pluginsRegistered = {};
 const pluginLoaders = {};
 
-export const loadPlugins = function(id, config) {
+function getPluginLoader(id, config) {
     pluginLoaders[id] = new PluginsLoader(new PluginsModel(pluginsRegistered), config);
     return pluginLoaders[id];
-};
+}
 
 export const registerPlugin = function(name, minimumVersion, pluginClass) {
     let plugin = pluginsRegistered[name];
@@ -20,6 +20,26 @@ export const registerPlugin = function(name, minimumVersion, pluginClass) {
     if (!plugin.js) {
         plugin.registerPlugin(name, minimumVersion, pluginClass);
     } else {
-        utils.log('JW Plugin already loaded', name);
+        log('JW Plugin already loaded', name);
     }
 };
+
+export default function loadPlugins(model, api) {
+    const playerId = model.get('id');
+    const plugins = model.get('plugins');
+
+    window.jwplayerPluginJsonp = registerPlugin;
+
+    const pluginLoader = getPluginLoader(playerId, plugins);
+    return pluginLoader.load(api).then(events => {
+        if (events) {
+            events.forEach(object => {
+                if (object instanceof Error) {
+                    log(object.message);
+                }
+            });
+        }
+    }).then(() => {
+        delete window.jwplayerPluginJsonp;
+    });
+}

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -378,8 +378,9 @@ export default class Controlbar {
     }
 
     togglePlaybackRateControls(model) {
-        const showPlaybackRateControls =
-            model.getVideo().supportsPlaybackRate &&
+        const provider = model.getVideo();
+        const showPlaybackRateControls = provider &&
+            provider.supportsPlaybackRate &&
             model.get('streamType') !== 'LIVE' &&
             model.get('playbackRateControls').length > 1;
 

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -13,13 +13,13 @@ import NextDisplayIcon from 'view/controls/next-display-icon';
 import NextUpToolTip from 'view/controls/nextuptooltip';
 import RightClick from 'view/controls/rightclick';
 
+require('css/controls.less');
+
 const ACTIVE_TIMEOUT = OS.mobile ? 4000 : 2000;
 
 const reasonInteraction = function() {
     return { reason: 'interaction' };
 };
-
-let stylesInjected = false;
 
 export default class Controls {
     constructor(context, playerContainer) {
@@ -47,10 +47,6 @@ export default class Controls {
             mouseout: () => this.userActive()
         };
         this.dimensions = {};
-        if (!stylesInjected) {
-            stylesInjected = true;
-            require('css/controls.less');
-        }
     }
 
     enable(api, model) {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -35,12 +35,12 @@ import Logo from 'view/logo';
 import Preview from 'view/preview';
 import Title from 'view/title';
 
+require('css/jwplayer.less');
+
 let ControlsModule;
 
 const _isMobile = OS.mobile;
 const _isIE = Browser.ie;
-
-let stylesInjected = false;
 
 function View(_api, _model) {
     const _this = Object.assign(this, Events, {
@@ -376,10 +376,6 @@ function View(_api, _model) {
             addClass(_playerElement, 'jw-flag-controls-hidden');
         }
 
-        if (!stylesInjected) {
-            stylesInjected = true;
-            require('css/jwplayer.less');
-        }
         if (_isIE) {
             addClass(_playerElement, 'jw-ie');
         }
@@ -396,7 +392,12 @@ function View(_api, _model) {
 
         this.isSetup = true;
         _model.set('viewSetup', true);
-        _model.set('inDom', document.body.contains(_playerElement));
+
+        const inDOM = document.body.contains(_playerElement);
+        if (inDOM) {
+            viewsManager.observe(_playerElement);
+        }
+        _model.set('inDom', inDOM);
     };
 
     function updateVisibility() {


### PR DESCRIPTION
### This PR will...

- Move filterPlugins out of setup-steps and into commercial api/config
- Remove view from setup-setup
- Setup each plugin once it's loaded
- Start IntersectionObserver earlier to avoid using getClientBounds check on view.init
- Inject CSS on view and controls module load
- Restore key-test that was removed in test refactor

### Why is this Pull Request needed?

These changes improve setup speed. Plugins will load while loading core player, and can be initialized independently of setup steps and view setup.

Since view, controls and the IntersectionObserver are loaded at once with core.controls.polyfills bundles, we can start observing and inject CSS at once, to improve setup speed by decreasing forced layouts.

### Are there any points in the code the reviewer needs to double check?

Player setup with different configurations - like chromeless, or no plugins.

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-commercial/pull/3913

#### Addresses Issue(s):

JW8-180
