### PR TITLE
Remove bad guard check before activating the playback rate submenu item

### DIFF
--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -452,7 +452,7 @@ export default class Controls {
         model.change('playbackRate', (changedModel, playbackRate) => {
             const rates = model.get('playbackRates');
             if (rates) {
-                activateSubmenuItem('playbackRates', rates.indexOf(playbackRate) || 1);
+                activateSubmenuItem('playbackRates', rates.indexOf(playbackRate));
             }
         });
     }


### PR DESCRIPTION
### This PR will...
Remove a guard check from activating the `playbackRate` content item, which prevented the selection at index `0` from being selected. `activateSubmenuItem` has it's own guard check.

### Why is this Pull Request needed?
The first playback rate would not be activated

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-363
