### PR TITLE
Don't fire state change 'play' event when destroying instream

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -286,6 +286,7 @@ var InstreamAdapter = function(_controller, _model, _view) {
             }
 
             const adState = _instream._adModel.get('state');
+            _model.attributes.state = adState;
 
             _model.off(null, null, _instream);
             _instream.off(null, null, _this);
@@ -303,7 +304,6 @@ var InstreamAdapter = function(_controller, _model, _view) {
 
             // Re-attach the controller
             _controller.attachMedia();
-            _model.set('state', adState);
 
             if (_oldpos === null) {
                 _model.stopVideo();


### PR DESCRIPTION
### This PR will...

Fix a regression introduced yesterday that triggers a state change on the player when an ads end.

### Why is this Pull Request needed?

The state was being changed to sync the player model with the instream model. This should be done silently since we don't want a 'play' event to be fired before the media src is changed back to the primary video.

#### Addresses Issue(s):

JW8-577

