### PR TITLE
Prevent control gradient from covering nonlinear ads

### DIFF
--- a/src/css/jwplayer/imports/jwplayerlayout.less
+++ b/src/css/jwplayer/imports/jwplayerlayout.less
@@ -77,6 +77,11 @@
     }
 }
 
+.jw-plugin-vast,
+.jw-plugin-googima {
+    z-index: 1;
+}
+
 /* Allow pointer events through to the provider */
 .jw-preview,
 .jw-captions,

--- a/src/js/plugins/loader.js
+++ b/src/js/plugins/loader.js
@@ -7,10 +7,6 @@ function configurePlugin(pluginObj, pluginConfig, api) {
     div.id = api.id + '_' + pluginName;
     div.className = 'jw-plugin jw-reset';
 
-    if (pluginName === 'googima' || pluginName === 'vast') {
-        div.style.zIndex = "1";
-    }
-
     const pluginOptions = Object.assign({}, pluginConfig);
     const pluginInstance = pluginObj.getNewInstance(api, pluginOptions, div);
 

--- a/src/js/plugins/loader.js
+++ b/src/js/plugins/loader.js
@@ -7,10 +7,14 @@ function configurePlugin(pluginObj, pluginConfig, api) {
     div.id = api.id + '_' + pluginName;
     div.className = 'jw-plugin jw-reset';
 
+    if (pluginName === 'googima' || pluginName === 'vast') {
+        div.style.zIndex = "1";
+    }
+
     const pluginOptions = Object.assign({}, pluginConfig);
     const pluginInstance = pluginObj.getNewInstance(api, pluginOptions, div);
 
-    api.addPlugin(pluginName, pluginInstance, div);
+    api.addPlugin(pluginName, pluginInstance);
 }
 
 const PluginLoader = function () {


### PR DESCRIPTION
### This PR will...
add a z-index of 1 to the ads plugins
### Why is this Pull Request needed?
to prevent the control gradient from making nonlinear ads less visible
### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-ads-vast/pull/249
https://github.com/jwplayer/jwplayer-ads-googima/pull/250
#### Addresses Issue(s):
JW8-396

