### PR TITLE
Do not set element localName when not rendering captions natively

### DIFF
--- a/src/js/polyfills/webvtt.js
+++ b/src/js/polyfills/webvtt.js
@@ -194,9 +194,6 @@ function parseContent(window, input) {
             return null;
         }
         var element = window.document.createElement(tagName);
-        Object.assign(element, {
-            localName: tagName
-        });
         var name = TAG_ANNOTATION[type];
         if (name && annotation) {
             element[name] = annotation.trim();


### PR DESCRIPTION
### This PR will...

No longer attempt to set a value to `element.localName` since it is read-only

### Why is this Pull Request needed?

A change was made in JW8 where it used `Object.assign` to set `localName`, which throws an exception because it is read-only. Previously it was trying to set by `element.localName = localName` which failed silently. This broke non-native rendering captions.

#### Addresses Issue(s):

JW8-459

