### PR TITLE
Use background color for time slider cues

### DIFF
--- a/src/css/controls/imports/slider.less
+++ b/src/css/controls/imports/slider.less
@@ -128,7 +128,7 @@
     }
 
     .jw-cue {
-        background-color: @accent-color;
+        background-color: @background-color;
         cursor: pointer;
         position: relative;
         width: 6px;

--- a/src/js/view/utils/skin.js
+++ b/src/js/view/utils/skin.js
@@ -1,3 +1,4 @@
+import _ from 'utils/underscore';
 import { prefix } from 'utils/strings';
 import { css } from 'utils/css';
 
@@ -78,14 +79,23 @@ export function handleColorOverrides(playerId, skin = {}) {
     // These will use standard style names for CSS since they are added directly to a style sheet
     // Using background instead of background-color so we don't have to clear gradients with background-image
 
-    styleControlbar(skin.controlbar);
-    styleTimeslider(skin.timeslider);
-    styleMenus(skin.menus);
-    styleTooltips(skin.tooltips);
+    if (_.size(skin.controlbar)) {
+        styleControlbar(skin.controlbar);
+    }
+    if (_.size(skin.timeslider)) {
+        styleTimeslider(skin.timeslider);
+    }
+    if (_.size(skin.menus)) {
+        styleMenus(skin.menus);
+    }
+    if (_.size(skin.tooltips)) {
+        styleTooltips(skin.tooltips);
+    }
 
     insertGlobalColorClasses(skin.menus);
 
-    function styleControlbar(config = {}) {
+    function styleControlbar(config) {
+
         addStyle([
             // controlbar text colors
             '.jw-controlbar .jw-text',
@@ -120,7 +130,6 @@ export function handleColorOverrides(playerId, skin = {}) {
         if (config.icons) {
             css('.jw-icon-cast button.jw-off', `{--disconnected-color: ${config.icons}}`, playerId);
         }
-
         if (config.iconsActive) {
             css('.jw-icon-cast:hover button.jw-off', `{--disconnected-color: ${config.iconsActive}}`, playerId);
             css('.jw-icon-cast button.jw-off:focus', `{--disconnected-color: ${config.iconsActive}}`, playerId);
@@ -135,25 +144,21 @@ export function handleColorOverrides(playerId, skin = {}) {
         ], 'background', config.background);
     }
 
-    function styleTimeslider(config = {}) {
-        if (config.progress) {
-            addStyle([
-                '.jw-progress',
-                '.jw-buffer',
-                '.jw-knob'
-            ], 'background', 'none ' + config.progress);
+    function styleTimeslider(config) {
 
-            // Buffer uses the same color as progress, but is distinguished by opacity
-            addStyle([
-                '.jw-buffer',
-            ], 'opacity', 0.4);
-        }
+        addStyle([
+            '.jw-progress',
+            '.jw-buffer',
+            '.jw-knob'
+        ], 'background', 'none ' + config.progress);
 
-        if (config.rail) {
-            addStyle([
-                '.jw-rail'
-            ], 'background', 'none ' + config.rail);
-        }
+        addStyle([
+            '.jw-buffer',
+        ], 'opacity', 0.5);
+
+        addStyle([
+            '.jw-rail'
+        ], 'background', 'none ' + config.rail);
 
         addStyle([
             '.jw-background-color.jw-slider-time',
@@ -161,7 +166,8 @@ export function handleColorOverrides(playerId, skin = {}) {
         ], 'background', config.background);
     }
 
-    function styleMenus(config = {}) {
+    function styleMenus(config) {
+
         addStyle([
             '.jw-option',
             '.jw-toggle.jw-off',
@@ -194,7 +200,8 @@ export function handleColorOverrides(playerId, skin = {}) {
         }
     }
 
-    function styleTooltips(config = {}) {
+    function styleTooltips(config) {
+
         addStyle([
             '.jw-skip',
             '.jw-tooltip .jw-text',
@@ -206,11 +213,9 @@ export function handleColorOverrides(playerId, skin = {}) {
             '.jw-tooltip'
         ], 'color', config.background);
 
-        if (config.background) {
-            addStyle([
-                '.jw-skip',
-            ], 'border', 'none');
-        }
+        addStyle([
+            '.jw-skip',
+        ], 'border', 'none');
 
         addStyle([
             '.jw-skip .jw-text',
@@ -232,7 +237,6 @@ export function handleColorOverrides(playerId, skin = {}) {
             css('#' + playerId + ' .jw-color-active', activeColorSet, playerId);
             css('#' + playerId + ' .jw-color-active-hover:hover', activeColorSet, playerId);
         }
-
         if (config.text) {
             const inactiveColorSet = {
                 color: config.text,

--- a/src/js/view/utils/skin.js
+++ b/src/js/view/utils/skin.js
@@ -85,7 +85,7 @@ export function handleColorOverrides(playerId, skin = {}) {
 
     insertGlobalColorClasses(skin.menus);
 
-    function styleControlbar(config) {
+    function styleControlbar(config = {}) {
         addStyle([
             // controlbar text colors
             '.jw-controlbar .jw-text',
@@ -135,24 +135,25 @@ export function handleColorOverrides(playerId, skin = {}) {
         ], 'background', config.background);
     }
 
-    function styleTimeslider(config) {
-
-        addStyle([
-            '.jw-progress',
-            '.jw-buffer',
-            '.jw-knob'
-        ], 'background', 'none ' + config.progress);
-
+    function styleTimeslider(config = {}) {
         if (config.progress) {
+            addStyle([
+                '.jw-progress',
+                '.jw-buffer',
+                '.jw-knob'
+            ], 'background', 'none ' + config.progress);
+
             // Buffer uses the same color as progress, but is distinguished by opacity
             addStyle([
                 '.jw-buffer',
             ], 'opacity', 0.4);
         }
 
-        addStyle([
-            '.jw-rail'
-        ], 'background', 'none ' + config.rail);
+        if (config.rail) {
+            addStyle([
+                '.jw-rail'
+            ], 'background', 'none ' + config.rail);
+        }
 
         addStyle([
             '.jw-background-color.jw-slider-time',
@@ -160,7 +161,7 @@ export function handleColorOverrides(playerId, skin = {}) {
         ], 'background', config.background);
     }
 
-    function styleMenus(config) {
+    function styleMenus(config = {}) {
         addStyle([
             '.jw-option',
             '.jw-toggle.jw-off',
@@ -193,7 +194,7 @@ export function handleColorOverrides(playerId, skin = {}) {
         }
     }
 
-    function styleTooltips(config) {
+    function styleTooltips(config = {}) {
         addStyle([
             '.jw-skip',
             '.jw-tooltip .jw-text',

--- a/src/js/view/utils/skin.js
+++ b/src/js/view/utils/skin.js
@@ -1,4 +1,3 @@
-import _ from 'utils/underscore';
 import { prefix } from 'utils/strings';
 import { css } from 'utils/css';
 
@@ -79,23 +78,14 @@ export function handleColorOverrides(playerId, skin = {}) {
     // These will use standard style names for CSS since they are added directly to a style sheet
     // Using background instead of background-color so we don't have to clear gradients with background-image
 
-    if (_.size(skin.controlbar)) {
-        styleControlbar(skin.controlbar);
-    }
-    if (_.size(skin.timeslider)) {
-        styleTimeslider(skin.timeslider);
-    }
-    if (_.size(skin.menus)) {
-        styleMenus(skin.menus);
-    }
-    if (_.size(skin.tooltips)) {
-        styleTooltips(skin.tooltips);
-    }
+    styleControlbar(skin.controlbar);
+    styleTimeslider(skin.timeslider);
+    styleMenus(skin.menus);
+    styleTooltips(skin.tooltips);
 
     insertGlobalColorClasses(skin.menus);
 
     function styleControlbar(config) {
-
         addStyle([
             // controlbar text colors
             '.jw-controlbar .jw-text',
@@ -130,6 +120,7 @@ export function handleColorOverrides(playerId, skin = {}) {
         if (config.icons) {
             css('.jw-icon-cast button.jw-off', `{--disconnected-color: ${config.icons}}`, playerId);
         }
+
         if (config.iconsActive) {
             css('.jw-icon-cast:hover button.jw-off', `{--disconnected-color: ${config.iconsActive}}`, playerId);
             css('.jw-icon-cast button.jw-off:focus', `{--disconnected-color: ${config.iconsActive}}`, playerId);
@@ -149,25 +140,27 @@ export function handleColorOverrides(playerId, skin = {}) {
         addStyle([
             '.jw-progress',
             '.jw-buffer',
-            '.jw-slider-time .jw-cue',
             '.jw-knob'
         ], 'background', 'none ' + config.progress);
 
-        addStyle([
-            '.jw-buffer',
-        ], 'opacity', 0.5);
+        if (config.progress) {
+            // Buffer uses the same color as progress, but is distinguished by opacity
+            addStyle([
+                '.jw-buffer',
+            ], 'opacity', 0.4);
+        }
 
         addStyle([
             '.jw-rail'
         ], 'background', 'none ' + config.rail);
 
         addStyle([
-            '.jw-background-color.jw-slider-time'
+            '.jw-background-color.jw-slider-time',
+            '.jw-slider-time .jw-cue'
         ], 'background', config.background);
     }
 
     function styleMenus(config) {
-
         addStyle([
             '.jw-option',
             '.jw-toggle.jw-off',
@@ -201,7 +194,6 @@ export function handleColorOverrides(playerId, skin = {}) {
     }
 
     function styleTooltips(config) {
-
         addStyle([
             '.jw-skip',
             '.jw-tooltip .jw-text',
@@ -213,9 +205,11 @@ export function handleColorOverrides(playerId, skin = {}) {
             '.jw-tooltip'
         ], 'color', config.background);
 
-        addStyle([
-            '.jw-skip',
-        ], 'border', 'none');
+        if (config.background) {
+            addStyle([
+                '.jw-skip',
+            ], 'border', 'none');
+        }
 
         addStyle([
             '.jw-skip .jw-text',
@@ -237,6 +231,7 @@ export function handleColorOverrides(playerId, skin = {}) {
             css('#' + playerId + ' .jw-color-active', activeColorSet, playerId);
             css('#' + playerId + ' .jw-color-active-hover:hover', activeColorSet, playerId);
         }
+
         if (config.text) {
             const inactiveColorSet = {
                 color: config.text,

--- a/test/unit/skin-test.js
+++ b/test/unit/skin-test.js
@@ -16,7 +16,6 @@ describe('Skin Customization', function() {
     });
 
     describe('handleColorOverrides', function() {
-
         let cssStub;
 
         before(function() {
@@ -28,7 +27,7 @@ describe('Skin Customization', function() {
         });
 
         it('should not style any element with an empty config', function() {
-            handleColorOverrides({});
+            handleColorOverrides('id');
 
             expect(cssUtils.css.callCount).to.equal(0);
         });


### PR DESCRIPTION
### This PR will...
- Use background color for time slider cues
- Add custom styles conditionally
### Why is this Pull Request needed?
- We want the player to be monochromatic by default and the cues were blue.
- Styles were being added for a player instance when there were no custom styles specified in the config. Also, `_.size` counts undefined object properties. The `addStyle` function does not add `undefined` styles, so this check was not necessary to begin with.
### Are there any points in the code the reviewer needs to double check?
No.
### Are there any Pull Requests open in other repos which need to be merged with this?
No.
#### Addresses Issue(s):
JW8-428

