### PR TITLE
Clone volume icon for mute toggle button in controlbar

### DIFF
--- a/src/js/view/controls/components/button.js
+++ b/src/js/view/controls/components/button.js
@@ -27,7 +27,7 @@ export default function (icon, apiAction, ariaText, svgIcons) {
     });
 
     if (svgIcons) {
-        Array.prototype.slice.call(svgIcons).forEach((svgIcon) => {
+        Array.prototype.forEach.call(svgIcons, svgIcon => {
             if (typeof svgIcon === 'string') {
                 element.appendChild(svgParse(svgIcon));
             } else {

--- a/src/js/view/controls/components/tooltip.js
+++ b/src/js/view/controls/components/tooltip.js
@@ -1,6 +1,6 @@
 import Events from 'utils/backbone.events';
 import ariaLabel from 'utils/aria';
-import utils from 'utils/helpers';
+import { toggleClass } from 'utils/dom';
 import svgParse from 'utils/svgParser';
 
 export default class Tooltip {
@@ -22,7 +22,7 @@ export default class Tooltip {
 
         this.el.appendChild(this.container);
         if (svgIcons && svgIcons.length > 0) {
-            Array.prototype.slice.call(svgIcons).forEach((svgIcon) => {
+            Array.prototype.forEach.call(svgIcons, svgIcon => {
                 if (typeof svgIcon === 'string') {
                     this.el.appendChild(svgParse(svgIcon));
                 } else {
@@ -59,13 +59,13 @@ export default class Tooltip {
     openTooltip(evt) {
         this.trigger('open-' + this.componentType, evt, { isOpen: true });
         this.isOpen = true;
-        utils.toggleClass(this.el, this.openClass, this.isOpen);
+        toggleClass(this.el, this.openClass, this.isOpen);
     }
 
     closeTooltip(evt) {
         this.trigger('close-' + this.componentType, evt, { isOpen: false });
         this.isOpen = false;
-        utils.toggleClass(this.el, this.openClass, this.isOpen);
+        toggleClass(this.el, this.openClass, this.isOpen);
     }
 
     toggleOpenState(evt) {

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -157,17 +157,21 @@ export default class Controlbar {
             DVR_ICON +
         '</xml>');
 
+        // Do not show the volume toggle in the mobile SDKs or <iOS10
+        if (!_model.get('sdkplatform') && !(OS.iOS && OS.version.major < 10)) {
+            // Clone icons so that can be used in VolumeTooltip
+            const svgIcons = Array.prototype.map.call(
+                svgCollection.querySelectorAll('.jw-svg-icon-volume-0,.jw-svg-icon-volume-100'),
+                icon => icon.cloneNode(true));
+            muteButton = button('jw-icon-volume', () => {
+                _api.setMute();
+            }, vol, svgIcons);
+        }
 
         // Do not initialize volume slider or tooltip on mobile
         if (!this._isMobile) {
             volumeTooltip = new VolumeTooltip(_model, 'jw-icon-volume', vol,
                 svgCollection.querySelectorAll('.jw-svg-icon-volume-0,.jw-svg-icon-volume-50,.jw-svg-icon-volume-100'));
-        }
-        // Do not show the volume toggle in the mobile SDKs or <iOS10
-        if (!_model.get('sdkplatform') && !(OS.iOS && OS.version.major < 10)) {
-            muteButton = button('jw-icon-volume', () => {
-                _api.setMute();
-            }, vol, svgCollection.querySelectorAll('.jw-svg-icon-volume-0,.jw-svg-icon-volume-100'));
         }
 
         const nextButton = button('jw-icon-next', () => {


### PR DESCRIPTION
### Why is this Pull Request needed?

DOM elements can only be added to one parent. Since the volume icons are parsed once in the controlbar and used in two different buttons, the ones we use in the mute button should be cloned so that they are not removed from `svgCollection` .

This, and the `svgCollection` change, added some tech-debt. All the querySelectors and Array calls should be replaced by a module to manage SVG assets, and retrieve clones of the parsed nodes: https://github.com/jwplayer/jwplayer/issues/2336

#### Addresses Issue(s):

JW8-460

