### PR TITLE
Fix vpaid2 nonlinear from not firing events

### DIFF
--- a/src/js/controller/instream-html5.js
+++ b/src/js/controller/instream-html5.js
@@ -152,12 +152,10 @@ const InstreamHtml5 = function(_controller, _model) {
      *****************************/
 
     function _checkProvider(pseudoProvider) {
-        var provider = pseudoProvider || _adModel.getVideo();
+        var provider = _currentProvider = pseudoProvider || _adModel.getVideo();
         if (!provider) {
             return;
         }
-
-        _currentProvider = provider;
 
         var isVpaidProvider = provider.type === 'vpaid';
 


### PR DESCRIPTION
### This PR will...
Fix vpaid2 nonlinear from not firing events

### Why is this Pull Request needed?
Vpaid nonlinear sets the provider to null so that event listeners are not destroyed when instreamDestroy is called. This is neeeded since nonlinear ads play with the content, so the listeners need to stay active when blocking instream is destroyed.

#### Addresses Issue(s):
JW8-657


