### PR TITLE
Include jwplayer.defaults in compatibility script

### DIFF
--- a/src/js/compatibility.js
+++ b/src/js/compatibility.js
@@ -154,6 +154,7 @@
         jwplayerCompatible.utils = utils;
         jwplayerCompatible.version = playerLibrary.version;
         jwplayerCompatible.vid = playerLibrary.vid;
+        jwplayerCompatible.defaults = playerLibrary.defaults;
 
         /*
             In JW8 we've removed the jwplayer.events.JWPLAYER_* events, as well as the jwplayer.events.states.* states.


### PR DESCRIPTION
### This PR will...

Add `jwplayer.defaults` to the updated `jwplayer` library when the compatibility script is added after a libraries script.

### Why is this Pull Request needed?

libraries/ end-point includes jwplayer.js which defines `jwplayer` followed by `jwplayer.defaults`, default setup config settings. Since the compatibility script replaces `jwplayer`, `jwplayer.defaults` needs to be added to the replacement.

### Are there any points in the code the reviewer needs to double check?

I noticed this was needed while doing some JW8 mapping of v7 libraries on websites using the player.