### PR TITLE
Only fire "visualQuality" events while playing

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -60,6 +60,7 @@ function VideoProvider(_playerId, _playerConfig) {
             VideoEvents.progress.call(_this);
             checkStaleStream();
         },
+        
         timeupdate() {
             VideoEvents.timeupdate.call(_this);
             checkStaleStream();
@@ -67,9 +68,7 @@ function VideoProvider(_playerId, _playerConfig) {
                 checkVisualQuality();
             }
         },
-        resize() {
-            checkVisualQuality();
-        },
+
         ended() {
             _currentQuality = -1;
             clearTimeouts();


### PR DESCRIPTION
### This PR will...

Remove the media element "resize" listener that fires "visualQuality" events.

### Why is this Pull Request needed?

"visualQuality" events are fired before playback. Our test expect them to only be fired while playing. `getVisualQuality` will not be available for preloaded playlist items. It will only be available after the first time event when the player state is playing.

#### Addresses Issue(s):

JW8-656

