### PR TITLE
Ensure player-rendered captions show for all tracks

### DIFF
--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -25,22 +25,22 @@ const Captions = function(_model) {
             return;
         }
 
-        var tracks = e.tracks || [];
-        for (var i = 0; i < tracks.length; i++) {
+        const tracks = e.tracks || [];
+        for (let i = 0; i < tracks.length; i++) {
             _addTrack(tracks[i]);
         }
 
         // To avoid duplicate tracks in the menu when we reuse an _id, regenerate the tracks array
         _tracks = Object.keys(_tracksById).map(id => _tracksById[id]);
 
-        var captionsMenu = _captionsMenu();
+        const captionsMenu = _captionsMenu();
         _selectDefaultIndex();
         this.setCaptionsList(captionsMenu);
     }
 
-    var _tracks = [];
-    var _tracksById = {};
-    var _unknownCount = 0;
+    let _tracks = [];
+    let _tracksById = {};
+    let _unknownCount = 0;
 
     /** Listen to playlist item updates. **/
     function _itemHandler() {
@@ -53,17 +53,14 @@ const Captions = function(_model) {
         // Clean up in case we're replaying
         _itemHandler(_model, item);
 
-        var tracks = item.tracks;
-        var len = tracks && tracks.length;
+        const tracks = item.tracks;
+        const len = tracks && tracks.length;
 
         // Sideload tracks when not rendering natively
         if (!_model.get('renderCaptionsNatively') && len) {
-            var i;
-            var track;
-
-            for (i = 0; i < len; i++) {
+            for (let i = 0; i < len; i++) {
                 /* eslint-disable no-loop-func */
-                track = tracks[i];
+                const track = tracks[i];
                 if (_kindSupported(track.kind) && !_tracksById[track._id]) {
                     _addTrack(track);
                     loadFile(track,
@@ -80,7 +77,7 @@ const Captions = function(_model) {
             }
         }
 
-        var captionsMenu = _captionsMenu();
+        const captionsMenu = _captionsMenu();
         _selectDefaultIndex();
         this.setCaptionsList(captionsMenu);
     }
@@ -94,7 +91,7 @@ const Captions = function(_model) {
     }
 
     function _captionsIndexHandler(model, captionsMenuIndex) {
-        var track = null;
+        let track = null;
         if (captionsMenuIndex !== 0) {
             track = _tracks[captionsMenuIndex - 1];
         }
@@ -107,7 +104,7 @@ const Captions = function(_model) {
         track._id = createId(track, _tracks.length);
 
         if (!track.name) {
-            var labelInfo = createLabel(track, _unknownCount);
+            const labelInfo = createLabel(track, _unknownCount);
             track.name = labelInfo.label;
             _unknownCount = labelInfo.unknownCount;
         }
@@ -118,11 +115,11 @@ const Captions = function(_model) {
     }
 
     function _captionsMenu() {
-        var list = [{
+        const list = [{
             id: 'off',
             label: 'Off'
         }];
-        for (var i = 0; i < _tracks.length; i++) {
+        for (let i = 0; i < _tracks.length; i++) {
             list.push({
                 id: _tracks[i]._id,
                 label: _tracks[i].name || 'Unknown CC'
@@ -132,8 +129,8 @@ const Captions = function(_model) {
     }
 
     function _selectDefaultIndex() {
-        var captionsMenuIndex = 0;
-        var label = _model.get('captionLabel');
+        let captionsMenuIndex = 0;
+        const label = _model.get('captionLabel');
 
         // Because there is no explicit track for "Off"
         //  it is the implied zeroth track
@@ -142,8 +139,8 @@ const Captions = function(_model) {
             return;
         }
 
-        for (var i = 0; i < _tracks.length; i++) {
-            var track = _tracks[i];
+        for (let i = 0; i < _tracks.length; i++) {
+            const track = _tracks[i];
             if (label && label === track.name) {
                 captionsMenuIndex = i + 1;
                 break;

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -732,7 +732,7 @@ Object.assign(Controller.prototype, {
                 btnClass: btnClass
             };
 
-            customButtons = _.reduce(customButtons, function(buttons, button) {
+            customButtons = customButtons.reduce(function(buttons, button) {
                 if (button.id === newButton.id) {
                     added = true;
                     buttons.push(newButton);
@@ -743,11 +743,7 @@ Object.assign(Controller.prototype, {
             }, []);
 
             if (!added) {
-                if (newButton.id === 'related') {
-                    customButtons.push(newButton);
-                } else {
-                    customButtons.unshift(newButton);
-                }
+                customButtons.unshift(newButton);
             }
 
             _model.set('customButtons', customButtons);

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -563,15 +563,19 @@ export default class Controlbar {
                 SimpleTooltip(newButton.element(), buttonProps.id, buttonProps.tooltip);
             }
 
-            let firstButton = buttonContainer.querySelector('.jw-spacer').nextSibling;
-            if (firstButton && firstButton.getAttribute('button') === 'logo') {
-                firstButton = firstButton.nextSibling;
+            let firstButton;
+            if (newButton.id === 'related') {
+                firstButton = this.elements.settingsButton.element();
+            } else if (newButton.id === 'share') {
+                firstButton = buttonContainer.querySelector('[button="related"]') ||
+                    this.elements.settingsButton.element();
+            } else {
+                firstButton = this.elements.spacer.nextSibling;
+                if (firstButton && firstButton.getAttribute('button') === 'logo') {
+                    firstButton = firstButton.nextSibling;
+                }
             }
-
-            buttonContainer.insertBefore(
-                newButton.element(),
-                firstButton
-            );
+            buttonContainer.insertBefore(newButton.element(), firstButton);
         }
     }
 

--- a/test/unit/controlbar-test.js
+++ b/test/unit/controlbar-test.js
@@ -21,12 +21,15 @@ describe('Control Bar', function() {
     beforeEach(function() {
         const spacer = document.createElement('div');
         spacer.className += 'jw-spacer';
+        const settingsButton = document.createElement('div');
 
         container = document.createElement('div');
-        container.appendChild(document.createElement('div'));
+        container.appendChild(settingsButton);
         container.appendChild(spacer);
 
         controlBar = new ControlBar({}, model);
+        controlBar.elements.spacer = spacer;
+        controlBar.elements.settingsButton = settingsButton;
         controlBar.elements.buttonContainer = container;
         children = container.children;
     });


### PR DESCRIPTION
### This PR will...
- Fix variable scoping issue causing captions cues to be written to the last track in the array 
- ES6’d the vars
### Why is this Pull Request needed?
- Sideloaded captions were only showing for one of the tracks in the captions menu when using the player's renderer. This was caused by incorrect variable scoping.
- var should be replaced with let/const.
### Are there any points in the code the reviewer needs to double check?
No.
### Are there any Pull Requests open in other repos which need to be merged with this?
No.
#### Addresses Issue(s):
JW8-454

