### PR TITLE
Sync player and media state with ad

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -285,7 +285,12 @@ var InstreamAdapter = function(_controller, _model, _view) {
                 _view.clickHandler().revertAlternateClickHandlers();
             }
 
+            // Sync player and media state with ad for model "change:state" events to trigger
             const adState = _instream._adModel.get('state');
+            const adMediaModel = _instream._adModel.mediaModel;
+            if (adMediaModel) {
+                _model.mediaModel.attributes.state = adMediaModel.get('state');
+            }
             _model.attributes.state = adState;
 
             _model.off(null, null, _instream);


### PR DESCRIPTION
### This PR will...

Sync player and media state with ad model and ad media model (vast)

### Why is this Pull Request needed?

For model "change:state" events to trigger and update player state when instream is destroyed.

#### Addresses Issue(s):

JW8-579

