### PR TITLE
Show display icon when play attempt fails

### DIFF
--- a/src/css/controls/states.less
+++ b/src/css/controls/states.less
@@ -235,12 +235,18 @@ body .jwplayer.jw-state-error,
 }
 
 .jwplayer.jw-state-playing:not(.jw-flag-touch):not(.jw-flag-small-player):not(.jw-flag-casting),
-.jwplayer.jw-state-paused:not(.jw-flag-touch):not(.jw-flag-small-player):not(.jw-flag-casting) {
+.jwplayer.jw-state-paused:not(.jw-flag-touch):not(.jw-flag-small-player):not(.jw-flag-casting):not(.jw-flag-play-rejected) {
     .jw-display {
         display: none;
     }
 }
 /* stylelint-enable indentation */
+.jwplayer.jw-state-paused.jw-flag-play-rejected:not(.jw-flag-touch):not(.jw-flag-small-player):not(.jw-flag-casting) {
+    .jw-display-icon-rewind,
+    .jw-display-icon-next {
+        display: none;
+    }
+}
 
 // Hide text
 .jwplayer.jw-state-buffering .jw-display-icon-display,

--- a/src/js/controller/instream-html5.js
+++ b/src/js/controller/instream-html5.js
@@ -59,6 +59,10 @@ const InstreamHtml5 = function(_controller, _model) {
             _checkProvider(_adModel.getVideo());
         });
         _checkProvider();
+        
+        _adModel.mediaModel.on('change:' + PLAYER_STATE, (changeAdModel, state) => {
+            stateHandler(state);
+        });
 
         // Match the main player's controls state
         _adModel.off(ERROR);
@@ -171,7 +175,10 @@ const InstreamHtml5 = function(_controller, _model) {
                 this.trigger(type, Object.assign({}, data, { type: type }));
             }, _this);
 
-            provider.on(PLAYER_STATE, stateHandler);
+            const mediaModelContext = _adModel.mediaModel;
+            provider.on(PLAYER_STATE, (event) => {
+                mediaModelContext.set(PLAYER_STATE, event.newstate);
+            });
             provider.attachMedia();
             provider.volume(_model.get('volume'));
             provider.mute(_model.get('mute') || _model.get('autostartMuted'));
@@ -183,12 +190,11 @@ const InstreamHtml5 = function(_controller, _model) {
         }
     }
 
-    function stateHandler(evt) {
-        _adModel.mediaModel.set(PLAYER_STATE, evt.newstate);
-        switch (evt.newstate) {
+    function stateHandler(state) {
+        switch (state) {
             case STATE_PLAYING:
             case STATE_PAUSED:
-                _adModel.set(PLAYER_STATE, evt.newstate);
+                _adModel.set(PLAYER_STATE, state);
                 break;
             default:
                 break;

--- a/src/js/controller/instream-html5.js
+++ b/src/js/controller/instream-html5.js
@@ -59,10 +59,6 @@ const InstreamHtml5 = function(_controller, _model) {
             _checkProvider(_adModel.getVideo());
         });
         _checkProvider();
-        
-        _adModel.mediaModel.on('change:' + PLAYER_STATE, (changeAdModel, state) => {
-            stateHandler(state);
-        });
 
         // Match the main player's controls state
         _adModel.off(ERROR);
@@ -178,6 +174,9 @@ const InstreamHtml5 = function(_controller, _model) {
             const mediaModelContext = _adModel.mediaModel;
             provider.on(PLAYER_STATE, (event) => {
                 mediaModelContext.set(PLAYER_STATE, event.newstate);
+            });
+            mediaModelContext.on('change:' + PLAYER_STATE, (changeAdModel, state) => {
+                stateHandler(state);
             });
             provider.attachMedia();
             provider.volume(_model.get('volume'));

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -515,7 +515,7 @@ const Model = function() {
         }
 
         playPromise.then(() => {
-            if (!mediaModelContext.setup) {
+            if (!mediaModelContext.get('setup')) {
                 // Exit if model state was reset
                 return;
             }

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -5,7 +5,7 @@ import Providers from 'providers/providers';
 import { loadProvidersForPlaylist } from 'api/set-playlist';
 import getMediaElement from 'api/get-media-element';
 import initQoe from 'controller/qoe';
-import { PLAYER_STATE, STATE_IDLE, STATE_BUFFERING, STATE_COMPLETE, MEDIA_VOLUME, MEDIA_MUTE,
+import { PLAYER_STATE, STATE_IDLE, STATE_BUFFERING, STATE_PAUSED, STATE_COMPLETE, MEDIA_VOLUME, MEDIA_MUTE,
     MEDIA_TYPE, PROVIDER_CHANGED, AUDIO_TRACKS, AUDIO_TRACK_CHANGED,
     MEDIA_PLAY_ATTEMPT, MEDIA_PLAY_ATTEMPT_FAILED, MEDIA_RATE_CHANGE,
     MEDIA_BUFFER, MEDIA_TIME, MEDIA_LEVELS, MEDIA_LEVEL_CHANGED, MEDIA_ERROR,
@@ -341,6 +341,7 @@ const Model = function() {
         mediaModelState.position = position;
         mediaModelState.duration = duration;
 
+        model.set('playRejected', false);
         model.set('itemMeta', {});
         model.set('position', position);
         model.set('duration', duration);
@@ -523,6 +524,11 @@ const Model = function() {
                 syncPlayerWithMediaModel(mediaModelContext);
             }
         }).catch(error => {
+            model.set('playRejected', true);
+            const videoTagPaused = _provider && _provider.video && _provider.video.paused;
+            if (videoTagPaused) {
+                mediaModelContext.set(PLAYER_STATE, STATE_PAUSED);
+            }
             model.mediaController.trigger(MEDIA_PLAY_ATTEMPT_FAILED, {
                 error: error,
                 item: itemContext,
@@ -572,6 +578,7 @@ const Model = function() {
 
         let playPromise;
 
+        this.set('playRejected', false);
         if (!this.mediaModel.get('setup')) {
             playPromise = loadAndPlay(this, item);
             playAttempt(this, playPromise, playReason);

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -233,6 +233,10 @@ function View(_api, _model) {
         _model.on('change:scrubbing', function (model, val) {
             toggleClass(_playerElement, 'jw-flag-dragging', val);
         });
+        _model.on('change:playRejected', function (model, val) {
+            toggleClass(_playerElement, 'jw-flag-play-rejected', val);
+        });
+
         // Native fullscreen (coming through from the provider)
         _model.mediaController.on('fullscreenchange', _fullscreenChangeHandler);
 
@@ -756,6 +760,9 @@ function View(_api, _model) {
         this.instreamModel = _instreamModel = instreamModel;
         _instreamModel.on('change:controls', _onChangeControls, this);
         _instreamModel.on('change:state', _stateHandler, this);
+        _instreamModel.on('change:playRejected', function (model, val) {
+            toggleClass(_playerElement, 'jw-flag-play-rejected', val);
+        }, this);
 
         addClass(_playerElement, 'jw-flag-ads');
         removeClass(_playerElement, 'jw-flag-live');


### PR DESCRIPTION
### This PR will...
- Show display icon when play attempt fails using `jw-flag-play-rejected` CSS class
- Fix play promise handler so that media model 'started' is set

### Why is this Pull Request needed?
JW8-611 Showing the display icon when a play attempt fails is a call to action making it clearer to the user that the player is paused and must be interacted with to start playback.

JW8-624 The mediaModel was never getting updated with 'started' set to `true` when the play promise resolved. This caused subsequent calls to `play()` to fire additional "playAttempt" events and to put the player in a buffering state when the video was already playing.


