### PR TITLE
Handle plugins that throw non-Error exceptions

### DIFF
--- a/src/js/plugins/loader.js
+++ b/src/js/plugins/loader.js
@@ -26,7 +26,12 @@ const PluginLoader = function () {
                 const pluginConfig = pluginsConfig[pluginUrl];
                 return plugin.load().then(() => {
                     configurePlugin(plugin, pluginConfig, api);
-                }).catch(error => error);
+                }).catch(error => {
+                    if (!(error instanceof Error)) {
+                        return new Error(`Error in ${pluginUrl} "${error}"`);
+                    }
+                    return error;
+                });
             }));
     };
 


### PR DESCRIPTION
### This PR will...

Handle console logging for plugins that fail to load because they throw non-Error instance errors (ex: `throw "a string"`).

Plugins that thow an Error instance have the error.message output to the console. Ones like this will log:

`Error in ../../assets/badPlugin.js "bad plugin always throws an error"`
That's (`Error in ${PLUGIN_URL} "${ERROR_TO_STRING}"`)

### Why is this Pull Request needed?

badPlugin.js test http://player-develop-test-jenkins.longtailvideo.com/builds/6469/archive/test/squash/bootstrap.html?edition=free&feature=embedding_bad_plugin

#### Addresses Issue(s):

JW8-316

