### PR TITLE
Shrink and add padding to breakpoint-1

### DIFF
--- a/src/css/controls/imports/display.less
+++ b/src/css/controls/imports/display.less
@@ -92,6 +92,7 @@ display icons
 .jw-breakpoint-1 {
     .jw-display-icon-container {
         margin: 0 (@mobile-touch-target * 0.5);
+        padding: (@mobile-touch-target * 0.125);
     }
 
     .jw-display .jw-icon,

--- a/src/css/controls/imports/display.less
+++ b/src/css/controls/imports/display.less
@@ -92,9 +92,9 @@ display icons
 .jw-breakpoint-1 {
     .jw-display .jw-icon,
     .jw-display .jw-svg-icon {
-        height: (@mobile-touch-target * 1.25);
-        line-height: (@mobile-touch-target * 1.25);
-        width: (@mobile-touch-target * 1.25);
+        height: (@mobile-touch-target);
+        line-height: (@mobile-touch-target);
+        width: (@mobile-touch-target);
 
         &:before {
             width: (@mobile-touch-target * 0.5);
@@ -103,6 +103,8 @@ display icons
     }
 
     .jw-display .jw-icon {
+        padding: 0 (@mobile-touch-target * 0.5);
+
         &.jw-icon-rewind:before {
             width: (@mobile-touch-target * 0.75);
             height: (@mobile-touch-target * 0.75);

--- a/src/css/controls/imports/display.less
+++ b/src/css/controls/imports/display.less
@@ -78,13 +78,13 @@ display icons
 
     .jw-display .jw-icon,
     .jw-display .jw-svg-icon {
-        height: @mobile-touch-target;
         width: @mobile-touch-target;
+        height: @mobile-touch-target;
         line-height: @mobile-touch-target;
 
         &:before {
-            height: (@mobile-touch-target * 0.5);
             width: (@mobile-touch-target * 0.5);
+            height: (@mobile-touch-target * 0.5);
         }
     }
 }
@@ -119,13 +119,13 @@ display icons
 .jw-breakpoint-3 {
     .jw-display .jw-icon,
     .jw-display .jw-svg-icon {
+        width: (@mobile-touch-target * 1.75);
         height: (@mobile-touch-target * 1.75);
         line-height: (@mobile-touch-target * 1.75);
-        width: (@mobile-touch-target * 1.75);
 
         &:before {
-            height: (@mobile-touch-target * 0.875);
             width: (@mobile-touch-target * 0.875);
+            height: (@mobile-touch-target * 0.875);
         }
     }
 }
@@ -136,9 +136,9 @@ display icons
 .jw-breakpoint-7 {
     .jw-display .jw-icon,
     .jw-display .jw-svg-icon {
+        width: (@mobile-touch-target * 2);
         height: (@mobile-touch-target * 2);
         line-height: (@mobile-touch-target * 2);
-        width: (@mobile-touch-target * 2);
 
         &:before {
             width: @mobile-touch-target;

--- a/src/css/controls/imports/display.less
+++ b/src/css/controls/imports/display.less
@@ -91,15 +91,15 @@ display icons
 
 .jw-breakpoint-1 {
     .jw-display-icon-container {
-        margin: 0 (@mobile-touch-target * 0.5);
         padding: (@mobile-touch-target * 0.125);
+        margin: 0 (@mobile-touch-target * 0.5);
     }
 
     .jw-display .jw-icon,
     .jw-display .jw-svg-icon {
+        width: (@mobile-touch-target);
         height: (@mobile-touch-target);
         line-height: (@mobile-touch-target);
-        width: (@mobile-touch-target);
 
         &:before {
             width: (@mobile-touch-target * 0.5);

--- a/src/css/controls/imports/display.less
+++ b/src/css/controls/imports/display.less
@@ -90,6 +90,10 @@ display icons
 }
 
 .jw-breakpoint-1 {
+    .jw-display-icon-container {
+        margin: 0 (@mobile-touch-target * 0.5);
+    }
+
     .jw-display .jw-icon,
     .jw-display .jw-svg-icon {
         height: (@mobile-touch-target);
@@ -103,8 +107,6 @@ display icons
     }
 
     .jw-display .jw-icon {
-        padding: 0 (@mobile-touch-target * 0.5);
-
         &.jw-icon-rewind:before {
             width: (@mobile-touch-target * 0.75);
             height: (@mobile-touch-target * 0.75);


### PR DESCRIPTION
### This PR will...

- Changed the size of the display icons to be the default touch target size
- Added padding to the sides of the display icons to add more space between the buttons 

### Why is this Pull Request needed?

To improve the UI at small player sizes

### Are there any points in the code the reviewer needs to double check?

@aliciahurst I feel like the the space between the display icons could be smaller. Right now, its the same size as the icon width. I think it would still be good at half that.

![screenshot 2017-09-26 13 22 36](https://user-images.githubusercontent.com/584053/30874488-78769fcc-a2be-11e7-9bef-f4d1325db827.png)
![screenshot 2017-09-26 13 27 00](https://user-images.githubusercontent.com/584053/30874487-7876894c-a2be-11e7-880a-7860f72d4e9c.png)

#### Addresses Issue(s):

JW8-527