### PR TITLE
DVR Live Edge Calculation

### DIFF
--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -378,7 +378,7 @@ export default class Controlbar {
         let countdownTime;
         const duration = model.get('duration');
         if (model.get('streamType') === 'DVR') {
-            elapsedTime = countdownTime = val >= dvrSeekLimit ? '' : '-' + utils.timeFormat(-val);
+            elapsedTime = countdownTime = Math.ceil(val) >= dvrSeekLimit ? '' : '-' + utils.timeFormat(-val);
         } else {
             elapsedTime = utils.timeFormat(val);
             countdownTime = utils.timeFormat(duration - val);
@@ -409,7 +409,7 @@ export default class Controlbar {
 
     checkDvrLiveEdge() {
         if (this._model.get('streamType') === 'DVR') {
-            const currentPosition = this._model.get('position');
+            const currentPosition = Math.ceil(this._model.get('position'));
             // update live icon and displayed time when DVR stream enters or exits live edge
             utils.toggleClass(this.elements.live.element(), 'jw-dvr-live', currentPosition >= dvrSeekLimit);
             this.onElapsed(this._model, currentPosition);


### PR DESCRIPTION
### This PR will...

Ceil the current time when checking for DVR live edge

### Why is this Pull Request needed?

If the current time is -25.xx: 
- The live edge check fails and the DVR live icon will be off
- The time elapsed will still be displayed, even if it says `-25:00`

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-commercial/pull/4109

#### Addresses Issue(s):

JW8-521

