### PR TITLE
Delay seek until the browser has enough data to play first frame to prevent stalled buffer in High Sierra

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -61,7 +61,6 @@ function VideoProvider(_playerId, _playerConfig) {
             checkStaleStream();
         },
         timeupdate() {
-            _checkDelayedSeek(_this.getDuration());
             VideoEvents.timeupdate.call(_this);
             checkStaleStream();
         },
@@ -85,20 +84,19 @@ function VideoProvider(_playerId, _playerConfig) {
                 width: _videotag.videoWidth
             };
             _this.trigger(MEDIA_META, metadata);
-            _checkDelayedSeek(duration);
         },
 
         durationchange() {
             if (_androidHls) {
                 return;
             }
-            _checkDelayedSeek(_this.getDuration());
             VideoEvents.progress.call(_this);
         },
 
         loadeddata() {
             VideoEvents.loadeddata.call(_this);
             _setAudioTracks(_videotag.audioTracks);
+            _checkDelayedSeek(_this.getDuration());
         },
 
         canplay() {


### PR DESCRIPTION
Chrome and Firefox can get stuck in a play attempt state in High Sierra 10.13.0 when setting `video.currentTime` before playback begins. This change prevents that from happening.

Chrome 61 with High Sierra using with `video.src = mp4; video.load(); video.play();` and setting `currentTime` on "durationchange" or "loadedmetadata". It's intermittent - maybe 1/10 - but definitely new since I just started using High Sierra today and saw this while working on a video player test case that switched out media element src's and seeks. The video tag was in this state:

- pending play promise
- `video.networkSate: 1` IDLE
- `video.readySate: 1` HAVE_METADATA
- `video.seeking: 1`
- `video.paused: false`
- `video.duration: 52`
- `video.buffered.end(0): 52`
- `video.currentTime: 18`
- `video.videoWidth: 722`

In this state, setting currentTime and calling play() or pause() and play() has no effect. The only way to clear this state is to call `video.load()` to empty the tag and start again.