### PR TITLE
Click to play fixes

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -44,6 +44,7 @@ Object.assign(Controller.prototype, {
         let _stopPlaylist = false;
         let _interruptPlay;
         let checkAutoStartCancelable = cancelable(_checkAutoStart);
+        let updatePlaylistCancelable = cancelable(function() {});
 
         _this.originalContainer = _this.currentContainer = originalContainer;
         _this._events = eventListeners;
@@ -288,6 +289,7 @@ Object.assign(Controller.prototype, {
 
             checkAutoStartCancelable.cancel();
             checkAutoStartCancelable = cancelable(_checkAutoStart);
+            updatePlaylistCancelable.cancel();
 
             let loadPromise;
 
@@ -298,9 +300,10 @@ Object.assign(Controller.prototype, {
                             message: `Error loading playlist: ${error.message}`
                         });
                     });
-                    loadPromise = loadPlaylistPromise.then(data => {
+                    updatePlaylistCancelable = cancelable((data) => {
                         return _updatePlaylist(data.playlist, data);
                     });
+                    loadPromise = loadPlaylistPromise.then(updatePlaylistCancelable.async);
                     break;
                 }
                 case 'object':

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -17,7 +17,7 @@ import { streamType } from 'providers/utils/stream-type';
 import { resolved } from 'polyfills/promise';
 import cancelable from 'utils/cancelable';
 import _ from 'utils/underscore';
-import { STATE_BUFFERING, STATE_IDLE, STATE_COMPLETE, STATE_PAUSED, STATE_PLAYING, STATE_ERROR, STATE_LOADING,
+import { PLAYER_STATE, STATE_BUFFERING, STATE_IDLE, STATE_COMPLETE, STATE_PAUSED, STATE_PLAYING, STATE_ERROR, STATE_LOADING,
     STATE_STALLED, MEDIA_BEFOREPLAY, PLAYLIST_LOADED, ERROR, PLAYLIST_COMPLETE, CAPTIONS_CHANGED, READY,
     MEDIA_ERROR, MEDIA_COMPLETE, CAST_SESSION, FULLSCREEN, PLAYLIST_ITEM, MEDIA_VOLUME, MEDIA_MUTE, PLAYBACK_RATE_CHANGED,
     CAPTIONS_LIST, CONTROLS, RESIZE } from 'events/events';
@@ -135,8 +135,8 @@ Object.assign(Controller.prototype, {
         });
 
         _model.on('change:mediaModel', function(model) {
-            model.mediaModel.on('change:state', function(mediaModel, state) {
-                model.set('state', normalizeState(state));
+            model.mediaModel.change(PLAYER_STATE, function(mediaModel, state) {
+                model.set(PLAYER_STATE, normalizeState(state));
             });
         });
 

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -285,6 +285,8 @@ var InstreamAdapter = function(_controller, _model, _view) {
                 _view.clickHandler().revertAlternateClickHandlers();
             }
 
+            const adState = _instream._adModel.get('state');
+
             _model.off(null, null, _instream);
             _instream.off(null, null, _this);
             _instream.instreamDestroy();
@@ -301,6 +303,7 @@ var InstreamAdapter = function(_controller, _model, _view) {
 
             // Re-attach the controller
             _controller.attachMedia();
+            _model.set('state', adState);
 
             if (_oldpos === null) {
                 _model.stopVideo();

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -364,6 +364,7 @@ const Model = function() {
                     throw new Error('Unsupported media');
                 }
                 if (mediaModelContext === this.mediaModel) {
+                    syncPlayerWithMediaModel(mediaModelContext);
                     return this.setProvider(item);
                 }
                 return resolved;
@@ -508,9 +509,7 @@ const Model = function() {
         playPromise.then(() => {
             mediaModelContext.set('started', true);
             if (mediaModelContext === model.mediaModel) {
-                // Sync player state with mediaModel state
-                const mediaState = mediaModelContext.get('state');
-                mediaModelContext.trigger('change:state', mediaModelContext, mediaState, mediaState);
+                syncPlayerWithMediaModel(mediaModelContext);
             }
         }).catch(error => {
             model.mediaController.trigger(MEDIA_PLAY_ATTEMPT_FAILED, {
@@ -519,6 +518,12 @@ const Model = function() {
                 playReason: playReason
             });
         });
+    }
+
+    function syncPlayerWithMediaModel(mediaModel) {
+        // Sync player state with mediaModel state
+        const mediaState = mediaModel.get('state');
+        mediaModel.trigger('change:state', mediaModel, mediaState, mediaState);
     }
 
     this.stopVideo = function() {
@@ -635,7 +640,9 @@ const Model = function() {
 
 // Represents the state of the provider/media element
 const MediaModel = Model.MediaModel = function() {
-    this.attributes = {};
+    this.attributes = {
+        state: STATE_IDLE
+    };
 };
 
 Object.assign(MediaModel.prototype, SimpleModel, {

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -554,10 +554,7 @@ const Model = function() {
         let playPromise;
 
         if (!this.mediaModel.get('setup')) {
-            resetItem(this, item);
-
             playPromise = loadAndPlay(this, item);
-
             playAttempt(this, playPromise, playReason);
         } else {
             playPromise = _provider.play() || resolved;

--- a/src/js/providers/default.js
+++ b/src/js/providers/default.js
@@ -1,4 +1,4 @@
-import { STATE_IDLE, PLAYER_STATE, MEDIA_TYPE } from 'events/events';
+import { PLAYER_STATE, MEDIA_TYPE } from 'events/events';
 
 const noop = function() {};
 const returnFalse = (() => false);
@@ -71,12 +71,7 @@ const DefaultProvider = {
     init: noop,
 
     setState: function(state) {
-        var oldState = this.state || STATE_IDLE;
         this.state = state;
-
-        if (state === oldState) {
-            return;
-        }
 
         this.trigger(PLAYER_STATE, {
             newstate: state

--- a/src/js/utils/cancelable.js
+++ b/src/js/utils/cancelable.js
@@ -4,12 +4,15 @@ export default function cancelable(callback) {
     let cancelled = false;
 
     return {
-        async: () => resolved.then(() => {
-            if (cancelled) {
-                return;
-            }
-            return callback();
-        }),
+        async: function() {
+            const args = arguments;
+            return resolved.then(() => {
+                if (cancelled) {
+                    return;
+                }
+                return callback.apply(this, args);
+            });
+        },
         cancel: () => {
             cancelled = true;
         },


### PR DESCRIPTION
### This PR will...

- Cancel playlist update for async playlist loading when a new call to `load()` interrupts the process. A call to load invalidates previous calls.
- Always fire "playAttemptFailed" and include "item" for context. This will make it easier to trouble shoot ads behavior.
- Don't reset visualPlaylist when starting playback (It may have already been determined during preloading)
- Keep player and media model states in sync and pass ad state on to player after ads end. This helps keep the player state from getting out of sync when the main model is detached.

#### Addresses Issue(s):

JW8-532, JW8-569, JW8-132
