### PR TITLE
Error handling fixes

### DIFF
--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -95,6 +95,7 @@ const Model = function() {
                 return;
             case PLAYER_STATE:
                 if (data.newstate === STATE_IDLE) {
+                    thenPlayPromise.cancel();
                     mediaModel.srcReset();
                 }
                 mediaModel.set(PLAYER_STATE, data.newstate);
@@ -104,6 +105,7 @@ const Model = function() {
                 //  Instead letting the master controller do so
                 return;
             case MEDIA_ERROR:
+                thenPlayPromise.cancel();
                 mediaModel.srcReset();
                 break;
             case MEDIA_BUFFER:
@@ -507,6 +509,10 @@ const Model = function() {
         }
 
         playPromise.then(() => {
+            if (!mediaModelContext.setup) {
+                // Exit if model state was reset
+                return;
+            }
             mediaModelContext.set('started', true);
             if (mediaModelContext === model.mediaModel) {
                 syncPlayerWithMediaModel(mediaModelContext);

--- a/src/js/providers/video-listener-mixin.js
+++ b/src/js/providers/video-listener-mixin.js
@@ -172,7 +172,7 @@ const VideoListenerMixin = {
         }[code] || 'Unknown');
         this.trigger(MEDIA_ERROR, {
             code: code,
-            message: 'Error playing file: ' + message
+            message: 'Error loading media: ' + message
         });
     }
 };


### PR DESCRIPTION
### This PR will...

Address issues with error handling.

### Why is this Pull Request needed?

Error messages should be the same across all video tag providers and match existing documentation.

Async loading of Shaka player was causing a specific error to fire but then get hidden by a subsequent player state change.

#### Addresses Issue(s):

JW8-590, JW8-601

