### PR TITLE
Move sharing and ad skip button to commercial controls

### DIFF
--- a/src/css/controls/flags/overlay.less
+++ b/src/css/controls/flags/overlay.less
@@ -1,5 +1,4 @@
 .jw-flag-overlay-open {
-    &-sharing.jw-flag-small-player,
     &-related {
         .jw-controls,
         .jw-title,

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -105,6 +105,7 @@ var InstreamAdapter = function(_controller, _model, _view) {
         }
 
         // Show instream state instead of normal player state
+        _model.set('adModel', _instream._adModel);
         _view.setupInstream(_instream._adModel);
         _instream._adModel.set('state', STATE_BUFFERING);
 
@@ -118,11 +119,13 @@ var InstreamAdapter = function(_controller, _model, _view) {
     };
 
     function _loadNextItem() {
+        const adModel = _instream._adModel;
+
         // We want a play event for the next item, so we ensure the state != playing
-        _instream._adModel.set('state', STATE_BUFFERING);
+        adModel.set('state', STATE_BUFFERING);
 
         // destroy skip button
-        _model.set('skipButton', false);
+        adModel.set('skipButton', false);
 
         _arrayIndex++;
         var item = _array[_arrayIndex];
@@ -233,14 +236,15 @@ var InstreamAdapter = function(_controller, _model, _view) {
     };
 
     this.setupSkipButton = function(skipoffset, options, customNext) {
-        _model.set('skipButton', false);
+        const adModel = _instream._adModel;
+        adModel.set('skipButton', false);
         if (customNext) {
             _instreamItemNext = customNext;
         }
-        _instream._adModel.set('skipMessage', options.skipMessage);
-        _instream._adModel.set('skipText', options.skipText);
-        _instream._adModel.set('skipOffset', skipoffset);
-        _model.set('skipButton', true);
+        adModel.set('skipMessage', options.skipMessage);
+        adModel.set('skipText', options.skipText);
+        adModel.set('skipOffset', skipoffset);
+        adModel.set('skipButton', true);
     };
 
     this.applyProviderListeners = function(provider) {
@@ -285,7 +289,7 @@ var InstreamAdapter = function(_controller, _model, _view) {
     this.destroy = function() {
         this.off();
 
-        _model.set('skipButton', false);
+        _model.set('adModel', null);
 
         if (_instream) {
             if (_view.clickHandler()) {


### PR DESCRIPTION
### This PR will...

Move skip button state into ad model. Add ad model to model when in insteam mode.

### Why is this Pull Request needed?

This allows controls to show ad skip button without interacting with the view.

### Are there any Pull Requests open in other repos which need to be merged with this?

jwplayer-commercial

#### Addresses Issue(s):

JW8-114

