### PR TITLE
Improve setup error details and show icon when controls load

### DIFF
--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -1,6 +1,6 @@
 import { OS } from 'environment/environment';
 import { dvrSeekLimit } from 'view/constants';
-import { DISPLAY_CLICK, USER_ACTION, STATE_PAUSED, STATE_PLAYING } from 'events/events';
+import { DISPLAY_CLICK, USER_ACTION, STATE_PAUSED, STATE_PLAYING, STATE_ERROR } from 'events/events';
 import Events from 'utils/backbone.events';
 import utils from 'utils/helpers';
 import button from 'view/controls/components/button';
@@ -12,12 +12,21 @@ import { createSettingsMenu, setupSubmenuListeners } from 'view/controls/setting
 import { getBreakpoint } from 'view/utils/breakpoint';
 import { cloneIcon } from 'view/controls/icons';
 import ErrorContainer from 'view/error-container';
+import instances from 'api/players';
 
 require('css/controls.less');
 
 const ACTIVE_TIMEOUT = OS.mobile ? 4000 : 2000;
 
 ErrorContainer.cloneIcon = cloneIcon;
+instances.forEach(api => {
+    if (api.getState() === STATE_ERROR) {
+        const errorIconContainer = api.getContainer().querySelector('.jw-error-msg .jw-icon');
+        if (errorIconContainer && !errorIconContainer.hasChildNodes()) {
+            errorIconContainer.appendChild(ErrorContainer.cloneIcon('error'));
+        }
+    }
+});
 
 const reasonInteraction = function() {
     return { reason: 'interaction' };


### PR DESCRIPTION
### This PR will...

- Add the playback error icon to a setup error once controls has loaded.
- Add properties to the setup error event:
  - code: The error code, if present, of the internal error (otherwise undefined)
  - error: The error object, which includes the stack and native error type
- Updates player state the same way player errors do
  - jwplayer().getState() will return "error" in this state
  - jwplayer().getConfig() will include the "errorEvent" model property

### Why is this Pull Request needed?

To improve the UX of simple setup errors like "No playable sources...", and to provide all the fields we need in the setup error event to track setup errors - once error codes are assigned to internal errors (where we throw in setup or trigger setupError explicitly).

#### Addresses Issue(s):

JW8-98
JW8-427

