### PR TITLE
Prevent our UI from overlapping IMA's overlay

### DIFF
--- a/src/css/controls/flags/ads.less
+++ b/src/css/controls/flags/ads.less
@@ -98,6 +98,13 @@
             pointer-events: none;
         }
     }
+
+    &.jw-flag-small-player {
+        .jw-icon-inline,
+        .jw-icon-tooltip{
+            height: 30px;
+        }
+    }
 }
 
 .jwplayer.jw-flag-ads-vpaid,

--- a/src/css/controls/flags/ads.less
+++ b/src/css/controls/flags/ads.less
@@ -100,8 +100,7 @@
     }
 
     &.jw-flag-small-player {
-        .jw-icon-inline,
-        .jw-icon-tooltip{
+        .jw-controlbar .jw-icon {
             height: 30px;
         }
     }


### PR DESCRIPTION
### This PR will...
set the height of icons in the control bar to 30px when IMA ads play in small player.
### Why is this Pull Request needed?
To prevent our buttons from overlapping with IMA's overlays.
### Are there any points in the code the reviewer needs to double check?
n/a
### Are there any Pull Requests open in other repos which need to be merged with this?
n/a
#### Addresses Issue(s):
JW8-301

