### PR TITLE
Guard check tracksById, which can be null 

### DIFF
--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -375,7 +375,9 @@ function clearTracks() {
 function clearCueData(trackId) {
     if (this._cachedVTTCues[trackId]) {
         this._cachedVTTCues[trackId] = {};
-        this._tracksById[trackId].data = [];
+        if (this._tracksById) {
+            this._tracksById[trackId].data = [];
+        }
     }
 }
 


### PR DESCRIPTION
### Why is this Pull Request needed?
`stop()`, which `null`s `_tracksById`, can be called before the `MEDIA_DETACHED` handler, which tries to access `_tracksById`. This causes an exception.

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/hls.js/pull/116

#### Addresses Issue(s):

JW8-465

