### PR TITLE
Move logo up when the control bar is visible

### DIFF
--- a/src/css/controls/imports/controlbar.less
+++ b/src/css/controls/imports/controlbar.less
@@ -15,7 +15,7 @@
     background-size: auto;
     box-shadow: none;
     max-height: 72px;
-    transition: 250ms cubic-bezier(0, -0.25, 0.25, 1);
+    transition: 250ms @default-timing-function;
     transition-property: opacity, visibility;
     transition-delay: 0s;
 

--- a/src/css/controls/imports/icons.less
+++ b/src/css/controls/imports/icons.less
@@ -112,7 +112,7 @@
         box-shadow: inset 0 -3px 0 -1px currentColor;
         margin: auto;
         opacity: 0;
-        transition: opacity 150ms cubic-bezier(0, -0.25, 0.25, 1);
+        transition: opacity 150ms @default-timing-function;
     }
 }
 

--- a/src/css/controls/imports/jwplayerlayout.less
+++ b/src/css/controls/imports/jwplayerlayout.less
@@ -14,7 +14,7 @@
 .jw-controls {
     background: svg-gradient(to bottom, transparent, fade(@black, 40%) 77%, fade(@black, 40%) 100%) 100% 100% / 100% 240px no-repeat transparent;
     overflow: hidden;
-    transition: opacity 250ms cubic-bezier(0, -0.25, 0.25, 1);
+    transition: opacity 250ms @default-timing-function;
     z-index: 0;
 
     .jw-flag-small-player & {

--- a/src/css/controls/imports/settings-menu.less
+++ b/src/css/controls/imports/settings-menu.less
@@ -40,7 +40,7 @@
             box-shadow: inset 0 -3px 0 -1px currentColor;
             margin: auto;
             opacity: 0;
-            transition: opacity 150ms cubic-bezier(0, -0.25, 0.25, 1);
+            transition: opacity 150ms @default-timing-function;
         }
 
         &[aria-checked="true"] {

--- a/src/css/controls/imports/slider.less
+++ b/src/css/controls/imports/slider.less
@@ -35,7 +35,7 @@
     pointer-events: none;
     position: absolute;
     transform: translate(-50%, -50%) scale(0);
-    transition: 150ms cubic-bezier(0, -0.25, 0.25, 1);
+    transition: 150ms @default-timing-function;
     transition-property: opacity, transform;
 
     .jw-flag-dragging .jw-slider-time &,

--- a/src/css/controls/imports/tooltip.less
+++ b/src/css/controls/imports/tooltip.less
@@ -57,7 +57,7 @@
         min-height: @mobile-touch-target;
         min-width: @mobile-touch-target;
         opacity: 0;
-        transition: 150ms cubic-bezier(0, -0.25, 0.25, 1);
+        transition: 150ms @default-timing-function;
         transition-property: opacity, visibility;
         transition-delay: 0s, 150ms;
         transform: translate(-50%, 0);
@@ -95,7 +95,7 @@
         .bottomleft(100%, 50%);
         opacity: 0;
         transform: translate(-50%, 0);
-        transition: 100ms 0s cubic-bezier(0, -0.25, 0.25, 1);
+        transition: 100ms 0s @default-timing-function;
         transition-property: opacity, transform, visibility;
         visibility: hidden;
         white-space: nowrap;

--- a/src/css/controls/states.less
+++ b/src/css/controls/states.less
@@ -200,7 +200,7 @@ body .jwplayer.jw-state-error.jw-flag-audio-player {
 
 // Hide control bar
 body .jwplayer.jw-state-error,
-.jwplayer.jw-state-idle:not(.jw-flag-audio-player):not(.jw-flag-casting):not(.jw-flag-cast-available) {
+.jwplayer.jw-state-idle:not(.jw-flag-audio-player):not(.jw-flag-cast-available) {
     .jw-controlbar {
         display: none;
     }

--- a/src/css/controls/states.less
+++ b/src/css/controls/states.less
@@ -60,6 +60,11 @@
         .jw-controls {
             opacity: 0;
         }
+
+        .jw-logo-bottom-left,
+        .jw-logo-bottom-right {
+            bottom: 0;
+        }
     }
 }
 
@@ -206,6 +211,11 @@ body .jwplayer.jw-state-error,
 
     .jw-display {
         padding: 0;
+    }
+
+    .jw-logo-bottom-left,
+    .jw-logo-bottom-right {
+        bottom: 0;
     }
 }
 

--- a/src/css/jwplayer/imports/logo.less
+++ b/src/css/jwplayer/imports/logo.less
@@ -39,6 +39,6 @@
 
 .jw-logo-bottom-left,
 .jw-logo-bottom-right {
-    bottom: 44px;
-    transition: bottom 150ms cubic-bezier(0, -0.25, 0.25, 1);
+    bottom: @mobile-touch-target;
+    transition: bottom 150ms @default-timing-function;
 }

--- a/src/css/jwplayer/imports/logo.less
+++ b/src/css/jwplayer/imports/logo.less
@@ -30,11 +30,15 @@
 }
 
 .jw-logo-bottom-left {
-    bottom: 0;
     left: 0;
 }
 
 .jw-logo-bottom-right {
-    bottom: 0;
     right: 0;
+}
+
+.jw-logo-bottom-left,
+.jw-logo-bottom-right {
+    bottom: 44px;
+    transition: bottom 150ms cubic-bezier(0, -0.25, 0.25, 1);
 }

--- a/src/css/shared-imports/vars.less
+++ b/src/css/shared-imports/vars.less
@@ -108,3 +108,6 @@
 @menu-background-color: lighten(@black, 20%);
 @menu-color: fade(@white, 90%);
 @menu-active-color: @white;
+
+// Transition animation
+@default-timing-function: cubic-bezier(0, -0.25, 0.25, 1);


### PR DESCRIPTION

### This PR will...

- Move the logo up when the control bar is visible if it's positioned in the bottom-right or bottom-left
- Add var for transition function 
- Remove `jw-flag-casting` from control bar visibility rule since `jw-flag-cast-available` is always present whether casting or not

### Why is this Pull Request needed?
The logo may be a link and shouldn't obscure other controls.
### Are there any points in the code the reviewer needs to double check?
No.
### Are there any Pull Requests open in other repos which need to be merged with this?
No.
#### Addresses Issue(s):
JW8-243
