### PR TITLE
console exception on error

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -346,7 +346,7 @@ Object.assign(Controller.prototype, {
             });
             loader.on(ERROR, function(evt) {
                 evt.message = `Error loading playlist: ${evt.message}`;
-                this.triggerError(evt);
+                _this.triggerError(evt);
             }, this);
             loader.load(toLoad);
         }

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -850,7 +850,7 @@ Object.assign(Controller.prototype, {
         ], () => !_model.getVideo());
         // Add commands from CoreLoader to queue
         apiQueue.queue.push.apply(apiQueue.queue, commandQueue);
-        
+
         _view.setup();
     },
     get(property) {


### PR DESCRIPTION
### This PR will...

Call `triggerError` from the controller and not the bound `this`

### Why is this Pull Request needed?

Was producing a console error that obfuscated the actual error when `api.load()`

### Are there any points in the code the reviewer needs to double check?

To reproduce: 

- Go to http://player-develop-test-jenkins.longtailvideo.com/builds/lastSuccessfulBuild/archive/test/harness.html?edition=ads&config=basic_mp4&feature=basic_mp4
- Setup Player
- execute jwplayer().load('a') in console

Expected: Player should display the `Error loading playlist: File not found`
Actual: Exception in console log
![screenshot 2017-09-14 14 51 12](https://user-images.githubusercontent.com/584053/30448227-2ccb1780-995c-11e7-941e-82391091fa86.png)



