### PR TITLE
Alleviate text flicker during animations in Firefox

### DIFF
--- a/src/css/controls/imports/controlbar.less
+++ b/src/css/controls/imports/controlbar.less
@@ -195,5 +195,9 @@
 .jwplayer:not(.jw-flag-user-inactive) {
     .jw-controlbar {
         will-change: transform;
+
+        .jw-text {
+            transform-style: preserve-3d;
+        }
     }
 }


### PR DESCRIPTION
### This PR will...
Enforce `transform-style` to prevent flickering text on Firefox when animations/transitions are happening.

### Why is this Pull Request needed?
Firefox on MacOS on Retina screens has trouble switching between composite layers.

### Are there any points in the code the reviewer needs to double check?

#### Addresses Issue(s):
JW8-438
