### PR TITLE
Audiotracks and levels now use .change instead of on.('change')

### DIFF
--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -361,7 +361,7 @@ export default class Controls {
 
         model.change('mediaModel', (newModel, mediaModel) => {
             // Quality Levels
-            mediaModel.on('change:levels', (changedModel, levels) => {
+            mediaModel.change('levels', (changedModel, levels) => {
                 if (!levels || levels.length <= 1) {
                     removeQualitiesSubmenu(settingsMenu);
                     return;
@@ -393,12 +393,10 @@ export default class Controls {
                     mediaModel.get('currentAudioTrack')
                 );
             };
-            mediaModel.on('change:audioTracks', onAudiotracksChange);
+            mediaModel.change('audioTracks', onAudiotracksChange);
             mediaModel.on('change:currentAudioTrack', (changedModel, currentAudioTrack) => {
                 activateSubmenuItem('audioTracks', currentAudioTrack);
             });
-            // change:audioTracks does not get triggered if the next item has no tracks, so trigger it every time the mediaModel changes (i.e. we're on a new item)
-            onAudiotracksChange(newModel, mediaModel.get('audioTracks'));
         });
 
         // Captions


### PR DESCRIPTION
### This PR will...
Ensure that setControls renders all desired control bar elements

### Why is this Pull Request needed?
Right now, setting setControls to false and then true doesn't render the quality levels setting or the audio tracks setting. 
### Are there any points in the code the reviewer needs to double check?
No
### Are there any Pull Requests open in other repos which need to be merged with this?
No
#### Addresses Issue(s):

JW8-190

