### PR TITLE
Hide tooltips when button is in focus

### DIFF
--- a/src/js/view/controls/components/settings/content-item.js
+++ b/src/js/view/controls/components/settings/content-item.js
@@ -6,7 +6,7 @@ export default function SettingsContentItem(name, content, action) {
     let active;
     const contentItemElement = createElement(ContentItemTemplate(content));
     const contentItemUI = new UI(contentItemElement);
-    contentItemUI.on('click tap enter', () => {
+    contentItemUI.on('click tap', () => {
         action();
     });
 
@@ -23,6 +23,9 @@ export default function SettingsContentItem(name, content, action) {
         },
         element() {
             return contentItemElement;
+        },
+        uiElement() {
+            return contentItemUI;
         },
         destroy() {
             this.deactivate();

--- a/src/js/view/controls/components/settings/menu.js
+++ b/src/js/view/controls/components/settings/menu.js
@@ -29,14 +29,14 @@ export function SettingsMenu(onVisibility, onSubmenuAdded, onMenuEmpty) {
             return;
         }
 
-        instance.close();
+        instance.close(true);
     });
 
     topbarElement.appendChild(closeButton.element());
 
     const keyHandler = function(evt) {
         if (evt && evt.keyCode === 27) {
-            instance.close();
+            instance.close(true);
             evt.stopPropagation();
         }
     };
@@ -57,9 +57,9 @@ export function SettingsMenu(onVisibility, onSubmenuAdded, onMenuEmpty) {
             }
 
         },
-        close() {
+        close(isKeyEvent = false) {
             visible = false;
-            onVisibility(visible);
+            onVisibility(visible, isKeyEvent);
 
             active = null;
             deactivateAllSubmenus(submenus);

--- a/src/js/view/controls/components/settings/menu.js
+++ b/src/js/view/controls/components/settings/menu.js
@@ -17,31 +17,31 @@ export function SettingsMenu(onVisibility, onSubmenuAdded, onMenuEmpty) {
     let visible;
     let active = null;
     const submenus = {};
+
     const settingsMenuElement = createElement(SettingsMenuTemplate());
-    const topbarElement = settingsMenuElement.querySelector('.jw-settings-topbar');
 
-    const closeButton = button('jw-settings-close', () => {
-        instance.close();
-    }, 'Close Settings', [cloneIcon('close')]);
-    closeButton.show();
-    closeButton.element().addEventListener('keydown', function(evt) {
-        if (evt.keyCode !== 9 || evt.shiftKey) {
-            return;
-        }
-
-        instance.close(true);
-    });
-
-    topbarElement.appendChild(closeButton.element());
-
-    const keyHandler = function(evt) {
+    const closeOnEnter = function(evt) {
         if (evt && evt.keyCode === 27) {
             instance.close(true);
             evt.stopPropagation();
         }
     };
+    settingsMenuElement.addEventListener('keydown', closeOnEnter);
 
-    settingsMenuElement.addEventListener('keydown', keyHandler);
+    const closeButton = button('jw-settings-close', () => {
+        instance.close();
+    }, 'Close Settings', [cloneIcon('close')]);
+
+    const closeOnButton = function(evt) {
+        if (evt.keyCode === 13 || (evt.keyCode === 9 && !evt.shiftKey)) {
+            instance.close(true);
+        }
+    };
+    closeButton.show();
+    closeButton.element().addEventListener('keydown', closeOnButton);
+
+    const topbarElement = settingsMenuElement.querySelector('.jw-settings-topbar');
+    topbarElement.appendChild(closeButton.element());
 
     const instance = {
         open(isDefault) {
@@ -83,6 +83,11 @@ export function SettingsMenu(onVisibility, onSubmenuAdded, onMenuEmpty) {
 
             if (submenu.isDefault) {
                 prependChild(topbarElement, submenu.categoryButtonElement);
+                submenu.categoryButtonElement.addEventListener('keydown', function(evt) {
+                    if (evt.keyCode === 9 && evt.shiftKey) {
+                        instance.close(true);
+                    }
+                });
             } else {
                 // sharing should always be the last submenu
                 const sharingButton = topbarElement.querySelector('.jw-submenu-sharing');
@@ -137,7 +142,8 @@ export function SettingsMenu(onVisibility, onSubmenuAdded, onMenuEmpty) {
         },
         destroy() {
             this.close();
-            settingsMenuElement.removeEventListener('keydown', keyHandler);
+            settingsMenuElement.removeEventListener('keydown', closeOnEnter);
+            closeButton.element().removeEventListener('keydown', closeOnButton);
             emptyElement(settingsMenuElement);
         }
     };

--- a/src/js/view/controls/components/settings/menu.js
+++ b/src/js/view/controls/components/settings/menu.js
@@ -26,7 +26,7 @@ export function SettingsMenu(onVisibility, onSubmenuAdded, onMenuEmpty) {
             evt.stopPropagation();
         }
     };
-    settingsMenuElement.addEventListener('keyup', closeOnEnter);
+    settingsMenuElement.addEventListener('keydown', closeOnEnter);
 
     const closeButton = button('jw-settings-close', () => {
         instance.close();
@@ -40,7 +40,7 @@ export function SettingsMenu(onVisibility, onSubmenuAdded, onMenuEmpty) {
         }
     };
     closeButton.show();
-    closeButton.element().addEventListener('keyup', closeOnButton);
+    closeButton.element().addEventListener('keydown', closeOnButton);
 
     const topbarElement = settingsMenuElement.querySelector('.jw-settings-topbar');
     topbarElement.appendChild(closeButton.element());

--- a/src/js/view/controls/components/settings/menu.js
+++ b/src/js/view/controls/components/settings/menu.js
@@ -26,19 +26,21 @@ export function SettingsMenu(onVisibility, onSubmenuAdded, onMenuEmpty) {
             evt.stopPropagation();
         }
     };
-    settingsMenuElement.addEventListener('keydown', closeOnEnter);
+    settingsMenuElement.addEventListener('keyup', closeOnEnter);
 
     const closeButton = button('jw-settings-close', () => {
         instance.close();
     }, 'Close Settings', [cloneIcon('close')]);
 
     const closeOnButton = function(evt) {
+        // Close settings menu when enter is pressed on the close button
+        // or when tab key is pressed since it is the last element in topbar
         if (evt.keyCode === 13 || (evt.keyCode === 9 && !evt.shiftKey)) {
             instance.close(true);
         }
     };
     closeButton.show();
-    closeButton.element().addEventListener('keydown', closeOnButton);
+    closeButton.element().addEventListener('keyup', closeOnButton);
 
     const topbarElement = settingsMenuElement.querySelector('.jw-settings-topbar');
     topbarElement.appendChild(closeButton.element());

--- a/src/js/view/controls/components/settings/menu.js
+++ b/src/js/view/controls/components/settings/menu.js
@@ -86,6 +86,7 @@ export function SettingsMenu(onVisibility, onSubmenuAdded, onMenuEmpty) {
             if (submenu.isDefault) {
                 prependChild(topbarElement, submenu.categoryButtonElement);
                 submenu.categoryButtonElement.addEventListener('keydown', function(evt) {
+                    // close settings menu if you shift-tab on the first category button element
                     if (evt.keyCode === 9 && evt.shiftKey) {
                         instance.close(true);
                     }

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -124,7 +124,7 @@ export default class Controls {
 
         // Settings Menu
         let lastState = null;
-        const visibilityChangeHandler = (visible) => {
+        const visibilityChangeHandler = (visible, isKeyEvent) => {
             const state = model.get('state');
             const settingsInteraction = { reason: 'settingsInteraction' };
 
@@ -143,8 +143,9 @@ export default class Controls {
             this.userActive();
             lastState = state;
 
-            if (!visible && this.controlbar.elements.settingsButton) {
-                this.controlbar.elements.settingsButton.element().focus();
+            const settingsButton = this.controlbar.elements.settingsButton;
+            if (!visible && isKeyEvent && settingsButton) {
+                settingsButton.element().focus();
             }
         };
         const settingsMenu = this.settingsMenu = createSettingsMenu(controlbar, visibilityChangeHandler);

--- a/src/js/view/utils/submenu-factory.js
+++ b/src/js/view/utils/submenu-factory.js
@@ -26,7 +26,9 @@ export const makeSubmenu = (settingsMenu, name, contentItems, icon, tooltipText)
         // Qualities submenu is the default submenu
         submenu = SettingsSubmenu(name, categoryButton, name === DEFAULT_SUBMENU);
         submenu.addContent(contentItems);
-        SimpleTooltip(categoryButtonElement, name, tooltipText);
+        if (!('ontouchstart' in window)) {
+            SimpleTooltip(categoryButtonElement, name, tooltipText);
+        }
         settingsMenu.addSubmenu(submenu);
     }
 

--- a/src/js/view/utils/submenu-factory.js
+++ b/src/js/view/utils/submenu-factory.js
@@ -37,10 +37,17 @@ export const makeSubmenu = (settingsMenu, name, contentItems, icon, tooltipText)
 
 export function addCaptionsSubmenu(settingsMenu, captionsList, action, initialSelectionIndex, tooltipText) {
     const captionsContentItems = captionsList.map((track, index) => {
-        return SettingsContentItem(track.id, track.label, () => {
+        const contentItemElement = SettingsContentItem(track.id, track.label, () => {
             action(index);
             settingsMenu.close();
         });
+
+        contentItemElement.uiElement().on('enter', () => {
+            action(index);
+            settingsMenu.close(true);
+        });
+
+        return contentItemElement;
     });
 
     const captionsSubmenu = makeSubmenu(settingsMenu, CAPTIONS_SUBMENU, captionsContentItems, cloneIcon('cc-off'), tooltipText);


### PR DESCRIPTION
### This PR will...

- Not create tooltips for the topnav icons in the settings menu
- Not focus on the settings button after closing if its not triggered by a key event

### Why is this Pull Request needed?

So that the tooltips do not show up on mobile devices after button is tapped

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-plugin-related/pull/170

#### Addresses Issue(s):

JW8-616

