### PR TITLE
Fix Android version HLS html5 support check

### DIFF
--- a/src/js/providers/html5-android-hls.js
+++ b/src/js/providers/html5-android-hls.js
@@ -7,7 +7,7 @@ export function isAndroidHls(source) {
         }
 
         // Allow Android hls playback on versions 4.1 and above, excluding Firefox (which does not support HLS in any version)
-        return OS.version.major >= 4 && OS.version.minor >= 1 && !Browser.firefox;
+        return !Browser.firefox && parseFloat(OS.version.version) >= 4.1;
     }
     return null;
 }


### PR DESCRIPTION
Fixes a regression that cause Android versions with minor revision "0" (ex: 6.0) from choosing the html5 provider for HLS playback.

#### Addresses Issue(s):

JW8-391
