### PR TITLE
Ads / Autostart UI conflict fixes

### DIFF
--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -384,8 +384,6 @@ export default class Controls {
         const focused = document.activeElement;
         if (container !== focused && container.contains(focused)) {
             return;
-        } else if (container === focused) {
-            return;
         }
 
         this.showing = false;
@@ -417,11 +415,15 @@ export default class Controls {
         if (this.settingsMenu) {
             this.settingsMenu.close();
         }
+        utils.removeClass(this.playerContainer, 'jw-flag-autostart');
     }
 
     destroyInstream(model) {
         this.instreamState = null;
         this.addBackdrop();
         this.controlbar.syncPlaybackTime(model);
+        if (model.get('autostartMuted')) {
+            utils.addClass(this.playerContainer, 'jw-flag-autostart');
+        }
     }
 }


### PR DESCRIPTION
### This PR will...

- Remove "jw-flag-autostart" class when in instream mode (css for this flag conflicts with ads mode controls)
- Allow user-inactive when player element has focus (tapping on mobile gives focus)

