### PR TITLE
Assign uniqueId of 1 to first player

### DIFF
--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -64,8 +64,9 @@ function removePlayer(api) {
  */
 export default function Api(element) {
     // Add read-only properties which access privately scoped data
-    // TODO: The alternative to pass this to the controller/model and access it from there
-    const uniqueId = instancesCreated++;
+
+    // `uniqueId` should start at 1
+    const uniqueId = ++instancesCreated;
     const playerId = element.id;
     const qoeTimer = new Timer();
     const pluginsMap = {};


### PR DESCRIPTION
### Why is this Pull Request needed?

Truthy `uniqueId` allows `!jwplayer(i).uniqueId` to be a valid player check. We use it to count player instances on a page. It starts at 1 in v7. This addresses a regression in player tracking introduced in v8 alpha.