### PR TITLE
Map controlbar background color to gear menu

### DIFF
--- a/src/js/view/utils/skin.js
+++ b/src/js/view/utils/skin.js
@@ -1,5 +1,5 @@
 import { prefix } from 'utils/strings';
-import { css } from 'utils/css';
+import { css, getRgba } from 'utils/css';
 
 export function normalizeSkin(skinConfig = {}) {
 
@@ -156,7 +156,8 @@ export function handleColorOverrides(playerId, skin) {
         }
 
         addStyle([
-            '.jw-controlbar'
+            '.jw-controlbar',
+            '.jw-settings-topbar'
         ], 'background', config.background);
     }
 
@@ -164,22 +165,21 @@ export function handleColorOverrides(playerId, skin) {
 
         addStyle([
             '.jw-progress',
-            '.jw-buffer',
             '.jw-knob'
-        ], 'background', 'none ' + config.progress);
+        ], 'background-color', config.progress);
 
         addStyle([
             '.jw-buffer',
-        ], 'opacity', 0.5);
+        ], 'background-color', getRgba(config.progress, 50));
 
         addStyle([
             '.jw-rail'
-        ], 'background', 'none ' + config.rail);
+        ], 'background-color', config.rail);
 
         addStyle([
             '.jw-background-color.jw-slider-time',
             '.jw-slider-time .jw-cue'
-        ], 'background', config.background);
+        ], 'background-color', config.background);
     }
 
     function styleMenus(config) {
@@ -205,12 +205,10 @@ export function handleColorOverrides(playerId, skin) {
             '.jw-nextup-body',
             '.jw-nextup-header',
             '.jw-settings-submenu',
-            '.jw-settings-topbar'
         ], 'background', config.background);
 
         if (config.background) {
             addStyle([
-                '.jw-settings-submenu',
                 '.jw-nextup-body',
             ], 'opacity', 0.7);
         }


### PR DESCRIPTION
### This PR will...
Map custom styles for the settings menu so the top bar matches the controlbar background.

### Why is this Pull Request needed?
The forced opacity applied to the settings submenu caused visual artifacts in certain cases. This removes that opacity.

### Are there any points in the code the reviewer needs to double check?
```
"skin": {
    "active": "red",
    "tooltips": {
      "text": "pink"
    },
    "menus": {
      "text": "rgba(0,255,255,1)",
      "textActive": "#FFFF00",
      "background": "#FFA500"
    },
    "timeslider": {
      "progress": "rgb(255,0,255)",
      "rail": "rgba(255,165,0,1)"
    },
    "controlbar": {
      "icons": "#008000",
      "iconsActive": "yellow",
      "text": "#00F",
      "background": "#c0c0c0"
    }
  }
```

#### Addresses Issue(s):

JW8-450

