### PR TITLE
Fixed nextUp tooltip text 

### DIFF
--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -257,7 +257,7 @@ export default class Controlbar {
         _model.on('change:captionsList', onCaptionsChanged, this);
         _model.change('nextUp', (model, nextUp) => {
             let tipText = localization.nextUp;
-            if (nextUp) {
+            if (nextUp && nextUp.title) {
                 tipText = (`NEXT: ${nextUp.title}`);
             }
             nextUpTip.setText(tipText);


### PR DESCRIPTION
### This PR will...
Render a generic tooltip message when no title is found in nextUp object.

### Why is this Pull Request needed?
Right now the text renders a colon with empty whitespace in anticipation for the title which does not exist.

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-413

