### PR TITLE
Show tooltips in submenus

### DIFF
--- a/src/css/controls/imports/settings-menu.less
+++ b/src/css/controls/imports/settings-menu.less
@@ -156,7 +156,7 @@
     }
 
     .jw-tooltip-settings,
-    .jw-tooltip-captions {
+    .jw-settings-submenu-button .jw-tooltip-captions {
         display: none;
     }
 }

--- a/src/js/view/controls/components/settings/submenu.js
+++ b/src/js/view/controls/components/settings/submenu.js
@@ -1,5 +1,6 @@
 import SubmenuTemplate from 'view/controls/templates/settings/submenu';
 import { createElement, emptyElement, toggleClass } from 'utils/dom';
+import { SimpleTooltip } from 'view/controls/components/simple-tooltip';
 
 export default function SettingsSubmenu(name, categoryButton, isDefault) {
 
@@ -10,6 +11,7 @@ export default function SettingsSubmenu(name, categoryButton, isDefault) {
 
     categoryButtonElement.setAttribute('name', name);
     categoryButtonElement.className += ' jw-submenu-' + name;
+    SimpleTooltip(categoryButtonElement, name, name);
     categoryButton.show();
 
     const instance = {

--- a/src/js/view/controls/components/settings/submenu.js
+++ b/src/js/view/controls/components/settings/submenu.js
@@ -1,6 +1,5 @@
 import SubmenuTemplate from 'view/controls/templates/settings/submenu';
 import { createElement, emptyElement, toggleClass } from 'utils/dom';
-import { SimpleTooltip } from 'view/controls/components/simple-tooltip';
 
 export default function SettingsSubmenu(name, categoryButton, isDefault) {
 
@@ -11,7 +10,6 @@ export default function SettingsSubmenu(name, categoryButton, isDefault) {
 
     categoryButtonElement.setAttribute('name', name);
     categoryButtonElement.className += ' jw-submenu-' + name;
-    SimpleTooltip(categoryButtonElement, name, name);
     categoryButton.show();
 
     const instance = {

--- a/src/js/view/controls/settings-menu.js
+++ b/src/js/view/controls/settings-menu.js
@@ -72,7 +72,8 @@ export function setupSubmenuListeners(settingsMenu, controlbar, model, api) {
             settingsMenu,
             audioTracks,
             model.getVideo().setCurrentAudioTrack.bind(model.getVideo()),
-            mediaModel.get('currentAudioTrack')
+            mediaModel.get('currentAudioTrack'),
+            model.get('localization').audioTracks
         );
     };
 
@@ -86,7 +87,8 @@ export function setupSubmenuListeners(settingsMenu, controlbar, model, api) {
             settingsMenu,
             levels,
             model.getVideo().setCurrentQuality.bind(model.getVideo()),
-            changedModel.get('currentLevel')
+            changedModel.get('currentLevel'),
+            model.get('localization').hd
         );
     };
 
@@ -101,7 +103,8 @@ export function setupSubmenuListeners(settingsMenu, controlbar, model, api) {
         addCaptionsSubmenu(settingsMenu,
             captionsList,
             api.setCurrentCaptions.bind(this),
-            model.get('captionsIndex')
+            model.get('captionsIndex'),
+            model.get('localization').cc
         );
         controlbar.toggleCaptionsButtonState(!!model.get('captionsIndex'));
         controlbarButton.show();
@@ -124,7 +127,8 @@ export function setupSubmenuListeners(settingsMenu, controlbar, model, api) {
             settingsMenu,
             playbackRates,
             provider.setPlaybackRate.bind(model.getVideo()),
-            model.get('playbackRate')
+            model.get('playbackRate'),
+            model.get('localization').playbackRates
         );
     };
 

--- a/src/js/view/utils/submenu-factory.js
+++ b/src/js/view/utils/submenu-factory.js
@@ -1,6 +1,7 @@
 import SettingsSubmenu from 'view/controls/components/settings/submenu';
 import SettingsContentItem from 'view/controls/components/settings/content-item';
 import button from 'view/controls/components/button';
+import SimpleTooltip from 'view/controls/components/simple-tooltip';
 import CAPTIONS_OFF_ICON from 'assets/SVG/captions-off.svg';
 import AUDIO_TRACKS_ICON from 'assets/SVG/audio-tracks.svg';
 import QUALITY_ICON from 'assets/SVG/quality-100.svg';
@@ -12,7 +13,7 @@ const QUALITIES_SUBMENU = 'quality';
 const PLAYBACK_RATE_SUBMENU = 'playbackRates';
 const DEFAULT_SUBMENU = QUALITIES_SUBMENU;
 
-export const makeSubmenu = (settingsMenu, name, contentItems, icon) => {
+export const makeSubmenu = (settingsMenu, name, contentItems, icon, localizedText) => {
     let submenu = settingsMenu.getSubmenu(name);
     if (submenu) {
         submenu.replaceContent(contentItems);
@@ -31,13 +32,14 @@ export const makeSubmenu = (settingsMenu, name, contentItems, icon) => {
         // Qualities submenu is the default submenu
         submenu = SettingsSubmenu(name, categoryButton, name === DEFAULT_SUBMENU);
         submenu.addContent(contentItems);
+        SimpleTooltip(categoryButtonElement, name, localizedText);
         settingsMenu.addSubmenu(submenu);
     }
 
     return submenu;
 };
 
-export function addCaptionsSubmenu(settingsMenu, captionsList, action, initialSelectionIndex) {
+export function addCaptionsSubmenu(settingsMenu, captionsList, action, initialSelectionIndex, localizedText) {
     const captionsContentItems = captionsList.map((track, index) => {
         return SettingsContentItem(track.id, track.label, () => {
             action(index);
@@ -45,7 +47,7 @@ export function addCaptionsSubmenu(settingsMenu, captionsList, action, initialSe
         });
     });
 
-    const captionsSubmenu = makeSubmenu(settingsMenu, CAPTIONS_SUBMENU, captionsContentItems, CAPTIONS_OFF_ICON);
+    const captionsSubmenu = makeSubmenu(settingsMenu, CAPTIONS_SUBMENU, captionsContentItems, CAPTIONS_OFF_ICON, localizedText);
     captionsSubmenu.activateItem(initialSelectionIndex);
 }
 
@@ -53,7 +55,7 @@ export function removeCaptionsSubmenu(settingsMenu) {
     settingsMenu.removeSubmenu(CAPTIONS_SUBMENU);
 }
 
-export function addAudioTracksSubmenu(settingsMenu, audioTracksList, action, initialSelectionIndex) {
+export function addAudioTracksSubmenu(settingsMenu, audioTracksList, action, initialSelectionIndex, localizedText) {
     const audioTracksItems = audioTracksList.map((track, index) => {
         return SettingsContentItem(track.name, track.name, () => {
             action(index);
@@ -61,7 +63,7 @@ export function addAudioTracksSubmenu(settingsMenu, audioTracksList, action, ini
         });
     });
 
-    const audioTracksSubmenu = makeSubmenu(settingsMenu, AUDIO_TRACKS_SUBMENU, audioTracksItems, AUDIO_TRACKS_ICON);
+    const audioTracksSubmenu = makeSubmenu(settingsMenu, AUDIO_TRACKS_SUBMENU, audioTracksItems, AUDIO_TRACKS_ICON, localizedText);
     audioTracksSubmenu.activateItem(initialSelectionIndex);
 }
 
@@ -69,7 +71,7 @@ export function removeAudioTracksSubmenu(settingsMenu) {
     settingsMenu.removeSubmenu(AUDIO_TRACKS_SUBMENU);
 }
 
-export function addQualitiesSubmenu(settingsMenu, qualitiesList, action, initialSelectionIndex) {
+export function addQualitiesSubmenu(settingsMenu, qualitiesList, action, initialSelectionIndex, localizedText) {
     const qualitiesItems = qualitiesList.map((track, index) => {
         return SettingsContentItem(track.label, track.label, () => {
             action(index);
@@ -77,7 +79,7 @@ export function addQualitiesSubmenu(settingsMenu, qualitiesList, action, initial
         });
     });
 
-    const qualitiesSubmenu = makeSubmenu(settingsMenu, QUALITIES_SUBMENU, qualitiesItems, QUALITY_ICON);
+    const qualitiesSubmenu = makeSubmenu(settingsMenu, QUALITIES_SUBMENU, qualitiesItems, QUALITY_ICON, localizedText);
     qualitiesSubmenu.activateItem(initialSelectionIndex);
 }
 
@@ -85,7 +87,7 @@ export function removeQualitiesSubmenu(settingsMenu) {
     settingsMenu.removeSubmenu(QUALITIES_SUBMENU);
 }
 
-export function addPlaybackRatesSubmenu(settingsMenu, rateList, action, initialSelectionIndex) {
+export function addPlaybackRatesSubmenu(settingsMenu, rateList, action, initialSelectionIndex, localizedText) {
     const rateItems = rateList.map((playbackRate) => {
         return SettingsContentItem(playbackRate, playbackRate + 'x', () => {
             action(playbackRate);
@@ -93,7 +95,7 @@ export function addPlaybackRatesSubmenu(settingsMenu, rateList, action, initialS
         });
     });
 
-    const playbackRatesSubmenu = makeSubmenu(settingsMenu, PLAYBACK_RATE_SUBMENU, rateItems, PLAYBACK_RATE_ICON);
+    const playbackRatesSubmenu = makeSubmenu(settingsMenu, PLAYBACK_RATE_SUBMENU, rateItems, PLAYBACK_RATE_ICON, localizedText);
     playbackRatesSubmenu.activateItem(initialSelectionIndex);
 }
 

--- a/src/js/view/utils/submenu-factory.js
+++ b/src/js/view/utils/submenu-factory.js
@@ -1,7 +1,7 @@
 import SettingsSubmenu from 'view/controls/components/settings/submenu';
 import SettingsContentItem from 'view/controls/components/settings/content-item';
 import button from 'view/controls/components/button';
-import SimpleTooltip from 'view/controls/components/simple-tooltip';
+import { SimpleTooltip } from 'view/controls/components/simple-tooltip';
 import CAPTIONS_OFF_ICON from 'assets/SVG/captions-off.svg';
 import AUDIO_TRACKS_ICON from 'assets/SVG/audio-tracks.svg';
 import QUALITY_ICON from 'assets/SVG/quality-100.svg';

--- a/src/js/view/utils/submenu-factory.js
+++ b/src/js/view/utils/submenu-factory.js
@@ -13,7 +13,7 @@ const QUALITIES_SUBMENU = 'quality';
 const PLAYBACK_RATE_SUBMENU = 'playbackRates';
 const DEFAULT_SUBMENU = QUALITIES_SUBMENU;
 
-export const makeSubmenu = (settingsMenu, name, contentItems, icon, localizedText) => {
+export const makeSubmenu = (settingsMenu, name, contentItems, icon, tooltipText) => {
     let submenu = settingsMenu.getSubmenu(name);
     if (submenu) {
         submenu.replaceContent(contentItems);
@@ -32,14 +32,14 @@ export const makeSubmenu = (settingsMenu, name, contentItems, icon, localizedTex
         // Qualities submenu is the default submenu
         submenu = SettingsSubmenu(name, categoryButton, name === DEFAULT_SUBMENU);
         submenu.addContent(contentItems);
-        SimpleTooltip(categoryButtonElement, name, localizedText);
+        SimpleTooltip(categoryButtonElement, name, tooltipText);
         settingsMenu.addSubmenu(submenu);
     }
 
     return submenu;
 };
 
-export function addCaptionsSubmenu(settingsMenu, captionsList, action, initialSelectionIndex, localizedText) {
+export function addCaptionsSubmenu(settingsMenu, captionsList, action, initialSelectionIndex, tooltipText) {
     const captionsContentItems = captionsList.map((track, index) => {
         return SettingsContentItem(track.id, track.label, () => {
             action(index);
@@ -47,7 +47,7 @@ export function addCaptionsSubmenu(settingsMenu, captionsList, action, initialSe
         });
     });
 
-    const captionsSubmenu = makeSubmenu(settingsMenu, CAPTIONS_SUBMENU, captionsContentItems, CAPTIONS_OFF_ICON, localizedText);
+    const captionsSubmenu = makeSubmenu(settingsMenu, CAPTIONS_SUBMENU, captionsContentItems, CAPTIONS_OFF_ICON, tooltipText);
     captionsSubmenu.activateItem(initialSelectionIndex);
 }
 
@@ -55,7 +55,7 @@ export function removeCaptionsSubmenu(settingsMenu) {
     settingsMenu.removeSubmenu(CAPTIONS_SUBMENU);
 }
 
-export function addAudioTracksSubmenu(settingsMenu, audioTracksList, action, initialSelectionIndex, localizedText) {
+export function addAudioTracksSubmenu(settingsMenu, audioTracksList, action, initialSelectionIndex, tooltipText) {
     const audioTracksItems = audioTracksList.map((track, index) => {
         return SettingsContentItem(track.name, track.name, () => {
             action(index);
@@ -63,7 +63,7 @@ export function addAudioTracksSubmenu(settingsMenu, audioTracksList, action, ini
         });
     });
 
-    const audioTracksSubmenu = makeSubmenu(settingsMenu, AUDIO_TRACKS_SUBMENU, audioTracksItems, AUDIO_TRACKS_ICON, localizedText);
+    const audioTracksSubmenu = makeSubmenu(settingsMenu, AUDIO_TRACKS_SUBMENU, audioTracksItems, AUDIO_TRACKS_ICON, tooltipText);
     audioTracksSubmenu.activateItem(initialSelectionIndex);
 }
 
@@ -71,7 +71,7 @@ export function removeAudioTracksSubmenu(settingsMenu) {
     settingsMenu.removeSubmenu(AUDIO_TRACKS_SUBMENU);
 }
 
-export function addQualitiesSubmenu(settingsMenu, qualitiesList, action, initialSelectionIndex, localizedText) {
+export function addQualitiesSubmenu(settingsMenu, qualitiesList, action, initialSelectionIndex, tooltipText) {
     const qualitiesItems = qualitiesList.map((track, index) => {
         return SettingsContentItem(track.label, track.label, () => {
             action(index);
@@ -79,7 +79,7 @@ export function addQualitiesSubmenu(settingsMenu, qualitiesList, action, initial
         });
     });
 
-    const qualitiesSubmenu = makeSubmenu(settingsMenu, QUALITIES_SUBMENU, qualitiesItems, QUALITY_ICON, localizedText);
+    const qualitiesSubmenu = makeSubmenu(settingsMenu, QUALITIES_SUBMENU, qualitiesItems, QUALITY_ICON, tooltipText);
     qualitiesSubmenu.activateItem(initialSelectionIndex);
 }
 
@@ -87,7 +87,7 @@ export function removeQualitiesSubmenu(settingsMenu) {
     settingsMenu.removeSubmenu(QUALITIES_SUBMENU);
 }
 
-export function addPlaybackRatesSubmenu(settingsMenu, rateList, action, initialSelectionIndex, localizedText) {
+export function addPlaybackRatesSubmenu(settingsMenu, rateList, action, initialSelectionIndex, tooltipText) {
     const rateItems = rateList.map((playbackRate) => {
         return SettingsContentItem(playbackRate, playbackRate + 'x', () => {
             action(playbackRate);
@@ -95,7 +95,7 @@ export function addPlaybackRatesSubmenu(settingsMenu, rateList, action, initialS
         });
     });
 
-    const playbackRatesSubmenu = makeSubmenu(settingsMenu, PLAYBACK_RATE_SUBMENU, rateItems, PLAYBACK_RATE_ICON, localizedText);
+    const playbackRatesSubmenu = makeSubmenu(settingsMenu, PLAYBACK_RATE_SUBMENU, rateItems, PLAYBACK_RATE_ICON, tooltipText);
     playbackRatesSubmenu.activateItem(initialSelectionIndex);
 }
 


### PR DESCRIPTION
### This PR will...
- add tooltips to submenus
- add specificity the tooltip captions in the control bar to enable the tooltip captions in the settings menu
### Why is this Pull Request needed?
To show tooltips on submenus
### Are there any points in the code the reviewer needs to double check?
Upon opening the menu, since an element is focused, a tooltip pops up automatically. 
### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/4099
#### Addresses Issue(s):

JW8-531

