### PR TITLE
Fix issues with VPAID midrolls replaying content

### DIFF
--- a/src/js/controller/instream-html5.js
+++ b/src/js/controller/instream-html5.js
@@ -51,6 +51,8 @@ const InstreamHtml5 = function(_controller, _model) {
 
     /** Load an instream item and initialize playback **/
     _this.load = function() {
+        // Let the player media model know we're using it's video tag
+        _model.mediaModel.srcReset();
 
         // Make sure it chooses a provider
         _adModel.stopVideo();
@@ -159,10 +161,7 @@ const InstreamHtml5 = function(_controller, _model) {
             return;
         }
 
-        // Let the player media model know we're using it's video tag
-        _model.mediaModel.srcReset();
-
-        const isVpaidProvider = provider.type === 'vpaid';
+        var isVpaidProvider = provider.type === 'vpaid';
 
         provider.off();
         provider.on('all', function(type, data) {

--- a/src/js/controller/instream-html5.js
+++ b/src/js/controller/instream-html5.js
@@ -51,8 +51,6 @@ const InstreamHtml5 = function(_controller, _model) {
 
     /** Load an instream item and initialize playback **/
     _this.load = function() {
-        // Let the player media model know we're using it's video tag
-        _model.mediaModel.srcReset();
 
         // Make sure it chooses a provider
         _adModel.stopVideo();
@@ -161,7 +159,10 @@ const InstreamHtml5 = function(_controller, _model) {
             return;
         }
 
-        var isVpaidProvider = provider.type === 'vpaid';
+        // Let the player media model know we're using it's video tag
+        _model.mediaModel.srcReset();
+
+        const isVpaidProvider = provider.type === 'vpaid';
 
         provider.off();
         provider.on('all', function(type, data) {

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -253,6 +253,7 @@ const Model = function() {
     this.detachMedia = function() {
         thenPlayPromise.cancel();
         _attached = false;
+        this.mediaModel.set('setup', false);
         if (_provider) {
             _provider.off('all', _videoEventHandler, this);
             _provider.detachMedia();

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -253,7 +253,6 @@ const Model = function() {
     this.detachMedia = function() {
         thenPlayPromise.cancel();
         _attached = false;
-        this.mediaModel.set('setup', false);
         if (_provider) {
             _provider.off('all', _videoEventHandler, this);
             _provider.detachMedia();
@@ -587,6 +586,9 @@ const Model = function() {
             playPromise = loadAndPlay(this, item);
             playAttempt(this, playPromise, playReason);
         } else {
+            if (item.starttime) {
+                _provider.seek(item.starttime);
+            }
             playPromise = _provider.play() || resolved;
             if (!this.mediaModel.get('started')) {
                 playAttempt(this, playPromise, playReason);

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -21,6 +21,7 @@ const Model = function() {
     const _this = this;
     let _providers;
     let _provider;
+    let _oldSrc;
     let _beforecompleted = false;
     let _attached = true;
     let thenPlayPromise = cancelable(function() {});
@@ -250,11 +251,23 @@ const Model = function() {
         return _beforecompleted;
     };
 
+    function sourceChanged(event) {
+        _provider.video.removeEventListener('loadeddata', sourceChanged);
+        if (_oldSrc && event && event.srcElement && event.srcElement.src !== _oldSrc) {
+            _this.mediaModel.srcReset();
+        }
+        _oldSrc = null;
+    }
+
     this.detachMedia = function() {
         thenPlayPromise.cancel();
         _attached = false;
         if (_provider) {
             _provider.off('all', _videoEventHandler, this);
+            if (_provider.video) {
+                _oldSrc = _provider.video.src;
+                _provider.video.addEventListener('loadeddata', sourceChanged);
+            }
             _provider.detachMedia();
         }
     };
@@ -262,6 +275,10 @@ const Model = function() {
     this.attachMedia = function() {
         _attached = true;
         if (_provider) {
+            if (_provider.video) {
+                _provider.video.removeEventListener('loadeddata', sourceChanged);
+                _oldSrc = null;
+            }
             _provider.off('all', _videoEventHandler, this);
             _provider.on('all', _videoEventHandler, this);
         }

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -586,9 +586,6 @@ const Model = function() {
             playPromise = loadAndPlay(this, item);
             playAttempt(this, playPromise, playReason);
         } else {
-            if (item.starttime) {
-                _provider.seek(item.starttime);
-            }
             playPromise = _provider.play() || resolved;
             if (!this.mediaModel.get('started')) {
                 playAttempt(this, playPromise, playReason);


### PR DESCRIPTION
### This PR will...
Reset the mediaModel when detaching the media.

### Why is this Pull Request needed?
When vpaid ads are played as midrolls, there is nothing that sets the mediaModel's setup back to false. This causes the providers to start the content from the beginning after the midrolls, because it never loads the video again. 
See line: https://github.com/jwplayer/jwplayer/blob/master/src/js/controller/model.js#L585

#### Addresses Issue(s):
ADS-583 ADS-579

