### PR TITLE
Fix loading of plugins between multiple players

### DIFF
--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -106,6 +106,9 @@ Object.assign(CoreShim.prototype, {
             storage.track(this._model);
             return setupPromise;
         }).catch((error) => {
+            if (!this.apiQueue) {
+                return;
+            }
             setupError(this, error);
         });
     },

--- a/src/js/plugins/loader.js
+++ b/src/js/plugins/loader.js
@@ -1,45 +1,33 @@
 import Promise from 'polyfills/promise';
 
-function configurePlugin(pluginObj, api) {
+function configurePlugin(pluginObj, pluginConfig, api) {
     const pluginName = pluginObj.name;
-    const config = pluginObj.config;
 
     const div = document.createElement('div');
     div.id = api.id + '_' + pluginName;
     div.className = 'jw-plugin jw-reset';
 
-    const pluginOptions = Object.assign({}, config);
+    const pluginOptions = Object.assign({}, pluginConfig);
     const pluginInstance = pluginObj.getNewInstance(api, pluginOptions, div);
 
     api.addPlugin(pluginName, pluginInstance, div);
 }
 
-const PluginLoader = function (pluginsModel, _config) {
-    this.load = function (api) {
+const PluginLoader = function () {
+    this.load = function (api, pluginsModel, pluginsConfig) {
         // Must be a hash map
-        if (!_config || typeof _config !== 'object') {
+        if (!pluginsConfig || typeof pluginsConfig !== 'object') {
             return Promise.resolve();
         }
 
-        /** First pass to create the plugins and add listeners **/
-        Object.keys(_config).forEach(pluginUrl => {
-            if (pluginUrl) {
-                pluginsModel.addPlugin(pluginUrl, _config[pluginUrl]);
-            }
-        });
-
-        const plugins = pluginsModel.getPlugins();
-
-        /** Second pass to actually load the plugins **/
-        const pluginPromises = Object.keys(plugins).map(name => {
-            // Plugin object ensures that it's only loaded once
-            const plugin = plugins[name];
-            return plugin.load().then(() => {
-                configurePlugin(plugin, api);
-            }).catch(error => error);
-        });
-
-        return Promise.all(pluginPromises);
+        return Promise.all(Object.keys(pluginsConfig).filter(pluginUrl => pluginUrl)
+            .map(pluginUrl => {
+                const plugin = pluginsModel.addPlugin(pluginUrl, true);
+                const pluginConfig = pluginsConfig[pluginUrl];
+                return plugin.load().then(() => {
+                    configurePlugin(plugin, pluginConfig, api);
+                }).catch(error => error);
+            }));
     };
 
 };

--- a/src/js/plugins/model.js
+++ b/src/js/plugins/model.js
@@ -1,4 +1,7 @@
 import Plugin from 'plugins/plugin';
+import { log } from 'utils/helpers';
+
+const pluginsRegistered = {};
 
 /**
  * Extracts a plugin name from a string
@@ -8,16 +11,16 @@ const getPluginName = function (url) {
     return url.replace(/^(.*\/)?([^-]*)-?.*\.(js)$/, '$2');
 };
 
-const PluginModel = function (pluginsRegistered) {
-    this.addPlugin = function (url, config) {
+const PluginModel = function () {
+    this.addPlugin = function (url, fromLoader) {
         const pluginName = getPluginName(url);
         let plugin = pluginsRegistered[pluginName];
-        if (plugin) {
-            plugin.config = config;
-        } else {
-            plugin = new Plugin(url, config);
+        if (!plugin) {
+            plugin = new Plugin(url);
+            pluginsRegistered[pluginName] = plugin;
+        } else if (fromLoader && plugin.url !== url) {
+            log(`JW Plugin "${pluginName}" already loaded from "${plugin.url}". Ignoring "${url}."`);
         }
-        pluginsRegistered[pluginName] = plugin;
         return plugin;
     };
 

--- a/src/js/plugins/plugin.js
+++ b/src/js/plugins/plugin.js
@@ -35,9 +35,8 @@ function getJSPath(url) {
     }
 }
 
-const Plugin = function(url, config) {
+const Plugin = function(url) {
     this.url = url;
-    this.config = config;
 };
 
 Object.assign(Plugin.prototype, {

--- a/src/js/plugins/plugins.js
+++ b/src/js/plugins/plugins.js
@@ -1,37 +1,34 @@
 import PluginsLoader from 'plugins/loader';
 import PluginsModel from 'plugins/model';
-import Plugin from 'plugins/plugin';
 import { log } from 'utils/helpers';
 
-const pluginsRegistered = {};
+const pluginsModel = new PluginsModel();
 const pluginLoaders = {};
 
-function getPluginLoader(id, config) {
-    pluginLoaders[id] = new PluginsLoader(new PluginsModel(pluginsRegistered), config);
+function getPluginLoader(id) {
+    pluginLoaders[id] = new PluginsLoader();
     return pluginLoaders[id];
 }
 
 export const registerPlugin = function(name, minimumVersion, pluginClass) {
-    let plugin = pluginsRegistered[name];
-    if (!plugin) {
-        plugin = new Plugin(name);
-        pluginsRegistered[name] = plugin;
-    }
+    let plugin = pluginsModel.addPlugin(name);
     if (!plugin.js) {
         plugin.registerPlugin(name, minimumVersion, pluginClass);
-    } else {
-        log('JW Plugin already loaded', name);
     }
 };
 
 export default function loadPlugins(model, api) {
     const playerId = model.get('id');
-    const plugins = model.get('plugins');
+    const pluginsConfig = model.get('plugins');
 
     window.jwplayerPluginJsonp = registerPlugin;
 
-    const pluginLoader = getPluginLoader(playerId, plugins);
-    return pluginLoader.load(api).then(events => {
+    const pluginLoader = getPluginLoader(playerId);
+    return pluginLoader.load(api, pluginsModel, pluginsConfig).then(events => {
+        if (pluginLoader !== pluginLoaders[playerId]) {
+            // Player and plugin loader was replaced
+            return;
+        }
         if (events) {
             events.forEach(object => {
                 if (object instanceof Error) {
@@ -39,7 +36,6 @@ export default function loadPlugins(model, api) {
                 }
             });
         }
-    }).then(() => {
         delete window.jwplayerPluginJsonp;
     });
 }


### PR DESCRIPTION
### This PR will...

Fix the plugin loader and plugin code so that it only instantiates plugins configured to run for specific player instances and pass the correct configuration to each of them.
 
### Why is this Pull Request needed?

I introduced a regression that would instantiate all registered plugins for all players on the page and assign player plugin configs which should be unique to plugin instances to plugin singletons.

#### Addresses Issue(s):

JW8-302
