### PR TITLE
	Clear video width and height when resizing video element

### DIFF
--- a/src/js/providers/video-actions-mixin.js
+++ b/src/js/providers/video-actions-mixin.js
@@ -30,7 +30,7 @@ const VideoActionsMixin = {
                 objectFit = 'fill';
             }
             style(this.video, {
-                objectFit: objectFit,
+                objectFit,
                 width: null,
                 height: null
             });

--- a/src/js/providers/video-actions-mixin.js
+++ b/src/js/providers/video-actions-mixin.js
@@ -30,7 +30,9 @@ const VideoActionsMixin = {
                 objectFit = 'fill';
             }
             style(this.video, {
-                objectFit: objectFit
+                objectFit: objectFit,
+                width: null,
+                height: null
             });
         }
         return false;


### PR DESCRIPTION
### Why is this Pull Request needed?
Sometimes external scripts like VPAID js creatives add inline width and height style settings to the video element. These should be cleared when the player is resized.

https://github.com/jwplayer/jwplayer/pull/2418

#### Addresses Issue(s):
JW8-621

