### PR TITLE
Ad skip ui

### DIFF
--- a/src/css/controls/imports/skipad.less
+++ b/src/css/controls/imports/skipad.less
@@ -4,7 +4,7 @@
     cursor: default;
     position: absolute;
     float: right;
-    display: inline-block;
+    display: flex;
     right: 0.75em;
     bottom: 3em;
     padding: @ui-padding;
@@ -25,10 +25,13 @@
 
     .jw-text,
     .jw-skip-icon {
-        color: @inactive-color;
         vertical-align: middle;
         line-height: 1.5em;
         font-size: 0.7em;
+    }
+
+    .jw-text {
+        color:#0b7ef4;
     }
 
     &.jw-skippable:hover {
@@ -42,6 +45,9 @@
 
     &.jw-skippable .jw-skip-icon {
         display: inline;
+        height: 24px;
+        width: 24px;
         margin: 0;
+        color: @inactive-color;
     }
 }

--- a/src/css/controls/imports/skipad.less
+++ b/src/css/controls/imports/skipad.less
@@ -13,6 +13,7 @@
     border-width: 1px;
     background-color: #000;
     align-items: center;
+    height: 1.7em;
 
     &.jw-skippable {
         cursor: pointer;

--- a/src/css/controls/imports/skipad.less
+++ b/src/css/controls/imports/skipad.less
@@ -31,7 +31,7 @@
     }
 
     .jw-text {
-        color:#0b7ef4;
+        color: #0b7ef4;
     }
 
     &.jw-skippable:hover {

--- a/src/css/controls/imports/skipad.less
+++ b/src/css/controls/imports/skipad.less
@@ -8,6 +8,11 @@
     right: 0.75em;
     bottom: 3em;
     padding: @ui-padding;
+    border-color: #333333;
+    border-style: solid;
+    border-width: 1px;
+    background-color: #000000;
+    align-items: center;
 
     &.jw-skippable {
         cursor: pointer;
@@ -26,7 +31,6 @@
     .jw-text,
     .jw-skip-icon {
         vertical-align: middle;
-        line-height: 1.5em;
         font-size: 0.7em;
     }
 

--- a/src/css/controls/imports/skipad.less
+++ b/src/css/controls/imports/skipad.less
@@ -8,14 +8,15 @@
     right: 0.75em;
     bottom: 3em;
     padding: @ui-padding;
-    border-color: #333333;
+    border-color: #333;
     border-style: solid;
     border-width: 1px;
-    background-color: #000000;
+    background-color: #000;
     align-items: center;
 
     &.jw-skippable {
         cursor: pointer;
+        padding: 0.25em 0.75em;
     }
 
     .jw-skip-icon {
@@ -36,12 +37,13 @@
 
     .jw-text {
         color: #0b7ef4;
+        // Make bold to improve color contrast
+        font-weight: bold;
     }
 
     &.jw-skippable:hover {
         cursor: pointer;
 
-        .jw-text,
         .jw-skip-icon {
             color: @accent-color;
         }

--- a/src/css/shared-imports/mixins.less
+++ b/src/css/shared-imports/mixins.less
@@ -171,8 +171,7 @@
                 color: @inactive-color;
             }
 
-            &.jw-skippable:hover .jw-skip-icon,
-            &.jw-skippable:hover .jw-text {
+            &.jw-skippable:hover .jw-skip-icon {
                 color: @active-color;
             }
         }


### PR DESCRIPTION
### This PR will...
- add border to skip button
- set background color to black
- make skip button wrap around icon and text
- align svg icon and text
- color text to be same blue as progress bar
- disable active color on text hover
### Why is this Pull Request needed?
to resemble the skip button in the mocks
### NOTE
p/d/w Monica, number in 'skip ad in XX' is NOT required to be white 
### Are there any points in the code the reviewer needs to double check?
n/a
### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/3948
jwplayer/jwplayer-ads-vast#230
jwplayer/jwplayer-ads-googima#243
jwplayer/jwplayer-ads-freewheel#62
#### Addresses Issue(s):
JW8-292

