### PR TITLE
Show airplay in audio player

### DIFF
--- a/src/css/controls/flags/audioplayer.less
+++ b/src/css/controls/flags/audioplayer.less
@@ -42,6 +42,7 @@
         .jw-icon-next,
         .jw-icon-rewind,
         .jw-icon-cast,
+        .jw-icon-airplay,
         .jw-text-elapsed,
         .jw-text-duration {
             display: flex;


### PR DESCRIPTION
### This PR will...

Not hide the airplay icon in audio player mode if airplay is available in Safari

### Why is this Pull Request needed?

So users can airplay audio-only streams

#### Addresses Issue(s):

JW8-620