### PR TITLE
Raise nextShown event when a user hovers over the next button

### DIFF
--- a/src/js/view/controls/components/simple-tooltip.js
+++ b/src/js/view/controls/components/simple-tooltip.js
@@ -1,7 +1,7 @@
 import SimpleTooltipTemplate from 'view/controls/templates/simple-tooltip';
 import { createElement, addClass, removeClass } from 'utils/dom';
 
-export function SimpleTooltip(attachToElement, name, text) {
+export function SimpleTooltip(attachToElement, name, text, openCallback) {
     const tooltipElement = createElement(SimpleTooltipTemplate(name, text));
     attachToElement.appendChild(tooltipElement);
 
@@ -9,6 +9,10 @@ export function SimpleTooltip(attachToElement, name, text) {
         open() {
             tooltipElement.setAttribute('aria-expanded', 'true');
             addClass(tooltipElement, 'jw-open');
+
+            if (openCallback) {
+                openCallback();
+            }
         },
         close() {
             tooltipElement.setAttribute('aria-expanded', 'false');

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -200,7 +200,17 @@ export default class Controlbar {
             captionsTip.setText(newText);
         };
 
-        const nextUpTip = SimpleTooltip(elements.next.element(), 'next', localization.nextUp);
+        const nextUpTip = SimpleTooltip(elements.next.element(), 'next', localization.nextUp, () => {
+            const nextUp = _model.get('nextUp');
+
+            this.trigger('nextShown', {
+                mode: nextUp.mode,
+                ui: 'nextup',
+                itemsShown: [nextUp],
+                feedData: nextUp.feedData,
+                reason: 'hover'
+            });
+        });
         SimpleTooltip(elements.rewind.element(), 'rewind', localization.rewind);
         SimpleTooltip(elements.settingsButton.element(), 'settings', localization.settings);
         SimpleTooltip(elements.fullscreen.element(), 'fullscreen', localization.fullscreen);
@@ -270,7 +280,7 @@ export default class Controlbar {
         _model.change('nextUp', (model, nextUp) => {
             let tipText = localization.nextUp;
             if (nextUp && nextUp.title) {
-                tipText = (`NEXT: ${nextUp.title}`);
+                tipText += (`: ${nextUp.title}`);
             }
             nextUpTip.setText(tipText);
             elements.next.toggle(!!nextUp);

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -108,6 +108,10 @@ export default class Controls {
         // Controlbar
         const controlbar = this.controlbar = new Controlbar(api, model);
         controlbar.on(USER_ACTION, () => this.userActive());
+        controlbar.on('nextShown', function(data) {
+            this.trigger('nextShown', data);
+        }, this);
+
         // Next Up Tooltip
         if (model.get('nextUpDisplay') && !controlbar.nextUpToolTip) {
             const nextUpToolTip = new NextUpToolTip(model, api, this.playerContainer);
@@ -118,6 +122,7 @@ export default class Controls {
             // NextUp needs to be behind the controlbar to not block other tooltips
             this.div.appendChild(nextUpToolTip.element());
         }
+
         this.addActiveListeners(controlbar.element());
         this.div.appendChild(controlbar.element());
 


### PR DESCRIPTION
### This PR will...
- Raise nextShown event when a user hovers over the next button
- Use localization text for next tooltip
### Why is this Pull Request needed?
The next button's hover state no longer shows the nextUp tooltip - it uses a simple, text-based tooltip. The `nextShown` event was tied to the nextUp tooltip, so the event was no longer being raised on hover. Also, the "NEXT" text should be localized to use the nextUp localization property.
### Are there any points in the code the reviewer needs to double check?
There may be a simpler way to propagate the event from the simple tooltip. Suggestions welcomed.
### Are there any Pull Requests open in other repos which need to be merged with this?
No.
#### Addresses Issue(s):
JW8-433

