### PR TITLE
Make Sharing Submenu Last

### DIFF
--- a/src/css/controls/imports/transitions.less
+++ b/src/css/controls/imports/transitions.less
@@ -1,4 +1,3 @@
-.jw-plugin-sharing,
 .jw-display,
 .jw-overlay {
     transition: opacity 0.3s ease, visibility 0.3s ease;

--- a/src/js/view/controls/components/settings/menu.js
+++ b/src/js/view/controls/components/settings/menu.js
@@ -56,7 +56,12 @@ export function SettingsMenu(onVisibility, onSubmenuAdded, onMenuEmpty) {
             if (submenu.isDefault) {
                 prependChild(topbarElement, submenu.categoryButtonElement);
             } else {
-                topbarElement.insertBefore(submenu.categoryButtonElement, closeButton.element());
+                // sharing should always be the last submenu
+                const sharingButton = topbarElement.getElementsByClassName('jw-submenu-sharing')[0];
+                topbarElement.insertBefore(
+                    submenu.categoryButtonElement,
+                    sharingButton ? sharingButton : closeButton.element()
+                );
             }
 
             settingsMenuElement.appendChild(submenu.element());

--- a/src/js/view/controls/components/settings/menu.js
+++ b/src/js/view/controls/components/settings/menu.js
@@ -57,10 +57,10 @@ export function SettingsMenu(onVisibility, onSubmenuAdded, onMenuEmpty) {
                 prependChild(topbarElement, submenu.categoryButtonElement);
             } else {
                 // sharing should always be the last submenu
-                const sharingButton = topbarElement.getElementsByClassName('jw-submenu-sharing')[0];
+                const sharingButton = topbarElement.querySelector('.jw-submenu-sharing');
                 topbarElement.insertBefore(
                     submenu.categoryButtonElement,
-                    sharingButton ? sharingButton : closeButton.element()
+                    sharingButton || closeButton.element()
                 );
             }
 

--- a/src/js/view/controls/components/settings/submenu.js
+++ b/src/js/view/controls/components/settings/submenu.js
@@ -8,6 +8,7 @@ export default function SettingsSubmenu(name, categoryButton, isDefault) {
     const categoryButtonElement = categoryButton.element();
 
     categoryButtonElement.setAttribute('name', name);
+    categoryButtonElement.className += ' jw-submenu-' + name;
     categoryButton.show();
 
     const instance = {


### PR DESCRIPTION
### This PR will...

- Ensure that the sharing submenu is always the last
- Remove a css rule that is no longer needed

### Why is this Pull Request needed?

The `jw-sharing-plugin` class is no longer needed 

#### Addresses Issue(s):

JW8-361

