### PR TITLE
Use DOMParser to parse html in createElement util

### DIFF
--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -1,6 +1,9 @@
 import { trim } from 'utils/strings';
 import _ from 'utils/underscore';
 
+const DOMParser = window.DOMParser;
+let domParser = new DOMParser();
+
 // hasClass uses code from jQuery
 // jQuery v1.11.2 | (c) 2005, 2014 jQuery Foundation, Inc. | Released under the MIT license | jquery.org/license
 export function hasClass(element, searchClass) {
@@ -11,7 +14,11 @@ export function hasClass(element, searchClass) {
 
 // Given a string, convert to element and return
 export function createElement(html) {
-    var newElement = document.createElement('div');
+    const doc = domParser.parseFromString(html, 'text/html');
+    if (doc) {
+        return doc.body.firstChild;
+    }
+    const newElement = document.createElement('div');
     newElement.innerHTML = html;
     return newElement.firstChild;
 }


### PR DESCRIPTION
### Why is this Pull Request needed?

DOMParser is faster and more secure than `innerHtml`. The fallback is still there for older browsers and phantomjs.
