### PR TITLE
Logo placement and Sharing menu fixes

### DIFF
--- a/src/css/jwplayer/imports/logo.less
+++ b/src/css/jwplayer/imports/logo.less
@@ -42,3 +42,7 @@
     bottom: @mobile-touch-target;
     transition: bottom 150ms @default-timing-function;
 }
+
+.jw-state-idle .jw-logo {
+    z-index: 1;
+}

--- a/src/js/view/controls/components/settings/menu.js
+++ b/src/js/view/controls/components/settings/menu.js
@@ -9,7 +9,7 @@ export function SettingsMenu(onVisibility, onSubmenuAdded, onMenuEmpty) {
         // Let the display (jw-video) handles closing itself (display clicks do not pause if the menu is open)
         // Don't close if the user has dismissed the nextup tooltip via it's close button (the tooltip overlays the menu)
         const targetClass = e.target.className;
-        if (!targetClass.match(/jw-(settings|video|nextup-close)/)) {
+        if (!targetClass.match(/jw-(settings|video|nextup-close|sharing-link)/)) {
             instance.close();
         }
     };


### PR DESCRIPTION
### This PR will...
- Place logo above controls overlay in idle state
- Don’t close the settings menu when sharing links are clicked
### Why is this Pull Request needed?
- The logo was obscured by the controls overlay in the idle state.
- The settings menu would close when you click to get the link or the embed code, so there was no visual notification that the action succeeded.
### Are there any points in the code the reviewer needs to double check?
Testing on mobile. Seems fine on iOS devices, but I have no other devices to test on.
### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/4004
#### Addresses Issue(s):
JW8-434
JW8-361

