### PR TITLE
Don't Show Tooltips on Touch Events

### DIFF
--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -318,8 +318,8 @@ const UI = function (elem, options) {
 };
 
 // Expose what the source of the event is so that we can ensure it's handled correctly.
-// This returns only 'touch' or 'mouse'.  'pen' will be treated as a mouse.
-UI.getPointerType = function (evt) {
+// This returns only 'touch' or 'mouse'. 'pen' will be treated as a mouse.
+UI.getPointerType = function(evt) {
     if (_supportsPointerEvents && evt instanceof window.PointerEvent) {
         return (evt.pointerType === 'touch') ? 'touch' : 'mouse';
     } else if (_supportsTouchEvents && evt instanceof window.TouchEvent) {
@@ -330,5 +330,7 @@ UI.getPointerType = function (evt) {
 };
 
 Object.assign(UI.prototype, Events);
+
+export const getPointerType = UI.getPointerType;
 
 export default UI;

--- a/src/js/view/controls/components/simple-tooltip.js
+++ b/src/js/view/controls/components/simple-tooltip.js
@@ -1,4 +1,5 @@
 import { addClass, removeClass } from 'utils/dom';
+import UI from 'utils/ui';
 
 export function SimpleTooltip(attachToElement, name, text, openCallback) {
     const tooltipElement = document.createElement('div');
@@ -13,6 +14,11 @@ export function SimpleTooltip(attachToElement, name, text, openCallback) {
 
     const instance = {
         open() {
+            if (instance.pointerType === 'touch') {
+                delete instance.pointerType;
+                return;
+            }
+
             tooltipElement.setAttribute('aria-expanded', 'true');
             addClass(tooltipElement, 'jw-open');
 
@@ -21,6 +27,11 @@ export function SimpleTooltip(attachToElement, name, text, openCallback) {
             }
         },
         close() {
+            if (instance.pointerType === 'touch') {
+                delete instance.pointerType;
+                return;
+            }
+
             tooltipElement.setAttribute('aria-expanded', 'false');
             removeClass(tooltipElement, 'jw-open');
         },
@@ -29,13 +40,11 @@ export function SimpleTooltip(attachToElement, name, text, openCallback) {
         }
     };
 
-    if ('PointerEvent' in window) {
-        attachToElement.addEventListener('pointerover', instance.open);
-        attachToElement.addEventListener('pointerout', instance.close);
-    } else {
-        attachToElement.addEventListener('mouseover', instance.open);
-        attachToElement.addEventListener('mouseout', instance.close);
-    }
+    attachToElement.addEventListener('mouseover', instance.open);
+    attachToElement.addEventListener('mouseout', instance.close);
+    attachToElement.addEventListener('touchstart', (evt) => {
+        instance.pointerType = UI.getPointerType(evt);
+    });
 
     return instance;
 }

--- a/src/js/view/controls/components/simple-tooltip.js
+++ b/src/js/view/controls/components/simple-tooltip.js
@@ -14,7 +14,7 @@ export function SimpleTooltip(attachToElement, name, text, openCallback) {
 
     const instance = {
         open() {
-            if (instance.pointerType === 'touch') {
+            if (instance.touchEvent) {
                 delete instance.pointerType;
                 return;
             }
@@ -27,7 +27,7 @@ export function SimpleTooltip(attachToElement, name, text, openCallback) {
             }
         },
         close() {
-            if (instance.pointerType === 'touch') {
+            if (instance.touchEvent) {
                 delete instance.pointerType;
                 return;
             }
@@ -43,7 +43,7 @@ export function SimpleTooltip(attachToElement, name, text, openCallback) {
     attachToElement.addEventListener('mouseover', instance.open);
     attachToElement.addEventListener('mouseout', instance.close);
     attachToElement.addEventListener('touchstart', (evt) => {
-        instance.pointerType = getPointerType(evt);
+        instance.touchEvent = getPointerType(evt) === 'touch';
     });
 
     return instance;

--- a/src/js/view/controls/components/simple-tooltip.js
+++ b/src/js/view/controls/components/simple-tooltip.js
@@ -1,5 +1,5 @@
 import { addClass, removeClass } from 'utils/dom';
-import UI from 'utils/ui';
+import { getPointerType } from 'utils/ui';
 
 export function SimpleTooltip(attachToElement, name, text, openCallback) {
     const tooltipElement = document.createElement('div');
@@ -43,7 +43,7 @@ export function SimpleTooltip(attachToElement, name, text, openCallback) {
     attachToElement.addEventListener('mouseover', instance.open);
     attachToElement.addEventListener('mouseout', instance.close);
     attachToElement.addEventListener('touchstart', (evt) => {
-        instance.pointerType = UI.getPointerType(evt);
+        instance.pointerType = getPointerType(evt);
     });
 
     return instance;


### PR DESCRIPTION
### This PR will...

Does not show tooltips on touch events

### Why is this Pull Request needed?

So we dont show tooltips after tapping a control bar icon on iPad

#### Addresses Issue(s):

JW8-616

