### PR TITLE
Prevent customizing tooltip text when customizing controlbar text

### DIFF
--- a/src/js/view/utils/skin.js
+++ b/src/js/view/utils/skin.js
@@ -112,7 +112,7 @@ export function handleColorOverrides(playerId, skin) {
 
         addStyle([
             // controlbar text colors
-            '.jw-controlbar .jw-text',
+            '.jw-controlbar .jw-icon-inline.jw-text',
             '.jw-title-primary',
             '.jw-title-secondary',
         ], 'color', config.text);

--- a/test/unit/skin-test.js
+++ b/test/unit/skin-test.js
@@ -48,7 +48,7 @@ describe('Skin Customization', function() {
             });
 
             expect(cssUtils.css.args[0]).to.eql([
-                '#id .jw-controlbar .jw-text, ' +
+                '#id .jw-controlbar .jw-icon-inline.jw-text, ' +
                 '#id .jw-title-primary, ' +
                 '#id .jw-title-secondary',
                 { color: 'green' },
@@ -67,7 +67,7 @@ describe('Skin Customization', function() {
             });
 
             expect(cssUtils.css.args[0]).to.eql([
-                '#id .jw-controlbar .jw-text, ' +
+                '#id .jw-controlbar .jw-icon-inline.jw-text, ' +
                 '#id .jw-title-primary, ' +
                 '#id .jw-title-secondary',
                 { color: 'green' },


### PR DESCRIPTION
### This PR will...
add specificity to the css styling of controlbar text to prevent the tooltip texts from being mistakenly styled
### Why is this Pull Request needed?
to prevent the tooltip texts from being mistakenly styled when styling controlbar text (i.e. current time, also jw-text)
#### Addresses Issue(s):
JW8-625

