### PR TITLE
Move MediaModel to Controls

### DIFF
--- a/src/js/view/controls/components/settings/settings-menu.js
+++ b/src/js/view/controls/components/settings/settings-menu.js
@@ -3,7 +3,7 @@ import button from 'view/controls/components/button';
 import SettingsMenuTemplate from 'view/controls/templates/settings/settings-menu';
 import { createElement } from 'utils/dom';
 
-export default function SettingsMenu(visibilityChangeHandler) {
+export function SettingsMenu(visibilityChangeHandler) {
     const documentClickHandler = (e) => {
         // Close if anything other than the settings menu has been clicked
         // Let the display (jw-video) handles closing itself (display clicks do not pause if the menu is open)

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -264,7 +264,6 @@ export default class Controlbar {
         _model.change('volume', this.onVolume, this);
         _model.change('mute', this.onMute, this);
         _model.change('playlistItem', this.onPlaylistItem, this);
-        _model.change('mediaModel', this.onMediaModel, this);
         _model.change('castAvailable', this.onCastAvailable, this);
         _model.change('castActive', this.onCastActive, this);
         _model.change('duration', this.onDuration, this);
@@ -324,7 +323,7 @@ export default class Controlbar {
         elements.audiotracks.on('select', function (value) {
             this._model.getVideo().setCurrentAudioTrack(value);
         }, this);
-      
+
         this._model.mediaController.on('seeked', function () {
             this.checkDvrLiveEdge();
         }, this);
@@ -405,24 +404,7 @@ export default class Controlbar {
         this.elements.audiotracks.setup();
     }
 
-    onMediaModel(model, mediaModel) {
-        mediaModel.on('change:levels', function (levelsChangeModel, levels) {
-            this.elements.hd.setup(levels, levelsChangeModel.get('currentLevel'));
-        }, this);
-        mediaModel.on('change:currentLevel', function (currentLevelChangeModel, level) {
-            this.elements.hd.selectItem(level);
-        }, this);
-        mediaModel.on('change:audioTracks', function (audioTracksChangeModel, audioTracks) {
-            const list = _.map(audioTracks, function (track) {
-                return { label: track.name };
-            });
-            this.elements.audiotracks.setup(list, audioTracksChangeModel.get('currentAudioTrack'),
-                { isToggle: false });
-        }, this);
-        mediaModel.on('change:currentAudioTrack', function (currentAudioTrackChangeModel, currentAudioTrack) {
-            this.elements.audiotracks.selectItem(currentAudioTrack);
-        }, this);
-    }
+
 
     onVolume(model, pct) {
         this.renderVolume(model.get('mute'), pct);
@@ -485,7 +467,7 @@ export default class Controlbar {
     onFullscreen(model, val) {
         utils.toggleClass(this.elements.fullscreen.element(), 'jw-off', val);
     }
-              
+
     checkDvrLiveEdge() {
         if (this._model.get('streamType') === 'DVR') {
             const currentPosition = this._model.get('position');

--- a/test/unit/controls-test.js
+++ b/test/unit/controls-test.js
@@ -1,0 +1,118 @@
+import sinon from 'sinon';
+import SimpleModel from 'model/simplemodel';
+import * as menu from 'view/controls/components/settings/settings-menu';
+import Controls from 'view/controls/controls';
+
+
+
+describe('Controls', function() {
+
+    let controls;
+    let settingsMenu;
+
+    beforeEach(function() {
+        controls = new Controls({}, document.createElement('div'));
+        controls.div = document.createElement('div');
+        controls.controlbar = {};
+        controls.controlbar.on = sinon.stub();
+
+        sinon.stub(menu, 'SettingsMenu');
+
+        settingsMenu = {
+            setup: sinon.spy(),
+            element: sinon.stub()
+        };
+        settingsMenu.element.returns(document.createElement('div'));
+        menu.SettingsMenu.returns(settingsMenu);
+    });
+
+    afterEach(function() {
+        menu.SettingsMenu.restore();
+    });
+
+    describe('setupSettingsMenu', function() {
+
+        it('should create a SettingsMenu object', function() {
+            controls.setupSettingsMenu();
+
+            expect(controls.settingsMenu).to.equal(settingsMenu);
+        });
+
+        it('should setup Settings menu', function() {
+            controls.setupSettingsMenu();
+
+            expect(settingsMenu.setup.callCount).to.equal(1);
+        });
+
+        it('should add menu to controls div', function() {
+            controls.setupSettingsMenu();
+
+            expect(controls.div.children.length).to.equal(1);
+        });
+
+        it('should add a visibility listener', function() {
+            controls.userActive = sinon.spy();
+            controls.setupSettingsMenu();
+
+            const handler = menu.SettingsMenu.args[0][0];
+
+            handler(true);
+
+            expect(controls.userActive.callCount).to.equal(1);
+        });
+    });
+
+    describe('onMediaModel', function() {
+
+        let model;
+        let mediaModel;
+
+        beforeEach(function() {
+            model = Object.assign({}, SimpleModel);
+            model.change = sinon.spy();
+            mediaModel = Object.assign({}, SimpleModel);
+            mediaModel.on = sinon.spy();
+
+            controls.onMediaModel(model);
+
+            const changeHandler = model.change.args[0][1];
+            changeHandler('', mediaModel);
+        });
+
+        it('should setup qualities element on levels change', function() {
+            controls.controlbar.elements = { hd: { setup: sinon.spy() } };
+
+            const levelsHandler = mediaModel.on.args[0][1];
+            levelsHandler(model);
+
+            expect(controls.controlbar.elements.hd.setup.callCount).to.equal(1);
+        });
+
+        it('should update quality element on level change', function() {
+            controls.controlbar.elements = { hd: { selectItem: sinon.spy() } };
+
+            const levelHandler = mediaModel.on.args[1][1];
+            levelHandler(model);
+
+            expect(controls.controlbar.elements.hd.selectItem.callCount).to.equal(1);
+        });
+
+        it('should setup audio tracks element on tracks change', function() {
+            controls.controlbar.elements = { audiotracks: { setup: sinon.spy() } };
+
+            const tracksHandler = mediaModel.on.args[2][1];
+            tracksHandler(model, []);
+
+            expect(controls.controlbar.elements.audiotracks.setup.callCount).to.equal(1);
+        });
+
+        it('should setup audio tracks element on tracks change', function() {
+            controls.controlbar.elements = { audiotracks: { selectItem: sinon.spy() } };
+
+            const tracksHandler = mediaModel.on.args[3][1];
+            tracksHandler(model);
+
+            expect(controls.controlbar.elements.audiotracks.selectItem.callCount).to.equal(1);
+        });
+    });
+});


### PR DESCRIPTION
### This PR will...

Move the media mdoel change logic for quality and audio from the control bar and into controls

### Why is this Pull Request needed?

Since the quality and audio tracks menus are being moved out of the control bar, the media model logic should no longer be there. 


#### Addresses Issue(s):

JW8-311

