### PR TITLE
Fix Chromecast icon when custom colors are undefined

### DIFF
--- a/src/js/view/utils/skin.js
+++ b/src/js/view/utils/skin.js
@@ -127,13 +127,17 @@ export function handleColorOverrides(playerId, skin = {}) {
 
         // Chromecast overrides
         // Can't use addStyle since it will camel case the style name
-        css('.jw-icon-cast button.jw-off', `{--disconnected-color: ${config.icons}}`, playerId);
-        css('.jw-icon-cast:hover button.jw-off', `{--disconnected-color: ${config.iconsActive}}`, playerId);
-        css('.jw-icon-cast button.jw-off:focus', `{--disconnected-color: ${config.iconsActive}}`, playerId);
+        if (config.icons) {
+            css('.jw-icon-cast button.jw-off', `{--disconnected-color: ${config.icons}}`, playerId);
+        }
+        if (config.iconsActive) {
+            css('.jw-icon-cast:hover button.jw-off', `{--disconnected-color: ${config.iconsActive}}`, playerId);
+            css('.jw-icon-cast button.jw-off:focus', `{--disconnected-color: ${config.iconsActive}}`, playerId);
 
-        css('.jw-icon-cast button', `{--connected-color: ${config.iconsActive}}`, playerId);
-        css('.jw-icon-cast button:focus', `{--connected-color: ${config.iconsActive}}`, playerId);
-        css('.jw-icon-cast:hover button', `{--connected-color: ${config.iconsActive}}`, playerId);
+            css('.jw-icon-cast button', `{--connected-color: ${config.iconsActive}}`, playerId);
+            css('.jw-icon-cast button:focus', `{--connected-color: ${config.iconsActive}}`, playerId);
+            css('.jw-icon-cast:hover button', `{--connected-color: ${config.iconsActive}}`, playerId);
+        }
 
         addStyle([
             '.jw-controlbar'


### PR DESCRIPTION
### This PR will...
Prevent the Chromecast icon CSS variables from being set to `undefined` when values aren't available in the config.

#### Addresses Issue(s):
JW8-358

