### PR TITLE
Clear current instream provider when applyProviderListeners(null) is called

### DIFF
--- a/src/js/controller/instream-html5.js
+++ b/src/js/controller/instream-html5.js
@@ -82,14 +82,14 @@ const InstreamHtml5 = function(_controller, _model) {
             this.trigger(ERROR, data);
         }, _this);
         _model.on('change:volume', function(data, value) {
-            _currentProvider.volume(value);
+            provider.volume(value);
         }, _this);
         _model.on('change:mute', function(data, value) {
-            _currentProvider.mute(value);
+            provider.mute(value);
         }, _this);
         _model.on('change:autostartMuted', function(data, value) {
             if (!value) {
-                _currentProvider.mute(_model.get('mute'));
+                provider.mute(_model.get('mute'));
             }
         }, _this);
     };
@@ -152,12 +152,14 @@ const InstreamHtml5 = function(_controller, _model) {
      *****************************/
 
     function _checkProvider(pseudoProvider) {
-        var provider = pseudoProvider || _adModel.getVideo();
+        const provider = pseudoProvider || _adModel.getVideo();
+
+        // Clear current provider when applyProviderListeners(null) is called
+        _currentProvider = provider;
+
         if (!provider) {
             return;
         }
-
-        _currentProvider = provider;
 
         var isVpaidProvider = provider.type === 'vpaid';
 


### PR DESCRIPTION
### This PR will...

- Fix vpaid2 nonlinear ads from not firing events
- Reduce some side effects of using `_currentProvider` and clarify when it should be cleared with a comment

### Why is this Pull Request needed?

The [VAST plugin calls `applyProviderListeners(null)`](https://github.com/jwplayer/jwplayer-ads-vast/blob/e2fb1efa00635b4f8133991cab5ac2f0251b0095/src/js/VpaidPlayerJS.js#L86) to clear instream's reference to a provider (VPAIDPlayerJS) before it's destroyed so that we don't remove event listeners from the VPAID interface.

### Are there any points in the code the reviewer needs to double check?

Instream provider is set (or cleared) in `_checkProvider` which can be called from 3 different places. This adds the listeners we want on the provider, but only `applyProviderListeners` called by ad plugins resets the provider's error listener and adds player model listeners to update the provider player's volume and mute state. The error reset is redundant, and the player `_mode;` listeners are not reset anywhere in instream-html5.
 
### Are there any Pull Requests related to this?

This PR replaces #2439 2439

#### Addresses Issue(s):

JW8-657

