### PR TITLE
Fix hover state layout breaking alignment on svg icons

### DIFF
--- a/src/css/controls/flags/ads.less
+++ b/src/css/controls/flags/ads.less
@@ -67,8 +67,8 @@
             display: none;
         }
 
-        .jw-icon[aria-label]::after {
-            content: none;
+        .jw-volume-tip {
+            padding: @slider-fixed-knob-height 0;
         }
 
         .jw-text-alt {

--- a/src/css/controls/imports/controlbar.less
+++ b/src/css/controls/imports/controlbar.less
@@ -32,17 +32,9 @@
         align-self: stretch;
     }
 
-    .jw-icon {
-        &:focus {
-            .jw-svg-icon {
-                box-shadow: inset 0 -3px 0 -1px currentColor;
-            }
-        }
-
-        &.jw-button-color {
-            &:hover {
-                color: @hover-color;
-            }
+    .jw-icon.jw-button-color {
+        &:hover {
+            color: @hover-color;
         }
     }
 }

--- a/src/css/controls/imports/icons.less
+++ b/src/css/controls/imports/icons.less
@@ -1,14 +1,11 @@
 .jw-svg-icon {
-    .rect(24px, 100%);
+    .square(24px);
     fill: currentColor;
-    padding: 10px 0;
     pointer-events: none;
-    box-shadow: inset 0 0 0 currentColor;
-    transition: box-shadow 150ms cubic-bezier(0, -0.25, 0.25, 1);
 }
 
 .jw-icon {
-    .rect(24px, 100%);
+    .square(44px);
     background-color: transparent;
 }
 
@@ -103,5 +100,26 @@
         .jw-svg-icon-dvr {
             display: none;
         }
+    }
+}
+
+.jw-settings-menu .jw-icon,
+.jw-icon-settings,
+.jw-icon-volume {
+    &::after {
+        &:extend(._pseudo, ._bottomleft, ._right);
+        .rect(24px, 100%);
+        box-shadow: inset 0 -3px 0 -1px currentColor;
+        margin: auto;
+        opacity: 0;
+        transition: opacity 150ms cubic-bezier(0, -0.25, 0.25, 1);
+    }
+}
+
+.jw-settings-menu .jw-icon.jw-button-color[aria-checked="true"],
+.jw-settings-open .jw-icon-settings,
+.jw-icon-volume.jw-open {
+    &::after {
+        opacity: 1;
     }
 }

--- a/src/css/controls/imports/icons.less
+++ b/src/css/controls/imports/icons.less
@@ -116,10 +116,13 @@
     }
 }
 
-.jw-settings-menu .jw-icon.jw-button-color[aria-checked="true"],
+// Stylelint doesn't seem to like this list of selectors for no apparent reason https://github.com/stylelint/stylelint/issues/1741
+// stylelint-disable indentation
+.jw-settings-menu .jw-icon[aria-checked="true"],
 .jw-settings-open .jw-icon-settings,
 .jw-icon-volume.jw-open {
     &::after {
         opacity: 1;
     }
 }
+// stylelint-enable indentation

--- a/src/css/controls/imports/settings-menu.less
+++ b/src/css/controls/imports/settings-menu.less
@@ -34,10 +34,19 @@
     }
 
     .jw-icon.jw-button-color {
-        &:extend(.jw-controlbar .jw-icon.jw-button-color all);
+        &::after {
+            &:extend(._pseudo, ._bottomleft, ._right);
+            .rect(24px, 100%);
+            box-shadow: inset 0 -3px 0 -1px currentColor;
+            margin: auto;
+            opacity: 0;
+            transition: opacity 150ms cubic-bezier(0, -0.25, 0.25, 1);
+        }
 
-        &[aria-checked="true"] .jw-svg-icon {
-            box-shadow: inset 0 -2px 0 -1px currentColor;
+        &[aria-checked="true"] {
+            &::after {
+                opacity: 1;
+            }
         }
     }
 }
@@ -80,7 +89,7 @@
 }
 
 .jw-settings-content-item {
-    color: #d2d2d2;
+    color: @inactive-color;
     width: 100%;
     font-size: 12px;
     line-height: 1;
@@ -90,6 +99,10 @@
     &.jw-settings-item-active {
         color: #fff;
         font-weight: bold;
+    }
+
+    &:hover {
+        color: @hover-color;
     }
 }
 
