### PR TITLE
Fix caption alignment for DVR streams

### DIFF
--- a/src/js/view/captionsrenderer.js
+++ b/src/js/view/captionsrenderer.js
@@ -119,8 +119,8 @@ define([
                     return metadata[source];
                 }
                 return;
-            } else if (track.embedded && timeEvent.duration < 0) {
-                // In DVR mode, need to make alignmentPosition positive for captions to work
+            } else if (timeEvent.duration < 0) {
+                // When the duration is negative (DVR mode), make alignmentPosition positive to align captions
                 return timeEvent.position - timeEvent.duration;
             }
 


### PR DESCRIPTION



### This PR will...
Ensure captions are aligned when using the player's captions renderer with DVR streams.
### Why is this Pull Request needed?
This was fixed for `8.0.0-beta.2` but is needed for a customer still using the v7 player.
### Are there any points in the code the reviewer needs to double check?
No.
### Are there any Pull Requests open in other repos which need to be merged with this?
No.
#### Addresses Issue(s):
JW7-4492

