### PR TITLE
Checks if menu has childNode before removing a submenu

### DIFF
--- a/src/js/view/controls/components/settings/menu.js
+++ b/src/js/view/controls/components/settings/menu.js
@@ -101,7 +101,7 @@ export function SettingsMenu(onVisibility, onSubmenuAdded, onMenuEmpty) {
         },
         removeSubmenu(name) {
             const submenu = submenus[name];
-            if (!submenu || !settingsMenuElement.hasChildNodes()) {
+            if (!submenu || submenu.element().parentNode !== settingsMenuElement) {
                 return;
             }
             settingsMenuElement.removeChild(submenu.element());

--- a/src/js/view/controls/components/settings/menu.js
+++ b/src/js/view/controls/components/settings/menu.js
@@ -101,7 +101,7 @@ export function SettingsMenu(onVisibility, onSubmenuAdded, onMenuEmpty) {
         },
         removeSubmenu(name) {
             const submenu = submenus[name];
-            if (!submenu) {
+            if (!submenu || !settingsMenuElement.hasChildNodes([submenu.element()])) {
                 return;
             }
             settingsMenuElement.removeChild(submenu.element());

--- a/src/js/view/controls/components/settings/menu.js
+++ b/src/js/view/controls/components/settings/menu.js
@@ -101,7 +101,7 @@ export function SettingsMenu(onVisibility, onSubmenuAdded, onMenuEmpty) {
         },
         removeSubmenu(name) {
             const submenu = submenus[name];
-            if (!submenu || !settingsMenuElement.hasChildNodes([submenu.element()])) {
+            if (!submenu || !settingsMenuElement.hasChildNodes()) {
                 return;
             }
             settingsMenuElement.removeChild(submenu.element());


### PR DESCRIPTION
### This PR will...
prevent the removal of a node if it is not a child element of the menu
### Why is this Pull Request needed?
to prevent the player from crashing when controls are off and a new item is loaded
### Are there any points in the code the reviewer needs to double check?
according to [js perf](https://jsperf.com/haschildnodes-vs-childnodes-length) calling `hasChildNodes` is the most performant way of verifying.
#### Addresses Issue(s):
JW8-658

