### PR TITLE
Make logo max 15% of player size, center logo 

### DIFF
--- a/src/css/jwplayer/imports/logo.less
+++ b/src/css/jwplayer/imports/logo.less
@@ -6,13 +6,15 @@
     cursor: pointer;
     pointer-events: all;
 
-    background-repeat: no-repeat;
+    background: no-repeat center;
     background-size: contain;
 
     top: auto;
     right: auto;
     left: auto;
     bottom: auto;
+    max-height: 15%;
+    max-width: 15%;
 }
 
 .jw-flag-audio-player .jw-logo {

--- a/src/css/jwplayer/imports/logo.less
+++ b/src/css/jwplayer/imports/logo.less
@@ -13,8 +13,6 @@
     right: auto;
     left: auto;
     bottom: auto;
-    max-height: 15%;
-    max-width: 15%;
 }
 
 .jw-flag-audio-player .jw-logo {

--- a/src/css/jwplayer/imports/logo.less
+++ b/src/css/jwplayer/imports/logo.less
@@ -6,7 +6,7 @@
     cursor: pointer;
     pointer-events: all;
 
-    background: no-repeat center;
+    background: no-repeat right;
     background-size: contain;
 
     top: auto;

--- a/src/css/jwplayer/imports/logo.less
+++ b/src/css/jwplayer/imports/logo.less
@@ -6,7 +6,7 @@
     cursor: pointer;
     pointer-events: all;
 
-    background: no-repeat right;
+    background-repeat: no-repeat;
     background-size: contain;
 
     top: auto;

--- a/src/js/view/logo.js
+++ b/src/js/view/logo.js
@@ -40,12 +40,10 @@ export default function Logo(_model) {
         // apply styles onload when image width and height are known
         _img.onload = function () {
             // update logo style
-            const height = this.height;
-            const width = this.width;
+            let height = this.height;
+            let width = this.width;
             const styles = {
-                backgroundImage: 'url("' + this.src + '")',
-                width,
-                height
+                backgroundImage: 'url("' + this.src + '")'
             };
             if (_settings.margin !== LogoDefaults.margin) {
                 const positions = (/(\w+)-(\w+)/).exec(_settings.position);
@@ -56,8 +54,26 @@ export default function Logo(_model) {
             }
 
             // Constraint logo size to 15% of their respective player dimension
-            styles.width = Math.min(width, Math.round(_model.get('containerWidth') / 6.67));
-            styles.height = Math.min(height, Math.round( _model.get('containerHeight') / 6.67));
+            const maxHeight = _model.get('containerHeight') * 0.15;
+            const maxWidth = _model.get('containerWidth') * 0.15;
+
+            if (height > maxHeight || width > maxWidth) {
+                const logoAR = width / height;
+                const videoAR = maxWidth / maxHeight;
+
+                if (videoAR > logoAR) {
+                    // height = max dimension
+                    height = maxHeight;
+                    width = maxHeight * logoAR;
+                } else {
+                    // width = max dimension
+                    width = maxWidth;
+                    height = maxWidth * logoAR;
+                }
+            }
+
+            styles.width = Math.round(width);
+            styles.height = Math.round(height);
 
             style(_logo, styles);
 

--- a/src/js/view/logo.js
+++ b/src/js/view/logo.js
@@ -17,7 +17,7 @@ export default function Logo(_model) {
 
     var _logo;
     var _settings;
-    var _img = new Image();
+    const _img = new Image();
 
     this.setup = function() {
         _settings = Object.assign({}, LogoDefaults, _model.get('logo'));
@@ -40,18 +40,25 @@ export default function Logo(_model) {
         // apply styles onload when image width and height are known
         _img.onload = function () {
             // update logo style
-            var styles = {
+            const height = this.height;
+            const width = this.width;
+            const styles = {
                 backgroundImage: 'url("' + this.src + '")',
-                width: this.width,
-                height: this.height
+                width,
+                height
             };
             if (_settings.margin !== LogoDefaults.margin) {
-                var positions = (/(\w+)-(\w+)/).exec(_settings.position);
+                const positions = (/(\w+)-(\w+)/).exec(_settings.position);
                 if (positions.length === 3) {
                     styles['margin-' + positions[1]] = _settings.margin;
                     styles['margin-' + positions[2]] = _settings.margin;
                 }
             }
+
+            // Constraint logo size to 15% of their respective player dimension
+            styles.width = Math.min(width, Math.round(_model.get('containerWidth') / 6.67));
+            styles.height = Math.min(height, Math.round( _model.get('containerHeight') / 6.67));
+
             style(_logo, styles);
 
             // update title
@@ -60,7 +67,7 @@ export default function Logo(_model) {
 
         _img.src = _settings.file;
 
-        var logoInteractHandler = new UI(_logo);
+        const logoInteractHandler = new UI(_logo);
         logoInteractHandler.on('click tap', function (evt) {
             if (evt && evt.stopPropagation) {
                 evt.stopPropagation();

--- a/src/js/view/logo.js
+++ b/src/js/view/logo.js
@@ -68,7 +68,7 @@ export default function Logo(_model) {
                 } else {
                     // width = max dimension
                     width = maxWidth;
-                    height = maxWidth * logoAR;
+                    height = maxWidth / logoAR;
                 }
             }
 


### PR DESCRIPTION
### This PR will...
- Set max-width and max-height to 15% of player size
- Right align the logo, since it can be rectangular, and left aligns by default

### Why is this Pull Request needed?
We shouldn't let large logos obscure the player

### Are there any points in the code the reviewer needs to double check?
Test config w/ large logo: 
````
{
    "sources": [
        {
            "file": "http://content.bitsontherun.com/videos/3XnJSIm4-52qL9xLP.mp4"
        }
    ],
    "image": "http://content.bitsontherun.com/thumbs/3XnJSIm4-480.jpg",
    "title": "Sintel, the Durian Open Movie Project",
    "description": "Now this is an achievement! When characters go beyond the screen right inside our lives.",
    "displaytitle": true,
    "displaydescription": true,
    "logo": {
        "file": "https://buildahead.com/wp-content/uploads/2017/02/eggplant-300x300.png"
    }
}
````

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-280
