### PR TITLE
Support HLS ads in non-safari browesers

### DIFF
--- a/src/js/controller/instream-html5.js
+++ b/src/js/controller/instream-html5.js
@@ -25,8 +25,10 @@ const InstreamHtml5 = function(_controller, _model) {
             volume: _model.get('volume'),
             fullscreen: _model.get('fullscreen'),
             mute: _model.get('mute') || _model.get('autostartMuted'),
-            instreamMode: true
+            instreamMode: true,
+            edition: 'ads',
         });
+        _adModel.set('mediaContainer', _model.get('mediaContainer'));
         _adModel.on('fullscreenchange', _nativeFullscreenHandler);
 
         this._adModel = _adModel;

--- a/src/js/controller/instream-html5.js
+++ b/src/js/controller/instream-html5.js
@@ -26,7 +26,7 @@ const InstreamHtml5 = function(_controller, _model) {
             fullscreen: _model.get('fullscreen'),
             mute: _model.get('mute') || _model.get('autostartMuted'),
             instreamMode: true,
-            edition: 'ads',
+            edition: _model.get('edition'),
         });
         _adModel.set('mediaContainer', _model.get('mediaContainer'));
         _adModel.on('fullscreenchange', _nativeFullscreenHandler);


### PR DESCRIPTION
### This PR will...
Add edition and mediaContainer to new model created by instream-html5 provider.

### Why is this Pull Request needed?
Edition is needed to check if hls is able to play, and mediaContainer is needed to play the ad in it.

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-ads-vast/pull/239

#### Addresses Issue(s):
ADS-464

