### PR TITLE
Further Accessibility Improvements

### DIFF
--- a/src/css/shared-imports/mixins.less
+++ b/src/css/shared-imports/mixins.less
@@ -99,10 +99,12 @@
             color: @inactive-color;
         }
 
-        &:not(.jw-flag-touch) .jw-button-color:hover,
-        .jw-button-color:focus {
-            outline: none;
-            color: @hover-color;
+        &:not(.jw-flag-touch) .jw-button-color:not(.jw-logo-button) {
+            &:focus,
+            &:hover {
+                outline: none;
+                color: @hover-color;
+            }
         }
 
         .jw-toggle {

--- a/src/js/view/controls/components/settings/menu.js
+++ b/src/js/view/controls/components/settings/menu.js
@@ -24,27 +24,46 @@ export function SettingsMenu(onVisibility, onSubmenuAdded, onMenuEmpty) {
         instance.close();
     }, 'Close Settings', [cloneIcon('close')]);
     closeButton.show();
+    closeButton.element().addEventListener('keydown', function(evt) {
+        if (evt.keyCode !== 9 || evt.shiftKey) {
+            return;
+        }
+
+        instance.close();
+    });
+
     topbarElement.appendChild(closeButton.element());
-    settingsMenuElement.addEventListener('keydown', function(evt) {
+
+    const keyHandler = function(evt) {
         if (evt && evt.keyCode === 27) {
             instance.close();
             evt.stopPropagation();
         }
-    });
+    };
+
+    settingsMenuElement.addEventListener('keydown', keyHandler);
 
     const instance = {
-        open() {
+        open(isDefault) {
             visible = true;
             onVisibility(visible);
             settingsMenuElement.setAttribute('aria-expanded', 'true');
             addDocumentListeners(documentClickHandler);
-            active.categoryButtonElement.focus();
+
+            if (isDefault) {
+                active.categoryButtonElement.focus();
+            } else {
+                active.element().firstChild.focus();
+            }
+
         },
         close() {
             visible = false;
             onVisibility(visible);
+
             active = null;
             deactivateAllSubmenus(submenus);
+
             settingsMenuElement.setAttribute('aria-expanded', 'false');
             removeDocumentListeners(documentClickHandler);
         },
@@ -74,6 +93,7 @@ export function SettingsMenu(onVisibility, onSubmenuAdded, onMenuEmpty) {
             }
 
             settingsMenuElement.appendChild(submenu.element());
+
             onSubmenuAdded();
         },
         getSubmenu(name) {
@@ -99,9 +119,14 @@ export function SettingsMenu(onVisibility, onSubmenuAdded, onMenuEmpty) {
             if (!submenu || submenu.active) {
                 return;
             }
+
             deactivateAllSubmenus(submenus);
             submenu.activate();
             active = submenu;
+
+            if (!submenu.isDefault) {
+                active.element().firstChild.focus();
+            }
         },
         activateFirstSubmenu() {
             const firstSubmenuName = Object.keys(submenus)[0];
@@ -112,6 +137,7 @@ export function SettingsMenu(onVisibility, onSubmenuAdded, onMenuEmpty) {
         },
         destroy() {
             this.close();
+            settingsMenuElement.removeEventListener('keydown', keyHandler);
             emptyElement(settingsMenuElement);
         }
     };
@@ -120,10 +146,6 @@ export function SettingsMenu(onVisibility, onSubmenuAdded, onMenuEmpty) {
         visible: {
             enumerable: true,
             get: () => visible
-        },
-        active: {
-            enumerable: true,
-            get: () => active
         },
     });
 

--- a/src/js/view/controls/components/settings/submenu.js
+++ b/src/js/view/controls/components/settings/submenu.js
@@ -12,6 +12,20 @@ export default function SettingsSubmenu(name, categoryButton, isDefault) {
     categoryButtonElement.className += ' jw-submenu-' + name;
     categoryButton.show();
 
+    // return focus to topbar element when tabbing after the first or last item
+    const onFocus = function(evt) {
+        const focus =
+            categoryButtonElement &&
+            evt.keyCode === 9 && (
+                evt.srcElement === contentItems[0].element() && evt.shiftKey ||
+                evt.srcElement === contentItems[contentItems.length - 1].element() && !evt.shiftKey
+            );
+
+        if (focus) {
+            categoryButtonElement.focus();
+        }
+    };
+
     const instance = {
         addContent(items) {
             if (!items) {
@@ -20,13 +34,20 @@ export default function SettingsSubmenu(name, categoryButton, isDefault) {
             items.forEach(item => {
                 submenuElement.appendChild(item.element());
             });
+
             contentItems = items;
+
+            contentItems[0].element().addEventListener('keydown', onFocus);
+            contentItems[contentItems.length - 1].element().addEventListener('keydown', onFocus);
         },
         replaceContent(items) {
-            emptyElement(submenuElement);
+            instance.removeContent();
             this.addContent(items);
         },
         removeContent() {
+            contentItems[0].element().removeEventListener('keydown', onFocus);
+            contentItems[contentItems.length - 1].element().removeEventListener('keydown', onFocus);
+
             emptyElement(submenuElement);
             contentItems = [];
         },

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -393,6 +393,7 @@ export default class Controlbar {
 
     onFullscreen(model, val) {
         utils.toggleClass(this.elements.fullscreen.element(), 'jw-off', val);
+        this.elements.play.element().focus();
     }
 
     onAudioMode(model, val) {
@@ -477,9 +478,13 @@ export default class Controlbar {
                     window.open(logo.link, '_blank');
                 }
             },
-            'logo'
+            'logo',
+            'jw-logo-button'
         );
 
+        if (!logo.link) {
+            logoButton.element().setAttribute('tabindex', '-1');
+        }
         buttonContainer.insertBefore(
             logoButton.element(),
             buttonContainer.querySelector('.jw-spacer').nextSibling

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -137,6 +137,10 @@ export default class Controls {
             // Trigger userActive so that a dismissive click outside the player can hide the controlbar
             this.userActive();
             lastState = state;
+
+            if (!visible && this.controlbar.elements.settingsButton) {
+                this.controlbar.elements.settingsButton.element().focus();
+            }
         };
         const settingsMenu = this.settingsMenu = createSettingsMenu(controlbar, visibilityChangeHandler);
         setupSubmenuListeners(settingsMenu, controlbar, model, api);
@@ -348,10 +352,12 @@ export default class Controls {
         }
     }
 
-    userActive(timeout) {
-        clearTimeout(this.activeTimeout);
-        this.activeTimeout = setTimeout(() => this.userInactive(),
-            timeout || ACTIVE_TIMEOUT);
+    userActive(timeout = ACTIVE_TIMEOUT, isKeyDown) {
+        if (!isKeyDown) {
+            clearTimeout(this.activeTimeout);
+            this.activeTimeout = setTimeout(() => this.userInactive(),
+                timeout || ACTIVE_TIMEOUT);
+        }
         if (!this.showing) {
             utils.removeClass(this.playerContainer, 'jw-flag-user-inactive');
             this.showing = true;
@@ -365,8 +371,17 @@ export default class Controls {
             return;
         }
 
+        const container = this.playerContainer;
+        const focused = document.activeElement;
+        if (container !== focused && container.contains(focused)) {
+            return;
+        } else if (container === focused) {
+            return;
+        }
+
         this.showing = false;
-        utils.addClass(this.playerContainer, 'jw-flag-user-inactive');
+        utils.addClass(container, 'jw-flag-user-inactive');
+
         this.trigger('userInactive');
     }
 }

--- a/src/js/view/controls/settings-menu.js
+++ b/src/js/view/controls/settings-menu.js
@@ -46,7 +46,7 @@ export function createSettingsMenu(controlbar, onVisibility) {
                 // Activate the first submenu if clicking the default button
                 settingsMenu.activateFirstSubmenu();
             }
-            settingsMenu.open();
+            settingsMenu.open(isDefault);
         }
     });
 

--- a/src/js/view/utils/submenu-factory.js
+++ b/src/js/view/utils/submenu-factory.js
@@ -22,9 +22,6 @@ export const makeSubmenu = (settingsMenu, name, contentItems, icon, tooltipText)
         const categoryButtonElement = categoryButton.element();
         categoryButtonElement.setAttribute('role', 'menuitemradio');
         categoryButtonElement.setAttribute('aria-checked', 'false');
-        categoryButtonElement.addEventListener('focus', function() {
-            settingsMenu.activateSubmenu(name);
-        });
 
         // Qualities submenu is the default submenu
         submenu = SettingsSubmenu(name, categoryButton, name === DEFAULT_SUBMENU);

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -773,7 +773,7 @@ function View(_api, _model) {
     function onFocus() {
         // On tab-focus, show the control bar for a few seconds
         if (_controls && !_instreamModel && !_isMobile) {
-            _controls.userActive();
+            _controls.userActive(null, true);
         }
     }
 


### PR DESCRIPTION
### This PR will...

- Closing the related or settings overlay will keep focus on the respective control bar icons
- In Settings
   - Enter on a submenu icon will open the submenu and go to the first item
   - Tab after the close button will loop back to the first submenu icon
- Logo in control bar now has a focus ring
- After toggling fullscreen, focus goes to the play button
- When tabbing through the player, keep the control bar displayed

### Why is this Pull Request needed?

To improve the experience when tabbing through elements


### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-plugin-related/pull/168

#### Addresses Issue(s):

JW8-603

