### PR TITLE
Revert "Use DOMParser to parse html in createElement util"

### DIFF
--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -1,9 +1,6 @@
 import { trim } from 'utils/strings';
 import _ from 'utils/underscore';
 
-const DOMParser = window.DOMParser;
-let domParser = new DOMParser();
-
 // hasClass uses code from jQuery
 // jQuery v1.11.2 | (c) 2005, 2014 jQuery Foundation, Inc. | Released under the MIT license | jquery.org/license
 export function hasClass(element, searchClass) {
@@ -14,11 +11,7 @@ export function hasClass(element, searchClass) {
 
 // Given a string, convert to element and return
 export function createElement(html) {
-    const doc = domParser.parseFromString(html, 'text/html');
-    if (doc) {
-        return doc.body.firstChild;
-    }
-    const newElement = document.createElement('div');
+    var newElement = document.createElement('div');
     newElement.innerHTML = html;
     return newElement.firstChild;
 }

--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -11,7 +11,7 @@ export function hasClass(element, searchClass) {
 
 // Given a string, convert to element and return
 export function createElement(html) {
-    var newElement = document.createElement('div');
+    const newElement = document.createElement('div');
     newElement.innerHTML = html;
     return newElement.firstChild;
 }


### PR DESCRIPTION
### This PR will...
Reverts commit 0dace0c23e359638fe97190f26cc3620af936938

### Why is this Pull Request needed?
Mixed HTML/SVG elements created with DOMParser do not produce `touchstart` events on iOS. We should revisit this optimization in the future.

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-352

