### PR TITLE
Only apply opacity to nextup container when customization options set

### DIFF
--- a/src/js/view/utils/skin.js
+++ b/src/js/view/utils/skin.js
@@ -188,13 +188,15 @@ export function handleColorOverrides(playerId, skin = {}) {
             '.jw-nextup-body',
             '.jw-nextup-header',
             '.jw-settings-submenu',
-            '.jw-settings-topbar',
+            '.jw-settings-topbar'
         ], 'background', config.background);
 
-        addStyle([
-            '.jw-settings-submenu',
-            '.jw-nextup-body',
-        ], 'opacity', 0.7);
+        if (config.background) {
+            addStyle([
+                '.jw-settings-submenu',
+                '.jw-nextup-body',
+            ], 'opacity', 0.7);
+        }
     }
 
     function styleTooltips(config) {


### PR DESCRIPTION
### This PR will...
Apply opacity to the nextup container only when the player config has a background color set.

#### Addresses Issue(s):
JW8-374