### PR TITLE
Move Next Up button to the left of Volume

### DIFF
--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -199,6 +199,7 @@ export default class Controlbar {
         const buttonLayout = [
             elements.play,
             elements.rewind,
+            elements.next,
             elements.volumetooltip,
             elements.mute,
             elements.alt,
@@ -207,7 +208,6 @@ export default class Controlbar {
             elements.countdown,
             elements.duration,
             elements.spacer,
-            elements.next,
             elements.cast,
             elements.captionsButton,
             elements.settingsButton,


### PR DESCRIPTION
### This PR will...

move the next up icon to always be left of the volume button when it is available

### Why is this Pull Request needed?

Conforms to the JW8 skin

#### Addresses Issue(s):

JW8-318

