### PR TITLE
Restrict max controlbar logo height to 24px 

### DIFF
--- a/src/css/controls/imports/controlbar.less
+++ b/src/css/controls/imports/controlbar.less
@@ -22,6 +22,7 @@
     .jw-button-image {
         background: no-repeat 50% 50%;
         background-size: contain;
+        max-height: 24px;
     }
 
     .jw-spacer {


### PR DESCRIPTION
### Why is this Pull Request needed?
To prevent square aspect controlbar logos from appearing too tall

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-284
