### PR TITLE
Ensure the order of related, sharing and custom controlbar buttons

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -732,7 +732,7 @@ Object.assign(Controller.prototype, {
                 btnClass: btnClass
             };
 
-            customButtons = _.reduce(customButtons, function(buttons, button) {
+            customButtons = customButtons.reduce(function(buttons, button) {
                 if (button.id === newButton.id) {
                     added = true;
                     buttons.push(newButton);
@@ -743,11 +743,7 @@ Object.assign(Controller.prototype, {
             }, []);
 
             if (!added) {
-                if (newButton.id === 'related') {
-                    customButtons.push(newButton);
-                } else {
-                    customButtons.unshift(newButton);
-                }
+                customButtons.unshift(newButton);
             }
 
             _model.set('customButtons', customButtons);

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -563,15 +563,19 @@ export default class Controlbar {
                 SimpleTooltip(newButton.element(), buttonProps.id, buttonProps.tooltip);
             }
 
-            let firstButton = buttonContainer.querySelector('.jw-spacer').nextSibling;
-            if (firstButton && firstButton.getAttribute('button') === 'logo') {
-                firstButton = firstButton.nextSibling;
+            let firstButton;
+            if (newButton.id === 'related') {
+                firstButton = this.elements.settingsButton.element();
+            } else if (newButton.id === 'share') {
+                firstButton = buttonContainer.querySelector('[button="related"]') ||
+                    this.elements.settingsButton.element();
+            } else {
+                firstButton = this.elements.spacer.nextSibling;
+                if (firstButton && firstButton.getAttribute('button') === 'logo') {
+                    firstButton = firstButton.nextSibling;
+                }
             }
-
-            buttonContainer.insertBefore(
-                newButton.element(),
-                firstButton
-            );
+            buttonContainer.insertBefore(newButton.element(), firstButton);
         }
     }
 

--- a/test/unit/controlbar-test.js
+++ b/test/unit/controlbar-test.js
@@ -21,12 +21,15 @@ describe('Control Bar', function() {
     beforeEach(function() {
         const spacer = document.createElement('div');
         spacer.className += 'jw-spacer';
+        const settingsButton = document.createElement('div');
 
         container = document.createElement('div');
-        container.appendChild(document.createElement('div'));
+        container.appendChild(settingsButton);
         container.appendChild(spacer);
 
         controlBar = new ControlBar({}, model);
+        controlBar.elements.spacer = spacer;
+        controlBar.elements.settingsButton = settingsButton;
         controlBar.elements.buttonContainer = container;
         children = container.children;
     });


### PR DESCRIPTION
### This PR will...

Ensure that the related button is always added next to settings button, and that sharing is always added next to related if present, otherwise next to settings.

### Why is this Pull Request needed?

Fixes a regression with button order added by optimizations that no longer remove and recreate and add all buttons with each change in the button list.

#### Addresses Issue(s):

JW8-461

