### PR TITLE
Fix "Playlist error: No playable sources found" when an invalid playlist is loaded

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -14,7 +14,7 @@ import eventsMiddleware from 'controller/events-middleware';
 import Events from 'utils/backbone.events';
 import { OS } from 'environment/environment';
 import { streamType } from 'providers/utils/stream-type';
-import { resolved } from 'polyfills/promise';
+import Promise, { resolved } from 'polyfills/promise';
 import cancelable from 'utils/cancelable';
 import _ from 'utils/underscore';
 import { PLAYER_STATE, STATE_BUFFERING, STATE_IDLE, STATE_COMPLETE, STATE_PAUSED, STATE_PLAYING, STATE_ERROR, STATE_LOADING,
@@ -323,12 +323,18 @@ Object.assign(Controller.prototype, {
                 });
             });
 
-            loadPromise.then(checkAutoStartCancelable.async);
+            loadPromise.then(checkAutoStartCancelable.async).catch(function() {});
         }
 
         function _updatePlaylist(data, feedData) {
             const playlist = Playlist(data);
-            setPlaylist(_model, playlist, feedData);
+            try {
+                setPlaylist(_model, playlist, feedData);
+            } catch (error) {
+                _model.set('item', 0);
+                _model.set('playlistItem', null);
+                return Promise.reject(error);
+            }
             return _setItem(0);
         }
 

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -309,11 +309,12 @@ const Model = function() {
     };
 
     this.setItemIndex = function(index) {
-        var playlist = this.get('playlist');
+        const playlist = this.get('playlist');
+        const length = playlist.length;
 
         // If looping past the end, or before the beginning
         index = parseInt(index, 10) || 0;
-        index = (index + playlist.length) % playlist.length;
+        index = (index + length) % length;
 
         this.set('item', index);
         return this.setActiveItem(playlist[index]);
@@ -333,8 +334,8 @@ const Model = function() {
     };
 
     function resetItem(model, item) {
-        const position = seconds(item.starttime);
-        const duration = seconds(item.duration);
+        const position = item ? seconds(item.starttime) : 0;
+        const duration = item ? seconds(item.duration) : 0;
         const mediaModelState = model.mediaModel.attributes;
         model.mediaModel.srcReset();
         mediaModelState.position = position;
@@ -561,6 +562,9 @@ const Model = function() {
 
     this.playVideo = function(playReason) {
         const item = this.get('playlistItem');
+        if (!item) {
+            return;
+        }
 
         if (!playReason) {
             playReason = this.get('playReason');

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -721,11 +721,13 @@ function View(_api, _model) {
         switch (state) {
             case STATE_IDLE:
             case STATE_ERROR:
-            case STATE_COMPLETE:
-                _preview.setImage(_model.get('playlistItem').image);
+            case STATE_COMPLETE: {
+                const playlistItem = _model.get('playlistItem');
+                _preview.setImage(playlistItem && playlistItem.image);
                 if (_captionsRenderer) {
                     _captionsRenderer.hide();
                 }
+            }
                 break;
             default:
                 if (_captionsRenderer) {


### PR DESCRIPTION
### This PR will...

- When a playlist is loaded that contains no playable sources, fire a "Playlist error: No playable sources found" error.
- Guard against JavaScript exceptions when recovering from this empty playlist state.
- Prevent `play()` from throwing errors when in this error state.

### Why is this Pull Request needed?

This maintains existing playlist error handling. `jwplayer().load([])` is an easy way to reproduce this error state.

#### Addresses Issue(s):

JW8-623

