### PR TITLE
Enable playbackRates for mgmt api

### DIFF
--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -13,6 +13,7 @@ const Defaults = {
     mobilecontrols: false,
     defaultPlaybackRate: 1,
     playbackRateControls: false,
+    playbackRates: [0.5, 1, 1.25, 1.5, 2],
     repeat: false,
     castAvailable: false,
     skin: '',
@@ -104,7 +105,7 @@ const Config = function(options, persisted) {
     let rateControls = config.playbackRateControls;
 
     if (rateControls) {
-        let rates = [0.5, 1, 1.25, 1.5, 2];
+        let rates = config.playbackRates;
 
         if (_.isArray(rateControls)) {
             rates = rateControls

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -108,22 +108,22 @@ const Config = function(options, persisted) {
         let rates = config.playbackRates;
 
         if (_.isArray(rateControls)) {
-            rates = rateControls
-                .filter(rate => _.isNumber(rate) && rate >= 0.25 && rate <= 4)
-                .map(rate => Math.round(rate * 4) / 4);
-
-            if (rates.indexOf(1) < 0) {
-                rates.push(1);
-            }
-
-            rates.sort();
+            rates = rateControls;
         }
+        rates = rates.filter(rate => _.isNumber(rate) && rate >= 0.25 && rate <= 4)
+            .map(rate => Math.round(rate * 4) / 4);
 
-        config.playbackRateControls = rates;
+        if (rates.indexOf(1) < 0) {
+            rates.push(1);
+        }
+        rates.sort();
+
+        config.playbackRateControls = true;
+        config.playbackRates = rates;
     }
 
     // Set defaultPlaybackRate to 1 if the value from storage isn't in the playbackRateControls menu
-    if (!config.playbackRateControls || config.playbackRateControls.indexOf(config.defaultPlaybackRate) < 0) {
+    if (!config.playbackRateControls || config.playbackRates.indexOf(config.defaultPlaybackRate) < 0) {
         config.defaultPlaybackRate = 1;
     }
 

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -107,7 +107,7 @@ const Config = function(options, persisted) {
     if (rateControls) {
         let rates = config.playbackRates;
 
-        if (_.isArray(rateControls)) {
+        if (Array.isArray(rateControls)) {
             rates = rateControls;
         }
         rates = rates.filter(rate => _.isNumber(rate) && rate >= 0.25 && rate <= 4)
@@ -149,7 +149,7 @@ const Config = function(options, persisted) {
         ]);
 
         config.playlist = [ obj ];
-    } else if (_.isArray(configPlaylist.playlist)) {
+    } else if (Array.isArray(configPlaylist.playlist)) {
         // The "playlist" in the config is actually a feed that contains a playlist
         config.feedData = configPlaylist;
         config.playlist = configPlaylist.playlist;

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -329,8 +329,9 @@ export default class Controlbar {
 
         let playbackRateControls = _model.get('playbackRateControls');
         if (playbackRateControls) {
-            let selectedIndex = playbackRateControls.indexOf(this._model.get('playbackRate'));
-            let playbackRateLabels = playbackRateControls.map((playbackRate) => {
+            let playbackRates = _model.get('playbackRates');
+            let selectedIndex = playbackRates.indexOf(this._model.get('playbackRate'));
+            let playbackRateLabels = playbackRates.map((playbackRate) => {
                 return {
                     label: playbackRate + 'x',
                     rate: playbackRate
@@ -340,19 +341,19 @@ export default class Controlbar {
             elements.playbackrates.setup(
                 playbackRateLabels,
                 selectedIndex,
-                { defaultIndex: playbackRateControls.indexOf(1), isToggle: false }
+                { defaultIndex: playbackRates.indexOf(1), isToggle: false }
             );
 
             _model.change('streamType provider', this.togglePlaybackRateControls, this);
             _model.change('playbackRate', this.onPlaybackRate, this);
 
             elements.playbackrates.on('select', function (index) {
-                this._model.setPlaybackRate(playbackRateControls[index]);
+                this._model.setPlaybackRate(playbackRates[index]);
             }, this);
 
             elements.playbackrates.on('toggleValue', function () {
-                const index = playbackRateControls.indexOf(this._model.get('playbackRate'));
-                this._model.setPlaybackRate(playbackRateControls[index ? 0 : 1]);
+                const index = playbackRates.indexOf(this._model.get('playbackRate'));
+                this._model.setPlaybackRate(playbackRates[index ? 0 : 1]);
             }, this);
         }
 
@@ -387,13 +388,14 @@ export default class Controlbar {
         const showPlaybackRateControls =
             model.getVideo().supportsPlaybackRate &&
             model.get('streamType') !== 'LIVE' &&
-            model.get('playbackRateControls').length > 1;
+            model.get('playbackRateControls') &&
+            model.get('playbackRates').length > 1;
 
         utils.toggleClass(this.elements.playbackrates.el, 'jw-hidden', !showPlaybackRateControls);
     }
 
     onPlaybackRate(model, value) {
-        this.elements.playbackrates.selectItem(model.get('playbackRateControls').indexOf(value));
+        this.elements.playbackrates.selectItem(model.get('playbackRates').indexOf(value));
     }
 
     onPlaylistItem() {


### PR DESCRIPTION
### This PR will...
add playbackRates key to config and set its default to our default rates.
### Why is this Pull Request needed?
Papi wants to expose a field for playbackRateControls (bool) and playbackRates (array of rates) in the management API, without breaking JW7 behavior where playbackRateControls can be a bool or array.
### Are there any points in the code the reviewer needs to double check?
p/d/w @dYale, management API will omit the playbackRates key from the config if the value is null. If the value is ever null however, our default will be overriden. Do we want to protect against this? 
### Are there any Pull Requests open in other repos which need to be merged with this?
n/a
#### Addresses Issue(s):
JW8-240

