### PR TITLE
Setup skip button after loading instream media

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -208,14 +208,16 @@ var InstreamAdapter = function(_controller, _model, _view) {
 
         _this.addClickHandler();
 
+        adModel.set('skipButton', false);
+
+        const playPromise = _instream.load(item);
+
         const skipoffset = item.skipoffset || _options.skipoffset;
         if (skipoffset) {
             _this.setupSkipButton(skipoffset, _options);
-        } else {
-            adModel.set('skipButton', false);
         }
 
-        return _instream.load(item);
+        return playPromise;
     };
 
     this.setupSkipButton = function(skipoffset, options, customNext) {


### PR DESCRIPTION
### Why is this Pull Request needed?

This prevents the skip button on subsequent ad pods from picking up the duration and position of the previous pod's media.

#### Addresses Issue(s):

JW8-606

