### PR TITLE
Handle logo insertion correctly for controls true|false

### DIFF
--- a/src/js/view/logo.js
+++ b/src/js/view/logo.js
@@ -81,11 +81,13 @@ define([
         this.setContainer = function(container) {
             if (_logo) {
                 const dock = container.querySelector('.jw-dock');
-                if (dock) {
+
+                if (_model.get('controls') && dock) {
                     container.insertBefore(_logo, dock);
-                } else {
-                    container.appendChild(_logo);
+                    return;
                 }
+
+                container.appendChild(_logo);
             }
         };
 


### PR DESCRIPTION
### This PR will...
Insert the logo before the dock icons when controls are enabled. Append the logo otherwise.
### Why is this Pull Request needed?
When `controls: false`, `.insertBefore` causes an exception because of the dom structure.
### Are there any points in the code the reviewer needs to double check?
No.
### Are there any Pull Requests open in other repos which need to be merged with this?
No.
#### Addresses Issue(s):
JW7-4494

