### PR TITLE
Move background gradient away from after element

### DIFF
--- a/src/css/controls/imports/jwplayerlayout.less
+++ b/src/css/controls/imports/jwplayerlayout.less
@@ -12,23 +12,13 @@
 }
 
 .jw-controls {
+    background: svg-gradient(to bottom, transparent, fade(@black, 40%) 77%, fade(@black, 40%) 100%) 100% 100% / 100% 240px no-repeat transparent;
     overflow: hidden;
+    transition: opacity 250ms cubic-bezier(0, 0.25, 0.25, 1);
     z-index: 0;
 
-    &::after {
-        &:extend(._pseudo);
-        .bottomleft(60px, 0);
-        .rect(100%, 50%);
-        min-height: 240px;
-        background: svg-gradient(to bottom, transparent, fade(@black, 40%)) no-repeat transparent;
-        opacity: 1;
-        pointer-events: none;
-        transition: opacity 250ms cubic-bezier(0, 0.25, 0.25, 1);
-        z-index: -1;
-
-        .jwplayer.jw-state-playing.jw-flag-user-inactive:not(.jw-flag-casting) & {
-            opacity: 0;
-        }
+    .jwplayer.jw-state-playing.jw-flag-user-inactive:not(.jw-flag-casting) & {
+        opacity: 0;
     }
 
     .jw-flag-small-player & {

--- a/src/js/utils/skin.js
+++ b/src/js/utils/skin.js
@@ -135,8 +135,10 @@ export function handleColorOverrides(playerId, skin = {}) {
         css('.jw-icon-cast button:focus', `{--connected-color: ${config.iconsActive}}`, playerId);
         css('.jw-icon-cast:hover button', `{--connected-color: ${config.iconsActive}}`, playerId);
 
+
+
         addStyle([
-            '.jw-background-color.jw-controlbar'
+            '.jw-controlbar'
         ], 'background', config.background);
     }
 

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -224,7 +224,7 @@ export default class Controlbar {
         ].filter(e => e);
 
         this.el = document.createElement('div');
-        this.el.className = 'jw-controlbar jw-background-color jw-reset';
+        this.el.className = 'jw-controlbar jw-reset';
 
         appendChildren(elements.buttonContainer, buttonLayout);
         appendChildren(this.el, layout);


### PR DESCRIPTION
### This PR will...
Reduce the after pseudo element used for the gradient and just use the controlbar element

#### Addresses Issue(s):
JW8-95