@@ -111,12 +124,13 @@
     }
 
     .jw-icon-settings {
-        .jw-svg-icon-settings {
-            &:extend(.jw-controlbar .jw-icon:hover .jw-svg-icon all);
-        }
-
         &::after {
-            content: none;
+            opacity: 1;
         }
+    }
+
+    .jw-tooltip-settings,
+    .jw-tooltip-captions {
+        display: none;
     }
 }

--- a/src/css/controls/imports/slider.less
+++ b/src/css/controls/imports/slider.less
@@ -112,7 +112,7 @@
 
 .jw-slider-time {
     .rect(100%, 16px);
-    align-items: flex-end;
+    align-items: center;
     background: transparent none;
     padding: 0 12px;
     z-index: 1;

--- a/src/css/controls/imports/slider.less
+++ b/src/css/controls/imports/slider.less
@@ -134,7 +134,8 @@
         width: 6px;
     }
 
-    &:hover {
+    &:hover,
+    .jw-flag-touch & {
         .jw-rail,
         .jw-buffer,
         .jw-progress,
@@ -152,7 +153,8 @@
     }
 
     &:hover,
-    .jw-flag-dragging & {
+    .jw-flag-dragging &,
+    .jw-flag-touch & {
         .jw-knob {
             transform: translate(-50%, -50%) scale(1);
         }

--- a/src/css/controls/imports/tooltip.less
+++ b/src/css/controls/imports/tooltip.less
@@ -12,7 +12,7 @@
 }
 
 .jw-volume-tip {
-    padding: @default-em-size 0;
+    padding: @slider-fixed-knob-height 0 (@slider-fixed-knob-height * 2);
 }
 
 .jw-time-tip {
@@ -28,7 +28,7 @@
     &::after {
         &:extend(._pseudo);
         .topleft(100%, 50%);
-        .square((@tooltip-arrow-size * 2));
+        .square(@tooltip-arrow-size);
         border-radius: 1px;
         background-color: currentColor;
         transform-origin: 75% 50%;
@@ -43,7 +43,7 @@
         font-size: @tooltip-font-size;
         height: auto;
         line-height: 1;
-        padding: @tooltip-arrow-size @tooltip-font-size;
+        padding: (@tooltip-arrow-size / 2) @tooltip-font-size;
         display: inline-block;
         min-width: 100%;
         vertical-align: middle;
@@ -120,7 +120,7 @@
     .rect(0, auto);
     line-height: normal;
     padding: 0;
-    bottom: @slider-fixed-knob-height;
+    bottom: 100%;
     user-select: none;
 
     .jw-overlay {

--- a/src/css/controls/imports/tooltip.less
+++ b/src/css/controls/imports/tooltip.less
@@ -154,12 +154,6 @@
     }
 }
 
-.jw-settings-open & {
-    .jw-tooltip-settings {
-        display: none;
-    }
-}
-
 .jw-flag-small-player .jw-time-thumb {
     display: none;
 }

--- a/src/css/shared-imports/vars.less
+++ b/src/css/shared-imports/vars.less
@@ -86,7 +86,7 @@
 @volume-border-radius: 0;
 
 // Text tooltip
-@tooltip-arrow-size: 7px;
+@tooltip-arrow-size: 14px;
 @tooltip-background-color: @white;
 @tooltip-color: @black;
 @tooltip-font-size: 10px;

--- a/src/js/view/utils/skin.js
+++ b/src/js/view/utils/skin.js
@@ -180,7 +180,8 @@ export function handleColorOverrides(playerId, skin = {}) {
         addStyle([
             '.jw-option.jw-active-option',
             '.jw-option:not(.jw-active-option):hover',
-            '.jw-settings-item-active'
+            '.jw-settings-item-active',
+            '.jw-settings-content-item:hover'
         ], 'color', config.textActive);
 
         addStyle([


### PR DESCRIPTION
### This PR will...
* Allow for reduced hand-eye coordination when interacting with the time slider
* Only apply the icon underline to icons that have sub-controls (Volume and Gear)
* Improve hover and active states for submenu items and control bar icons

### Are there any Pull Requests open in other repos which need to be merged with this?
#2306

#### Addresses Issue(s):

JW8-383
JW8-384
JW8-386
JW8-392
