### PR TITLE
Fix "playReason" when autostart is on

### DIFF
--- a/src/js/api/core-loader.js
+++ b/src/js/api/core-loader.js
@@ -1,6 +1,6 @@
 import Item from 'playlist/item';
 import ProvidersSupported from 'providers/providers-supported';
-import Promise from 'polyfills/promise';
+import { resolved } from 'polyfills/promise';
 
 let bundlePromise = null;
 
@@ -120,5 +120,5 @@ function loadIntersectionObserverIfNeeded() {
             return require('intersection-observer');
         }, chunkLoadErrorHandler, 'polyfills.intersection-observer');
     }
-    return Promise.resolve();
+    return resolved;
 }

--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -9,7 +9,7 @@ import { INITIAL_PLAYER_STATE } from 'model/player-model';
 import { SETUP_ERROR } from 'events/events';
 import Events from 'utils/backbone.events';
 import loadCoreBundle from 'api/core-loader';
-import Promise from 'polyfills/promise';
+import Promise, { resolved } from 'polyfills/promise';
 import viewError from 'templates/error';
 import { style } from 'utils/css';
 import { createElement } from 'utils/dom';
@@ -76,7 +76,7 @@ Object.assign(CoreShim.prototype, {
         const configuration = Config(options, persisted);
         Object.assign(model.attributes, configuration, INITIAL_PLAYER_STATE);
 
-        Promise.resolve().then(() => {
+        resolved.then(() => {
             model.getProviders = function() {
                 return new Providers(configuration);
             };
@@ -220,7 +220,7 @@ function setupError(core, error) {
 
     showView(core, errorElement);
 
-    Promise.resolve().then(() => {
+    resolved.then(() => {
         core.trigger(SETUP_ERROR, {
             message
         });

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -391,7 +391,6 @@ Object.assign(Controller.prototype, {
 
             if (_isIdle()) {
                 _model.mediaController.trigger(MEDIA_PLAY_ATTEMPT, { playReason: playReason });
-                _model.mediaModel.set('playAttempt', true);
             }
 
             if (!_preplay) {
@@ -412,6 +411,7 @@ Object.assign(Controller.prototype, {
                     });
                     _actionOnAttach = null;
                 });
+                _model.mediaModel.set('playAttempt', true);
             } else if (_model.get('state') === STATE_PAUSED) {
                 _model.playVideo().catch(error => {
                     _this.triggerError({

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -13,6 +13,8 @@ import { STATE_BUFFERING, STATE_IDLE, STATE_COMPLETE, STATE_PAUSED, STATE_PLAYIN
     MEDIA_ERROR, MEDIA_COMPLETE, CAST_SESSION, FULLSCREEN, PLAYLIST_ITEM, MEDIA_VOLUME, MEDIA_MUTE, PLAYBACK_RATE_CHANGED,
     CAPTIONS_LIST, CONTROLS, RESIZE } from 'events/events';
 import InstreamAdapter from 'controller/instream-adapter';
+import { resolved } from 'polyfills/promise';
+import cancelable from 'utils/cancelable';
 import _ from 'utils/underscore';
 import Captions from 'controller/captions';
 import Model from 'controller/model';
@@ -44,6 +46,7 @@ Object.assign(Controller.prototype, {
         let _stopPlaylist = false;
         let _interruptPlay;
         let _preloaded = false;
+        let checkAutoStartCancelable = cancelable(_checkAutoStart);
 
         _this.originalContainer = _this.currentContainer = originalContainer;
         _this._events = eventListeners;
@@ -59,7 +62,7 @@ Object.assign(Controller.prototype, {
         _model.mediaController.on('all', _triggerAfterReady, _this);
         _model.mediaController.on(MEDIA_COMPLETE, function() {
             // Insert a small delay here so that other complete handlers can execute
-            _.defer(_completeHandler);
+            resolved.then(_completeHandler);
         });
         _model.mediaController.on(MEDIA_ERROR, _this.triggerError, _this);
 
@@ -306,7 +309,9 @@ Object.assign(Controller.prototype, {
             _this.trigger('destroyPlugin', {});
             _stop(true);
 
-            _model.once('itemReady', _checkAutoStart);
+            checkAutoStartCancelable.cancel();
+            checkAutoStartCancelable = cancelable(_checkAutoStart);
+            _model.once('itemReady', checkAutoStartCancelable.async);
 
             switch (typeof item) {
                 case 'string':
@@ -363,7 +368,8 @@ Object.assign(Controller.prototype, {
         }
 
         function _play(meta = {}) {
-            _model.off('itemReady', _checkAutoStart);
+            checkAutoStartCancelable.cancel();
+
             const playReason = meta.reason;
             _model.set('playReason', playReason);
 
@@ -384,8 +390,8 @@ Object.assign(Controller.prototype, {
             }
 
             if (_isIdle()) {
-                _model.mediaModel.set('playAttempt', true);
                 _model.mediaController.trigger(MEDIA_PLAY_ATTEMPT, { playReason: playReason });
+                _model.mediaModel.set('playAttempt', true);
             }
 
             if (!_preplay) {
@@ -424,7 +430,8 @@ Object.assign(Controller.prototype, {
         }
 
         function _stop(internal) {
-            _model.off('itemReady', _checkAutoStart);
+            checkAutoStartCancelable.cancel();
+            _model.mediaModel.set('playAttempt', false);
 
             const fromApi = !internal;
 

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -9,6 +9,7 @@ import { STATE_IDLE, STATE_COMPLETE, STATE_BUFFERING, STATE_PAUSED, STATE_PLAYIN
 import utils from 'utils/helpers';
 import _ from 'utils/underscore';
 import Events from 'utils/backbone.events';
+import { resolved } from 'polyfills/promise';
 
 // Represents the state of the player
 const Model = function() {
@@ -101,13 +102,12 @@ const Model = function() {
                 break;
             case MEDIA_BUFFER_FULL:
                 // media controller
-                if (mediaModel.get('playAttempt')) {
-                    this.playVideo();
-                } else {
-                    mediaModel.on('change:playAttempt', function() {
+                mediaModel.change('playAttempt', (mediaModelChanged, playAttempt) => {
+                    if (playAttempt) {
+                        mediaModelChanged.off('playAttempt', null, this);
                         this.playVideo();
-                    }, this);
-                }
+                    }
+                }, this);
                 this.setPlaybackRate(this.get('defaultPlaybackRate'));
                 break;
             case MEDIA_TIME:
@@ -429,7 +429,7 @@ const Model = function() {
 
         if (_provider) {
             _provider.load(item);
-            return Promise.resolve();
+            return resolved;
         }
         this.set('state', STATE_BUFFERING);
         const providerNeeded = _providers.required([item]);
@@ -437,6 +437,7 @@ const Model = function() {
             if (!_provider && _attached && this.get('playlist')[this.get('item')].file === item.file) {
                 this.setProvider(item);
                 _provider.load(item);
+                return resolved;
             }
         });
     };
@@ -450,8 +451,8 @@ const Model = function() {
     this.playVideo = function() {
         const playPromise = _provider.play();
         if (!playPromise) {
-            // TODO: return new Promise that resolves when playback starts, or rejects on error/timeout
-            return Promise.resolve();
+            // TODO: polyfill video tag play promise
+            return resolved;
         }
         return playPromise;
     };

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -319,6 +319,7 @@ const Model = function() {
         this.set('position', item.starttime || 0);
         this.set('minDvrWindow', item.minDvrWindow);
         this.set('duration', (item.duration && utils.seconds(item.duration)) || 0);
+        this.attributes.playlistItem = null;
         this.set('playlistItem', item);
         this.setProvider(item);
     };

--- a/src/js/controller/setup-steps.js
+++ b/src/js/controller/setup-steps.js
@@ -1,11 +1,9 @@
 import setPlaylist, { loadProvidersForPlaylist } from 'api/set-playlist';
 import { PLAYLIST_LOADED, ERROR } from 'events/events';
-import Promise from 'polyfills/promise';
+import Promise, { resolved } from 'polyfills/promise';
 import PlaylistLoader from 'playlist/loader';
 import Playlist from 'playlist/playlist';
 import ScriptLoader from 'utils/scriptloader';
-
-const resolved = Promise.resolve();
 
 export function loadPlaylist(_model) {
     const playlist = _model.get('playlist');

--- a/src/js/plugins/loader.js
+++ b/src/js/plugins/loader.js
@@ -1,4 +1,4 @@
-import Promise from 'polyfills/promise';
+import Promise, { resolved } from 'polyfills/promise';
 
 function configurePlugin(pluginObj, pluginConfig, api) {
     const pluginName = pluginObj.name;
@@ -17,7 +17,7 @@ const PluginLoader = function () {
     this.load = function (api, pluginsModel, pluginsConfig) {
         // Must be a hash map
         if (!pluginsConfig || typeof pluginsConfig !== 'object') {
-            return Promise.resolve();
+            return resolved;
         }
 
         return Promise.all(Object.keys(pluginsConfig).filter(pluginUrl => pluginUrl)

--- a/src/js/plugins/plugin.js
+++ b/src/js/plugins/plugin.js
@@ -1,4 +1,4 @@
-import Promise from 'polyfills/promise';
+import { resolved } from 'polyfills/promise';
 import ScriptLoader from 'utils/scriptloader';
 import { getAbsolutePath } from 'utils/parser';
 import { extension } from 'utils/strings';
@@ -42,7 +42,7 @@ const Plugin = function(url) {
 Object.assign(Plugin.prototype, {
     load() {
         if (getPluginPathType(this.url) === PLUGIN_PATH_TYPE_CDN) {
-            return Promise.resolve();
+            return resolved;
         }
         const loader = new ScriptLoader(getJSPath(this.url));
         this.loader = loader;

--- a/src/js/polyfills/promise.js
+++ b/src/js/polyfills/promise.js
@@ -228,4 +228,6 @@ PromisePolyfill._unhandledRejectionFn = function _unhandledRejectionFn(err) {
 
 const Promise = window.Promise || (window.Promise = PromisePolyfill);
 
+export const resolved = Promise.resolve();
+
 export default Promise;

--- a/src/js/utils/cancelable.js
+++ b/src/js/utils/cancelable.js
@@ -1,0 +1,17 @@
+import { resolved } from 'polyfills/promise';
+
+export default function cancelable(callback) {
+    let cancelled = false;
+
+    return {
+        async: () => resolved.then(() => {
+            if (cancelled) {
+                return;
+            }
+            return callback();
+        }),
+        cancel: () => {
+            cancelled = true;
+        }
+    };
+}


### PR DESCRIPTION
### This PR will...
1. Add a `cancelable` module used to handle checking autostart after the event loop is complete.

```js
const cancelableHandle = cancelable(callback);

// invoke the callback on Promise.resolve().then()
cancelableHandle.async();

// cancel firing the callback 
cancelableHandle.cancel();
```

2. Moves setting of "playAttempt" to true on the model until after "beforePlay" is triggered. Setting "playAttempt" to true triggers the start of playback if the current provider has fired "bufferFull".

3. Clears the model's "playlistItem" attribute before setting it to ensure a change event is fired from the model, triggering "playlistItem" from the player api. (We used to fire this on "itemReady", but playlistItem should fire as soon as "playlistItem" is set and media model properties are reset).

### Why is this Pull Request needed?

See https://github.com/jwplayer/jwplayer/pull/2230

These changes add a module we can reuse for cancelable `setImmediate` like behavior, and export a resolved Promise from the promise module and uses it everywhere we use `Promise.resolve()` to reduce memory usage.

#### Addresses Issue(s):
JW8-309
JW8-312
JW8-313


