### PR TITLE
Add in autoadvance event for nextUp

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -539,7 +539,20 @@ Object.assign(Controller.prototype, {
             }
 
             // It wasn't the last item in the playlist,
-            //  so go to the next one
+            //  so go to the next one and trigger an autoadvance event
+            const related = _api.getPlugin('related');
+            if (related) {
+                const nextUp = _model.get('nextUp');
+                if (nextUp) {
+                    _this.trigger('nextAutoAdvance', {
+                        mode: nextUp.mode,
+                        ui: 'nextup',
+                        target: nextUp,
+                        itemsShown: [ nextUp ],
+                        feedData: nextUp.feedData,
+                    });
+                }
+            }
             _next({ reason: 'playlist' });
         }
 
@@ -850,7 +863,7 @@ Object.assign(Controller.prototype, {
         ], () => !_model.getVideo());
         // Add commands from CoreLoader to queue
         apiQueue.queue.push.apply(apiQueue.queue, commandQueue);
-        
+
         _view.setup();
     },
     get(property) {

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -541,18 +541,7 @@ Object.assign(Controller.prototype, {
             // It wasn't the last item in the playlist,
             //  so go to the next one and trigger an autoadvance event
             const related = _api.getPlugin('related');
-            if (related) {
-                const nextUp = _model.get('nextUp');
-                if (nextUp) {
-                    _this.trigger('nextAutoAdvance', {
-                        mode: nextUp.mode,
-                        ui: 'nextup',
-                        target: nextUp,
-                        itemsShown: [ nextUp ],
-                        feedData: nextUp.feedData,
-                    });
-                }
-            }
+            triggerAdvanceEvent(related, 'nextAutoAdvance');
             _next({ reason: 'playlist' });
         }
 
@@ -675,18 +664,25 @@ Object.assign(Controller.prototype, {
 
         function _nextUp() {
             const related = _api.getPlugin('related');
-            if (related) {
-                const nextUp = _model.get('nextUp');
-                if (nextUp) {
-                    _this.trigger('nextClick', {
-                        mode: nextUp.mode,
-                        ui: 'nextup',
-                        target: nextUp,
-                        itemsShown: [ nextUp ],
-                        feedData: nextUp.feedData,
-                    });
-                }
-                related.next();
+            triggerAdvanceEvent(related, 'nextClick', () => related.next());
+        }
+
+        function triggerAdvanceEvent(related, evt, cb) {
+            if (!related) {
+                return;
+            }
+            const nextUp = _model.get('nextUp');
+            if (nextUp) {
+                _this.trigger(evt, {
+                    mode: nextUp.mode,
+                    ui: 'nextup',
+                    target: nextUp,
+                    itemsShown: [ nextUp ],
+                    feedData: nextUp.feedData,
+                });
+            }
+            if (typeof cb === 'function') {
+                cb();
             }
         }
 


### PR DESCRIPTION
### This PR will...
Add a new event to the player api which denotes when a player auto-advances to the next video after the `next up` ui is displayed.

### Why is this Pull Request needed?
We would like to add an API event when the player advances to the next video on its own in the event that the related plugin is being used to set up playlists/recs.

### Are there any points in the code the reviewer needs to double check?
It would be good to ensure that the consolidation of the event firing makes sense. Instead of simple making them a single API event (`nextAdvance` or something similar) this approach makes the two different types of advancement individually trackable.

### Are there any Pull Requests open in other repos which need to be merged with this?
This can be merged with associated functionality in other PRs

#### Addresses Issue(s):
DATA948

