### PR TITLE
Controls backdrop fixes (aka "Gradient Layer")

### DIFF
--- a/src/css/controls/flags/ads.less
+++ b/src/css/controls/flags/ads.less
@@ -137,7 +137,7 @@
 }
 
 .jwplayer.jw-flag-ads-hide-controls {
-    .jw-gradient,
+    .jw-controls-backdrop,
     .jw-controls {
         /* Important is required to controls are never displayed */
         /* stylelint-disable-next-line declaration-no-important */

--- a/src/css/controls/flags/ads.less
+++ b/src/css/controls/flags/ads.less
@@ -71,7 +71,7 @@
 
     // Control bar should always be visible during ad playback on touch devices
     // except when jw-flag-ads-vpaid is set
-    &.jw-flag-ads.jw-flag-touch:not(.jw-flag-ads-vpaid) {
+    &.jw-flag-ads.jw-state-playing.jw-flag-touch:not(.jw-flag-ads-vpaid) {
         &,
         &.jw-flag-autostart {
             .jw-controls .jw-controlbar {
@@ -79,6 +79,12 @@
                 pointer-events: all;
                 visibility: visible;
                 opacity: 1;
+            }
+
+            &.jw-flag-user-inactive .jw-controls-backdrop {
+                opacity: 1;
+                // Change gradient height with background-size
+                background-size: 100% 60px;
             }
         }
     }

--- a/src/css/controls/flags/controls-hidden.less
+++ b/src/css/controls/flags/controls-hidden.less
@@ -27,7 +27,7 @@
         transition-delay: 0s, 250ms;
     }
 
-    .jw-gradient {
+    .jw-controls-backdrop {
         opacity: 0;
     }
 

--- a/src/css/controls/flags/flash-blocked.less
+++ b/src/css/controls/flags/flash-blocked.less
@@ -2,7 +2,7 @@
 body .jwplayer.jw-flag-flash-blocked {
     .jw-controls,
     .jw-overlays,
-    .jw-gradient,
+    .jw-controls-backdrop,
     .jw-preview {
         display: none;
     }

--- a/src/css/controls/imports/controlbar.less
+++ b/src/css/controls/imports/controlbar.less
@@ -151,7 +151,7 @@
             transition-delay: 0s, 250ms;
         }
 
-        .jw-gradient {
+        .jw-controls-backdrop {
             opacity: 0;
         }
     }

--- a/src/css/controls/imports/jwplayerlayout.less
+++ b/src/css/controls/imports/jwplayerlayout.less
@@ -7,7 +7,7 @@
     pointer-events: none; // Allow pointer events through to the provider
 }
 
-.jw-gradient {
+.jw-controls-backdrop {
     &:extend(._stretch, ._topleft);
     display: block;
     background: linear-gradient(to bottom, transparent, fade(@black, 40%) 77%, fade(@black, 40%) 100%) 100% 100% / 100% 240px no-repeat transparent;

--- a/src/css/controls/imports/jwplayerlayout.less
+++ b/src/css/controls/imports/jwplayerlayout.less
@@ -11,7 +11,7 @@
     &:extend(._stretch, ._topleft);
     display: block;
     background: linear-gradient(to bottom, transparent, fade(@black, 40%) 77%, fade(@black, 40%) 100%) 100% 100% / 100% 240px no-repeat transparent;
-    transition: opacity 250ms @default-timing-function;
+    transition: opacity 250ms @default-timing-function, background-size 250ms @default-timing-function;
     pointer-events: none;
 }
 

--- a/src/css/controls/states.less
+++ b/src/css/controls/states.less
@@ -57,7 +57,7 @@
     }
 
     &.jw-flag-user-inactive:not(.jw-flag-audio-player):not(.jw-flag-casting):not(.jw-flag-media-audio) {
-        .jw-gradient {
+        .jw-controls-backdrop {
             opacity: 0;
         }
 
@@ -214,7 +214,7 @@ body .jwplayer.jw-state-error,
         bottom: 0;
     }
 
-    .jw-gradient {
+    .jw-controls-backdrop {
         opacity: 0;
     }
 

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -394,6 +394,7 @@ export default class Controls {
     }
 
     setupInstream(instreamModel) {
+        this.instreamState = instreamModel.get('state');
         // Call Controls.userActivity to display the UI temporarily for the start of the ad
         this.userActive();
         this.addBackdrop();
@@ -404,6 +405,7 @@ export default class Controls {
     }
 
     destroyInstream(model) {
+        this.instreamState = null;
         this.addBackdrop();
         this.controlbar.syncPlaybackTime(model);
     }

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -68,7 +68,7 @@ export default class Controls {
         this.div = element;
 
         const backdrop = this.context.createElement('div');
-        backdrop.className = 'jw-gradient jw-reset';
+        backdrop.className = 'jw-controls-backdrop jw-reset';
         this.backdrop = backdrop;
 
         const touchMode = model.get('touchMode');

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -42,6 +42,7 @@ export default class Controls {
         this.context = context;
         this.controlbar = null;
         this.displayContainer = null;
+        this.backdrop = null;
         this.enabled = true;
         this.instreamState = null;
         this.keydownCallback = null;
@@ -65,6 +66,10 @@ export default class Controls {
         const element = this.context.createElement('div');
         element.className = 'jw-controls jw-reset';
         this.div = element;
+
+        const backdrop = this.context.createElement('div');
+        backdrop.className = 'jw-gradient jw-reset';
+        this.backdrop = backdrop;
 
         const touchMode = model.get('touchMode');
 
@@ -248,6 +253,8 @@ export default class Controls {
         this.userActive();
 
         this.playerContainer.appendChild(this.div);
+
+        this.addBackdrop();
     }
 
     disable(model) {
@@ -288,6 +295,8 @@ export default class Controls {
             settingsMenu.destroy();
             this.div.removeChild(settingsMenu.element());
         }
+
+        this.removeBackdrop();
     }
 
     controlbarHeight() {
@@ -368,5 +377,34 @@ export default class Controls {
         this.showing = false;
         utils.addClass(this.playerContainer, 'jw-flag-user-inactive');
         this.trigger('userInactive');
+    }
+
+    addBackdrop() {
+        // Put the backdrop element on top of overlays during instream mode
+        // otherwise keep it behind captions and on top of preview poster
+        const element = this.instreamState ? this.div : this.playerContainer.querySelector('.jw-captions');
+        this.playerContainer.insertBefore(this.backdrop, element);
+    }
+
+    removeBackdrop() {
+        const parent = this.backdrop.parentNode;
+        if (parent) {
+            parent.removeChild(this.backdrop);
+        }
+    }
+
+    setupInstream(instreamModel) {
+        // Call Controls.userActivity to display the UI temporarily for the start of the ad
+        this.userActive();
+        this.addBackdrop();
+        this.controlbar.useInstreamTime(instreamModel);
+        if (this.settingsMenu) {
+            this.settingsMenu.close();
+        }
+    }
+
+    destroyInstream(model) {
+        this.addBackdrop();
+        this.controlbar.syncPlaybackTime(model);
     }
 }


### PR DESCRIPTION
### This PR will...
- Fix exception with backdrop removal when controls are disabled
- Rename jw-gradient to jw-controls-backdrop
- Move backdrop element to controls
- Pass instream model to controls when controls are enabled during ads playback

#### Addresses Issue(s):
JW8-644
JW8-635
