### PR TITLE
Apply hover color to focus state

### DIFF
--- a/src/css/controls/imports/settings-menu.less
+++ b/src/css/controls/imports/settings-menu.less
@@ -97,11 +97,12 @@
     cursor: pointer;
 
     &.jw-settings-item-active {
-        color: #fff;
+        color: @active-color;
         font-weight: bold;
     }
 
-    &:hover {
+    &:hover,
+    &:focus {
         color: @hover-color;
     }
 }


### PR DESCRIPTION
### This PR will...
Apply the hover color to the focus state.
### Why is this Pull Request needed?
The sharing items needed to apply styles that should be handled by the generic `jw-settings-content-item` class.
### Are there any points in the code the reviewer needs to double check?
No.
### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/4000
#### Addresses Issue(s):
JW8-421

