### PR TITLE
Firefox: Do not unobserve before observe for viewability

### DIFF
--- a/src/js/view/utils/views-manager.js
+++ b/src/js/view/utils/views-manager.js
@@ -7,13 +7,9 @@ const observed = [];
 let intersectionObserver;
 let responsiveRepaintRequestId = -1;
 
-console.log('lazyInitIntersectionObservers');
-
 function lazyInitIntersectionObserver() {
     const IntersectionObserver = window.IntersectionObserver;
-
     if (!intersectionObserver) {
-
         // Fire the callback every time 25% of the player comes in/out of view
         intersectionObserver = new IntersectionObserver((entries) => {
             if (entries && entries.length) {

--- a/src/js/view/utils/views-manager.js
+++ b/src/js/view/utils/views-manager.js
@@ -2,7 +2,7 @@ import activeTab from 'utils/active-tab';
 import { requestAnimationFrame, cancelAnimationFrame } from 'utils/request-animation-frame';
 
 const views = [];
-const observed = [];
+const observed = {};
 
 let intersectionObserver;
 let responsiveRepaintRequestId = -1;
@@ -88,7 +88,7 @@ export default {
     },
     unobserve(container) {
         if (intersectionObserver && observed[container.id]) {
-            observed[container.id] = false;
+            delete observed[container.id];
             intersectionObserver.unobserve(container);
         }
     },

--- a/src/js/view/utils/views-manager.js
+++ b/src/js/view/utils/views-manager.js
@@ -2,13 +2,18 @@ import activeTab from 'utils/active-tab';
 import { requestAnimationFrame, cancelAnimationFrame } from 'utils/request-animation-frame';
 
 const views = [];
+const observed = [];
 
 let intersectionObserver;
 let responsiveRepaintRequestId = -1;
 
+console.log('lazyInitIntersectionObservers');
+
 function lazyInitIntersectionObserver() {
     const IntersectionObserver = window.IntersectionObserver;
+
     if (!intersectionObserver) {
+
         // Fire the callback every time 25% of the player comes in/out of view
         intersectionObserver = new IntersectionObserver((entries) => {
             if (entries && entries.length) {
@@ -77,14 +82,21 @@ export default {
     },
     observe(container) {
         lazyInitIntersectionObserver();
-        try {
-            intersectionObserver.unobserve(container);
-        } catch (e) {/* catch Exception thrown by Edge 15 browser */}
+
+        if (observed[container.id]) {
+            return;
+        }
+
+        observed[container.id] = true;
         intersectionObserver.observe(container);
     },
     unobserve(container) {
-        if (intersectionObserver) {
+        if (intersectionObserver && observed[container.id]) {
+            observed[container.id] = false;
             intersectionObserver.unobserve(container);
         }
+    },
+    getIntersectionObsever() {
+        return intersectionObserver;
     }
 };

--- a/test/unit/views-manager-test.js
+++ b/test/unit/views-manager-test.js
@@ -15,7 +15,7 @@ describe('viewsManager', function() {
 
         it('should observe & unobserve the same container', function() {
             const container = document.createElement('div');
-            container.id = 1;
+            container.id = 'player-1';
 
             viewsManager.observe(container);
             viewsManager.unobserve(container);
@@ -26,7 +26,7 @@ describe('viewsManager', function() {
 
         it('should observe & unobserve the same container once on multiple calls', function() {
             const container = document.createElement('div');
-            container.id = 1;
+            container.id = 'player-1';
 
             viewsManager.observe(container);
             viewsManager.observe(container);
@@ -39,10 +39,10 @@ describe('viewsManager', function() {
 
         it('should observe & unobserve multiple containers', function() {
             const container1 = document.createElement('div');
-            container1.id = 1;
+            container1.id = 'player-1';
 
             const container2 = document.createElement('div');
-            container2.id = 2;
+            container2.id = 'player-2';
 
             viewsManager.observe(container1);
             viewsManager.observe(container2);
@@ -56,7 +56,7 @@ describe('viewsManager', function() {
 
     it('should do nothing when there is nothing to unobserve', function() {
         const container = document.createElement('div');
-        container.id = 1;
+        container.id = 'player-1';
 
         viewsManager.unobserve(container);
 

--- a/test/unit/views-manager-test.js
+++ b/test/unit/views-manager-test.js
@@ -1,0 +1,64 @@
+import viewsManager from 'view/utils/views-manager';
+import sinon from 'sinon';
+
+describe('viewsManager', function() {
+
+    let intersectionObserver;
+
+    beforeEach(function() {
+        intersectionObserver = viewsManager.getIntersectionObsever();
+        intersectionObserver.observe = sinon.spy();
+        intersectionObserver.unobserve = sinon.spy();
+    });
+
+    describe('intersectionObserver', function() {
+
+        it('should observe & unobserve the same container', function() {
+            const container = document.createElement('div');
+            container.id = 1;
+
+            viewsManager.observe(container);
+            viewsManager.unobserve(container);
+
+            expect(intersectionObserver.observe.callCount).to.equal(1);
+            expect(intersectionObserver.unobserve.callCount).to.equal(1);
+        });
+
+        it('should observe the same container once on multiple calls', function() {
+            const container = document.createElement('div');
+            container.id = 1;
+
+            viewsManager.observe(container);
+            viewsManager.observe(container);
+            viewsManager.unobserve(container);
+
+            expect(intersectionObserver.observe.callCount).to.equal(1);
+            expect(intersectionObserver.unobserve.callCount).to.equal(1);
+        });
+
+        it('should observe the same container once on multiple calls', function() {
+            const container1 = document.createElement('div');
+            container1.id = 1;
+
+            const container2 = document.createElement('div');
+            container2.id = 1;
+
+            viewsManager.observe(container1);
+            viewsManager.observe(container2);
+            viewsManager.unobserve(container1);
+            viewsManager.unobserve(container2);
+
+            expect(intersectionObserver.observe.callCount).to.equal(2);
+            expect(intersectionObserver.unobserve.callCount).to.equal(2);
+        });
+    });
+
+    it('should do nothing when there is nothing to unobserve', function() {
+        const container = document.createElement('div');
+        container.id = 1;
+
+        viewsManager.unobserve(container);
+
+        expect(intersectionObserver.unobserve.callCount).to.equal(0);
+    });
+});

--- a/test/unit/views-manager-test.js
+++ b/test/unit/views-manager-test.js
@@ -24,24 +24,25 @@ describe('viewsManager', function() {
             expect(intersectionObserver.unobserve.callCount).to.equal(1);
         });
 
-        it('should observe the same container once on multiple calls', function() {
+        it('should observe & unobserve the same container once on multiple calls', function() {
             const container = document.createElement('div');
             container.id = 1;
 
             viewsManager.observe(container);
             viewsManager.observe(container);
             viewsManager.unobserve(container);
+            viewsManager.unobserve(container);
 
             expect(intersectionObserver.observe.callCount).to.equal(1);
             expect(intersectionObserver.unobserve.callCount).to.equal(1);
         });
 
-        it('should observe the same container once on multiple calls', function() {
+        it('should observe & unobserve multiple containers', function() {
             const container1 = document.createElement('div');
             container1.id = 1;
 
             const container2 = document.createElement('div');
-            container2.id = 1;
+            container2.id = 2;
 
             viewsManager.observe(container1);
             viewsManager.observe(container2);


### PR DESCRIPTION
### This PR will...

Keep track of observed players to avoid observing the same player multiple times, due to async calls.

### Why is this Pull Request needed?

Now that Firefox supports the Intersection Observer API, there exists a bug in v55 that breaks observing if you unobserve before ever observing

#### Addresses Issue(s):

JW8-476