### PR TITLE
Show Chromecast icon on idle state

### DIFF
--- a/src/css/controls/flags/cast-available.less
+++ b/src/css/controls/flags/cast-available.less
@@ -3,4 +3,13 @@
     .jw-icon-airplay {
         display: flex;
     }
+
+    &.jw-state-idle {
+        .jw-controlbar {
+            .jw-slider-time,
+            .jw-icon:not(.jw-icon-cast):not(.jw-icon-airplay) {
+                display: none;
+            }
+        }
+    }
 }


### PR DESCRIPTION
### This PR will...
Make sure the Chromecast button is displayed on idle state

#### Addresses Issue(s):

JW8-378

