### PR TITLE
Click to Play Setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ node_js:
   - 5
 
 before_install:
-  - npm install -g npm
   - npm config set loglevel warn
 
 before_script:

--- a/src/js/api/api-queue.js
+++ b/src/js/api/api-queue.js
@@ -37,6 +37,10 @@ export default function ApiQueueDecorator(instance, queuedCommands, predicate) {
 
     this.flush = executeQueuedCommands;
 
+    this.empty = function() {
+        commandQueue.length = 0;
+    };
+
     this.destroy = function() {
         commandQueue.forEach(({ command }) => {
             const method = undecoratedMethods[command];
@@ -45,6 +49,6 @@ export default function ApiQueueDecorator(instance, queuedCommands, predicate) {
                 delete undecoratedMethods[command];
             }
         });
-        commandQueue.length = 0;
+        this.empty();
     };
 }

--- a/src/js/api/core-loader.js
+++ b/src/js/api/core-loader.js
@@ -50,12 +50,13 @@ export function requiresPolyfills() {
 export function requiresProvider(model, providerName) {
     const playlist = model.get('playlist');
     if (Array.isArray(playlist) && playlist.length) {
-        const firstSource = Item(playlist[0]).sources[0];
-        if (firstSource) {
+        const sources = Item(playlist[0]).sources;
+        for (let i = 0; i < sources.length; i++) {
+            const source = sources[i];
             const providersManager = model.getProviders();
-            for (let i = 0; i < ProvidersSupported.length; i++) {
-                const provider = ProvidersSupported[i];
-                if (providersManager.providerSupports(provider, firstSource)) {
+            for (let j = 0; j < ProvidersSupported.length; j++) {
+                const provider = ProvidersSupported[j];
+                if (providersManager.providerSupports(provider, source)) {
                     return (provider.name === providerName);
                 }
             }

--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -14,6 +14,7 @@ import Promise, { resolved } from 'polyfills/promise';
 import viewError from 'templates/error';
 import { style } from 'utils/css';
 import { createElement } from 'utils/dom';
+import getMediaElement from 'api/get-media-element';
 
 const ModelShim = function() {};
 Object.assign(ModelShim.prototype, SimpleModel);
@@ -82,6 +83,11 @@ Object.assign(CoreShim.prototype, {
         };
         model.setProvider = function() {};
 
+        // Create/get click-to-play media element, and call .load() to unblock user-gesture to play requirement
+        const mediaElement =
+            model.attributes.mediaElement = getMediaElement(api.id, this.originalContainer);
+        mediaElement.load();
+
         return Promise.all([
             loadCoreBundle(model),
             this.setup.start(),
@@ -109,10 +115,7 @@ Object.assign(CoreShim.prototype, {
             storage.track(coreModel);
 
             // Set the active playlist item after plugins are loaded and the view is setup
-            return new Promise(resolve => {
-                coreModel.once('itemReady', resolve);
-                coreModel.setItemIndex(coreModel.get('item'));
-            });
+            return coreModel.setItemIndex(coreModel.get('item'));
         }).then(() => {
             if (!this.setup) {
                 return;

--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -85,7 +85,7 @@ Object.assign(CoreShim.prototype, {
 
         // Create/get click-to-play media element, and call .load() to unblock user-gesture to play requirement
         const mediaElement =
-            model.attributes.mediaElement = getMediaElement(api.id, this.originalContainer);
+            model.attributes.mediaElement = getMediaElement(this.originalContainer);
         mediaElement.load();
 
         return Promise.all([

--- a/src/js/api/get-media-element.js
+++ b/src/js/api/get-media-element.js
@@ -2,11 +2,7 @@ export default function getMediaElement(parent) {
     // Find video tag, or create it if it doesn't exist.  View may not be built yet.
     let media = null;
     if (parent) {
-        if (parent.nodeName === 'VIDEO' || parent.nodeName === 'AUDIO') {
-            media = parent;
-        } else {
-            media = parent.querySelector('video, audio');
-        }
+        media = parent.querySelector('video, audio');
     }
     if (!media) {
         media = document.createElement('video');

--- a/src/js/api/get-media-element.js
+++ b/src/js/api/get-media-element.js
@@ -1,0 +1,17 @@
+export default function getMediaElement(playerId, container) {
+    // Find video tag, or create it if it doesn't exist.  View may not be built yet.
+    const element = container || document.getElementById(playerId);
+    let media = null;
+    if (element) {
+        if (element.nodeName === 'VIDEO' || element.nodeName === 'AUDIO') {
+            media = element;
+        } else {
+            media = element.querySelector('video, audio');
+        }
+    }
+    if (!media) {
+        media = document.createElement('video');
+    }
+    media.className = 'jw-video jw-reset';
+    return media;
+}

--- a/src/js/api/get-media-element.js
+++ b/src/js/api/get-media-element.js
@@ -1,12 +1,11 @@
-export default function getMediaElement(playerId, container) {
+export default function getMediaElement(parent) {
     // Find video tag, or create it if it doesn't exist.  View may not be built yet.
-    const element = container || document.getElementById(playerId);
     let media = null;
-    if (element) {
-        if (element.nodeName === 'VIDEO' || element.nodeName === 'AUDIO') {
-            media = element;
+    if (parent) {
+        if (parent.nodeName === 'VIDEO' || parent.nodeName === 'AUDIO') {
+            media = parent;
         } else {
-            media = element.querySelector('video, audio');
+            media = parent.querySelector('video, audio');
         }
     }
     if (!media) {

--- a/src/js/api/set-playlist.js
+++ b/src/js/api/set-playlist.js
@@ -19,13 +19,9 @@ const setPlaylist = function(model, playlist, feedData = {}) {
 export function loadProvidersForPlaylist(model) {
     const playlist = model.get('playlist');
     const providersManager = model.getProviders();
-    const firstProviderNeeded = providersManager.required([playlist[0]]);
+    const providersNeeded = providersManager.required(playlist);
 
-    return providersManager.load(firstProviderNeeded).then(() => {
-        if (!model.get('provider')) {
-            model.setProvider(model.get('playlistItem'));
-        }
-    });
+    return providersManager.load(providersNeeded);
 }
 
 export default setPlaylist;

--- a/src/js/api/timer.js
+++ b/src/js/api/timer.js
@@ -1,4 +1,4 @@
-import clock from 'utils/clock';
+import { dateTime } from 'utils/clock';
 
 /**
  * QoE metrics returned by `jwplayer()._qoe.dump()`.
@@ -20,8 +20,6 @@ const Timer = function() {
 
     const ticks = {};
 
-    const started = Math.max(1, new Date().getTime());
-
     /** @lends Timer */
     return {
         // Profile methods
@@ -33,7 +31,7 @@ const Timer = function() {
          * @param {string} methodName - The method or player state name.
          */
         start: function(methodName) {
-            startTimes[methodName] = started + clock.now();
+            startTimes[methodName] = dateTime();
             counts[methodName] = counts[methodName] + 1 || 1;
         },
         /**
@@ -46,7 +44,7 @@ const Timer = function() {
             if (!startTimes[methodName]) {
                 return;
             }
-            const now = started + clock.now();
+            const now = dateTime();
             const e = now - startTimes[methodName];
             delete startTimes[methodName];
             sum[methodName] = sum[methodName] + e || e;
@@ -63,7 +61,7 @@ const Timer = function() {
             const runningSums = Object.assign({}, sum);
             for (const methodName in startTimes) {
                 if (Object.prototype.hasOwnProperty.call(startTimes, methodName)) {
-                    const now = started + clock.now();
+                    const now = dateTime();
                     const e = now - startTimes[methodName];
                     runningSums[methodName] = runningSums[methodName] + e || e;
                 }
@@ -83,7 +81,7 @@ const Timer = function() {
          * @param {string} event - The event name.
          */
         tick: function(event) {
-            ticks[event] = started + clock.now();
+            ticks[event] = dateTime();
         },
 
         /**

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -405,10 +405,9 @@ Object.assign(Controller.prototype, {
             const state = _model.get('state');
             if (state === STATE_IDLE || state === STATE_PAUSED) {
                 _play({ reason: 'autostart' }).catch(error => {
-                    _model.set('autostartFailed', true);
-                    _this.triggerError({
-                        message: `Could not play video: ${error.message}`
-                    });
+                    if (!_this._instreamAdapter || !_this._instreamAdapter._adModel) {
+                        _model.set('autostartFailed', true);
+                    }
                     _actionOnAttach = null;
                 });
             }

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -160,12 +160,7 @@ Object.assign(Controller.prototype, {
 
         _model.on('change:viewSetup', function(model, viewSetup) {
             if (viewSetup) {
-                const mediaElement = this.currentContainer.querySelector('video, audio');
                 showView(this, _view.element());
-                if (mediaElement) {
-                    const mediaContainer = _model.get('mediaContainer');
-                    mediaContainer.appendChild(mediaElement);
-                }
             }
         }, this);
 

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -409,7 +409,7 @@ Object.assign(Controller.prototype, {
 
         function _stop(internal) {
             checkAutoStartCancelable.cancel();
-            apiQueue.queue.length = 0;
+            apiQueue.empty();
 
             const fromApi = !internal;
 

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -258,7 +258,7 @@ Object.assign(Controller.prototype, {
             });
 
 
-            // Only attempt to preload if this is the first player on the page and viewable
+            // Only attempt to preload if this is the first player on the page or viewable
             if (instances[0] === _api || viewable === 1) {
                 model.preloadVideo();
             }

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -371,12 +371,12 @@ Object.assign(Controller.prototype, {
         function _play(meta = {}) {
             checkAutoStartCancelable.cancel();
 
-            const playReason = meta.reason;
-            _model.set('playReason', playReason);
-
             if (_model.get('state') === STATE_ERROR) {
                 return resolved;
             }
+
+            const playReason = meta.reason;
+            _model.set('playReason', playReason);
 
             const adState = _getAdState();
             if (_.isString(adState)) {
@@ -401,11 +401,9 @@ Object.assign(Controller.prototype, {
                 }
             }
 
-            if (!_model.mediaModel.get('setup')) {
-                const item = _model.get('playlist')[_model.get('item')];
-                return _model.loadVideo(item, playReason);
-            }
-            return _model.playVideo(playReason);
+            const item = _model.get('playlist')[_model.get('item')];
+
+            return _model.playVideo(item, playReason);
         }
 
         function _autoStart() {

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -1,6 +1,7 @@
 import { OS } from 'environment/environment';
-import { STATE_BUFFERING, STATE_COMPLETE, STATE_PAUSED, STATE_PLAYING, ERROR, MEDIA_TIME, MEDIA_COMPLETE,
-    PLAYLIST_ITEM, PLAYLIST_COMPLETE, INSTREAM_CLICK, MEDIA_META, AD_SKIPPED } from 'events/events';
+import { STATE_BUFFERING, STATE_COMPLETE, STATE_PAUSED, STATE_PLAYING,
+    ERROR, MEDIA_META, MEDIA_TIME, MEDIA_COMPLETE,
+    PLAYLIST_ITEM, PLAYLIST_COMPLETE, INSTREAM_CLICK, AD_SKIPPED } from 'events/events';
 import InstreamHtml5 from 'controller/instream-html5';
 import InstreamFlash from 'controller/instream-flash';
 import utils from 'utils/helpers';
@@ -80,6 +81,7 @@ var InstreamAdapter = function(_controller, _model, _view) {
         _instream.on(MEDIA_TIME, _instreamTime, this);
         _instream.on(MEDIA_COMPLETE, _instreamItemComplete, this);
         _instream.init();
+        _instream._adModel.set('mediaElement', sharedVideoTag || _model.get('mediaElement'));
 
         // Make sure the original player's provider stops broadcasting events (pseudo-lock...)
         _controller.detachMedia();

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -222,7 +222,9 @@ var InstreamAdapter = function(_controller, _model, _view) {
                 });
 
                 _options = Object.assign({}, _defaultOptions, options);
-                _instream.load(item);
+                _instream.load(item).catch(error => {
+                    console.warn('Creative play request rejected.', error);
+                });
 
                 _this.addClickHandler();
 

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -212,22 +212,23 @@ var InstreamAdapter = function(_controller, _model, _view) {
 
         _this.addClickHandler();
 
-        _instream._adModel.set('skipButton', false);
-        _skipAd = _instreamItemNext;
+
         var skipoffset = item.skipoffset || _options.skipoffset;
         if (skipoffset) {
             _this.setupSkipButton(skipoffset, _options);
+        } else {
+            _instream._adModel.set('skipButton', false);
         }
 
-        return _instream.load(item).catch(error => {
-            console.warn('Creative play request rejected.', error);
-        });
+        return _instream.load(item);
     };
 
     this.setupSkipButton = function(skipoffset, options, customNext) {
         const adModel = _instream._adModel;
         if (customNext) {
             _skipAd = customNext;
+        } else {
+            _skipAd = _instreamItemNext;
         }
         adModel.set('skipMessage', options.skipMessage);
         adModel.set('skipText', options.skipText);

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -95,8 +95,6 @@ var InstreamAdapter = function(_controller, _model, _view) {
             }
         }
 
-        _model.mediaModel.set('state', STATE_BUFFERING);
-
         if (_controller.checkBeforePlay() || (_oldpos === 0 && !_model.checkComplete())) {
             // make sure video restarts after preroll
             _oldpos = 0;
@@ -318,7 +316,11 @@ var InstreamAdapter = function(_controller, _model, _view) {
             } else {
                 const item = Object.assign({}, _olditem);
                 item.starttime = _oldpos;
-                _model.loadVideo(item);
+                _model.loadVideo(item).catch(function(error) {
+                    _model.mediaController.trigger('error', {
+                        message: error.message
+                    });
+                });
             }
         }
     };

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -308,8 +308,8 @@ var InstreamAdapter = function(_controller, _model, _view) {
                 const mediaModelContext = _model.mediaModel;
                 const item = Object.assign({}, _olditem);
                 item.starttime = _oldpos;
-                _model.set(PLAYER_STATE, STATE_IDLE);
-                _model.playVideo(item).catch(function(error) {
+                _model.attributes.playlistItem = item;
+                _model.playVideo().catch(function(error) {
                     if (mediaModelContext === _model.mediaModel) {
                         _model.mediaController.trigger('error', {
                             message: error.message

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -316,12 +316,15 @@ var InstreamAdapter = function(_controller, _model, _view) {
             if (_oldpos === null) {
                 _model.stopVideo();
             } else {
+                const mediaModelContext = _model.mediaModel;
                 const item = Object.assign({}, _olditem);
                 item.starttime = _oldpos;
                 _model.loadVideo(item).catch(function(error) {
-                    _model.mediaController.trigger('error', {
-                        message: error.message
-                    });
+                    if (mediaModelContext === _model.mediaModel) {
+                        _model.mediaController.trigger('error', {
+                            message: error.message
+                        });
+                    }
                 });
             }
         }

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -309,7 +309,7 @@ var InstreamAdapter = function(_controller, _model, _view) {
                 const item = Object.assign({}, _olditem);
                 item.starttime = _oldpos;
                 _model.set(PLAYER_STATE, STATE_IDLE);
-                _model.loadVideo(item).catch(function(error) {
+                _model.playVideo(item).catch(function(error) {
                     if (mediaModelContext === _model.mediaModel) {
                         _model.mediaController.trigger('error', {
                             message: error.message

--- a/src/js/controller/instream-flash.js
+++ b/src/js/controller/instream-flash.js
@@ -1,5 +1,5 @@
 import { Browser } from 'environment/environment';
-import { STATE_PAUSED, STATE_PLAYING, PLAYER_STATE, MEDIA_COMPLETE, MEDIA_TIME, MEDIA_ERROR } from 'events/events';
+import { STATE_BUFFERING, STATE_PAUSED, STATE_PLAYING, PLAYER_STATE, MEDIA_COMPLETE, MEDIA_TIME, MEDIA_ERROR } from 'events/events';
 import Events from 'utils/backbone.events';
 import Model from 'controller/model';
 import changeStateEvent from 'events/change-state-event';
@@ -117,6 +117,7 @@ Object.assign(InstreamFlash.prototype, {
     },
 
     load: function(item) {
+        this._adModel.set('state', STATE_BUFFERING);
         // Show the instream layer
         this.swf.triggerFlash('instream:load', item);
         return resolved;

--- a/src/js/controller/instream-flash.js
+++ b/src/js/controller/instream-flash.js
@@ -3,6 +3,7 @@ import { STATE_PAUSED, STATE_PLAYING, PLAYER_STATE, MEDIA_COMPLETE, MEDIA_TIME, 
 import Events from 'utils/backbone.events';
 import Model from 'controller/model';
 import changeStateEvent from 'events/change-state-event';
+import { resolved } from 'polyfills/promise';
 
 const InstreamFlash = function(_controller, _model) {
     this.model = _model;
@@ -118,6 +119,7 @@ Object.assign(InstreamFlash.prototype, {
     load: function(item) {
         // Show the instream layer
         this.swf.triggerFlash('instream:load', item);
+        return resolved;
     },
 
     instreamPlay: function() {

--- a/src/js/controller/instream-html5.js
+++ b/src/js/controller/instream-html5.js
@@ -19,7 +19,7 @@ const InstreamHtml5 = function(_controller, _model) {
      *****  Public instream API methods  *****
      *****************************************/
 
-    this.init = function() {
+    this.init = function(mediaElement) {
         // Initialize the instream player's model copied from main player's model
         _adModel = new Model().setup({
             id: _model.get('id'),
@@ -28,6 +28,7 @@ const InstreamHtml5 = function(_controller, _model) {
             mute: _model.get('mute') || _model.get('autostartMuted'),
             instreamMode: true,
             edition: _model.get('edition'),
+            mediaElement: mediaElement
         });
         if (!OS.mobile) {
             _adModel.set('mediaContainer', _model.get('mediaContainer'));
@@ -43,10 +44,12 @@ const InstreamHtml5 = function(_controller, _model) {
         _adModel.set('item', 0);
         _adModel.set('playlistItem', item);
         // Make sure it chooses a provider
-        _adModel.setActiveItem(item);
-
-        // check provider after item change
-        _checkProvider();
+        _adModel.setActiveItem(item).then(() => {
+            if (!_adModel) {
+                return;
+            }
+            _checkProvider(_adModel.getVideo());
+        });
 
         // Match the main player's controls state
         _adModel.off(ERROR);

--- a/src/js/controller/instream-html5.js
+++ b/src/js/controller/instream-html5.js
@@ -55,7 +55,7 @@ const InstreamHtml5 = function(_controller, _model) {
         }, _this);
 
         // Load the instream item
-        _adModel.loadVideo(item);
+        return _adModel.loadVideo(item);
     };
 
     _this.applyProviderListeners = function(provider) {

--- a/src/js/controller/instream-html5.js
+++ b/src/js/controller/instream-html5.js
@@ -115,7 +115,7 @@ const InstreamHtml5 = function(_controller, _model) {
         if (!_adModel.getVideo()) {
             return;
         }
-        _adModel.getVideo().play(true);
+        _adModel.getVideo().play();
     };
 
     /** Pause instream playback **/
@@ -123,7 +123,7 @@ const InstreamHtml5 = function(_controller, _model) {
         if (!_adModel.getVideo()) {
             return;
         }
-        _adModel.getVideo().pause(true);
+        _adModel.getVideo().pause();
     };
 
 

--- a/src/js/controller/instream-html5.js
+++ b/src/js/controller/instream-html5.js
@@ -21,14 +21,19 @@ const InstreamHtml5 = function(_controller, _model) {
 
     this.init = function(mediaElement) {
         // Initialize the instream player's model copied from main player's model
+        const playerAttributes = _model.attributes;
         _adModel = new Model().setup({
-            id: _model.get('id'),
-            volume: _model.get('volume'),
-            fullscreen: _model.get('fullscreen'),
-            mute: _model.get('mute') || _model.get('autostartMuted'),
+            id: playerAttributes.id,
+            volume: playerAttributes.volume,
+            fullscreen: playerAttributes.fullscreen,
             instreamMode: true,
-            edition: _model.get('edition'),
-            mediaElement: mediaElement
+            edition: playerAttributes.edition,
+            mediaElement: mediaElement,
+            mute: playerAttributes.mute || playerAttributes.autostartMuted,
+            autostartMuted: playerAttributes.autostartMuted,
+            autostart: playerAttributes.autostart,
+            advertising: playerAttributes.advertising,
+            sdkplatform: playerAttributes.sdkplatform,
         });
         if (!OS.mobile) {
             _adModel.set('mediaContainer', _model.get('mediaContainer'));
@@ -50,6 +55,7 @@ const InstreamHtml5 = function(_controller, _model) {
             }
             _checkProvider(_adModel.getVideo());
         });
+        _checkProvider();
 
         // Match the main player's controls state
         _adModel.off(ERROR);
@@ -161,6 +167,9 @@ const InstreamHtml5 = function(_controller, _model) {
             provider.attachMedia();
             provider.volume(_model.get('volume'));
             provider.mute(_model.get('mute') || _model.get('autostartMuted'));
+            if (provider.setPlaybackRate) {
+                provider.setPlaybackRate(1);
+            }
 
             _adModel.on('change:state', changeStateEvent, _this);
         }

--- a/src/js/controller/instream-html5.js
+++ b/src/js/controller/instream-html5.js
@@ -1,5 +1,5 @@
-import { STATE_IDLE, STATE_PAUSED, STATE_PLAYING, ERROR, FULLSCREEN,
-    MEDIA_BUFFER_FULL, PLAYER_STATE, MEDIA_COMPLETE } from 'events/events';
+import { STATE_PAUSED, STATE_PLAYING, ERROR, FULLSCREEN,
+    PLAYER_STATE, MEDIA_COMPLETE } from 'events/events';
 import { OS } from 'environment/environment';
 import Events from 'utils/backbone.events';
 import changeStateEvent from 'events/change-state-event';
@@ -51,6 +51,7 @@ const InstreamHtml5 = function(_controller, _model) {
         mediaModelState.started = false;
 
         // Make sure it chooses a provider
+        _adModel.stopVideo();
         _adModel.setItemIndex(0).then(() => {
             if (!_adModel) {
                 return;
@@ -163,8 +164,6 @@ const InstreamHtml5 = function(_controller, _model) {
                 this.trigger(type, Object.assign({}, data, { type: type }));
             }, _this);
 
-            provider.on(MEDIA_BUFFER_FULL, _bufferFullHandler);
-
             provider.on(PLAYER_STATE, stateHandler);
             provider.attachMedia();
             provider.volume(_model.get('volume'));
@@ -178,10 +177,11 @@ const InstreamHtml5 = function(_controller, _model) {
     }
 
     function stateHandler(evt) {
+        _adModel.mediaModel.set(PLAYER_STATE, evt.newstate);
         switch (evt.newstate) {
             case STATE_PLAYING:
             case STATE_PAUSED:
-                _adModel.set('state', evt.newstate);
+                _adModel.set(PLAYER_STATE, evt.newstate);
                 break;
             default:
                 break;
@@ -194,11 +194,6 @@ const InstreamHtml5 = function(_controller, _model) {
         _this.trigger(FULLSCREEN, {
             fullscreen: evt.jwstate
         });
-    }
-
-    /** Handle the MEDIA_BUFFER_FULL event **/
-    function _bufferFullHandler() {
-        _adModel.getVideo().play();
     }
 
     return _this;

--- a/src/js/controller/instream-html5.js
+++ b/src/js/controller/instream-html5.js
@@ -1,4 +1,4 @@
-import { STATE_PAUSED, STATE_PLAYING, ERROR, FULLSCREEN,
+import { STATE_IDLE, STATE_PAUSED, STATE_PLAYING, ERROR, FULLSCREEN,
     MEDIA_BUFFER_FULL, PLAYER_STATE, MEDIA_COMPLETE } from 'events/events';
 import { OS } from 'environment/environment';
 import Events from 'utils/backbone.events';
@@ -44,12 +44,14 @@ const InstreamHtml5 = function(_controller, _model) {
     };
 
     /** Load an instream item and initialize playback **/
-    _this.load = function(item) {
+    _this.load = function() {
+        // Let the player media model know we're using it's video tag
+        const mediaModelState = _model.mediaModel.attributes;
+        mediaModelState.setup = false;
+        mediaModelState.started = false;
 
-        _adModel.set('item', 0);
-        _adModel.set('playlistItem', item);
         // Make sure it chooses a provider
-        _adModel.setActiveItem(item).then(() => {
+        _adModel.setItemIndex(0).then(() => {
             if (!_adModel) {
                 return;
             }
@@ -64,7 +66,7 @@ const InstreamHtml5 = function(_controller, _model) {
         }, _this);
 
         // Load the instream item
-        return _adModel.playVideo(item);
+        return _adModel.playVideo();
     };
 
     _this.applyProviderListeners = function(provider) {

--- a/src/js/controller/instream-html5.js
+++ b/src/js/controller/instream-html5.js
@@ -49,6 +49,7 @@ const InstreamHtml5 = function(_controller, _model) {
         const mediaModelState = _model.mediaModel.attributes;
         mediaModelState.setup = false;
         mediaModelState.started = false;
+        mediaModelState.preloaded = false;
 
         // Make sure it chooses a provider
         _adModel.stopVideo();

--- a/src/js/controller/instream-html5.js
+++ b/src/js/controller/instream-html5.js
@@ -64,7 +64,7 @@ const InstreamHtml5 = function(_controller, _model) {
         }, _this);
 
         // Load the instream item
-        return _adModel.loadVideo(item);
+        return _adModel.playVideo(item);
     };
 
     _this.applyProviderListeners = function(provider) {

--- a/src/js/controller/instream-html5.js
+++ b/src/js/controller/instream-html5.js
@@ -29,6 +29,7 @@ const InstreamHtml5 = function(_controller, _model) {
             instreamMode: true,
             edition: playerAttributes.edition,
             mediaElement: mediaElement,
+            mediaSrc: mediaElement.src,
             mute: playerAttributes.mute || playerAttributes.autostartMuted,
             autostartMuted: playerAttributes.autostartMuted,
             autostart: playerAttributes.autostart,
@@ -46,10 +47,7 @@ const InstreamHtml5 = function(_controller, _model) {
     /** Load an instream item and initialize playback **/
     _this.load = function() {
         // Let the player media model know we're using it's video tag
-        const mediaModelState = _model.mediaModel.attributes;
-        mediaModelState.setup = false;
-        mediaModelState.started = false;
-        mediaModelState.preloaded = false;
+        _model.mediaModel.srcReset();
 
         // Make sure it chooses a provider
         _adModel.stopVideo();
@@ -113,6 +111,13 @@ const InstreamHtml5 = function(_controller, _model) {
             if (_adModel.getVideo()) {
                 _currentProvider.destroy();
             }
+        }
+
+
+        // Reset the player media model if the src was changed externally
+        const srcChanged = _adModel.get('mediaElement').src !== _adModel.get('mediaSrc');
+        if (srcChanged) {
+            _model.mediaModel.srcReset();
         }
 
         // Return the view to its normal state

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -232,6 +232,7 @@ const Model = function() {
     };
 
     this.detachMedia = function() {
+        thenPlayPromise.cancel();
         _attached = false;
         if (_provider) {
             _provider.off('all', _videoEventHandler, this);
@@ -499,7 +500,7 @@ const Model = function() {
             const mediaState = mediaModelContext.get('state');
             mediaModelContext.trigger('change:state', mediaModelContext, mediaState, mediaState);
         }).catch(error => {
-            if (mediaModelContext === model.mediaModel) {
+            if (mediaModelContext === model.mediaModel && _attached) {
                 model.mediaController.trigger(MEDIA_PLAY_ATTEMPT_FAILED, {
                     error: error,
                     playReason: playReason

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -488,9 +488,8 @@ const Model = function() {
         model.mediaController.trigger(MEDIA_PLAY_ATTEMPT, { playReason: playReason });
 
         // Immediately set player state to buffering if these conditions are met
-        const settingUpProviderOrPlayer = !thenPlayPromise.cancelled();
         const videoTagUnpaused = _provider && _provider.video && !_provider.video.paused;
-        if (settingUpProviderOrPlayer || videoTagUnpaused) {
+        if (videoTagUnpaused) {
             model.set(PLAYER_STATE, STATE_BUFFERING);
         }
 

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -496,6 +496,9 @@ const Model = function() {
 
         playPromise.then(() => {
             mediaModelContext.set('started', true);
+            // Sync player state with mediaModel state
+            const mediaState = mediaModelContext.get('state');
+            mediaModelContext.trigger('change:state', mediaModelContext, mediaState, mediaState);
         }).catch(error => {
             if (mediaModelContext === model.mediaModel) {
                 model.mediaController.trigger(MEDIA_PLAY_ATTEMPT_FAILED, {

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -3,6 +3,7 @@ import SimpleModel from 'model/simplemodel';
 import { INITIAL_PLAYER_STATE } from 'model/player-model';
 import Providers from 'providers/providers';
 import { loadProvidersForPlaylist } from 'api/set-playlist';
+import getMediaElement from 'api/get-media-element';
 import initQoe from 'controller/qoe';
 import { PLAYER_STATE, STATE_IDLE, STATE_BUFFERING, STATE_COMPLETE, MEDIA_VOLUME, MEDIA_MUTE,
     MEDIA_TYPE, PROVIDER_CHANGED, AUDIO_TRACKS, AUDIO_TRACK_CHANGED,
@@ -388,7 +389,7 @@ const Model = function() {
         // Replace click-to-play media element, and call .load() to unblock user-gesture to play requirement
         const lastMediaElement = model.attributes.mediaElement;
         const mediaElement =
-            model.attributes.mediaElement = document.createElement('video');
+            model.attributes.mediaElement = getMediaElement();
         mediaElement.volume = lastMediaElement.volume;
         mediaElement.muted = lastMediaElement.muted;
         mediaElement.load();

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -91,6 +91,7 @@ const Model = function() {
                 if (data.newstate === STATE_IDLE) {
                     mediaModel.set('setup', false);
                     mediaModel.set('started', false);
+                    mediaModel.set('preloaded', false);
                 }
                 mediaModel.set(PLAYER_STATE, data.newstate);
 
@@ -101,6 +102,7 @@ const Model = function() {
             case MEDIA_ERROR:
                 mediaModel.set('setup', false);
                 mediaModel.set('started', false);
+                mediaModel.set('preloaded', false);
                 break;
             case MEDIA_BUFFER:
                 this.set('buffer', data.bufferPercent);
@@ -330,6 +332,7 @@ const Model = function() {
         const mediaModelState = model.mediaModel.attributes;
         mediaModelState.setup = false;
         mediaModelState.started = false;
+        mediaModelState.preloaded = false;
         mediaModelState.visualQuality = null;
         mediaModelState.position = position;
         mediaModelState.duration = duration;
@@ -528,8 +531,13 @@ const Model = function() {
 
     this.preloadVideo = function() {
         const item = this.get('playlistItem');
-        if (_provider && item.preload !== 'none' && this.get('autostart') === false &&
-            !this.mediaModel.get('setup')) {
+        // Only attempt to preload if media is attached and hasn't been loaded
+        if (_attached && _provider &&
+            item.preload !== 'none' &&
+            this.get('autostart') === false &&
+            !this.mediaModel.get('setup') &&
+            !this.mediaModel.get('preloaded')) {
+            this.mediaModel.set('preloaded', true);
             _provider.preload(item);
         }
     };

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -104,23 +104,25 @@ const Model = function() {
             case MEDIA_BUFFER:
                 this.set('buffer', data.bufferPercent);
             /* falls through */
-            case MEDIA_META:
-                var duration = data.duration;
+            case MEDIA_META: {
+                const duration = data.duration;
                 if (_.isNumber(duration) && !_.isNaN(duration)) {
                     mediaModel.set('duration', duration);
                     this.set('duration', duration);
                 }
-                var itemMeta = this.get('itemMeta');
-                Object.assign(itemMeta, data.metadata);
+                Object.assign(this.get('itemMeta'), data.metadata);
                 break;
-            case MEDIA_TIME:
+            }
+            case MEDIA_TIME: {
                 mediaModel.set('position', data.position);
                 this.set('position', data.position);
-                if (_.isNumber(data.duration)) {
-                    mediaModel.set('duration', data.duration);
-                    this.set('duration', data.duration);
+                const duration = data.duration;
+                if (_.isNumber(duration) && !_.isNaN(duration)) {
+                    mediaModel.set('duration', duration);
+                    this.set('duration', duration);
                 }
                 break;
+            }
             case PROVIDER_CHANGED:
                 this.set('provider', _provider.getName());
                 break;
@@ -322,8 +324,8 @@ const Model = function() {
     };
 
     function resetItem(model, item) {
-        const position = item.starttime || 0;
-        const duration = (item.duration && seconds(item.duration)) || 0;
+        const position = seconds(item.starttime);
+        const duration = seconds(item.duration);
         const mediaModelState = model.mediaModel.attributes;
         mediaModelState.setup = false;
         mediaModelState.started = false;
@@ -524,12 +526,12 @@ const Model = function() {
     };
 
     this.preloadVideo = function() {
-        if (_provider && !this.mediaModel.get('setup') &&
-            this.get('autostart') === false &&
-            this.get('playlistItem').preload !== 'none') {
-            _provider.preload();
+        const item = this.get('playlistItem');
+        if (_provider && item.preload !== 'none' && this.get('autostart') === false &&
+            !this.mediaModel.get('setup')) {
+            _provider.preload(item);
         }
-    }
+    };
 
     this.playVideo = function(playReason) {
         const item = this.get('playlistItem');

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -439,9 +439,6 @@ const Model = function() {
 
     // The model is also the mediaController for now
     this.loadVideo = function(item, playReason) {
-        if (!item) {
-            item = this.get('playlist')[this.get('item')];
-        }
         if (!playReason) {
             playReason = this.get('playReason');
         }
@@ -459,6 +456,8 @@ const Model = function() {
         thenPlayPromise.cancel();
 
         const mediaModelContext = model.mediaModel;
+
+        mediaModelContext.set('setup', true);
 
         if (_provider) {
             // Calling load() on Shaka may return a player setup promise
@@ -517,9 +516,6 @@ const Model = function() {
     };
 
     this.playVideo = function(playReason) {
-        if (!_provider) {
-            return this.loadVideo(null, playReason);
-        }
         const playPromise = _provider.play() || resolved;
         if (!this.mediaModel.get('started')) {
             playAttempt(this, playPromise, playReason);
@@ -599,6 +595,7 @@ const Model = function() {
 const MediaModel = Model.MediaModel = function() {
     this.attributes = {
         state: STATE_IDLE,
+        setup: false,
         started: false
     };
 };

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -89,7 +89,7 @@ const Model = function() {
                 return;
             case PLAYER_STATE:
                 if (data.newstate === STATE_IDLE) {
-                    resetMediaLoaded(mediaModel);
+                    mediaModel.srcReset();
                 }
                 mediaModel.set(PLAYER_STATE, data.newstate);
 
@@ -98,7 +98,7 @@ const Model = function() {
                 //  Instead letting the master controller do so
                 return;
             case MEDIA_ERROR:
-                resetMediaLoaded(mediaModel);
+                mediaModel.srcReset();
                 break;
             case MEDIA_BUFFER:
                 this.set('buffer', data.bufferPercent);
@@ -326,21 +326,13 @@ const Model = function() {
         const position = seconds(item.starttime);
         const duration = seconds(item.duration);
         const mediaModelState = model.mediaModel.attributes;
-        resetMediaLoaded(model.mediaModel);
+        model.mediaModel.srcReset();
         mediaModelState.position = position;
         mediaModelState.duration = duration;
 
         model.set('itemMeta', {});
         model.set('position', position);
         model.set('duration', duration);
-    }
-
-    function resetMediaLoaded(mediaModel) {
-        const mediaModelState = mediaModel.attributes;
-        mediaModelState.setup = false;
-        mediaModelState.started = false;
-        mediaModelState.preloaded = false;
-        mediaModelState.visualQuality = null;
     }
 
     this.setProvider = function(item) {
@@ -641,6 +633,14 @@ const MediaModel = Model.MediaModel = function() {
 };
 
 Object.assign(Model.prototype, SimpleModel);
-Object.assign(MediaModel.prototype, SimpleModel);
+Object.assign(MediaModel.prototype, SimpleModel, {
+    srcReset() {
+        const attributes = this.attributes;
+        attributes.setup = false;
+        attributes.started = false;
+        attributes.preloaded = false;
+        attributes.visualQuality = null;
+    }
+});
 
 export default Model;

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -89,9 +89,7 @@ const Model = function() {
                 return;
             case PLAYER_STATE:
                 if (data.newstate === STATE_IDLE) {
-                    mediaModel.set('setup', false);
-                    mediaModel.set('started', false);
-                    mediaModel.set('preloaded', false);
+                    resetMediaLoaded(mediaModel);
                 }
                 mediaModel.set(PLAYER_STATE, data.newstate);
 
@@ -100,9 +98,7 @@ const Model = function() {
                 //  Instead letting the master controller do so
                 return;
             case MEDIA_ERROR:
-                mediaModel.set('setup', false);
-                mediaModel.set('started', false);
-                mediaModel.set('preloaded', false);
+                resetMediaLoaded(mediaModel);
                 break;
             case MEDIA_BUFFER:
                 this.set('buffer', data.bufferPercent);
@@ -330,16 +326,21 @@ const Model = function() {
         const position = seconds(item.starttime);
         const duration = seconds(item.duration);
         const mediaModelState = model.mediaModel.attributes;
-        mediaModelState.setup = false;
-        mediaModelState.started = false;
-        mediaModelState.preloaded = false;
-        mediaModelState.visualQuality = null;
+        resetMediaLoaded(model.mediaModel);
         mediaModelState.position = position;
         mediaModelState.duration = duration;
 
         model.set('itemMeta', {});
         model.set('position', position);
         model.set('duration', duration);
+    }
+
+    function resetMediaLoaded(mediaModel) {
+        const mediaModelState = mediaModel.attributes;
+        mediaModelState.setup = false;
+        mediaModelState.started = false;
+        mediaModelState.preloaded = false;
+        mediaModelState.visualQuality = null;
     }
 
     this.setProvider = function(item) {

--- a/src/js/events/events.js
+++ b/src/js/events/events.js
@@ -221,6 +221,13 @@ export const MEDIA_FIRST_FRAME = 'firstFrame';
 export const MEDIA_PLAY_ATTEMPT = 'playAttempt';
 
 /**
+ * Fired when playback is aborted or blocked. Pausing the video or changing the media results
+ * in play attempts being aborted. In mobile browsers play attempts are blocked when not started by
+ * a user gesture.
+ */
+export const MEDIA_PLAY_ATTEMPT_FAILED = 'playAttemptFailed';
+
+/**
  * Fired when media has been loaded into the player.
 */
 export const MEDIA_LOADED = 'loaded';
@@ -261,6 +268,11 @@ export const MEDIA_BUFFER = 'bufferChange';
  * Fired as the playback position gets updated, while the player is playing.
 */
 export const MEDIA_TIME = 'time';
+
+/**
+ * Fired when the playbackRate of the video tag changes.
+ */
+export const MEDIA_RATE_CHANGE = 'ratechange';
 
 /**
  * Fired when a loaded item's media type is detected.

--- a/src/js/providers/html5-android-hls.js
+++ b/src/js/providers/html5-android-hls.js
@@ -1,9 +1,6 @@
 import { OS, Browser } from 'environment/environment';
 
-export function isAndroidHls(source, provider) {
-    if (provider && provider.name() !== 'html5') {
-        return false;
-    }
+export function isAndroidHls(source) {
     if (source.type === 'hls' && OS.android) {
         if (source.androidhls === false) {
             return false;

--- a/src/js/providers/html5-android-hls.js
+++ b/src/js/providers/html5-android-hls.js
@@ -1,6 +1,9 @@
 import { OS, Browser } from 'environment/environment';
 
-export function isAndroidHls(source) {
+export function isAndroidHls(source, provider) {
+    if (provider && provider.name() !== 'html5') {
+        return false;
+    }
     if (source.type === 'hls' && OS.android) {
         if (source.androidhls === false) {
             return false;

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -300,14 +300,18 @@ function VideoProvider(_playerId, _playerConfig) {
         _delayedSeek = 0;
         clearTimeouts();
 
-        var sourceElement = document.createElement('source');
+        const previousSource = _videotag.src;
+        const sourceElement = document.createElement('source');
         sourceElement.src = _levels[_currentQuality].file;
-        var sourceChanged = (_videotag.src !== sourceElement.src);
+        const sourceChanged = (sourceElement.src !== previousSource);
 
         if (sourceChanged) {
             _setVideotagSource(_levels[_currentQuality]);
             _this.setupSideloadedTracks(_this._itemTracks);
-            _videotag.load();
+            // Do not call load if src was not set. load() will cancel any active play promise.
+            if (previousSource) {
+                _videotag.load();
+            }
 
         } else if (startTime === 0 && _videotag.currentTime > 0) {
             // Load event is from the same video as before

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -1,7 +1,7 @@
 import { qualityLevel } from 'providers/data-normalizer';
 import { Browser, OS } from 'environment/environment';
 import { isAndroidHls } from 'providers/html5-android-hls';
-import { STATE_IDLE, MEDIA_META, MEDIA_BUFFER_FULL, MEDIA_ERROR,
+import { STATE_IDLE, MEDIA_META, MEDIA_ERROR,
     MEDIA_LEVELS, MEDIA_LEVEL_CHANGED, MEDIA_SEEK } from 'events/events';
 import VideoEvents from 'providers/video-listener-mixin';
 import VideoAction from 'providers/video-actions-mixin';
@@ -113,7 +113,7 @@ function VideoProvider(_playerId, _playerConfig) {
                 // on load
                 _this.setTextTracks(_this._textTracks);
             }
-            _this.trigger(MEDIA_BUFFER_FULL);
+            VideoEvents.canplay.call(_this);
         },
 
         webkitbeginfullscreen(e) {
@@ -174,7 +174,7 @@ function VideoProvider(_playerId, _playerConfig) {
         }
     });
 
-    const _videotag = _playerConfig.mediaElement || _this.getVideo(_playerId);
+    const _videotag = _this.video = _playerConfig.mediaElement;
     const visualQuality = { level: {} };
     const _staleStreamDuration = 3 * 10 * 1000;
 

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -273,13 +273,6 @@ function VideoProvider(_playerId, _playerConfig) {
     function _setLevels(levels) {
         _levels = levels;
         _currentQuality = _pickInitialQuality(levels);
-        var publicLevels = _getPublicLevels(levels);
-        if (publicLevels) {
-            _this.trigger(MEDIA_LEVELS, {
-                levels: publicLevels,
-                currentQuality: _currentQuality
-            });
-        }
     }
 
     function _pickInitialQuality(levels) {
@@ -326,6 +319,17 @@ function VideoProvider(_playerId, _playerConfig) {
 
         if (startTime > 0) {
             _this.seek(startTime);
+        }
+
+        var publicLevels = _getPublicLevels(_levels);
+        if (publicLevels) {
+            _this.trigger(MEDIA_LEVELS, {
+                levels: publicLevels,
+                currentQuality: _currentQuality
+            });
+        }
+        if (_levels.length && _levels[0].type !== 'hls') {
+            _this.sendMediaType(_levels);
         }
     }
 
@@ -426,10 +430,6 @@ function VideoProvider(_playerId, _playerConfig) {
 
     this.load = function(item) {
         _setLevels(item.sources);
-
-        if (item.sources.length && item.sources[0].type !== 'hls') {
-            this.sendMediaType(item.sources);
-        }
         _completeLoad(item.starttime || 0, item.duration || 0);
     };
 

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -238,8 +238,8 @@ function VideoProvider(_playerId, _playerConfig) {
     _this.getDuration = function() {
         var duration = _videotag.duration;
         // Don't sent time event on Android before real duration is known
-        if (_androidHls && duration === Infinity && _videotag.currentTime === 0) {
-            return;
+        if (_androidHls && (duration === Infinity && _videotag.currentTime === 0) || isNaN(duration)) {
+            return 0;
         }
         var end = _getSeekableEnd();
         if (_this.isLive() && end) {

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -40,8 +40,6 @@ function VideoProvider(_playerId, _playerConfig) {
     // Are we buffering due to seek, or due to playback?
     this.seeking = false;
 
-    this.renderNatively = renderNatively(_playerConfig.renderCaptionsNatively);
-
     // Always render natively in iOS and Safari, where HLS is supported.
     // Otherwise, use native rendering when set in the config for browsers that have adequate support.
     // FF, IE & Edge are excluded due to styling/positioning drawbacks.
@@ -136,6 +134,7 @@ function VideoProvider(_playerId, _playerConfig) {
     });
 
     Object.assign(this, Events, VideoAction, VideoAttached, Tracks, {
+        renderNatively: renderNatively(_playerConfig.renderCaptionsNatively),
         eventsOn_() {
             _setupListeners(MediaEvents, _videotag);
         },

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -307,7 +307,6 @@ function VideoProvider(_playerId, _playerConfig) {
 
         if (sourceChanged) {
             _setVideotagSource(_levels[_currentQuality]);
-            _this.setupSideloadedTracks(_this._itemTracks);
             // Do not call load if src was not set. load() will cancel any active play promise.
             if (previousSource) {
                 _videotag.load();
@@ -356,6 +355,8 @@ function VideoProvider(_playerId, _playerConfig) {
         if (sourceChanged) {
             _videotag.src = source.file;
         }
+
+        _this.setupSideloadedTracks(source.tracks);
     }
 
     function _clearVideotagSource() {

--- a/src/js/providers/providers-supported.js
+++ b/src/js/providers/providers-supported.js
@@ -26,9 +26,8 @@ const SupportsMatrix = [
     {
         name: 'html5',
         supports: function (source) {
-            const isAndroidHLS = isAndroidHls(source);
-            if (isAndroidHLS !== null) {
-                return isAndroidHLS;
+            if (isAndroidHls(source) === false) {
+                return false;
             }
 
             if (!video.canPlayType) {

--- a/src/js/providers/providers.js
+++ b/src/js/providers/providers.js
@@ -20,9 +20,9 @@ export const Loaders = {
 Object.assign(Providers.prototype, {
 
     load: function(providersToLoad) {
-        return Promise.all(providersToLoad.map(function(provider) {
+        return Promise.all(providersToLoad.filter(provider => !!Loaders[provider.name]).map(provider => {
             // Resolve event for unknown registered providers
-            const providerLoaderMethod = Loaders[provider.name] || Promise.resolve;
+            const providerLoaderMethod = Loaders[provider.name];
             return providerLoaderMethod();
         }));
     },

--- a/src/js/providers/utils/play-promise.js
+++ b/src/js/providers/utils/play-promise.js
@@ -1,0 +1,28 @@
+import Promise from 'polyfills/promise';
+
+export default function createPlayPromise(video) {
+    return new Promise(function(resolve, reject) {
+        if (video.paused) {
+            return reject(new Error('Play refused.'));
+        }
+        const removeEventListeners = function() {
+            video.removeEventListener('playing', listener);
+            video.removeEventListener('pause', listener);
+            video.removeEventListener('abort', listener);
+            video.removeEventListener('error', listener);
+        };
+        const listener = function(e) {
+            removeEventListeners();
+            if (e.type === 'playing') {
+                resolve();
+            } else {
+                reject(new Error('The play() request was interrupted by a "' + e.type + '" event.'));
+            }
+        };
+
+        video.addEventListener('playing', listener);
+        video.addEventListener('abort', listener);
+        video.addEventListener('error', listener);
+        video.addEventListener('pause', listener);
+    });
+}

--- a/src/js/providers/video-actions-mixin.js
+++ b/src/js/providers/video-actions-mixin.js
@@ -1,3 +1,4 @@
+import getMediaElement from 'api/get-media-element';
 import { style } from 'utils/css';
 
 const VideoActionsMixin = {
@@ -54,15 +55,9 @@ const VideoActionsMixin = {
     },
 
     getVideo: function(playerId, container) {
-        // Find video tag, or create it if it doesn't exist.  View may not be built yet.
-        var element = container || document.getElementById(playerId);
-        var video = element ? element.querySelector('video, audio') : null;
-        if (!video) {
-            video = document.createElement('video');
-        }
-        video.className = 'jw-video jw-reset';
-        this.video = video;
-        return video;
+        const media = getMediaElement(playerId, container);
+        this.video = media;
+        return media;
     }
 };
 

--- a/src/js/providers/video-actions-mixin.js
+++ b/src/js/providers/video-actions-mixin.js
@@ -1,4 +1,3 @@
-import getMediaElement from 'api/get-media-element';
 import { style } from 'utils/css';
 
 const VideoActionsMixin = {
@@ -52,12 +51,6 @@ const VideoActionsMixin = {
         if (this.container === this.video.parentNode) {
             this.container.removeChild(this.video);
         }
-    },
-
-    getVideo: function(playerId, container) {
-        const media = getMediaElement(playerId, container);
-        this.video = media;
-        return media;
     }
 };
 

--- a/src/js/providers/video-actions-mixin.js
+++ b/src/js/providers/video-actions-mixin.js
@@ -1,0 +1,69 @@
+import { style } from 'utils/css';
+
+const VideoActionsMixin = {
+    container: null,
+
+    volume: function(vol) {
+        vol = Math.max(Math.min(vol / 100, 1), 0);
+        this.video.volume = vol;
+    },
+
+    mute: function(state) {
+        this.video.muted = !!state;
+        if (!this.video.muted) {
+            // Remove muted attribute once user unmutes so the video element doesn't get
+            // muted by the browser when the src changes or on replay
+            this.video.removeAttribute('muted');
+        }
+    },
+
+    resize: function(width, height, stretching) {
+        if (!width || !height || !this.video.videoWidth || !this.video.videoHeight) {
+            return false;
+        }
+        if (stretching === 'uniform') {
+            // snap video to edges when the difference in aspect ratio is less than 9%
+            var playerAspectRatio = width / height;
+            var videoAspectRatio = this.video.videoWidth / this.video.videoHeight;
+            var objectFit = null;
+            if (Math.abs(playerAspectRatio - videoAspectRatio) < 0.09) {
+                objectFit = 'fill';
+            }
+            style(this.video, {
+                objectFit: objectFit
+            });
+        }
+        return false;
+    },
+
+    getContainer: function() {
+        return this.container;
+    },
+
+    setContainer: function(element) {
+        this.container = element;
+        element.insertBefore(this.video, element.firstChild);
+    },
+
+    remove: function() {
+        this.stop();
+        this.destroy();
+        if (this.container === this.video.parentNode) {
+            this.container.removeChild(this.video);
+        }
+    },
+
+    getVideo: function(playerId, container) {
+        // Find video tag, or create it if it doesn't exist.  View may not be built yet.
+        var element = container || document.getElementById(playerId);
+        var video = element ? element.querySelector('video, audio') : null;
+        if (!video) {
+            video = document.createElement('video');
+        }
+        video.className = 'jw-video jw-reset';
+        this.video = video;
+        return video;
+    }
+};
+
+export default VideoActionsMixin;

--- a/src/js/providers/video-actions-mixin.js
+++ b/src/js/providers/video-actions-mixin.js
@@ -42,7 +42,9 @@ const VideoActionsMixin = {
 
     setContainer: function(element) {
         this.container = element;
-        element.insertBefore(this.video, element.firstChild);
+        if (this.video !== element.firstChild) {
+            element.insertBefore(this.video, element.firstChild);
+        }
     },
 
     remove: function() {

--- a/src/js/providers/video-attached-mixin.js
+++ b/src/js/providers/video-attached-mixin.js
@@ -1,0 +1,77 @@
+import { STATE_LOADING, STATE_STALLED, STATE_ERROR } from 'events/events';
+import endOfRange from 'utils/time-ranges';
+
+const STALL_DELAY = 256;
+
+const VideoAttachedMixin = {
+    stallCheckTimeout_: -1,
+    lastStalledTime_: NaN,
+
+    attachMedia: function() {
+        this.eventsOn_();
+    },
+
+    detachMedia: function() {
+        this.stopStallCheck();
+        this.eventsOff_();
+
+        return this.video;
+    },
+
+    stopStallCheck: function() {
+        clearTimeout(this.stallCheckTimeout_);
+    },
+
+    startStallCheck: function() {
+        this.stopStallCheck();
+        this.stallCheckTimeout_ = setTimeout(this.stalledHandler.bind(this, this.video.currentTime), STALL_DELAY);
+    },
+
+    stalledHandler: function(checkStartTime) {
+        if (checkStartTime !== this.video.currentTime) {
+            return;
+        }
+
+        if (this.video.paused || this.video.ended) {
+            return;
+        }
+
+        // A stall after loading/error, should just stay loading/error
+        if (this.state === STATE_LOADING || this.state === STATE_ERROR) {
+            return;
+        }
+
+        // During seek we stay in paused state
+        if (this.seeking) {
+            return;
+        }
+
+        if (this.atEdgeOfLiveStream()) {
+            this.setPlaybackRate(1);
+        }
+
+        this.setState(STATE_STALLED);
+    },
+
+    atEdgeOfLiveStream: function() {
+        if (!this.isLive()) {
+            return false;
+        }
+
+        // currentTime doesn't always get to the end of the buffered range
+        const timeFudge = 2;
+        return (endOfRange(this.video.buffered) - this.video.currentTime) <= timeFudge;
+    },
+
+    setAutoplayAttributes: function() {
+        this.video.setAttribute('autoplay', '');
+        this.video.setAttribute('muted', '');
+    },
+
+    removeAutoplayAttributes: function() {
+        this.video.removeAttribute('autoplay');
+        this.video.removeAttribute('muted');
+    }
+};
+
+export default VideoAttachedMixin;

--- a/src/js/providers/video-listener-mixin.js
+++ b/src/js/providers/video-listener-mixin.js
@@ -1,5 +1,5 @@
 import { STATE_IDLE, STATE_COMPLETE, STATE_STALLED, STATE_LOADING, STATE_PLAYING, STATE_PAUSED,
-    PROVIDER_FIRST_FRAME, CLICK, MEDIA_RATE_CHANGE, MEDIA_ERROR,
+    PROVIDER_FIRST_FRAME, CLICK, MEDIA_BUFFER_FULL, MEDIA_RATE_CHANGE, MEDIA_ERROR,
     MEDIA_BUFFER, MEDIA_META, MEDIA_TIME, MEDIA_SEEKED, MEDIA_VOLUME, MEDIA_MUTE, MEDIA_COMPLETE
 } from 'events/events';
 import utils from 'utils/helpers';
@@ -12,6 +12,9 @@ import utils from 'utils/helpers';
 //  2. The provider has an attribute "video" which is the video tag
 
 const VideoListenerMixin = {
+    canplay() {
+        this.trigger(MEDIA_BUFFER_FULL);
+    },
 
     play() {
         if (!this.video.paused && this.state !== STATE_PLAYING) {

--- a/src/js/providers/video-listener-mixin.js
+++ b/src/js/providers/video-listener-mixin.js
@@ -1,0 +1,172 @@
+import { STATE_IDLE, STATE_COMPLETE, STATE_STALLED, STATE_LOADING, STATE_PLAYING, STATE_PAUSED,
+    PROVIDER_FIRST_FRAME, CLICK, MEDIA_RATE_CHANGE, MEDIA_ERROR,
+    MEDIA_BUFFER, MEDIA_META, MEDIA_TIME, MEDIA_SEEKED, MEDIA_VOLUME, MEDIA_MUTE, MEDIA_COMPLETE
+} from 'events/events';
+import utils from 'utils/helpers';
+
+// This will trigger the events required by jwplayer model to
+//  properly follow the state of the video tag
+//
+// Assumptions
+//  1. All functions are bound to the "this" of the provider
+//  2. The provider has an attribute "video" which is the video tag
+
+const VideoListenerMixin = {
+
+    play() {
+        if (!this.video.paused && this.state !== STATE_PLAYING) {
+            this.setState(STATE_LOADING);
+        }
+    },
+
+    loadedmetadata() {
+        var metadata = {
+            duration: this.getDuration(),
+            height: this.video.videoHeight,
+            width: this.video.videoWidth
+        };
+        var drmUsed = this.drmUsed;
+        if (drmUsed) {
+            metadata.drm = drmUsed;
+        }
+        this.trigger(MEDIA_META, metadata);
+    },
+
+    timeupdate() {
+        this.stopStallCheck();
+        var height = this.video.videoHeight;
+        if (height !== this._helperLastVideoHeight) {
+            if (this.adaptation) {
+                this.adaptation({
+                    size: {
+                        width: this.video.videoWidth,
+                        height: height
+                    }
+                });
+            }
+        }
+        this._helperLastVideoHeight = height;
+
+        if (!this.video.paused && (this.state === STATE_STALLED || this.state === STATE_LOADING)) {
+            this.startStallCheck();
+            this.setState(STATE_PLAYING);
+        }
+
+        var position = this.getCurrentTime();
+        var timeEventObject = {
+            position: position,
+            duration: this.getDuration()
+        };
+        if (this.getPtsOffset) {
+            var ptsOffset = this.getPtsOffset();
+            if (ptsOffset >= 0) {
+                timeEventObject.metadata = {
+                    mpegts: ptsOffset + position
+                };
+            }
+        }
+
+        // only emit time events when playing or seeking
+        if (this.state === STATE_PLAYING || this.seeking) {
+            this.trigger(MEDIA_TIME, timeEventObject);
+        }
+    },
+
+    click(evt) {
+        this.trigger(CLICK, evt);
+    },
+
+    volumechange() {
+        var video = this.video;
+
+        this.trigger(MEDIA_VOLUME, {
+            volume: Math.round(video.volume * 100)
+        });
+
+        this.trigger(MEDIA_MUTE, {
+            mute: video.muted
+        });
+    },
+
+    seeked() {
+        if (!this.seeking) {
+            return;
+        }
+        this.seeking = false;
+        this.trigger(MEDIA_SEEKED);
+    },
+
+    playing() {
+        this.setState(STATE_PLAYING);
+        this.trigger(PROVIDER_FIRST_FRAME);
+    },
+
+    pause() {
+        // Sometimes the browser will fire "complete" and then a "pause" event
+        if (this.state === STATE_COMPLETE) {
+            return;
+        }
+        if (this.video.ended) {
+            return;
+        }
+        if (this.video.error) {
+            return;
+        }
+        // If "pause" fires before "complete", we still don't want to propagate it
+        if (this.video.currentTime === this.video.duration) {
+            return;
+        }
+        this.setState(STATE_PAUSED);
+    },
+
+    progress() {
+        var dur = this.getDuration();
+        if (dur <= 0 || dur === Infinity) {
+            return;
+        }
+        var buf = this.video.buffered;
+        if (!buf || buf.length === 0) {
+            return;
+        }
+
+        var buffered = utils.between(buf.end(buf.length - 1) / dur, 0, 1);
+        this.trigger(MEDIA_BUFFER, {
+            bufferPercent: buffered * 100,
+            position: this.getCurrentTime(),
+            duration: dur
+        });
+    },
+
+    ratechange() {
+        this.trigger(MEDIA_RATE_CHANGE, { playbackRate: this.video.playbackRate });
+    },
+
+    ended() {
+        this.stopStallCheck();
+        this._helperLastVideoHeight = 0;
+        if (this.state !== STATE_IDLE && this.state !== STATE_COMPLETE) {
+            this.trigger(MEDIA_COMPLETE);
+        }
+    },
+    loadeddata () {
+        // If we're not rendering natively text tracks will be provided from another source - don't duplicate them here
+        if (this.renderNatively) {
+            this.setTextTracks(this.video.textTracks);
+        }
+    },
+    error() {
+        var code = (this.video.error && this.video.error.code) || -1;
+        var message = ({
+            1: 'Unknown operation aborted',
+            2: 'Unknown network error',
+            3: 'Unknown decode error',
+            4: 'Source not supported'
+        }[code] || 'Unknown');
+        this.trigger(MEDIA_ERROR, {
+            code: code,
+            message: 'Error playing file: ' + message
+        });
+    }
+};
+
+export default VideoListenerMixin;

--- a/src/js/providers/video-listener-mixin.js
+++ b/src/js/providers/video-listener-mixin.js
@@ -50,15 +50,20 @@ const VideoListenerMixin = {
         }
         this._helperLastVideoHeight = height;
 
+        const position = this.getCurrentTime();
+        const duration = this.getDuration();
+        if (isNaN(duration)) {
+            return;
+        }
+
         if (!this.video.paused && (this.state === STATE_STALLED || this.state === STATE_LOADING)) {
             this.startStallCheck();
             this.setState(STATE_PLAYING);
         }
 
-        var position = this.getCurrentTime();
         var timeEventObject = {
             position: position,
-            duration: this.getDuration()
+            duration: duration
         };
         if (this.getPtsOffset) {
             var ptsOffset = this.getPtsOffset();

--- a/src/js/utils/cancelable.js
+++ b/src/js/utils/cancelable.js
@@ -12,6 +12,7 @@ export default function cancelable(callback) {
         }),
         cancel: () => {
             cancelled = true;
-        }
+        },
+        cancelled: () => cancelled
     };
 }

--- a/src/js/utils/clock.js
+++ b/src/js/utils/clock.js
@@ -1,44 +1,17 @@
-
-const performance = window.performance;
-
-const supportsPerformance = !!(performance && performance.now);
-
-const MAX_INTERVAL = 10000;
-
-const getTime = function() {
-    if (supportsPerformance) {
-        return performance.now();
-    }
-    return new Date().getTime();
+const Date = window.Date;
+const performance = window.performance || {
+    timing: {}
 };
+const startDate = performance.timing.navigationStart || (new Date().getTime());
 
-const Clock = function() {
-    const started = getTime();
-    let updated = started;
+if (!('now' in performance)) {
+    performance.now = () => (new Date().getTime()) - startDate;
+}
 
-    const updateClock = function() {
-        let delta = getTime() - updated;
-        if (delta > MAX_INTERVAL) {
-            delta = MAX_INTERVAL;
-        } else if (delta < 0) {
-            delta = 0;
-        }
-        updated += delta;
-    };
-    setInterval(updateClock, 1000);
+export function now() {
+    return performance.now();
+}
 
-    Object.defineProperty(this, 'currentTime', {
-        get: function() {
-            updateClock();
-            return updated - started;
-        }
-    });
-};
-
-Clock.prototype.now = function() {
-    return this.currentTime;
-};
-
-const clock = new Clock();
-
-export default clock;
+export function dateTime() {
+    return startDate + performance.now();
+}

--- a/src/js/utils/strings.js
+++ b/src/js/utils/strings.js
@@ -59,7 +59,10 @@ export function hms(secondsNumber) {
 
 // Convert a time-representing string to a number
 export function seconds(str, frameRate) {
-    if (_.isNumber(str)) {
+    if (!str) {
+        return 0;
+    }
+    if (_.isNumber(str) && !_.isNaN(str)) {
         return str;
     }
 
@@ -89,6 +92,9 @@ export function seconds(str, frameRate) {
         }
     } else {
         sec = parseFloat(str);
+    }
+    if (_.isNaN(sec)) {
+        return 0;
     }
     return sec;
 }

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -89,6 +89,7 @@ function View(_api, _model) {
 
     let _resizeMediaTimeout = -1;
     let _resizeContainerRequestId = -1;
+    let _stateClassRequestId = -1;
 
     let displayClickHandler;
     let fullscreenHelpers;
@@ -286,7 +287,7 @@ function View(_api, _model) {
     };
 
     function updateVisibility() {
-        _model.set('visibility', getVisibility(_model, _playerElement, bounds));
+        _model.set('visibility', getVisibility(_model, _playerElement));
     }
 
     this.init = function() {
@@ -704,7 +705,8 @@ function View(_api, _model) {
             _controls.instreamState = instreamState;
         }
 
-        _stateUpdate(_playerState);
+        cancelAnimationFrame(_stateClassRequestId);
+        _stateClassRequestId = requestAnimationFrame(() => _stateUpdate(_playerState));
     }
 
     function _stateUpdate(state) {
@@ -714,18 +716,20 @@ function View(_api, _model) {
         replaceClass(_playerElement, /jw-state-\S+/, 'jw-state-' + state);
 
         // Update captions renderer
-        switch (state) {
-            case STATE_IDLE:
-            case STATE_ERROR:
-            case STATE_COMPLETE:
-                _captionsRenderer.hide();
-                break;
-            default:
-                _captionsRenderer.show();
-                if (state === STATE_PAUSED && _controls && !_controls.showing) {
-                    _captionsRenderer.renderCues(true);
-                }
-                break;
+        if (_captionsRenderer) {
+            switch (state) {
+                case STATE_IDLE:
+                case STATE_ERROR:
+                case STATE_COMPLETE:
+                    _captionsRenderer.hide();
+                    break;
+                default:
+                    _captionsRenderer.show();
+                    if (state === STATE_PAUSED && _controls && !_controls.showing) {
+                        _captionsRenderer.renderCues(true);
+                    }
+                    break;
+            }
         }
     }
 

--- a/test/mock/video-element-polyfill.js
+++ b/test/mock/video-element-polyfill.js
@@ -1,0 +1,32 @@
+import video from 'mock/video';
+
+// PhantomJS throws an error when video.load() is called
+// Installing this polyfill before tests makes all calls to
+// document.create('video') return the video instance in mock/video
+// which performs noop functions when load, play and pause are called
+
+let createElementNative;
+
+try {
+    document.createElement('video').load();
+} catch (error) {
+    console.error('video element load() not supported.');
+    createElementNative = document.createElement;
+}
+
+export function install() {
+    if (createElementNative) {
+        document.createElement = function(name) {
+            if (name === 'video') {
+                return video;
+            }
+            return createElementNative.call(this, name);
+        };
+    }
+}
+
+export function uninstall() {
+    if (createElementNative) {
+        document.createElement = createElementNative;
+    }
+}

--- a/test/unit/api-test.js
+++ b/test/unit/api-test.js
@@ -11,10 +11,15 @@ import apiMethodsChainable from 'data/api-methods-chainable';
 import apiMethodsDeprecated from 'data/api-methods-deprecated';
 import Events from 'utils/backbone.events';
 import utils from 'utils/helpers';
+import {
+    install as installVideoPolyfill,
+    uninstall as uninstallVideoPolyfill
+} from 'mock/video-element-polyfill';
 
 describe('Api', function() {
 
     beforeEach(function() {
+        installVideoPolyfill();
         utils.log = sinon.stub();
     });
 
@@ -25,6 +30,7 @@ describe('Api', function() {
             instances[i].remove();
         }
         utils.log.reset();
+        uninstallVideoPolyfill();
     });
 
     it('instances has a uniqueIds greater than 0', function() {

--- a/test/unit/model-qoe-test.js
+++ b/test/unit/model-qoe-test.js
@@ -29,28 +29,8 @@ describe('Model QoE', function() {
         validateQoeFirstFrame(assert, model._qoeItem, startTime);
     });
 
-    it('tracks first frame with first increasing time event', function() {
-        var startTime = now();
-        var model = new Model().setup({});
-
-        model.set('mediaModel', new MediaModel());
-        var mediaModel = model.get('mediaModel');
-
-        model.mediaController.trigger(MEDIA_PLAY_ATTEMPT);
-        mediaModel.set('state', STATE_LOADING);
-        mediaModel.set('state', STATE_PLAYING);
-        model.mediaController.trigger(MEDIA_TIME, {
-            position: 0
-        });
-        model.mediaController.trigger(MEDIA_TIME, {
-            position: 1
-        });
-
-        validateQoeFirstFrame(assert, model._qoeItem, startTime);
-    });
-
     it('removes media controller event listeners', function() {
-        var startTime = now();
+        var startTime = now() - 1;
         var model = new Model().setup({});
 
         model.set('mediaModel', new MediaModel());
@@ -59,7 +39,8 @@ describe('Model QoE', function() {
         var qoeItem = model._qoeItem;
 
         var qoeDump = qoeItem.dump();
-        assert.isOk(validateMeasurement(qoeDump.events.playAttempt, startTime), 'play attempt event was fired');
+        assert.isOk(validateMeasurement(qoeDump.events.playAttempt, startTime), 'play attempt event was fired ' +
+            JSON.stringify(qoeDump.events) + ' startTime: ' + startTime);
         assert.isOk(validateMeasurement(qoeDump.events.firstFrame, startTime), 'first frame event was fired');
 
         // test that listeners are removed by testing that tick events are no longer changed

--- a/test/unit/setup-test.js
+++ b/test/unit/setup-test.js
@@ -1,11 +1,16 @@
 import Api from 'api/api';
 import ApiSettings from 'api/api-settings';
 import $ from 'jquery';
+import {
+    install as installVideoPolyfill,
+    uninstall as uninstallVideoPolyfill
+} from 'mock/video-element-polyfill';
 
 describe('Setup', function() {
     this.timeout(3000);
 
     beforeEach(function() {
+        installVideoPolyfill();
         ApiSettings.debug = true;
         // remove fixture
         $('body').append('<div id="test-container"><div id="player"></div></div>');
@@ -15,6 +20,7 @@ describe('Setup', function() {
         ApiSettings.debug = false;
         // remove fixture
         $('#test-container').remove();
+        uninstallVideoPolyfill();
     });
 
     it('fails when playlist is undefined', function (done) {

--- a/test/unit/timer-test.js
+++ b/test/unit/timer-test.js
@@ -1,4 +1,16 @@
 import Timer from 'api/timer';
+import { dateTime } from 'utils/clock';
+import { now } from 'utils/date';
+
+describe('clock', function() {
+    it('provides date time equal or close to Date.now()', function() {
+        const clockTime = dateTime();
+        const dateGetTime = now();
+        // With rounding differences between Date.now() and performance.now(),
+        // and JavaScipt execution, only allow a few milliseconds difference
+        expect(Math.abs(clockTime - dateGetTime)).to.be.below(5);
+    });
+});
 
 describe('timer', function() {
 


### PR DESCRIPTION
### This PR will...

- Create/get media element on setup and call `load()` to unblock play when setup is called from a user-gesture event
- Make the model responsible for replacing video tags between provider instances
- Update html5 provider to use video mixins and return play promise
- Call `video.play()` on "playAttempt" rather than "bufferFull"
- Make rejected play promise trigger "playAttemptFailed" event (player should go to "pause" state when "playAttempt" fails)
- "playAttempt" is reattempted on next call to `controller.play()`, updating QoE
- Fix html5 provider bundling for iOS when first source is mpd
- Do not set "preload=none" attribute on video tag. It messes up play Promise on iOS. Preload "none" is achieved by not setting `video.src` on `provider.init()`
- Load additional providers in model where active provider is set
- LOADING state is set in providers when video tag fires "play" and on mediaModel when loading outside the provider occurs
- PAUSED state is set in provider when video tag fires "pause" per listener mixin rules (mediaModel should reflect `video.paused` when not loading or seeking)
- Added play promise polyfill to providers for older browsers
- Fixed initial visibility check on iOS
- Eliminate extended IDLE state between playlist items, while loading playlist/provider
    - Player state is set to BUFFERING while loading playlists and provider instead of leaving the player in IDLE state
    - Player state is reset to IDLE between playback items and modes
- Setup sideloaded tracks after setting the video source
- Remove tech-debt:
  - No longer require "bufferFull" event to initiate playback
  - Remove QoE timer clock hack
  - Remove state attributes added to video tag: "jw-gesture-required" and "jw-loaded"
  - Prevent calls to `preload()` on providers after "playAttempt" (not IDLE)
  - Simplify resetting of error state to idle state
  - Remove provider loading logic form instream handled by the model (or adModel in this case)
  - Use promise chain from `controller.load()` instead of listening for "ItemReady" allowing us to handle rejection for:
    - Playlist failing to load or parse
    - Provider failing to load or instantiate
    - Error setting playlist item

### Why is this Pull Request needed?

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-commercial/pull/4027

#### Addresses Issue(s):

JW8-19
Closes #896 