### PR TITLE
Hide thumbnails for small player

### DIFF
--- a/src/css/controls/imports/tooltip.less
+++ b/src/css/controls/imports/tooltip.less
@@ -104,3 +104,7 @@
         border-radius: @ui-corner-round;
     }
 }
+
+.jw-flag-small-player .jw-time-thumb {
+    display: none;
+}

--- a/src/js/view/controls/components/thumbnails.mixin.js
+++ b/src/js/view/controls/components/thumbnails.mixin.js
@@ -50,7 +50,6 @@ const ThumbnailsMixin = {
     loadThumbnail: function(seconds) {
         var url = this.chooseThumbnail(seconds);
         var style = {
-            display: 'block',
             margin: '0 auto',
             backgroundPosition: '0 0'
         };


### PR DESCRIPTION
### This PR will...
Hide thumbnails at breakpoints 0&1.
### Why is this Pull Request needed?
At small player sizes, the thumbnails obscure the display icons and make them almost unusable.
### Are there any points in the code the reviewer needs to double check?
No.
### Are there any Pull Requests open in other repos which need to be merged with this?
No.
#### Addresses Issue(s):

JW8-377

