### PR TITLE
Allow streams to resume with negative time

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -101,7 +101,7 @@ var InstreamAdapter = function(_controller, _model, _view) {
             // make sure video restarts after preroll
             _oldpos = 0;
         } else if (_model.checkComplete() || _model.get('state') === STATE_COMPLETE) {
-            _oldpos = -1;
+            _oldpos = null;
         }
 
         // Show instream state instead of normal player state
@@ -313,13 +313,12 @@ var InstreamAdapter = function(_controller, _model, _view) {
             // Re-attach the controller
             _controller.attachMedia();
 
-            // -1 is used to resume at the live edge
-            if (_oldpos !== -1) {
+            if (_oldpos === null) {
+                _model.stopVideo();
+            } else {
                 const item = Object.assign({}, _olditem);
                 item.starttime = _oldpos;
                 _model.loadVideo(item);
-            } else {
-                _model.stopVideo();
             }
         }
     };

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -313,11 +313,12 @@ var InstreamAdapter = function(_controller, _model, _view) {
             // Re-attach the controller
             _controller.attachMedia();
 
-            if (_oldpos >= 0) {
-                var item = Object.assign({}, _olditem);
+            // -1 is used to resume at the live edge
+            if (_oldpos !== -1) {
+                const item = Object.assign({}, _olditem);
                 item.starttime = _oldpos;
                 _model.loadVideo(item);
-            } else if (_oldpos === -1) {
+            } else {
                 _model.stopVideo();
             }
         }


### PR DESCRIPTION
### This PR will...
Allow streams with negative durations (DVR/live) to start.

### Why is this Pull Request needed?
Live streams coming back from midrolls were not starting

### Are there any points in the code the reviewer needs to double check?
We need to allow streams with -1 position to start. @robwalch 

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/4065

#### Addresses Issue(s):

JW8-466

