### PR TITLE
Fire playAttempt the same way JW7 does

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -317,7 +317,6 @@ var InstreamAdapter = function(_controller, _model, _view) {
                 var item = Object.assign({}, _olditem);
                 item.starttime = _oldpos;
                 _model.loadVideo(item);
-                _model.mediaModel.set('playAttempt', true);
             } else if (_oldpos === -1) {
                 _model.stopVideo();
             }


### PR DESCRIPTION
### This PR will...

Fix a regression in JW8 that affects when "playAttempt" is fired.

### Why is this Pull Request needed?

The "playAttempt" event is fired after "beforePlay" and, in the case a preroll ad is triggered by "beforePlay", deferred until after ad playback, so that time to first frame is calculated correctly; as the time between the "playAttempt" and "firstFrame" (or first "time") events.

If we want to fire "playAttempt" before the beforePlay event, to receive this event before prerolls, we would still need to fire it a second time after the ad break is finished.

How this affects analytics and what playReason(s) should be given should be discussed before making any changes. Any changes we do make should be made to both JW7 and JW8.
