### PR TITLE
Fix iOS check regression in HTML5 provider

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -278,7 +278,7 @@ function VideoProvider(_playerId, _playerConfig) {
 
     function _sendBufferFull() {
         // Wait until the canplay event on iOS to send the bufferFull event
-        if (!_bufferFull && (OS.iOS || _canPlay)) {
+        if (!_bufferFull && (!OS.iOS || _canPlay)) {
             _bufferFull = true;
             _canPlay = false;
             _this.trigger(MEDIA_BUFFER_FULL);


### PR DESCRIPTION
### This PR will...

Prevent "bufferFull" event from being sent on iOS from html5 provider before canPlay https://github.com/jwplayer/jwplayer/commit/22f1139d4409aea3799603f9c3f02f52972f254b

### Why is this Pull Request needed?

The iOS check was negated when we refactored the environment utils here https://github.com/jwplayer/jwplayer/commit/9683d3fa7fe2202b8d7a31579e112abcee43ed3d#diff-516afba75eaadc497dca75d8c83b0fe6L289

#### Addresses Issue(s):

JW8-###

