### PR TITLE
Setup sideloaded tracks using the item on load

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -355,8 +355,6 @@ function VideoProvider(_playerId, _playerConfig) {
         if (sourceChanged) {
             _videotag.src = source.file;
         }
-
-        _this.setupSideloadedTracks(source.tracks);
     }
 
     function _clearVideotagSource() {
@@ -435,6 +433,7 @@ function VideoProvider(_playerId, _playerConfig) {
     this.load = function(item) {
         _setLevels(item.sources);
         _completeLoad(item.starttime || 0, item.duration || 0);
+        this.setupSideloadedTracks(item.tracks);        
     };
 
     this.play = function() {


### PR DESCRIPTION
### This PR will...
On load, setup sideloaded tracks using the item.
### Why is this Pull Request needed?
Sideloaded tracks were being setup in `_setVideotagSource`. However, `item` should be used in lieu of `source` - `'kind'` and `'default'` properties are set on the `item`, which guarantees that text tracks have all the properties they need to be setup correctly. 
### Are there any points in the code the reviewer needs to double check?
No.
### Are there any Pull Requests open in other repos which need to be merged with this?
No.
#### Addresses Issue(s):

JW8-562


