### PR TITLE
Use view state update to load poster image

### DIFF
--- a/src/js/view/preview.js
+++ b/src/js/view/preview.js
@@ -1,36 +1,9 @@
-import { requestAnimationFrame, cancelAnimationFrame } from 'utils/request-animation-frame';
 import { style } from 'utils/css';
 
 const Preview = function(_model) {
     this.model = _model;
-    this.raf = -1;
     this.image = null;
 };
-
-function onMediaModel(model, mediaModel) {
-    mediaModel.off('change:mediaType', null, this);
-    mediaModel.on('change:mediaType', function(mediaTypeChangeModel, mediaType) {
-        if (mediaType === 'audio') {
-            this.setImage(model.get('playlistItem').image);
-        }
-    }, this);
-}
-
-function onPlaylistItem(model, playlistItem) {
-    if (this.image) {
-        this.setImage(null);
-    }
-    model.off('change:state', null, this);
-    model.change('state', function(stateChangeModel, state) {
-        if (validState(state)) {
-            cancelAnimationFrame(this.raf);
-            this.raf = requestAnimationFrame(() => {
-                this.setImage(playlistItem.image);
-                this.resize(null, null, stateChangeModel.get('stretching'));
-            });
-        }
-    }, this);
-}
 
 function validState(state) {
     return state === 'complete' || state === 'idle' || state === 'error';
@@ -39,8 +12,6 @@ function validState(state) {
 Object.assign(Preview.prototype, {
     setup: function(element) {
         this.el = element;
-        this.model.on('change:mediaModel', onMediaModel, this);
-        this.model.on('change:playlistItem', onPlaylistItem, this);
     },
     setImage: function(img) {
         // Remove onload function from previous image

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -719,21 +719,23 @@ function View(_api, _model) {
         }
         replaceClass(_playerElement, /jw-state-\S+/, 'jw-state-' + state);
 
-        // Update captions renderer
-        if (_captionsRenderer) {
-            switch (state) {
-                case STATE_IDLE:
-                case STATE_ERROR:
-                case STATE_COMPLETE:
+        switch (state) {
+            case STATE_IDLE:
+            case STATE_ERROR:
+            case STATE_COMPLETE:
+                _preview.setImage(_model.get('playlistItem').image);
+                if (_captionsRenderer) {
                     _captionsRenderer.hide();
-                    break;
-                default:
+                }
+                break;
+            default:
+                if (_captionsRenderer) {
                     _captionsRenderer.show();
                     if (state === STATE_PAUSED && _controls && !_controls.showing) {
                         _captionsRenderer.renderCues(true);
                     }
-                    break;
-            }
+                }
+                break;
         }
     }
 


### PR DESCRIPTION
### This PR will...

Make the view control when posters are loaded.

### Why is this Pull Request needed?

The view knows which model (instream/model) should be used. Preview exposes setImage so the view should use it. Preview model listeners were basing the logic off of player model state and completely ignoring instream. This eliminates code we don't need and centralizes some handling of idle/complete/error view state changes.

### Are there any points in the code the reviewer needs to double check?

It would be nice if we could load the preview image just ahead of the complete state, or in the background based off of playback and related plugin settings. If the image is not cached, on a slow connection, the state will change and the user will see the poster load. I think that's fine because this does not affect click to player where that happens anyway, and for autostart players with related autoplay idle/complete states are not seen or are covered by an overlay which loads (and thus caches) all poster images.

### Are there any Pull Requests open in other repos which need to be merged with this?

No

#### Addresses Issue(s):

JW8-612
