### PR TITLE
Only fade entire controls when necessary

### DIFF
--- a/src/css/controls/imports/jwplayerlayout.less
+++ b/src/css/controls/imports/jwplayerlayout.less
@@ -17,10 +17,6 @@
     transition: opacity 250ms cubic-bezier(0, 0.25, 0.25, 1);
     z-index: 0;
 
-    .jw-state-playing.jw-flag-user-inactive:not(.jw-flag-casting):not(.jw-flag-ads):not(.jw-flag-audio-player):not(.jw-flag-media-audio) & {
-        opacity: 0;
-    }
-
     .jw-flag-small-player & {
         text-align: center;
     }

--- a/src/css/controls/imports/jwplayerlayout.less
+++ b/src/css/controls/imports/jwplayerlayout.less
@@ -17,7 +17,7 @@
     transition: opacity 250ms cubic-bezier(0, 0.25, 0.25, 1);
     z-index: 0;
 
-    .jw-state-playing.jw-flag-user-inactive:not(.jw-flag-casting):not(.jw-flag-ads):not(.jw-flag-audio-player) & {
+    .jw-state-playing.jw-flag-user-inactive:not(.jw-flag-casting):not(.jw-flag-ads):not(.jw-flag-audio-player):not(.jw-flag-media-audio) & {
         opacity: 0;
     }
 

--- a/src/css/controls/states.less
+++ b/src/css/controls/states.less
@@ -68,8 +68,8 @@
         }
     }
 
-    &.jw-flag-user-inactive:not(.jw-flag-casting) {
-        .jw-controls::after {
+    &.jw-flag-user-inactive:not(.jw-flag-ads):not(.jw-flag-audio-player):not(.jw-flag-casting):not(.jw-flag-media-audio):not(.jw-flag-nextup) {
+        .jw-controls {
             opacity: 0;
         }
     }

--- a/src/css/controls/states.less
+++ b/src/css/controls/states.less
@@ -13,18 +13,6 @@
 
     .jw-controls {
         background: @controlbar-background;
-
-        &::after {
-            bottom: @mobile-touch-target;
-        }
-    }
-
-    .jw-controlbar {
-        .jw-slider-time,
-        .jw-icon,
-        .jw-icon-playback-rate {
-            display: none;
-        }
     }
 }
 


### PR DESCRIPTION
### This PR will...
Show the control bar at all times when playing an audio stream.
Show the controls container when idle and the nextup container is active.

### Why is this Pull Request needed?
This fixes a regression that resulted from changes to control bar.

### Are there any points in the code the reviewer needs to double check?
No.
### Are there any Pull Requests open in other repos which need to be merged with this?
No.
#### Addresses Issue(s):
JW8-374
JW8-378

