### PR TITLE
Use overflow-y: auto so that scrollbars do not display if content does not overflow 

### DIFF
--- a/src/css/controls/imports/settings-menu.less
+++ b/src/css/controls/imports/settings-menu.less
@@ -81,7 +81,7 @@
     align-items: flex-start;
     align-content: flex-start;
     padding: 8px 20px 0 5px;
-    overflow-y: scroll;
+    overflow-y: auto;
     -webkit-overflow-scrolling: touch;
 
     &::-webkit-scrollbar {

--- a/src/css/controls/imports/settings-menu.less
+++ b/src/css/controls/imports/settings-menu.less
@@ -82,7 +82,6 @@
     align-content: flex-start;
     padding: 8px 20px 0 5px;
     overflow-y: auto;
-    -webkit-overflow-scrolling: touch;
 
     &::-webkit-scrollbar {
         width: 6px;
@@ -93,6 +92,11 @@
         background-color: @white;
         border-radius: 6px;
         border: 1px solid @menu-background-color;
+    }
+
+    .jw-flag-touch & {
+        overflow-y: scroll;
+        -webkit-overflow-scrolling: touch;
     }
 }
 


### PR DESCRIPTION
### Why is this Pull Request needed?
Scrollbars should only show when needed

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-398
