### PR TITLE
Fix video scaling in iOS9+

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -823,7 +823,7 @@ function VideoProvider(_playerId, _playerConfig) {
         // object-fit is not implemented in IE or Android Browser in 4.4 and lower
         // http://caniuse.com/#feat=object-fit
         // feature detection may work for IE but not for browsers where object-fit works for images only
-        var fitVideoUsingTransforms = Browser.ie || (OS.iOS && OS.version.major >= 9) || (OS.android && Browser.firefox);
+        var fitVideoUsingTransforms = Browser.ie || (OS.iOS && OS.version.major < 9) || (OS.android && !Browser.firefox);
         if (fitVideoUsingTransforms) {
             // Use transforms to center and scale video in container
             var x = -Math.floor(_videotag.videoWidth / 2 + 1);


### PR DESCRIPTION
### This PR will...
Fix object-fit test in iOS9+, which affected captions font size. 

### Why is this Pull Request needed?
In 7.12, we used to check `_isIOS7 || _isIOS8` ([ref](https://github.com/jwplayer/jwplayer/blob/v7.12.x/src/js/providers/html5.js#L830)). While the new Environment module simplifies this check, the conditions for checking iOS version and FF were wrong.  

### Are there any points in the code the reviewer needs to double check?
No.

### Are there any Pull Requests open in other repos which need to be merged with this?
No.

#### Addresses Issue(s):

JW8-353

