### PR TITLE
Switch gradient back to pseudo element

### DIFF
--- a/src/css/controls/flags/ads.less
+++ b/src/css/controls/flags/ads.less
@@ -11,14 +11,6 @@
         display: none;
     }
 
-    .jw-controls {
-        z-index: auto;
-
-        &::after {
-            bottom: (@mobile-touch-target + @rail-height);
-        }
-    }
-
     /* captions styles code specific to native text track rendering */
     video::-webkit-media-text-track-container {
         display: none;

--- a/src/css/controls/imports/jwplayerlayout.less
+++ b/src/css/controls/imports/jwplayerlayout.less
@@ -12,10 +12,15 @@
 }
 
 .jw-controls {
-    background: svg-gradient(to bottom, transparent, fade(@black, 40%) 77%, fade(@black, 40%) 100%) 100% 100% / 100% 240px no-repeat transparent;
     overflow: hidden;
-    transition: opacity 250ms @default-timing-function;
     z-index: 0;
+
+    &::after {
+        &:extend(._pseudo, ._stretch, ._topleft);
+        background: linear-gradient(to bottom, transparent, fade(@black, 40%) 77%, fade(@black, 40%) 100%) 100% 100% / 100% 240px no-repeat transparent;
+        transition: opacity 250ms @default-timing-function;
+        z-index: -1;
+    }
 
     .jw-flag-small-player & {
         text-align: center;

--- a/src/css/controls/states.less
+++ b/src/css/controls/states.less
@@ -56,8 +56,8 @@
         }
     }
 
-    &.jw-flag-user-inactive:not(.jw-flag-ads):not(.jw-flag-audio-player):not(.jw-flag-casting):not(.jw-flag-media-audio):not(.jw-flag-nextup) {
-        .jw-controls {
+    &.jw-flag-user-inactive:not(.jw-flag-audio-player):not(.jw-flag-casting):not(.jw-flag-media-audio) {
+        .jw-controls::after {
             opacity: 0;
         }
 


### PR DESCRIPTION
### This PR will...
Switch the controls gradient to use an `::after` pseudoelement

### Why is this Pull Request needed?
We kept running into too many weird flag-specific bugs when the gradient was applied as a background image on the `.jw-controls` element and this method allows us to control the gradient and the controlbar states independently.

#### Addresses Issue(s):

JW8-397

