### PR TITLE
Detect when video src is set externally in instream mode

### DIFF
--- a/src/js/controller/instream-html5.js
+++ b/src/js/controller/instream-html5.js
@@ -59,7 +59,7 @@ const InstreamHtml5 = function(_controller, _model) {
     /** Load an instream item and initialize playback **/
     _this.load = function() {
         // Let the player media model know we're using it's video tag
-        _adModel.get('mediaContext').srcReset();
+        _this.srcReset();
 
         // Make sure it chooses a provider
         _adModel.stopVideo();
@@ -123,8 +123,8 @@ const InstreamHtml5 = function(_controller, _model) {
         }
 
         const mediaElement = _adModel.get('mediaElement');
-        mediaElement.addEventListener('abort', _this.srcReset);
-        mediaElement.addEventListener('emptied', _this.srcReset);
+        mediaElement.removeEventListener('abort', _this.srcReset);
+        mediaElement.removeEventListener('emptied', _this.srcReset);
 
         // Reset the player media model if the src was changed externally
         const srcChanged = mediaElement.src !== _adModel.get('mediaSrc');

--- a/src/js/controller/instream-html5.js
+++ b/src/js/controller/instream-html5.js
@@ -22,12 +22,14 @@ const InstreamHtml5 = function(_controller, _model) {
     this.init = function(mediaElement) {
         // Initialize the instream player's model copied from main player's model
         const playerAttributes = _model.attributes;
+        const mediaModelContext = _model.mediaModel;
         _adModel = new Model().setup({
             id: playerAttributes.id,
             volume: playerAttributes.volume,
             fullscreen: playerAttributes.fullscreen,
             instreamMode: true,
             edition: playerAttributes.edition,
+            mediaContext: mediaModelContext,
             mediaElement: mediaElement,
             mediaSrc: mediaElement.src,
             mute: playerAttributes.mute || playerAttributes.autostartMuted,
@@ -47,7 +49,7 @@ const InstreamHtml5 = function(_controller, _model) {
         }, _this);
         // Listen to media element for events that indicate src was reset or load() was called
         _this.srcReset = function() {
-            _model.mediaModel.srcReset();
+            mediaModelContext.srcReset();
         };
         mediaElement.addEventListener('abort', _this.srcReset);
         mediaElement.addEventListener('emptied', _this.srcReset);
@@ -57,7 +59,7 @@ const InstreamHtml5 = function(_controller, _model) {
     /** Load an instream item and initialize playback **/
     _this.load = function() {
         // Let the player media model know we're using it's video tag
-        _model.mediaModel.srcReset();
+        _adModel.get('mediaContext').srcReset();
 
         // Make sure it chooses a provider
         _adModel.stopVideo();
@@ -179,11 +181,11 @@ const InstreamHtml5 = function(_controller, _model) {
             this.trigger(type, Object.assign({}, data, { type: type }));
         }, _this);
 
-        const mediaModelContext = _adModel.mediaModel;
+        const adMediaModelContext = _adModel.mediaModel;
         provider.on(PLAYER_STATE, (event) => {
-            mediaModelContext.set(PLAYER_STATE, event.newstate);
+            adMediaModelContext.set(PLAYER_STATE, event.newstate);
         });
-        mediaModelContext.on('change:' + PLAYER_STATE, (changeAdModel, state) => {
+        adMediaModelContext.on('change:' + PLAYER_STATE, (changeAdModel, state) => {
             stateHandler(state);
         });
         provider.attachMedia();

--- a/src/js/controller/instream-html5.js
+++ b/src/js/controller/instream-html5.js
@@ -45,7 +45,12 @@ const InstreamHtml5 = function(_controller, _model) {
         _adModel.on(ERROR, function(data) {
             _this.trigger(ERROR, data);
         }, _this);
-
+        // Listen to media element for events that indicate src was reset or load() was called
+        _this.srcReset = function() {
+            _model.mediaModel.srcReset();
+        };
+        mediaElement.addEventListener('abort', _this.srcReset);
+        mediaElement.addEventListener('emptied', _this.srcReset);
         this._adModel = _adModel;
     };
 
@@ -115,9 +120,12 @@ const InstreamHtml5 = function(_controller, _model) {
             }
         }
 
+        const mediaElement = _adModel.get('mediaElement');
+        mediaElement.addEventListener('abort', _this.srcReset);
+        mediaElement.addEventListener('emptied', _this.srcReset);
 
         // Reset the player media model if the src was changed externally
-        const srcChanged = _adModel.get('mediaElement').src !== _adModel.get('mediaSrc');
+        const srcChanged = mediaElement.src !== _adModel.get('mediaSrc');
         if (srcChanged) {
             _model.mediaModel.srcReset();
         }


### PR DESCRIPTION
### This PR will...

Reset mediaModel when media element events indicate `src` was changed or `load()` was called externally.

### Why is this Pull Request needed?

When resuming playback from a mid-roll, in order for playback to be started from `item.startTime`, flags on the mediaModel must be reset if the video tag's src or currentTime where changed. Listening to 'abort' and 'emptied', and resetting these flags on these events ensures that playback will resume properly.

### Are there any points in the code the reviewer needs to double check?

I've limited the scope of this check to instream-html5 since this is the only place where we expect external code to tamper with the vide tag's src.

For debugging purposes, I use this code in [api/get-media-element.js](https://github.com/jwplayer/jwplayer/blob/v8.0.0-rc.2/src/js/api/get-media-element.js) to observe all attribute changes on the video tag, load play pause commands, and all events emitted from the media element:

```js
const observer = new MutationObserver(function(mutations) {
    mutations.forEach(function(mutation) {
        console.warn('mutation', mutation);
    });
});
observer.observe(media, {
    attributes: true
});
const load = media.load;
const pause = media.pause;
const play = media.play;
media.load = function() {
    console.error('media.load()');
    return load.call(this);
};
media.pause = function() {
    console.error('media.pause()');
    return pause.call(this);
};
media.play = function() {
    console.error('media.play()');
    return play.call(this);
};
function videoEventHandler(e) {
    console.warn('>> "' + e.type + '"');
}
media.addEventListener('loadstart', videoEventHandler);
media.addEventListener('progress', videoEventHandler);
media.addEventListener('suspend', videoEventHandler);
media.addEventListener('abort', videoEventHandler);
media.addEventListener('error', videoEventHandler);
media.addEventListener('emptied', videoEventHandler);
media.addEventListener('stalled', videoEventHandler);
media.addEventListener('loadedmetadata', videoEventHandler);
media.addEventListener('loadeddata', videoEventHandler);
media.addEventListener('canplay', videoEventHandler);
media.addEventListener('canplaythrough', videoEventHandler);
media.addEventListener('playing', videoEventHandler);
media.addEventListener('waiting', videoEventHandler);
media.addEventListener('seeking', videoEventHandler);
media.addEventListener('seeked', videoEventHandler);
media.addEventListener('ended', videoEventHandler);
media.addEventListener('durationchange', videoEventHandler);
media.addEventListener('timeupdate', videoEventHandler);
media.addEventListener('play', videoEventHandler);
media.addEventListener('pause', videoEventHandler);
media.addEventListener('ratechange', videoEventHandler);
media.addEventListener('resize', videoEventHandler);
media.addEventListener('volumechange', videoEventHandler);
```

#### Addresses Issue(s):

ADS-583 ADS-579

