### PR TITLE
Remove extra play() call from instream destroy

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -308,16 +308,15 @@ define([
                 switch (oldMode) {
                     case 'instream-preroll':
                     case 'instream-midroll':
-                        var item = _.extend({}, _olditem);
-                        item.starttime = _oldpos;
-                        _model.loadVideo(item);
-
                         // On error, mediaModel has buffering states in mobile, but oldProvider's state is playing.
                         // So, changing mediaModel's state to playing does not change provider state unless we do this
                         if (utils.isMobile() && (_model.mediaModel.get('state') === states.BUFFERING)) {
                             _oldProvider.setState(states.BUFFERING);
                         }
-                        _oldProvider.play();
+
+                        var item = _.extend({}, _olditem);
+                        item.starttime = _oldpos;
+                        _model.loadVideo(item);
                         break;
                     case 'instream-postroll':
                     case 'instream-idle':


### PR DESCRIPTION
Remove extra play() call from instream destroy. The extra call may be impacting time to resume after prerolls in Safari (iOS/Mac)

#### Addresses Issue(s):

JW7-4491

