### PR TITLE
Async setupError

### DIFF
--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -220,7 +220,7 @@ function setupError(core, error) {
 
     showView(core, errorElement);
 
-    setTimeout(() => {
+    Promise.resolve().then(() => {
         core.trigger(SETUP_ERROR, {
             message
         });


### PR DESCRIPTION
### This PR will...

Use Promise.resolve().then instead of setTimeout for async setupError

### Why is this Pull Request needed?

Speed and avoid use of timeouts.