### PR TITLE
Button improvements

### DIFF
--- a/src/js/view/controls/components/button.js
+++ b/src/js/view/controls/components/button.js
@@ -20,6 +20,12 @@ export default function (icon, apiAction, ariaText, svgIcons) {
         });
     }
 
+    // Prevent button from being focused on mousedown so that the tooltips don't remain visible until
+    // the user interacts with another element on the page
+    element.addEventListener('mousedown', (e) => {
+        e.preventDefault();
+    });
+
     if (svgIcons && svgIcons.length > 0) {
         svgIcons.forEach((svgIcon) => {
             element.appendChild(svgParse(svgIcon));

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -203,6 +203,7 @@ export default class Controlbar {
         const nextUpTip = SimpleTooltip(elements.next.element(), 'next', localization.nextUp);
         SimpleTooltip(elements.rewind.element(), 'rewind', localization.rewind);
         SimpleTooltip(elements.settingsButton.element(), 'settings', localization.settings);
+        SimpleTooltip(elements.fullscreen.element(), 'fullscreen', localization.fullscreen);
 
         // Filter out undefined elements
         const buttonLayout = [

--- a/src/js/view/controls/templates/custom-button.js
+++ b/src/js/view/controls/templates/custom-button.js
@@ -6,11 +6,11 @@ export default (buttonClass = '', buttonId = '', image = '', ariaText) => {
     } else {
         const style = image ? `style="background-image: url(${image})"` : '';
         const imageClass = image ? 'jw-button-image' : 'jw-button-image';
-        const aria = ariaText ? `aria-label="${ariaText}" role="button" tabindex="0"` : '';
+        const aria = ariaText ? `aria-label="${ariaText}"` : '';
         imageDiv = `<div class="jw-icon ${imageClass} jw-button-color jw-reset" ${style} ${aria}></div>`;
     }
     return (
-        `<div class="jw-icon jw-icon-inline jw-button-color jw-reset ${buttonClass}" button="${buttonId}">
+        `<div class="jw-icon jw-icon-inline jw-button-color jw-reset ${buttonClass}" button="${buttonId}" role="button" tabindex="0">
             ${imageDiv}
         </div>`
     );

--- a/src/js/view/controls/templates/nextup.js
+++ b/src/js/view/controls/templates/nextup.js
@@ -10,7 +10,7 @@ export default (header = '', title = '', closeAriaLabel = '') => {
                     `<div class="jw-nextup-title jw-reset">${title}</div>` +
                 `</div>` +
             `</div>` +
-            `<button class="jw-icon jw-nextup-close jw-reset" aria-label="${closeAriaLabel}">${CLOSE_ICON}</button>` +
+            `<button type="button" class="jw-icon jw-nextup-close jw-reset" aria-label="${closeAriaLabel}">${CLOSE_ICON}</button>` +
         `</div>`
     );
 };

--- a/src/js/view/controls/templates/settings/content-item.js
+++ b/src/js/view/controls/templates/settings/content-item.js
@@ -1,6 +1,6 @@
 export default (content) => {
     return (
-        `<button class="jw-reset jw-settings-content-item" role="menuitemradio" aria-checked="false">` +
+        `<button type="button" class="jw-reset jw-settings-content-item" role="menuitemradio" aria-checked="false">` +
             `${content}` +
         `</button>`
     );


### PR DESCRIPTION
### This PR will...

- Add tooltip for Fullscreen Icon
- Add button role and tabIndex to the correct element for custom buttons 
- Add `type="button"` to buttons so they don’t cause a form to be submitted when clicked
- Prevent default behavior on `mousedown` that causes the element to show its tooltip until the user interacts with another element on the page
### Why is this Pull Request needed?
- Fullscreen was lacking a tooltip.
- Some buttons were missing tabbing functionality.
- By default, a button's type is `submit`, which results in forms being submitted. 
- We want elements to be in focus when tabbing through them, but when using a mouse, hover suffices to let the user know what element they're on. By preventing the default `mousedown` behavior, an element wont stay in focus after a click, which ensures multiple tooltips aren't open at the same time.
### Are there any points in the code the reviewer needs to double check?
Maybe double check mobile interactivity and all button behavior.
### Are there any Pull Requests open in other repos which need to be merged with this?
No.
#### Addresses Issue(s):

JW8-364
JW8-385

