### PR TITLE
Maintain error state until stop(), load() or item is changed

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -135,8 +135,11 @@ Object.assign(Controller.prototype, {
         });
 
         _model.on('change:mediaModel', function(model) {
+            model.set('errorEvent', undefined);
             model.mediaModel.change(PLAYER_STATE, function(mediaModel, state) {
-                model.set(PLAYER_STATE, normalizeState(state));
+                if (!model.get('errorEvent')) {
+                    model.set(PLAYER_STATE, normalizeState(state));
+                }
             });
         });
 
@@ -459,6 +462,8 @@ Object.assign(Controller.prototype, {
             if (_preplay) {
                 _interruptPlay = true;
             }
+
+            _model.set('errorEvent', undefined);
 
             const provider = _model.getVideo();
             _model.stopVideo();

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -693,7 +693,7 @@ function View(_api, _model) {
             errorContainer.querySelector('.jw-icon').appendChild(ErrorContainer.cloneIcon('error'));
         }
         _playerElement.appendChild(errorContainer.firstChild);
-        toggleClass(_playerElement, 'jw-flag-audio-player', model.get('audioMode'));
+        toggleClass(_playerElement, 'jw-flag-audio-player', !!model.get('audioMode'));
     }
 
     function _stateHandler(model, newState, oldState) {


### PR DESCRIPTION
### This PR will...

- Prevent media model state changes that occur directly after an error from resetting the error state.
- Only clear the error state when the media model changes or when stop() is called (internally or externally)
- Set 'jw-flag-audio-player' properly

### Why is this Pull Request needed?

The play promise rejection handler that fires "playAttemptFailed" also will set the mediaModel state to "paused". This was setting the player state to "paused" clearing the player error before anyone had the chance to see it.

Since the change above prevents media model state changes from changing the player state when there is an error event we want to display, make sure we only clear the error event in the cases we test:
- loading a new playlist or item
- changing playlist items
- calling stop to reset the player state to idle

If 'audioMode' was undefined the 'jw-flag-audio-player' was being added to the player by the toggle call. Coercing this state to a boolean fixes this.

#### Addresses Issue(s):

JW8-675
