### PR TITLE
Store controls in a global module export

### DIFF
--- a/src/js/api/core-loader.js
+++ b/src/js/api/core-loader.js
@@ -1,6 +1,7 @@
 import Item from 'playlist/item';
 import ProvidersSupported from 'providers/providers-supported';
 import registerProvider from 'providers/providers-register';
+import { module as ControlsModule } from 'controller/controls-loader';
 import { resolved } from 'polyfills/promise';
 
 let bundlePromise = null;
@@ -63,18 +64,6 @@ export function requiresProvider(model, providerName) {
     return false;
 }
 
-function loadControlsHtml5Bundle() {
-    bundleContainsProviders.html5 = true;
-    return require.ensure([
-        'controller/controller',
-        'view/controls/controls',
-        'providers/html5'
-    ], function (require) {
-        registerProvider(require('providers/html5').default);
-        return require('controller/controller').default;
-    }, chunkLoadErrorHandler, 'jwplayer.core.controls.html5');
-}
-
 function loadControlsPolyfillHtml5Bundle() {
     bundleContainsProviders.html5 = true;
     return require.ensure([
@@ -83,10 +72,27 @@ function loadControlsPolyfillHtml5Bundle() {
         'intersection-observer',
         'providers/html5'
     ], function (require) {
+        // These modules should be required in this order
         require('intersection-observer');
+        const CoreMixin = require('controller/controller').default;
+        ControlsModule.controls = require('view/controls/controls').default;
         registerProvider(require('providers/html5').default);
-        return require('controller/controller').default;
+        return CoreMixin;
     }, chunkLoadErrorHandler, 'jwplayer.core.controls.polyfills.html5');
+}
+
+function loadControlsHtml5Bundle() {
+    bundleContainsProviders.html5 = true;
+    return require.ensure([
+        'controller/controller',
+        'view/controls/controls',
+        'providers/html5'
+    ], function (require) {
+        const CoreMixin = require('controller/controller').default;
+        ControlsModule.controls = require('view/controls/controls').default;
+        registerProvider(require('providers/html5').default);
+        return CoreMixin;
+    }, chunkLoadErrorHandler, 'jwplayer.core.controls.html5');
 }
 
 function loadControlsPolyfillBundle() {
@@ -96,7 +102,9 @@ function loadControlsPolyfillBundle() {
         'intersection-observer'
     ], function (require) {
         require('intersection-observer');
-        return require('controller/controller').default;
+        const CoreMixin = require('controller/controller').default;
+        ControlsModule.controls = require('view/controls/controls').default;
+        return CoreMixin;
     }, chunkLoadErrorHandler, 'jwplayer.core.controls.polyfills');
 }
 
@@ -105,7 +113,9 @@ function loadControlsBundle() {
         'controller/controller',
         'view/controls/controls'
     ], function (require) {
-        return require('controller/controller').default;
+        const CoreMixin = require('controller/controller').default;
+        ControlsModule.controls = require('view/controls/controls').default;
+        return CoreMixin;
     }, chunkLoadErrorHandler, 'jwplayer.core.controls');
 }
 

--- a/src/js/controller/controls-loader.js
+++ b/src/js/controller/controls-loader.js
@@ -2,10 +2,14 @@ import { chunkLoadErrorHandler } from '../api/core-loader';
 
 let controlsPromise = null;
 
+export const module = {};
+
 export function load() {
     if (!controlsPromise) {
         controlsPromise = require.ensure(['view/controls/controls'], function (require) {
-            return require('view/controls/controls').default;
+            const ControlsModule = require('view/controls/controls').default;
+            module.controls = ControlsModule;
+            return ControlsModule;
         }, function() {
             controlsPromise = null;
             chunkLoadErrorHandler();

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -97,13 +97,6 @@ function View(_api, _model) {
     let _breakpoint = null;
     let _controls;
 
-    // Fetch the ControlsModule now so we can  call `addControls()` synchronously on `init`
-    if (_model.get('controls')) {
-        ControlsLoader.load().then(Controls => {
-            ControlsModule = Controls;
-        });
-    }
-
     function reasonInteraction() {
         return { reason: 'interaction' };
     }
@@ -321,6 +314,7 @@ function View(_api, _model) {
 
     function changeControls(model, enable) {
         if (enable) {
+            ControlsModule = ControlsLoader.module.controls;
             if (!ControlsModule) {
                 ControlsLoader.load()
                     .then(function (Controls) {


### PR DESCRIPTION
### This PR will...

Ensure that controls module is accessible to the view when it's been loaded as part of a bundle. This allows sharing to be setup before the player is ready so that `jwplayer().getPlugin('sharing')` continues to work as expected.

#### Addresses Issue(s):

JW8-347

