### PR TITLE
Title padding improvements

### DIFF
--- a/src/css/jwplayer/imports/logo.less
+++ b/src/css/jwplayer/imports/logo.less
@@ -22,10 +22,6 @@
 .jw-logo-top-right {
     top: 0;
     right: 0;
-
-    &.jw-below {
-        top: 3.5em;
-    }
 }
 
 .jw-logo-top-left {

--- a/src/css/jwplayer/imports/title.less
+++ b/src/css/jwplayer/imports/title.less
@@ -12,6 +12,8 @@
 .jw-title-secondary {
     // ensure there's padding even when the logo is positioned in the top-left
     padding-left: @ui-margin;
+    padding-right: @ui-margin;
+    padding-bottom: 0.5em;
     width: 100%;
     color: #fff;
     white-space: nowrap;
@@ -21,10 +23,6 @@
 
 .jw-title-primary {
     font-size: 1.625em;
-}
-
-.jw-title-secondary {
-    padding-top: 0.5em;
 }
 
 .jw-flag-small-player {


### PR DESCRIPTION
### This PR will...
- Increase right padding so there’s space between long text and the logo when positioned to the right.
- Add bottom padding to title/description text so characters like ‘g’ don’t get cut off.
- Get rid of ‘.jw-below’ class that was used when the dock icons were in the old position.
### Why is this Pull Request needed?
Addresses issues with the title being too close to the logo when there's a logo present in the top right. It also fixes characters being cut off. Got rid of some dead code in the process.
### Are there any points in the code the reviewer needs to double check?
No.
### Are there any Pull Requests open in other repos which need to be merged with this?
No.
#### Addresses Issue(s):
JW8-99

