### PR TITLE
Title Text Improvements

### DIFF
--- a/src/css/jwplayer/imports/title.less
+++ b/src/css/jwplayer/imports/title.less
@@ -25,21 +25,19 @@
     font-size: 1.625em;
 }
 
-.jw-flag-small-player {
-    .jw-title {
-        background: linear-gradient(180deg, fade(mix(#000, #fff, 80%), 75%), fade(mix(#000, #fff, 80%), 0%));
-        height: auto;
-        padding: @default-em-size 0;
+.jw-breakpoint-3,
+.jw-breakpoint-2 {
+    .jw-title-primary {
+        font-size: 1.5em;
     }
+}
 
-    .jw-title-primary,
-    .jw-title-secondary {
-        min-height: inherit;
-        padding: 0 @default-em-size;
+.jw-flag-small-player {
+    .jw-title-primary {
+        font-size: 1.25em;
     }
 
     .jw-title-secondary {
         display: none;
-        margin-top: 5px;
     }
 }

--- a/src/templates/error.js
+++ b/src/templates/error.js
@@ -2,7 +2,7 @@ export default (id, title = '', body = '') => {
     return (
         `<div id="${id}" class="jw-error jw-reset">` +
             `<div class="jw-title jw-reset" style="font-size:16px;color:#fff;">` +
-                `<div class="jw-title-primary jw-reset" style="padding:.75em 1.5em;">${title}</div>` +
+                `<div class="jw-title-primary jw-reset" style="padding:.75em 1.5em; width: auto;">${title}</div>` +
                 `<div class="jw-title-secondary jw-reset">${body}</div>` +
             `</div>` +
             `<div class="jw-display-container jw-reset">` +


### PR DESCRIPTION
### This PR will...

- Fit error template text within the container
- Scale title text down at breakpoints 3, 2 and 1, 0
### Why is this Pull Request needed?
Error text should be styled in line to fit within the player's container whether controls are loaded or not. This ensures the text doesn't get cut off or truncated with ellipses.
Text size was not being scaled at different player breakpoints.
### Are there any points in the code the reviewer needs to double check?
No.
### Are there any Pull Requests open in other repos which need to be merged with this?
No.
#### Addresses Issue(s):
JW8-99

