### PR TITLE
Fix core-loader requiresProvider

### DIFF
--- a/src/js/api/core-loader.js
+++ b/src/js/api/core-loader.js
@@ -52,11 +52,11 @@ export function requiresProvider(model, providerName) {
     if (Array.isArray(playlist) && playlist.length) {
         const firstSource = Item(playlist[0]).sources[0];
         if (firstSource) {
-            for (let i = ProvidersSupported.length; i--;) {
-                const providerSupports = ProvidersSupported[i];
-                if (providerSupports.name === providerName) {
-                    const providersManager = model.getProviders();
-                    return providersManager.providerSupports(providerSupports, firstSource);
+            const providersManager = model.getProviders();
+            for (let i = 0; i < ProvidersSupported.length; i++) {
+                const provider = ProvidersSupported[i];
+                if (providersManager.providerSupports(provider, firstSource)) {
+                    return (provider.name === providerName);
                 }
             }
         }


### PR DESCRIPTION
### This PR will...

Fix an issue in core-loader where the html5 provider would be included in the core bundle when hlsjs (a higher priority provider) should be used.
