### PR TITLE
Move getScriptPath to playerutils

### DIFF
--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -1,6 +1,6 @@
 import _ from 'utils/underscore';
-import { loadFrom } from 'utils/playerutils';
-import { serialize, getScriptPath } from 'utils/parser';
+import { loadFrom, getScriptPath } from 'utils/playerutils';
+import { serialize } from 'utils/parser';
 
 /* global __webpack_public_path__:true*/
 /* eslint camelcase: 0 */

--- a/src/js/utils/parser.js
+++ b/src/js/utils/parser.js
@@ -43,20 +43,6 @@ export function isAbsolutePath(path) {
     return /^(?:(?:https?|file):)?\/\//.test(path);
 }
 
-export const getScriptPath = _.memoize(function(scriptName) {
-    const scripts = document.getElementsByTagName('script');
-    for (let i = 0; i < scripts.length; i++) {
-        const src = scripts[i].src;
-        if (src) {
-            const index = src.indexOf('/' + scriptName);
-            if (index >= 0) {
-                return src.substr(0, index + 1);
-            }
-        }
-    }
-    return '';
-});
-
 function containsParserErrors(childNodes) {
     return _.some(childNodes, function(node) {
         return node.nodeName === 'parsererror';

--- a/src/js/utils/playerutils.js
+++ b/src/js/utils/playerutils.js
@@ -1,23 +1,29 @@
 import { version } from 'version';
-import _ from 'utils/underscore';
-import { isHTTPS } from 'utils/validator';
-import { getScriptPath } from 'utils/parser';
 
-const REPO_URL = __REPO__;
+export const getScriptPath = function(scriptName) {
+    const scripts = document.getElementsByTagName('script');
+    for (let i = 0; i < scripts.length; i++) {
+        const src = scripts[i].src;
+        if (src) {
+            const index = src.lastIndexOf('/' + scriptName);
+            if (index >= 0) {
+                return src.substr(0, index + 1);
+            }
+        }
+    }
+    return '';
+};
 
 /** Gets the repository location **/
-export const repo = _.memoize(function () {
+export const repo = function () {
     if (__SELF_HOSTED__) {
         return getScriptPath('jwplayer.js');
     }
 
-    const semver = version.split('+')[0];
-    const playerRepo = REPO_URL + semver + '/';
-    if (isHTTPS()) {
-        return playerRepo.replace(/^http:/, 'https:');
-    }
-    return playerRepo;
-});
+    const playerRepo = __REPO__;
+    const protocol = (playerRepo && window.location.protocol === 'file:') ? 'https:' : '';
+    return `${protocol}${playerRepo}`;
+};
 
 // Is the player at least a minimum required version?
 export const versionCheck = function (target) {

--- a/src/js/utils/validator.js
+++ b/src/js/utils/validator.js
@@ -15,7 +15,7 @@ export function exists(item) {
 
 /** Determines if the current page is HTTPS **/
 export function isHTTPS() {
-    return (window.location.href.indexOf('https') === 0);
+    return (window.location.protocol === 'https:');
 }
 
 /**

--- a/test/unit/parser-test.js
+++ b/test/unit/parser-test.js
@@ -55,15 +55,6 @@ describe('parser', function() {
         test(['100%'], '100%', 'percentage values are not changed');
     });
 
-    it.skip('parser.getScriptPath', function() {
-        var path = parser.getScriptPath(null);
-        assert.equal(path, '', 'returns an empty string when no file name is provided');
-
-        var scriptPath = parser.getScriptPath('parser-test.js');
-        assert.isOk(/\S+\:\/\/.+\/$/.it(scriptPath),
-            'returns a directory url ending with a forward slash "' + scriptPath + '"');
-    });
-
     it('parser.parseXML', function() {
         var xml = parser.parseXML('<input>');
         assert.isNotOk(xml);

--- a/test/unit/playerutils-test.js
+++ b/test/unit/playerutils-test.js
@@ -1,20 +1,33 @@
 import { version } from 'version';
-import * as playerutils from 'utils/playerutils';
+import { getScriptPath, versionCheck } from 'utils/playerutils';
 
 describe('playerutils', function() {
 
-    it('playerutils.versionCheck', function() {
-        var versionCheck = playerutils.versionCheck('0.5');
-        assert.isOk(versionCheck, 'playerutils.versionCheck with valid version');
+    it('versionCheck with valid version', function() {
+        const versionRequirementMet = versionCheck('0.5');
+        assert.isOk(versionRequirementMet);
+    });
 
-        versionCheck = playerutils.versionCheck('99.1');
-        assert.isNotOk(versionCheck, 'playerutils.versionCheck with invalid version');
+    it('versionCheck with invalid version', function() {
+        const versionRequirementMet = versionCheck('99.1');
+        assert.isNotOk(versionRequirementMet);
+    });
 
-        var jParts = version.split(/\W/);
-        var jMajor = parseFloat(jParts[0]);
-        var jMinor = parseFloat(jParts[1]);
+    it('versionCheck with higher version', function() {
+        const jParts = version.split(/\W/);
+        const jMajor = parseFloat(jParts[0]);
+        const jMinor = parseFloat(jParts[1]);
+        const versionRequirementMet = versionCheck(jMajor + ' ' + (jMinor + 1));
+        assert.isNotOk(versionRequirementMet);
+    });
 
-        versionCheck = playerutils.versionCheck(jMajor + ' ' + (jMinor + 1));
-        assert.isNotOk(versionCheck, 'playerutils.versionCheck with higher version');
+    it('getScriptPath returns an empty string when no file name is provided', function() {
+        const path = getScriptPath(null);
+        assert.equal(path, '');
+    });
+
+    it('getScriptPath returns a directory url ending with a forward slash', function() {
+        const scriptPath = getScriptPath('sinon.js');
+        assert.isOk(/\S+\:\/\/.+\/$/.test(scriptPath), ' for "sinon.js" returned "' + scriptPath + '"');
     });
 });

--- a/test/unit/scriptloader-test.js
+++ b/test/unit/scriptloader-test.js
@@ -1,4 +1,4 @@
-import { getScriptPath } from 'utils/parser';
+import { getScriptPath } from 'utils/playerutils';
 import ScriptLoader, {
     SCRIPT_LOAD_STATUS_NEW
 } from 'utils/scriptloader';
@@ -39,6 +39,6 @@ describe('ScriptLoader', function() {
 
         // loaded script should be added to head as first child
         const tag = document.getElementsByTagName('head')[0].firstChild;
-        assert.isOk(tag.src.indexOf('sinon.js') >= 0, 'script is laded properly');
+        assert.isOk(tag.src.indexOf('sinon.js') >= 0, 'script is loaded properly');
     });
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,7 +28,7 @@ function getBuildVersion(build) {
 
 const compileConstants = {
     __SELF_HOSTED__: true,
-    __REPO__: '\'\'',
+    __REPO__: `''`,
     __DEBUG__: false,
     __BUILD_VERSION__: `'${getBuildVersion(packageInfo)}'`,
     __FLASH_VERSION__: flashVersion


### PR DESCRIPTION
### This PR will...

Move getScriptPath to playerutils and update `repo` and `isHTTPS`.

### Why is this Pull Request needed?

The changes support changes to commercial plugin loading.

### Are there any Pull Requests open in other repos which need to be merged with this?

jwplayer-commercial

#### Addresses Issue(s):

JW8-333

