### PR TITLE
Only attempt to preload an idle player

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -259,8 +259,8 @@ Object.assign(Controller.prototype, {
             });
 
 
-            // Only attempt to preload an idle player if it's the first player on the page or viewable
-            if (model.get('state') === 'idle' && (instances[0] === _api || viewable === 1)) {
+            // Only attempt to preload if this is the first player on the page or viewable
+            if (instances[0] === _api || viewable === 1) {
                 model.preloadVideo();
             }
         }

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -259,8 +259,8 @@ Object.assign(Controller.prototype, {
             });
 
 
-            // Only attempt to preload if this is the first player on the page or viewable
-            if (instances[0] === _api || viewable === 1) {
+            // Only attempt to preload an idle player if it's the first player on the page or viewable
+            if (model.get('state') === 'idle' && (instances[0] === _api || viewable === 1)) {
                 model.preloadVideo();
             }
         }

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -559,7 +559,7 @@ const Model = function() {
     this.preloadVideo = function() {
         const item = this.get('playlistItem');
         // Only attempt to preload if media is attached and hasn't been loaded
-        if (_attached && _provider &&
+        if (this.get('state') === 'idle' && _attached && _provider &&
             item.preload !== 'none' &&
             this.get('autostart') === false &&
             !this.mediaModel.get('setup') &&


### PR DESCRIPTION
### This PR will...
Only preload an idle player.
### Why is this Pull Request needed?
We were preloading when in the complete state after a postroll, caused by the player becoming viewable after switching away from then back to the tab it was in.
### Are there any points in the code the reviewer needs to double check?
No.
### Are there any Pull Requests open in other repos which need to be merged with this?
No.
#### Addresses Issue(s):
JW8-683

