### PR TITLE
Disable tooltips in ads

### DIFF
--- a/src/css/controls/flags/ads.less
+++ b/src/css/controls/flags/ads.less
@@ -54,6 +54,7 @@
             }
         }
 
+        .jw-tooltip,
         .jw-icon-tooltip:not(.jw-icon-volume),
         .jw-icon-inline:not(.jw-icon-playback):not(.jw-icon-fullscreen):not(.jw-icon-volume) {
             display: none;


### PR DESCRIPTION
### This PR will...
add jw-tooltip to the list of elements that are hidden in ads ui
### Why is this Pull Request needed?
to prevent tooltips from blocking ads UI (i.e. IMA skip button)
### Are there any points in the code the reviewer needs to double check?
n/a
### Are there any Pull Requests open in other repos which need to be merged with this?
n/a
#### Addresses Issue(s):
JW8-426

