### PR TITLE
VOD progress bar for ads in live and dvr streams

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -280,6 +280,10 @@ var InstreamAdapter = function(_controller, _model, _view) {
         if (evt.width && evt.height) {
             _view.resizeMedia();
         }
+        if (evt.duration) {
+            _model.mediaModel.set('duration', evt.duration);
+            _model.set('duration', evt.duration);
+        }
     };
 
     this.destroy = function() {

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -280,10 +280,6 @@ var InstreamAdapter = function(_controller, _model, _view) {
         if (evt.width && evt.height) {
             _view.resizeMedia();
         }
-        if (evt.duration) {
-            _model.mediaModel.set('duration', evt.duration);
-            _model.set('duration', evt.duration);
-        }
     };
 
     this.destroy = function() {

--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -91,7 +91,8 @@ class TimeSlider extends Slider {
             .on('duration', this.onDuration, this)
             .change('playlistItem', this.onPlaylistItem, this)
             .change('position', this.onPosition, this)
-            .change('buffer', this.onBuffer, this);
+            .change('buffer', this.onBuffer, this)
+            .change('streamType', this.onStreamType, this);
 
         this.elementRail.appendChild(this.timeTip.element());
 
@@ -106,8 +107,7 @@ class TimeSlider extends Slider {
             return this.activeCue.pct;
         }
         var duration = this._model.get('duration');
-        var streamType = this._model.get('streamType');
-        if (streamType === 'DVR') {
+        if (this.streamType === 'DVR') {
             var position = (1 - (percent / 100)) * duration;
             var currentPosition = this._model.get('position');
             var updatedPosition = Math.min(position, Math.max(dvrSeekLimit, currentPosition));
@@ -159,13 +159,16 @@ class TimeSlider extends Slider {
         this.updateTime(model.get('position'), duration);
     }
 
+    onStreamType(model, streamType) {
+        this.streamType = streamType;
+    }
+
     updateTime(position, duration) {
         var pct = 0;
         if (duration) {
-            var streamType = this._model.get('streamType');
-            if (streamType === 'DVR') {
+            if (this.streamType === 'DVR') {
                 pct = (duration - position) / duration * 100;
-            } else if (streamType === 'VOD' || !streamType) {
+            } else if (this.streamType === 'VOD' || !this.streamType) {
                 // Default to VOD behavior if streamType isn't set
                 pct = position / duration * 100;
             }
@@ -194,11 +197,10 @@ class TimeSlider extends Slider {
     performSeek() {
         var percent = this.seekTo;
         var duration = this._model.get('duration');
-        var streamType = this._model.get('streamType');
         var position;
         if (duration === 0) {
             this._api.play(reasonInteraction());
-        } else if (streamType === 'DVR') {
+        } else if (this.streamType === 'DVR') {
             position = (100 - percent) / 100 * duration;
             this._api.seek(position, reasonInteraction());
         } else {

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -630,8 +630,8 @@ export default class Controlbar {
 
         instreamModel
             .change('position', timeSlider.onPosition, timeSlider)
-            .change('duration', timeSlider.onDuration, timeSlider);
-        timeSlider.streamType = 'VOD';
+            .change('duration', timeSlider.onDuration, timeSlider)
+            .change('duration', () => {timeSlider.streamType = 'VOD';}, timeSlider);
     }
 
     syncPlaybackTime(model) {

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -631,6 +631,7 @@ export default class Controlbar {
         instreamModel
             .change('position', timeSlider.onPosition, timeSlider)
             .change('duration', timeSlider.onDuration, timeSlider);
+        timeSlider.streamType = 'VOD';
     }
 
     syncPlaybackTime(model) {
@@ -642,6 +643,7 @@ export default class Controlbar {
 
         timeSlider.onPosition(model, model.get('position'));
         timeSlider.onDuration(model, model.get('duration'));
+        timeSlider.onStreamType(model, model.get('streamType'));
     }
 }
 

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -844,6 +844,7 @@ function View(_api, _model) {
         _instreamModel.on('change:state', _stateHandler, this);
 
         addClass(_playerElement, 'jw-flag-ads');
+        removeClass(_playerElement, 'jw-flag-live');
 
         // Call Controls.userActivity to display the UI temporarily for the start of the ad
         if (_controls) {


### PR DESCRIPTION
### This PR will...
- remove jw-flag-live when jw-flag-ads is added.
-change the view to obtain streamType by listening to changes in the model or overriding when instream time is used, instead of pulling from model.
### Why is this Pull Request needed?
to display a VOD style progress bar when ads are played for live and dvr streams.
### Are there any points in the code the reviewer needs to double check?
n/a
### Are there any Pull Requests open in other repos which need to be merged with this?
n/a
#### Addresses Issue(s):
JW8-294

