### PR TITLE
Fix brute-force visibility test when no intersection is found

### DIFF
--- a/src/js/providers/video-listener-mixin.js
+++ b/src/js/providers/video-listener-mixin.js
@@ -168,7 +168,7 @@ const VideoListenerMixin = {
             1: 'Unknown operation aborted',
             2: 'Unknown network error',
             3: 'Unknown decode error',
-            4: 'Source not supported'
+            4: 'File could not be played'
         }[code] || 'Unknown');
         this.trigger(MEDIA_ERROR, {
             code: code,

--- a/src/js/view/utils/visibility.js
+++ b/src/js/view/utils/visibility.js
@@ -59,7 +59,7 @@ function computeVisibility(target) {
         if (parentRect) {
             intersectionRect = computeRectIntersection(parentRect, intersectionRect);
             if (!intersectionRect) {
-                break;
+                return 0;
             }
         }
         parent = parent.parentNode;


### PR DESCRIPTION
- [JW8-572] Use the error message from previous versions of the player and the html5 provider when video elements fire a code 4 (Source not supported) error
- [JW8-575] When no intersection is found return 0 for visibility check

#### Addresses Issue(s):

JW8-575
JW8-572


