### PR TITLE
Always update state when provider state event is received

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -283,12 +283,8 @@ var InstreamAdapter = function(_controller, _model, _view) {
                 _view.clickHandler().revertAlternateClickHandlers();
             }
 
-            // Sync player and media state with ad for model "change:state" events to trigger
+            // Sync player state with ad for model "change:state" events to trigger
             const adState = _instream._adModel.get('state');
-            const adMediaModel = _instream._adModel.mediaModel;
-            if (adMediaModel) {
-                _model.mediaModel.attributes.state = adMediaModel.get('state');
-            }
             _model.attributes.state = adState;
 
             _model.off(null, null, _instream);

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -93,13 +93,17 @@ const Model = function() {
                     this.mediaController.trigger(type, event);
                 }
                 return;
-            case PLAYER_STATE:
+            case PLAYER_STATE: {
                 if (data.newstate === STATE_IDLE) {
                     thenPlayPromise.cancel();
                     mediaModel.srcReset();
                 }
-                mediaModel.set(PLAYER_STATE, data.newstate);
+                // Always fire change:state to keep player model in sync
+                const previousState = mediaModel.attributes[PLAYER_STATE];
+                mediaModel.attributes[PLAYER_STATE] = data.newstate;
+                mediaModel.trigger('change:' + PLAYER_STATE, mediaModel, data.newstate, previousState);
 
+            }
                 // This "return" is important because
                 //  we are choosing to not propagate this event.
                 //  Instead letting the master controller do so

--- a/src/js/controller/qoe.js
+++ b/src/js/controller/qoe.js
@@ -91,8 +91,10 @@ const initQoe = function(initialModel) {
         trackFirstFrame(model);
 
         mediaModel.on('change:state', function (changeMediaModel, newstate, oldstate) {
-            model._qoeItem.end(oldstate);
-            model._qoeItem.start(newstate);
+            if (newstate !== oldstate) {
+                model._qoeItem.end(oldstate);
+                model._qoeItem.start(newstate);
+            }
         });
     }
 

--- a/src/js/model/player-model.js
+++ b/src/js/model/player-model.js
@@ -1,10 +1,12 @@
+import { STATE_IDLE } from 'events/events';
+
 export const INITIAL_PLAYER_STATE = {
     // always start on first playlist item
     item: 0,
     itemMeta: {},
     playlistItem: undefined,
     // Initial state, upon setup
-    state: 'idle',
+    state: STATE_IDLE,
     // Initially we don't assume Flash is needed
     flashBlocked: false,
     provider: undefined,

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -704,9 +704,13 @@ function View(_api, _model) {
         if (_controls) {
             _controls.instreamState = instreamState;
         }
-
+        
         cancelAnimationFrame(_stateClassRequestId);
-        _stateClassRequestId = requestAnimationFrame(() => _stateUpdate(_playerState));
+        if (_playerState === STATE_PLAYING) {
+            _stateUpdate(_playerState);
+        } else {
+            _stateClassRequestId = requestAnimationFrame(() => _stateUpdate(_playerState));
+        }
     }
 
     function _stateUpdate(state) {


### PR DESCRIPTION
### This PR will...

- Always send a change:state event from the media model when providers send state changes
  - Do not sync player media model with ads media model
- Immediately update view state class when state changes to playing

### Why is this Pull Request needed?

These changes ensure that player state is updated correctly after ad breaks regardless of whether or not the attempt at playing an ad was successful, interrupted or proceeded by preloading or playback priming.

#### Addresses Issue(s):

JW8-579

