### PR TITLE
Prime media element on user interaction

### DIFF
--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -678,9 +678,6 @@ export default function Api(element) {
             if (_.isObject(state) && state.reason) {
                 meta = state;
             }
-            if (!meta) {
-                meta = { reason: 'external' };
-            }
             if (state === true) {
                 core.play(meta);
                 return this;

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -291,6 +291,8 @@ Object.assign(Controller.prototype, {
             checkAutoStartCancelable = cancelable(_checkAutoStart);
             updatePlaylistCancelable.cancel();
 
+            _primeMediaElementForPlayback();
+
             let loadPromise;
 
             switch (typeof item) {
@@ -387,16 +389,23 @@ Object.assign(Controller.prototype, {
                 if (_interruptPlay) {
                     _interruptPlay = false;
                     _actionOnAttach = null;
-                    // If we're in a user-gesture event call load() on video to allow async playback
-                    const event = window.event;
-                    if (event && /mouse|pointer|touch|gesture|click/.test(event.type)) {
-                        _model.attributes.mediaElement.load();
-                    }
+                    _primeMediaElementForPlayback();
                     return resolved;
                 }
             }
 
             return _model.playVideo(playReason);
+        }
+
+        function _primeMediaElementForPlayback() {
+            // If we're in a user-gesture event call load() on video to allow async playback
+            const event = window.event;
+            if (event && /^(?:mouse|pointer|touch|gesture|click|key)/.test(event.type)) {
+                const mediaElement = _model.get('mediaElement');
+                if (!mediaElement.src) {
+                    mediaElement.load();
+                }
+            }
         }
 
         function _autoStart() {

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -360,14 +360,14 @@ Object.assign(Controller.prototype, {
             return _model.get('state');
         }
 
-        function _play(meta = {}) {
+        function _play(meta) {
             checkAutoStartCancelable.cancel();
 
             if (_model.get('state') === STATE_ERROR) {
                 return resolved;
             }
 
-            const playReason = meta.reason;
+            const playReason = _getReason(meta);
             _model.set('playReason', playReason);
 
             const adState = _getAdState();
@@ -397,10 +397,23 @@ Object.assign(Controller.prototype, {
             return _model.playVideo(playReason);
         }
 
+        function _getReason(meta) {
+            if (!meta) {
+                if (_inInteraction(window.event)) {
+                    return 'interaction';
+                }
+                return 'external';
+            }
+            return meta.reason;
+        }
+
+        function _inInteraction(event) {
+            return event && /^(?:mouse|pointer|touch|gesture|click|key)/.test(event.type);
+        }
+
         function _primeMediaElementForPlayback() {
             // If we're in a user-gesture event call load() on video to allow async playback
-            const event = window.event;
-            if (event && /^(?:mouse|pointer|touch|gesture|click|key)/.test(event.type)) {
+            if (_inInteraction(window.event)) {
                 const mediaElement = _model.get('mediaElement');
                 if (!mediaElement.src) {
                     mediaElement.load();
@@ -448,13 +461,14 @@ Object.assign(Controller.prototype, {
             }
         }
 
-        function _pause(meta = {}) {
+        function _pause(meta) {
             _actionOnAttach = null;
             checkAutoStartCancelable.cancel();
 
-            _model.set('pauseReason', meta.reason);
+            const pauseReason = _getReason(meta);
+            _model.set('pauseReason', pauseReason);
             // Stop autoplay behavior if the video is paused by the user or an api call
-            if (meta.reason === 'interaction' || meta.reason === 'external') {
+            if (pauseReason === 'interaction' || pauseReason === 'external') {
                 _model.set('playOnViewable', false);
             }
 

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -387,6 +387,11 @@ Object.assign(Controller.prototype, {
                 if (_interruptPlay) {
                     _interruptPlay = false;
                     _actionOnAttach = null;
+                    // If we're in a user-gesture event call load() on video to allow async playback
+                    const event = window.event;
+                    if (event && /mouse|pointer|touch|gesture|click/.test(event.type)) {
+                        _model.attributes.mediaElement.load();
+                    }
                     return resolved;
                 }
             }


### PR DESCRIPTION
### This PR will...

Call `load()` on video tag when a user gesture event triggers beforePlay interruption or load. 

Detect interaction outside the player using `window.event`.

### Why is this Pull Request needed?

So that playback can be started after a click in Safari 11. For example a user clicks the player - `load()` was already called on setup(). It needs to be called again because the player needs to load additional data before if can set the video src and play (like a certificate, ad creative, etc...).

Since we're using `window.event` to detect if the `jwplayer().load()` and `jwplayer().play()` we called in a user-gesture event, we can also use it to set "playReason" to "interaction" rather than "external".