### PR TITLE
Make gradient separate element

### DIFF
--- a/src/css/controls/flags/ads.less
+++ b/src/css/controls/flags/ads.less
@@ -138,4 +138,8 @@
         /* stylelint-disable-next-line declaration-no-important */
         display: none !important;
     }
+
+    .jw-gradient {
+        opacity: 0;
+    }
 }

--- a/src/css/controls/flags/controls-hidden.less
+++ b/src/css/controls/flags/controls-hidden.less
@@ -27,6 +27,10 @@
         transition-delay: 0s, 250ms;
     }
 
+    .jw-gradient {
+        opacity: 0;
+    }
+
     .jw-logo {
         visibility: visible;
     }

--- a/src/css/controls/flags/flash-blocked.less
+++ b/src/css/controls/flags/flash-blocked.less
@@ -5,4 +5,8 @@ body .jwplayer.jw-flag-flash-blocked {
     .jw-preview {
         display: none;
     }
+
+    .jw-gradient {
+        opacity: 0;
+    }
 }

--- a/src/css/controls/flags/overlay.less
+++ b/src/css/controls/flags/overlay.less
@@ -5,5 +5,9 @@
         .jw-logo {
             display: none;
         }
+
+        .jw-gradient {
+            opacity: 0;
+        }
     }
 }

--- a/src/css/controls/imports/controlbar.less
+++ b/src/css/controls/imports/controlbar.less
@@ -150,6 +150,10 @@
             opacity: 0;
             transition-delay: 0s, 250ms;
         }
+
+        .jw-gradient {
+            opacity: 0;
+        }
     }
 }
 

--- a/src/css/controls/imports/jwplayerlayout.less
+++ b/src/css/controls/imports/jwplayerlayout.less
@@ -7,20 +7,19 @@
     pointer-events: none; // Allow pointer events through to the provider
 }
 
+.jw-gradient {
+    &:extend(._pseudo, ._stretch, ._topleft);
+    background: linear-gradient(to bottom, transparent, fade(@black, 40%) 77%, fade(@black, 40%) 100%) 100% 100% / 100% 240px no-repeat transparent;
+    transition: opacity 250ms @default-timing-function;
+    pointer-events: none;
+}
+
 .jw-overlays {
     cursor: auto;
 }
 
 .jw-controls {
     overflow: hidden;
-    z-index: 0;
-
-    &::after {
-        &:extend(._pseudo, ._stretch, ._topleft);
-        background: linear-gradient(to bottom, transparent, fade(@black, 40%) 77%, fade(@black, 40%) 100%) 100% 100% / 100% 240px no-repeat transparent;
-        transition: opacity 250ms @default-timing-function;
-        z-index: -1;
-    }
 
     .jw-flag-small-player & {
         text-align: center;

--- a/src/css/controls/states.less
+++ b/src/css/controls/states.less
@@ -57,6 +57,7 @@
     }
 
     &.jw-flag-user-inactive:not(.jw-flag-audio-player):not(.jw-flag-casting):not(.jw-flag-media-audio) {
+        .jw-gradient,
         .jw-controls::after {
             opacity: 0;
         }
@@ -126,10 +127,8 @@
     }
 
     .jw-controls {
-        &::after {
-            background: @controlbar-background;
-            height: 100%;
-        }
+        background: @controlbar-background;
+        height: 100%;
     }
 }
 
@@ -163,6 +162,11 @@ body .jwplayer.jw-state-error {
         .jw-svg-icon-error {
             display: block;
         }
+    }
+
+    .jw-controls {
+        background: @controlbar-background;
+        height: 100%;
     }
 }
 
@@ -209,6 +213,10 @@ body .jwplayer.jw-state-error,
         height: 100%;
         top: 0;
         bottom: 0;
+    }
+
+    .jw-gradient {
+        opacity: 0;
     }
 
     .jw-controls::after {

--- a/src/css/controls/states.less
+++ b/src/css/controls/states.less
@@ -57,7 +57,6 @@
     }
 
     &.jw-flag-user-inactive:not(.jw-flag-audio-player):not(.jw-flag-casting):not(.jw-flag-media-audio) {
-        .jw-gradient,
         .jw-controls::after {
             opacity: 0;
         }

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -751,7 +751,7 @@ function View(_api, _model) {
         _instreamModel.on('change:controls', _onChangeControls, this);
         _instreamModel.on('change:state', _stateHandler, this);
 
-        _playerElement.insertBefore(_gradientLayer, _controls.element());
+        _playerElement.insertBefore(_gradientLayer, this.controlsContainer());
         addClass(_playerElement, 'jw-flag-ads');
         removeClass(_playerElement, 'jw-flag-live');
 

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -71,6 +71,7 @@ function View(_api, _model) {
 
     const _playerElement = createElement(playerTemplate(_model.get('id'), _model.get('localization').player));
     const _videoLayer = _playerElement.querySelector('.jw-media');
+    const _gradientLayer = _playerElement.querySelector('.jw-gradient');
 
     const _preview = new Preview(_model);
     const _title = new Title(_model);
@@ -215,7 +216,7 @@ function View(_api, _model) {
         // captions rendering
         _captionsRenderer.setup(_playerElement.id, _model.get('captions'));
 
-        // captions should be place behind controls, and not hidden when controls are hidden
+        // captions should be placed behind controls, and not hidden when controls are hidden
         _playerElement.insertBefore(_captionsRenderer.element(), _title.element());
 
         // Display Click and Double Click Handling
@@ -750,6 +751,7 @@ function View(_api, _model) {
         _instreamModel.on('change:controls', _onChangeControls, this);
         _instreamModel.on('change:state', _stateHandler, this);
 
+        _playerElement.insertBefore(_gradientLayer, _controls.element());
         addClass(_playerElement, 'jw-flag-ads');
         removeClass(_playerElement, 'jw-flag-live');
 
@@ -781,6 +783,7 @@ function View(_api, _model) {
         }
 
         this.setAltText('');
+        _playerElement.insertBefore(_gradientLayer, _preview.element());
         removeClass(_playerElement, ['jw-flag-ads', 'jw-flag-ads-hide-controls']);
         _model.set('hideAdsControls', false);
         const provider = _model.getVideo();

--- a/src/templates/player.js
+++ b/src/templates/player.js
@@ -3,6 +3,7 @@ export default (id, ariaLabel = '') => {
         `<div id="${id}" class="jwplayer jw-reset jw-state-setup" tabindex="0" aria-label="${ariaLabel}">` +
             `<div class="jw-aspect jw-reset"></div>` +
             `<div class="jw-media jw-reset"></div>` +
+            `<div class="jw-gradient jw-reset"></div>` +
             `<div class="jw-preview jw-reset"></div>` +
             `<div class="jw-title jw-reset">` +
                 `<div class="jw-title-primary jw-reset"></div>` +


### PR DESCRIPTION
### This PR will...
* make a gradient element that moves from the back of the poster image to the back of the controls when linear ads play.
* hides the gradient when controls are not displayed and when related is open
* darkens the controls background on error, mimicking the behavior on idle and complete
* removes z-index on controls
### Why is this Pull Request needed?
To prevent the gradient from blocking UI elements
### Are there any points in the code the reviewer needs to double check?
n/a
### Are there any Pull Requests open in other repos which need to be merged with this?
n/a
#### Addresses Issue(s):
JW8-396