### PR TITLE
Prevent button focus on click for custom buttons

### DIFF
--- a/src/js/view/controls/components/custom-button.js
+++ b/src/js/view/controls/components/custom-button.js
@@ -15,6 +15,12 @@ export default class CustomButton {
 
         new UI(buttonElement).on('click tap', callback, this);
 
+        // Prevent button from being focused on mousedown so that the tooltips don't remain visible until
+        // the user interacts with another element on the page
+        buttonElement.addEventListener('mousedown', (e) => {
+            e.preventDefault();
+        });
+
         this.id = id;
         this.buttonElement = buttonElement;
     }


### PR DESCRIPTION
### This PR will...
Apply the same fix that worked for other buttons in the player.
### Why is this Pull Request needed?
Buttons created via `api.addButton` still had the focus issue. 
### Are there any points in the code the reviewer needs to double check?
No.
### Are there any Pull Requests open in other repos which need to be merged with this?
No.
#### Addresses Issue(s):

JW8-385


