### PR TITLE
Fix handling of video playback around instream detach and attach

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -412,6 +412,7 @@ Object.assign(Controller.prototype, {
                     _actionOnAttach = null;
                 });
                 _model.mediaModel.set('playAttempt', true);
+
             } else if (_model.get('state') === STATE_PAUSED) {
                 _model.playVideo().catch(error => {
                     _this.triggerError({
@@ -643,6 +644,9 @@ Object.assign(Controller.prototype, {
 
         /** Used for the InStream API **/
         function _detachMedia() {
+            if (_preplay) {
+                _interruptPlay = true;
+            }
             return _model.detachMedia();
         }
 

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -313,6 +313,7 @@ var InstreamAdapter = function(_controller, _model, _view) {
                 var item = Object.assign({}, _olditem);
                 item.starttime = _oldpos;
                 _model.loadVideo(item);
+                _model.mediaModel.set('playAttempt', true);
             } else if (_oldpos === -1) {
                 _model.stopVideo();
             }


### PR DESCRIPTION
### This PR will...
- Prevent providers from loading video when a preroll is about to play and the provider is detached
- Make sure after ads playback, instream applies the "playAttempt" mediaModel property for video playback to start

### Why is this Pull Request needed?

This works around tech-debt that was added to the player that requires `_model.mediaModel.attributes.playAttempt` for playback to start. It was being set before both the
"playAttempt" and "beforePlay" events which could cause video to play before a preroll starts. [Moving it to a better location](https://github.com/jwplayer/jwplayer/pull/2245/files#diff-a181c6e20596563a55e5710b8f4dbab7R407) before `loadVideo()` is called for the first time, caused a regression where video would not start after the preroll was finished.

These changes ensure that we don't start playback or additional buffering of the main content before a preroll, and sets the media model attribute needed for playback to begin after the ad break is finished.

### Follow ups

Both this PR and this recent one https://github.com/jwplayer/jwplayer/pull/2245 show that removal of this media model "trick" and the dependency on "bufferFull" triggering playback after a "playAttempt" should be looked at more closely after alpha 3. `loadVideo()` should start playback in providers without any additional interaction from the controller or model.

#### Addresses Issue(s):
JW8-323

