### PR TITLE
Don't fail autostartmuted when instream cancels play attempt

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -425,7 +425,7 @@ Object.assign(Controller.prototype, {
             const state = _model.get('state');
             if (state === STATE_IDLE || state === STATE_PAUSED) {
                 _play({ reason: 'autostart' }).catch(() => {
-                    if (!_this._instreamAdapter || !_this._instreamAdapter._adModel) {
+                    if (!_this._instreamAdapter) {
                         _model.set('autostartFailed', true);
                     }
                     _actionOnAttach = null;
@@ -858,6 +858,7 @@ Object.assign(Controller.prototype, {
         this.instreamDestroy = function() {
             if (_this._instreamAdapter) {
                 _this._instreamAdapter.destroy();
+                _this._instreamAdapter = null;
             }
         };
 

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -229,7 +229,7 @@ const Model = function() {
         _provider.volume(_this.get('volume'));
 
         // Mute the video if autostarting on mobile. Otherwise, honor the model's mute value
-        _provider.mute(this.autoStartOnMobile() || _this.get('mute'));
+        _provider.mute(_this.autoStartOnMobile() || _this.get('mute'));
 
         _provider.on('all', _videoEventHandler, this);
 


### PR DESCRIPTION
### This PR will...

Only set 'autostartFailed' when `_instreamAdapter` is undefined or null. Set `_instreamAdapter` to null after it's destroyed.

### Why is this Pull Request needed?

The instream adapter is activated by ads plugins which trigger playAttempts and fail them on ioS before playing ads. This was triggering 'autostartFailed', but should only be failed when instream is not active for ads to autostart muted. 

jwplayer-ads-googima

#### Addresses Issue(s):

JW8-609

