### PR TITLE
Improve play/pause API, add playToggle method

### DIFF
--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -674,7 +674,7 @@ export default function Api(element) {
          * @return {Api}
          */
         play(meta = { reason: 'external' }) {
-            core.play();
+            core.play(meta);
             return this;
         },
 

--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -670,48 +670,26 @@ export default function Api(element) {
 
         /**
          * Toggles or un-pauses playback.
-         * @param {boolean} [state] - An optional argument that indicates whether to play (true) or pause (false).
          * @param {object} [meta] - An optional argument used to specify cause.
          * @return {Api}
          */
-        play(state, meta) {
-            if (_.isObject(state) && state.reason) {
-                meta = state;
+        play(meta) {
+            if (!meta) {
+                meta = { reason: 'external' };
             }
-            if (state === true) {
-                core.play(meta);
-                return this;
-            } else if (state === false) {
-                core.pause(meta);
-                return this;
-            }
-
-            state = this.getState();
-            switch (state) {
-                case STATE_PLAYING:
-                case STATE_BUFFERING:
-                    core.pause(meta);
-                    break;
-                default:
-                    core.play(meta);
-            }
-
+            core.play();
             return this;
         },
 
         /**
          * Toggles or pauses playback.
-         * @param {boolean} [state] - An optional argument that indicates whether to pause (true) or play (false).
          * @param {object} [meta] - An optional argument used to specify cause.
          * @return {Api}
          */
-        pause(state, meta) {
+        pause(meta) {
             // TODO: meta should no longer be accepted from the base API, it should be passed in to the controller by special wrapped interfaces
-            if (_.isBoolean(state)) {
-                return this.play(!state, meta);
-            }
-
-            return this.play(meta);
+            core.pause(meta);
+            return this;
         },
 
         /**

--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -669,27 +669,41 @@ export default function Api(element) {
         },
 
         /**
-         * Toggles or un-pauses playback.
+         * Starts playback.
          * @param {object} [meta] - An optional argument used to specify cause.
          * @return {Api}
          */
-        play(meta) {
-            if (!meta) {
-                meta = { reason: 'external' };
-            }
+        play(meta = { reason: 'external' }) {
             core.play();
             return this;
         },
 
         /**
-         * Toggles or pauses playback.
+         * Pauses playback.
          * @param {object} [meta] - An optional argument used to specify cause.
          * @return {Api}
          */
-        pause(meta) {
+        pause(meta = { reason: 'external' }) {
             // TODO: meta should no longer be accepted from the base API, it should be passed in to the controller by special wrapped interfaces
             core.pause(meta);
             return this;
+        },
+
+        /**
+         * Toggles playback between play and pause.
+         * @param {object} [meta] - An optional argument used to specify cause.
+         * @return {Api}
+         */
+
+        playToggle(meta) {
+            switch (this.getState()) {
+                case STATE_PLAYING:
+                case STATE_BUFFERING:
+                    this.pause(meta);
+                    break;
+                default:
+                    this.play(meta);
+            }
         },
 
         /**

--- a/src/js/compatibility.js
+++ b/src/js/compatibility.js
@@ -19,7 +19,7 @@
     if (parseInt(playerLibrary.version, 10) >= 8) {
         var jwplayerCompatible = function(query) {
             var playerInstance = playerLibrary(query);
-            if (!playerInstance.trigger) {
+            if (!playerInstance.trigger || playerInstance.compatibility) {
                 return playerInstance;
             }
 
@@ -108,14 +108,15 @@
                         }
                     });
                 }
+
                 return setup.call(this, options);
             };
 
             /*
              Play and Pause no longer accept the state argument, and no longer toggle.
              */
-            var play = playerInstance.play;
-            var pause = playerInstance.pause;
+            var play = playerInstance.play.bind(this);
+            var pause = playerInstance.pause.bind(this);
             playerInstance.play = function(state, meta) {
                 if (state && state.reason) {
                     meta = state;
@@ -127,8 +128,10 @@
 
                 if (state === true) {
                     play(meta);
+                    return playerInstance;
                 } else if (state === false) {
                     pause(meta);
+                    return playerInstance;
                 }
 
                 state = playerInstance.getState();
@@ -140,17 +143,20 @@
                     default:
                         play(meta);
                 }
+
+                return playerInstance;
             };
 
             playerInstance.pause = function(state, meta) {
                 if (typeof state === 'boolean') {
                     playerInstance.play(!state, meta);
-                    return;
+                } else {
+                    playerInstance.play(state, meta);
                 }
-
-                playerInstance.play(meta);
+                return playerInstance;
             };
 
+            playerInstance.compatibility = true;
             return playerInstance;
         };
 

--- a/src/js/compatibility.js
+++ b/src/js/compatibility.js
@@ -28,7 +28,6 @@
                 We've removed a few methods from the public API, and our events now implement Backbone events.
              */
             playerInstance.dispatchEvent = basePlayer.trigger;
-            playerInstance.removeEventListener = basePlayer.off;
             playerInstance.getItem = basePlayer.getPlaylistIndex;
             playerInstance.getMeta = basePlayer.getItemMeta;
             playerInstance.getRenderingMode = function() {
@@ -41,6 +40,7 @@
             */
             playerInstance.on = playerInstance.on.bind(basePlayer);
             playerInstance.off = playerInstance.off.bind(basePlayer);
+            playerInstance.removeEventListener = playerInstance.off;
 
             /*
                 In JW8 we've removed the on* events. They've been replaced by the on() method, which accepts a string and

--- a/src/js/compatibility.js
+++ b/src/js/compatibility.js
@@ -111,6 +111,46 @@
                 return setup.call(this, options);
             };
 
+            /*
+             Play and Pause no longer accept the state argument, and no longer toggle.
+             */
+            var play = playerInstance.play;
+            var pause = playerInstance.pause;
+            playerInstance.play = function(state, meta) {
+                if (state && state.reason) {
+                    meta = state;
+                }
+
+                if (!meta) {
+                    meta = { reason: 'external' };
+                }
+
+                if (state === true) {
+                    play(meta);
+                } else if (state === false) {
+                    pause(meta);
+                }
+
+                state = playerInstance.getState();
+                switch (state) {
+                    case 'playing':
+                    case 'buffering':
+                        pause(meta);
+                        break;
+                    default:
+                        play(meta);
+                }
+            };
+
+            playerInstance.pause = function(state, meta) {
+                if (typeof state === 'boolean') {
+                    playerInstance.play(!state, meta);
+                    return;
+                }
+
+                playerInstance.play(meta);
+            };
+
             return playerInstance;
         };
 

--- a/src/js/compatibility.js
+++ b/src/js/compatibility.js
@@ -116,8 +116,8 @@
             /*
              Play and Pause no longer accept the state argument, and no longer toggle.
              */
-            var play = basePlayer.play.bind(this);
-            var pause = basePlayer.pause.bind(this);
+            var play = basePlayer.play;
+            var pause = basePlayer.pause;
             playerInstance.play = function(state, meta) {
                 if (state && state.reason) {
                     meta = state;

--- a/src/js/compatibility.js
+++ b/src/js/compatibility.js
@@ -18,7 +18,8 @@
     */
     if (parseInt(playerLibrary.version, 10) >= 8) {
         var jwplayerCompatible = function(query) {
-            var playerInstance = playerLibrary(query);
+            var basePlayer = playerLibrary(query);
+            var playerInstance = Object.create(basePlayer);
             if (!playerInstance.trigger || playerInstance.compatibility) {
                 return playerInstance;
             }
@@ -26,10 +27,10 @@
             /*
                 We've removed a few methods from the public API, and our events now implement Backbone events.
              */
-            playerInstance.dispatchEvent = playerInstance.trigger;
-            playerInstance.removeEventListener = playerInstance.off;
-            playerInstance.getItem = playerInstance.getPlaylistIndex;
-            playerInstance.getMeta = playerInstance.getItemMeta;
+            playerInstance.dispatchEvent = basePlayer.trigger;
+            playerInstance.removeEventListener = basePlayer.off;
+            playerInstance.getItem = basePlayer.getPlaylistIndex;
+            playerInstance.getMeta = basePlayer.getItemMeta;
             playerInstance.getRenderingMode = function() {
                 return 'html5';
             };
@@ -96,7 +97,7 @@
              `jwplayer().setup({ events: { onReady: fn } })` becomes
              `jwplayer().setup({ events: { ready: fn } })`
              */
-            var setup = playerInstance.setup;
+            var setup = basePlayer.setup;
             playerInstance.setup = function(options) {
                 var eventMap = options.events;
                 if (eventMap) {
@@ -109,14 +110,14 @@
                     });
                 }
 
-                return setup.call(this, options);
+                return setup.call(basePlayer, options);
             };
 
             /*
              Play and Pause no longer accept the state argument, and no longer toggle.
              */
-            var play = playerInstance.play.bind(this);
-            var pause = playerInstance.pause.bind(this);
+            var play = basePlayer.play.bind(this);
+            var pause = basePlayer.pause.bind(this);
             playerInstance.play = function(state, meta) {
                 if (state && state.reason) {
                     meta = state;

--- a/src/js/compatibility.js
+++ b/src/js/compatibility.js
@@ -36,6 +36,13 @@
             };
 
             /*
+                Bind the context of events to basePlayer so events are registered the "real" API, which does the event triggering
+                Without this, the compatible API does not receive events
+            */
+            playerInstance.on = playerInstance.on.bind(basePlayer);
+            playerInstance.off = playerInstance.off.bind(basePlayer);
+
+            /*
                 In JW8 we've removed the on* events. They've been replaced by the on() method, which accepts a string and
                 a callback. The event name is typically the name as it's on* event, with the "on" removed and the first letter
                 decapitalized.

--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -201,7 +201,7 @@ class TimeSlider extends Slider {
         var duration = this._model.get('duration');
         var position;
         if (duration === 0) {
-            this._api.play(reasonInteraction());
+            this._api.playToggle(reasonInteraction());
         } else if (this.streamType === 'DVR') {
             position = (100 - percent) / 100 * duration;
             this._api.seek(position, reasonInteraction());

--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -201,7 +201,7 @@ class TimeSlider extends Slider {
         var duration = this._model.get('duration');
         var position;
         if (duration === 0) {
-            this._api.playToggle(reasonInteraction());
+            this._api.play(reasonInteraction());
         } else if (this.streamType === 'DVR') {
             position = (100 - percent) / 100 * duration;
             this._api.seek(position, reasonInteraction());

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -191,7 +191,7 @@ export default class Controlbar {
         const elements = this.elements = {
             alt: text('jw-text-alt', 'status'),
             play: button('jw-icon-playback', () => {
-                _api.play(null, reasonInteraction());
+                _api.playToggle(reasonInteraction());
             }, play, svgCollection.querySelectorAll('.jw-svg-icon-play,.jw-svg-icon-pause')),
             rewind: button('jw-icon-rewind', () => {
                 this.rewind();

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -65,7 +65,7 @@ export default class Controls {
             displayContainer.buttons.display.on('click tap', () => {
                 this.trigger(DISPLAY_CLICK);
                 this.userActive(1000);
-                api.play(reasonInteraction());
+                api.playToggle(reasonInteraction());
             });
 
             this.div.appendChild(displayContainer.element());
@@ -181,7 +181,7 @@ export default class Controls {
                     break;
                 case 13: // enter
                 case 32: // space
-                    api.play(reasonInteraction());
+                    api.playToggle(reasonInteraction());
                     break;
                 case 37: // left-arrow, if not adMode
                     if (!this.instreamState) {

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -117,10 +117,10 @@ export default class Controls {
             if (getBreakpoint(model.get('containerWidth')) < 2) {
                 if (visible && state === STATE_PLAYING) {
                     // Pause playback on open if we're currently playing
-                    api.pause(true, settingsInteraction);
+                    api.pause(settingsInteraction);
                 } else if (!visible && state === STATE_PAUSED && lastState === STATE_PLAYING) {
                     // Resume playback on close if we are paused and were playing before
-                    api.play(true, settingsInteraction);
+                    api.play(settingsInteraction);
                 }
             }
             // Trigger userActive so that a dismissive click outside the player can hide the controlbar

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -378,7 +378,7 @@ function View(_api, _model) {
                     if (settingsMenuVisible()) {
                         _controls.settingsMenu.close();
                     } else {
-                        api.play(reasonInteraction());
+                        api.playToggle(reasonInteraction());
                     }
                 }
             },
@@ -392,7 +392,7 @@ function View(_api, _model) {
                 if (controls &&
                     ((state === STATE_IDLE || state === STATE_COMPLETE) ||
                     (_instreamModel && _instreamModel.get('state') === STATE_PAUSED))) {
-                    api.play(reasonInteraction());
+                    api.playToggle(reasonInteraction());
                 }
 
                 if (controls && state === STATE_PAUSED) {
@@ -439,12 +439,11 @@ function View(_api, _model) {
 
     function _logoClickHandler(evt) {
         if (!evt.link) {
-            // _togglePlay();
             if (_model.get('controls')) {
-                _api.play(reasonInteraction());
+                _api.playToggle(reasonInteraction());
             }
         } else {
-            _api.pause(true, reasonInteraction());
+            _api.pause(reasonInteraction());
             _api.setFullscreen(false);
             window.open(evt.link, evt.linktarget);
         }

--- a/test/data/api-methods.js
+++ b/test/data/api-methods.js
@@ -55,6 +55,7 @@ export default {
     playlistItem: null,
     playlistNext: null,
     playlistPrev: null,
+    playToggle: null,
     qoe: null,
     registerPlugin: null,
     remove: null,


### PR DESCRIPTION
### This PR will...
- `play(true)` -> `play()`
- `play(false)` -> `pause()`
- `play(?null)` -> `playToggle()`
- `pause(true)` -> `pause()`
- `pause(false)` -> `play()`
- `pause(?null)` -> `playToggle()`

### Why is this Pull Request needed?
It makes the API more understandable

### Are there any points in the code the reviewer needs to double check?
Did I miss any instances of play/pause, or did I mistake previous usages of play/pause?

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/4088

#### Addresses Issue(s):

JW8-541
