### PR TITLE
Set slider height to 44px on mobile to improve touchability 

### DIFF
--- a/src/css/controls/imports/controlbar.less
+++ b/src/css/controls/imports/controlbar.less
@@ -39,7 +39,7 @@
     }
 
     .jw-flag-touch & {
-        max-height: 93px;
+        max-height: 88px;
     }
 }
 

--- a/src/css/controls/imports/controlbar.less
+++ b/src/css/controls/imports/controlbar.less
@@ -37,6 +37,10 @@
             color: @hover-color;
         }
     }
+
+    .jw-flag-touch & {
+        max-height: 93px;
+    }
 }
 
 .jw-button-container {
@@ -198,3 +202,4 @@
         }
     }
 }
+

--- a/src/css/controls/imports/slider.less
+++ b/src/css/controls/imports/slider.less
@@ -161,7 +161,7 @@
     }
 
     .jw-flag-touch & {
-        .rect(100%, 39px);
+        .rect(100%, 44px);
         align-items: flex-end;
         padding-bottom: 5px;
     }

--- a/src/css/controls/imports/slider.less
+++ b/src/css/controls/imports/slider.less
@@ -111,7 +111,7 @@
 }
 
 .jw-slider-time {
-    .rect(100%, 16px);
+    .rect(100%, 17px);
     align-items: center;
     background: transparent none;
     padding: 0 12px;
@@ -158,5 +158,11 @@
         .jw-knob {
             transform: translate(-50%, -50%) scale(1);
         }
+    }
+
+    .jw-flag-touch & {
+        .rect(100%, 39px);
+        align-items: flex-end;
+        padding-bottom: 5px;
     }
 }


### PR DESCRIPTION
### This PR will...
- Make the timeslider container 44px
- Align the slider itself to the bottom of the container
- Add 5px to the bottom of the slider container
- Increase the controlbar height max to 88px
- Default slider container size to 17px so the 5px slider divides evenly into it (half-pixels are bad)

### Why is this Pull Request needed?
To increase timeslider touchability on mobile

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-404
