### PR TITLE
Disable native rendering in Edge

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -44,9 +44,12 @@ function VideoProvider(_playerId, _playerConfig) {
 
     // Always render natively in iOS, Safari and Edge, where HLS is supported.
     // Otherwise, use native rendering when set in the config for browsers that have adequate support.
-    // FF and IE are excluded due to styling/positioning drawbacks.
+    // FF, IE & Edge are excluded due to styling/positioning drawbacks.
+    // The following issues need to be addressed before we enable native rendering in Edge:
+    // https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/8120475/
+    // https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12079271/
     function renderNatively (configRenderNatively) {
-        if (OS.iOS || Browser.safari || Browser.edge) {
+        if (OS.iOS || Browser.safari) {
             return true;
         }
         return configRenderNatively && Browser.chrome;

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -42,7 +42,7 @@ function VideoProvider(_playerId, _playerConfig) {
 
     this.renderNatively = renderNatively(_playerConfig.renderCaptionsNatively);
 
-    // Always render natively in iOS, Safari and Edge, where HLS is supported.
+    // Always render natively in iOS and Safari, where HLS is supported.
     // Otherwise, use native rendering when set in the config for browsers that have adequate support.
     // FF, IE & Edge are excluded due to styling/positioning drawbacks.
     // The following issues need to be addressed before we enable native rendering in Edge:


### PR DESCRIPTION
### This PR will...
Disable native rendering in Microsoft Edge.
### Why is this Pull Request needed?
Captions rendered by MS Edge cannot be styled or positioned with CSS. This is a huge drawback and puts us out of compliance with FCC guidelines.

The following issues need to be resolved before we can rely on Edge to render captions:
- https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/8120475/
- https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12079271/
### Are there any points in the code the reviewer needs to double check?
This change only affects streams that use the HTML5 provider, so only sideloaded captions need to be tested.
### Are there any Pull Requests open in other repos which need to be merged with this?
No.
#### Addresses Issue(s):
JW8-424

