### PR TITLE
Timeslider Tooltip improvements

### DIFF
--- a/src/css/controls/imports/display.less
+++ b/src/css/controls/imports/display.less
@@ -110,6 +110,7 @@ display icons
     }
 }
 
+.jw-breakpoint-2,
 .jw-breakpoint-3 {
     .jw-display .jw-icon,
     .jw-display .jw-svg-icon {

--- a/src/js/view/controls/components/thumbnails.mixin.js
+++ b/src/js/view/controls/components/thumbnails.mixin.js
@@ -61,6 +61,7 @@ const ThumbnailsMixin = {
                 url = matched[1];
                 style.backgroundPosition = (matched[2] * -1) + 'px ' + (matched[3] * -1) + 'px';
                 style.width = matched[4];
+                this.timeTip.setWidth(+style.width);
                 style.height = matched[5];
             } catch (e) {
                 // this.vttFailed('Could not parse thumbnail');
@@ -82,7 +83,8 @@ const ThumbnailsMixin = {
     },
 
     showThumbnail: function(seconds) {
-        if (this.thumbnails.length < 1) {
+        // Don't attempt to set thumbnail for small players or when a thumbnail doesn't exist
+        if (this._model.get('containerWidth') <= 420 || this.thumbnails.length < 1) {
             return;
         }
         this.timeTip.image(this.loadThumbnail(seconds));

--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -43,8 +43,10 @@ class TimeTip extends Tooltip {
     }
 
     setWidth (width) {
+        const tolerance = 16; // add a little padding so the tooltip isn't flush against the edge
+
         if (width) {
-            this.containerWidth = width + 16; // add a little padding so the image isn't flush against the edge
+            this.containerWidth = width + tolerance;
             return;
         }
 
@@ -52,7 +54,7 @@ class TimeTip extends Tooltip {
             return;
         }
 
-        this.containerWidth = utils.bounds(this.container).width;
+        this.containerWidth = utils.bounds(this.container).width + tolerance;
     }
 
     resetWidth () {


### PR DESCRIPTION
### This PR will...
- Set width for Sprited images and text
- Don’t display thumbnails below breakpoint 2
- Make the display icons the same size at breakpoint 2&3 (unrelated bug)
### Why is this Pull Request needed?
When the player is resized and crosses the 1 <> 2 threshold, the width of the tooltip didn't change. This also addresses ensuring the tooltip isn't flush with the edge of the video's container. 

In future, we should address keeping the arrow directly above the pointer. 
### Are there any points in the code the reviewer needs to double check?
No.
### Are there any Pull Requests open in other repos which need to be merged with this?
No.
#### Addresses Issue(s):

JW8-377

