### PR TITLE
Fix extra player being created by the compatibility script

### DIFF
--- a/src/js/compatibility.js
+++ b/src/js/compatibility.js
@@ -119,7 +119,10 @@
          an Environment object. This object details the environment in which the player thinks it's in. Refer to our
          API docs for more information.
          */
-        var environment = playerLibrary(document.createElement('div')).getEnvironment();
+        var tempPlayer = playerLibrary(document.createElement('div'));
+        var environment = tempPlayer.getEnvironment();
+        tempPlayer.remove();
+
         var utils = playerLibrary.utils;
         var valueFn = function (getter) {
             return function() {


### PR DESCRIPTION
### Why is this Pull Request needed?
With the compatibility script, calls to `jwplayer()` (without an id argument) will return an unsetup player.

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No
