### PR TITLE
Don't use related to execute next action

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -670,8 +670,8 @@ Object.assign(Controller.prototype, {
                         itemsShown: [ nextUp ],
                         feedData: nextUp.feedData,
                     });
+                    _item(nextUp.index);
                 }
-                related.next();
             }
         }
 


### PR DESCRIPTION
### This PR will...
Call `item()` internally with the next item when clicking the next button

### Why is this Pull Request needed?
Related executes actions async, which causes a the user gesture to be lost between playlist items, preventing autostart.

### Are there any points in the code the reviewer needs to double check?
- Need to go through the related suite, checking the transition between playlist/related
- Need to make sure the `playReason` is correct (it should be `interaction`)

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-390

