### PR TITLE
Remove flex properties from IE11 tooltips 

### DIFF
--- a/src/css/controls/imports/tooltip.less
+++ b/src/css/controls/imports/tooltip.less
@@ -134,13 +134,7 @@
 .jw-tooltip {
     bottom: @controlbar-height;
     display: none;
-    flex-wrap: nowrap;
-    flex: 1 1 auto;
     position: absolute;
-
-    &.jw-open {
-        display: flex;
-    }
 
     .jw-text {
         height: 100%;


### PR DESCRIPTION
### Why is this Pull Request needed?
There's some strange bug with flex and text truncation. The `.jw-open` class already sets `display:block`, so this code is not needed.

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-544
