### PR TITLE
Show casting in audio player

### DIFF
--- a/src/css/controls/flags/audioplayer.less
+++ b/src/css/controls/flags/audioplayer.less
@@ -28,7 +28,7 @@
         position: relative;
 
         .jw-button-container {
-            padding-right: 0;
+            padding-right: 3px;
             padding-left: 0;
         }
 

--- a/src/css/controls/flags/audioplayer.less
+++ b/src/css/controls/flags/audioplayer.less
@@ -28,7 +28,7 @@
         position: relative;
 
         .jw-button-container {
-            //padding-right: 22px; // Duration does not have the proper amount of right-padding
+            padding-right: 0;
             padding-left: 0;
         }
 
@@ -41,10 +41,15 @@
         .jw-icon-playback,
         .jw-icon-next,
         .jw-icon-rewind,
+        .jw-icon-cast,
         .jw-text-elapsed,
         .jw-text-duration {
             display: flex;
             flex: 0 0 auto;
+        }
+
+        .jw-text-duration {
+            padding-right: 10px;
         }
 
         .jw-slider-time {

--- a/src/css/controls/flags/cast-available.less
+++ b/src/css/controls/flags/cast-available.less
@@ -7,7 +7,7 @@
     &.jw-state-idle:not(.jw-flag-audio-player) {
         .jw-controlbar {
             .jw-slider-time,
-            .jw-icon:not(.jw-icon-cast):not(.jw-icon-airplay) {
+            .jw-icon:not(.jw-icon-cast):not(.jw-icon-airplay):not(.jw-icon-cardboard) {
                 display: none;
             }
         }

--- a/src/css/controls/flags/cast-available.less
+++ b/src/css/controls/flags/cast-available.less
@@ -3,4 +3,13 @@
     .jw-icon-airplay {
         display: flex;
     }
+
+    &.jw-state-idle:not(.jw-flag-audio-player) {
+        .jw-controlbar {
+            .jw-slider-time,
+            .jw-icon:not(.jw-icon-cast):not(.jw-icon-airplay) {
+                display: none;
+            }
+        }
+    }
 }

--- a/src/css/controls/flags/cast-available.less
+++ b/src/css/controls/flags/cast-available.less
@@ -3,13 +3,4 @@
     .jw-icon-airplay {
         display: flex;
     }
-
-    &.jw-state-idle:not(.jw-flag-audio-player) {
-        .jw-controlbar {
-            .jw-slider-time,
-            .jw-icon:not(.jw-icon-cast):not(.jw-icon-airplay):not(.jw-icon-cardboard) {
-                display: none;
-            }
-        }
-    }
 }

--- a/src/css/controls/flags/cast.less
+++ b/src/css/controls/flags/cast.less
@@ -1,7 +1,7 @@
 @import "../../shared-imports/vars";
 
 .jwplayer.jw-flag-casting {
-    .jw-cast {
+    &:not(.jw-flag-audio-player) .jw-cast {
         display: block;
     }
 
@@ -27,9 +27,9 @@
     }
 }
 
-.jwplayer.jw-state-playing.jw-flag-casting,
-.jwplayer.jw-state-paused.jw-flag-casting {
-    .jw-display {
+.jw-state-playing,
+.jw-state-paused {
+    &.jw-flag-casting:not(.jw-flag-audio-player) .jw-display {
         display: table;
     }
 }

--- a/src/css/controls/imports/controlbar.less
+++ b/src/css/controls/imports/controlbar.less
@@ -106,8 +106,8 @@
         background-color: transparent;
         border: none;
         padding: 0;
-        width: 20px;
-        height: 20px;
+        width: 24px;
+        height: 24px;
         cursor: pointer;
     }
 }

--- a/src/css/controls/states.less
+++ b/src/css/controls/states.less
@@ -15,7 +15,7 @@
         background: @controlbar-background;
     }
 
-    &.jw-flag-cast-available,
+    &.jw-flag-cast-available:not(.jw-flag-audio-player),
     &.jw-flag-cardboard-available {
         .jw-controlbar {
             .jw-slider-time,

--- a/src/js/view/controls/components/simple-tooltip.js
+++ b/src/js/view/controls/components/simple-tooltip.js
@@ -13,6 +13,10 @@ export function SimpleTooltip(attachToElement, name, text, openCallback) {
 
     const instance = {
         open() {
+            if (instance.isTouch) {
+                return;
+            }
+
             tooltipElement.setAttribute('aria-expanded', 'true');
             addClass(tooltipElement, 'jw-open');
 
@@ -21,6 +25,11 @@ export function SimpleTooltip(attachToElement, name, text, openCallback) {
             }
         },
         close() {
+            if (instance.isTouch) {
+                instance.isTouch = false;
+                return;
+            }
+
             tooltipElement.setAttribute('aria-expanded', 'false');
             removeClass(tooltipElement, 'jw-open');
         },
@@ -33,6 +42,9 @@ export function SimpleTooltip(attachToElement, name, text, openCallback) {
         attachToElement.addEventListener('pointerover', instance.open);
         attachToElement.addEventListener('pointerout', instance.close);
     } else {
+        attachToElement.addEventListener('touchstart', function() {
+            instance.isTouch = true;
+        });
         attachToElement.addEventListener('mouseover', instance.open);
         attachToElement.addEventListener('mouseout', instance.close);
     }


### PR DESCRIPTION
### This PR will...

Not hide the controls in audio player mode if casting is available

### Why is this Pull Request needed?

So users can play and cast audio-only streams

### Are there any points in the code the reviewer needs to double check?

@radium-v @johnBartos When there is no cast icon there was padding on the right side so that the elapsed time was not flushed again the player. I used a negative margin to offset it when the cast icon is there. Let me know if there's a better way to go about it.

#### Addresses Issue(s):

JW8-620

