### PR TITLE
Prevent tooltip showing on 1st menu when settings menu open

### DIFF
--- a/src/css/controls/imports/tooltip.less
+++ b/src/css/controls/imports/tooltip.less
@@ -111,7 +111,7 @@
         }
     }
 
-    .jw-icon:focus > .jw-tooltip {
+    .jw-icon:not(.jw-first-submenu):focus > .jw-tooltip {
         &:extend(.jw-controlbar .jw-tooltip.jw-open);
     }
 }

--- a/src/css/controls/imports/tooltip.less
+++ b/src/css/controls/imports/tooltip.less
@@ -111,7 +111,7 @@
         }
     }
 
-    .jw-icon:not(.jw-first-submenu):focus > .jw-tooltip {
+    .jw-icon:focus > .jw-tooltip {
         &:extend(.jw-controlbar .jw-tooltip.jw-open);
     }
 }

--- a/src/js/view/controls/components/settings/menu.js
+++ b/src/js/view/controls/components/settings/menu.js
@@ -1,7 +1,7 @@
 import { cloneIcon } from 'view/controls/icons';
 import button from 'view/controls/components/button';
 import SettingsMenuTemplate from 'view/controls/templates/settings/menu';
-import { createElement, emptyElement, prependChild } from 'utils/dom';
+import { createElement, emptyElement, prependChild, addClass, removeClass } from 'utils/dom';
 
 export function SettingsMenu(onVisibility, onSubmenuAdded, onMenuEmpty) {
     const documentClickHandler = (e) => {
@@ -41,6 +41,12 @@ export function SettingsMenu(onVisibility, onSubmenuAdded, onMenuEmpty) {
         }
     };
 
+    const outOfFocus = () => {
+        removeClass(active.categoryButtonElement, 'jw-first-submenu');
+//        window.removeEventListener('blur', outOfFocus);
+        console.log('blur out');
+    };
+
     settingsMenuElement.addEventListener('keydown', keyHandler);
 
     const instance = {
@@ -51,7 +57,10 @@ export function SettingsMenu(onVisibility, onSubmenuAdded, onMenuEmpty) {
             addDocumentListeners(documentClickHandler);
 
             if (isDefault) {
+                addClass(active.categoryButtonElement, 'jw-first-submenu');
                 active.categoryButtonElement.focus();
+                console.log('blur in');
+                window.addEventListener('blur', outOfFocus, true);
             } else {
                 active.element().firstChild.focus();
             }
@@ -66,6 +75,7 @@ export function SettingsMenu(onVisibility, onSubmenuAdded, onMenuEmpty) {
 
             settingsMenuElement.setAttribute('aria-expanded', 'false');
             removeDocumentListeners(documentClickHandler);
+            window.removeEventListener('blur', outOfFocus);
         },
         toggle() {
             if (visible) {

--- a/src/js/view/controls/components/settings/menu.js
+++ b/src/js/view/controls/components/settings/menu.js
@@ -43,8 +43,7 @@ export function SettingsMenu(onVisibility, onSubmenuAdded, onMenuEmpty) {
 
     const outOfFocus = () => {
         removeClass(active.categoryButtonElement, 'jw-first-submenu');
-//        window.removeEventListener('blur', outOfFocus);
-        console.log('blur out');
+        active.categoryButtonElement.removeEventListener('blur', outOfFocus);
     };
 
     settingsMenuElement.addEventListener('keydown', keyHandler);
@@ -57,10 +56,11 @@ export function SettingsMenu(onVisibility, onSubmenuAdded, onMenuEmpty) {
             addDocumentListeners(documentClickHandler);
 
             if (isDefault) {
-                addClass(active.categoryButtonElement, 'jw-first-submenu');
+                if (window.event.pointerType === 'mouse') {
+                    addClass(active.categoryButtonElement, 'jw-first-submenu');
+                    active.categoryButtonElement.addEventListener('blur', outOfFocus);
+                }
                 active.categoryButtonElement.focus();
-                console.log('blur in');
-                window.addEventListener('blur', outOfFocus, true);
             } else {
                 active.element().firstChild.focus();
             }
@@ -75,7 +75,6 @@ export function SettingsMenu(onVisibility, onSubmenuAdded, onMenuEmpty) {
 
             settingsMenuElement.setAttribute('aria-expanded', 'false');
             removeDocumentListeners(documentClickHandler);
-            window.removeEventListener('blur', outOfFocus);
         },
         toggle() {
             if (visible) {

--- a/src/js/view/controls/components/settings/menu.js
+++ b/src/js/view/controls/components/settings/menu.js
@@ -1,7 +1,7 @@
 import { cloneIcon } from 'view/controls/icons';
 import button from 'view/controls/components/button';
 import SettingsMenuTemplate from 'view/controls/templates/settings/menu';
-import { createElement, emptyElement, prependChild, addClass, removeClass } from 'utils/dom';
+import { createElement, emptyElement, prependChild } from 'utils/dom';
 
 export function SettingsMenu(onVisibility, onSubmenuAdded, onMenuEmpty) {
     const documentClickHandler = (e) => {
@@ -41,11 +41,6 @@ export function SettingsMenu(onVisibility, onSubmenuAdded, onMenuEmpty) {
         }
     };
 
-    const outOfFocus = () => {
-        removeClass(active.categoryButtonElement, 'jw-first-submenu');
-        active.categoryButtonElement.removeEventListener('blur', outOfFocus);
-    };
-
     settingsMenuElement.addEventListener('keydown', keyHandler);
 
     const instance = {
@@ -56,11 +51,9 @@ export function SettingsMenu(onVisibility, onSubmenuAdded, onMenuEmpty) {
             addDocumentListeners(documentClickHandler);
 
             if (isDefault) {
-                if (window.event.pointerType === 'mouse') {
-                    addClass(active.categoryButtonElement, 'jw-first-submenu');
-                    active.categoryButtonElement.addEventListener('blur', outOfFocus);
+                if (!window.event.pointerType) {
+                    active.categoryButtonElement.focus();
                 }
-                active.categoryButtonElement.focus();
             } else {
                 active.element().firstChild.focus();
             }


### PR DESCRIPTION
### This PR will...
focus the default submenu only when the settings menu is open via keyboard to prevent the tooltip from opening for it
### Why is this Pull Request needed?
We don't want the tooltip to show when the settings menu is open, unless opened with enter
### Are there any points in the code the reviewer needs to double check?
n/a
### Are there any Pull Requests open in other repos which need to be merged with this?
n/a
#### Addresses Issue(s):
JW8-633

