### PR TITLE
Fix custom button adding on controls toggle

### DIFF
--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -110,6 +110,11 @@ function reasonInteraction() {
     return { reason: 'interaction' };
 }
 
+function buttonsInFirstNotInSecond(buttonsA, buttonsB) {
+    return buttonsA.filter(a =>
+        !buttonsB.some(b => (b.id + b.btnClass === a.id + a.btnClass) && a.callback === b.callback));
+}
+
 const appendChildren = (container, elements) => {
     elements.forEach(e => {
         if (e.element) {
@@ -534,11 +539,8 @@ export default class Controlbar {
             addedButtons = newButtons;
 
         } else {
-            addedButtons = newButtons.filter(newButton =>
-                !oldButtons.some(oldButton => newButton.id + newButton.btnClass === oldButton.id + oldButton.btnClass));
-
-            removedButtons = oldButtons.filter(oldButton =>
-                !newButtons.some(newButton => newButton.id + newButton.btnClass === oldButton.id + oldButton.btnClass));
+            addedButtons = buttonsInFirstNotInSecond(newButtons, oldButtons);
+            removedButtons = buttonsInFirstNotInSecond(oldButtons, newButtons);
 
             this.removeButtons(buttonContainer, removedButtons);
         }

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -518,16 +518,30 @@ export default class Controlbar {
         }
     }
 
-    updateButtons(model, newButtons = [], oldButtons = []) {
+    updateButtons(model, newButtons, oldButtons) {
+        // If buttons are undefined exit, buttons are only removed if newButtons is an array
+        if (!newButtons) {
+            return;
+        }
+
         const buttonContainer = this.elements.buttonContainer;
 
-        const removedButtons = oldButtons.filter(oldButton =>
-            !newButtons.some(newButton => newButton.id + newButton.btnClass === oldButton.id + oldButton.btnClass));
+        let addedButtons;
+        let removedButtons;
 
-        this.removeButtons(buttonContainer, removedButtons);
+        // On model.change these obects are the same and all buttons need to be added
+        if (newButtons === oldButtons || !oldButtons) {
+            addedButtons = newButtons;
 
-        const addedButtons = newButtons.filter(newButton =>
-            !oldButtons.some(oldButton => newButton.id + newButton.btnClass === oldButton.id + oldButton.btnClass));
+        } else {
+            addedButtons = newButtons.filter(newButton =>
+                !oldButtons.some(oldButton => newButton.id + newButton.btnClass === oldButton.id + oldButton.btnClass));
+
+            removedButtons = oldButtons.filter(oldButton =>
+                !newButtons.some(newButton => newButton.id + newButton.btnClass === oldButton.id + oldButton.btnClass));
+
+            this.removeButtons(buttonContainer, removedButtons);
+        }
 
         for (let i = addedButtons.length - 1; i >= 0; i--) {
             let buttonProps = addedButtons[i];

--- a/test/unit/controlbar-test.js
+++ b/test/unit/controlbar-test.js
@@ -39,15 +39,6 @@ describe('Control Bar', function() {
             expect(children.length).to.equal(2);
         });
 
-        it('should removeButtons before adding any', function() {
-            controlBar.removeButtons = sinon.stub();
-            container.insertBefore = sinon.spy();
-
-            controlBar.updateButtons(model, [{ id: '1' }]);
-
-            expect(controlBar.removeButtons.calledBefore(container.insertBefore)).to.be.true;
-        });
-
         it('should add button after spacer if there is no logo', function() {
             controlBar.updateButtons(model, [{ id: '1' }]);
 


### PR DESCRIPTION
### This PR will...

Ensure that custom buttons are added to the controlbar when controls are reset.

### Why is this Pull Request needed?

`updateButtons` was optimized to not recreate and re-add custom buttons that were already added to the player. This is tracked in the model, but the model doesn't know that controls are removed and recreated each time `setControls()` toggles the controls. Now the model `change` event parameters are compared to only remove buttons when needed, and add all buttons when change is first called.

#### Addresses Issue(s):

JW8-361

