### PR TITLE
Don't start stall timeout if there are no buffered ranges

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -732,7 +732,7 @@ function VideoProvider(_playerId, _playerConfig) {
         var endOfBuffer = endOfRange(_videotag.buffered);
         var live = _this.isLive();
 
-        if (live && _lastEndOfBuffer === endOfBuffer) {
+        if (live && endOfBuffer && _lastEndOfBuffer === endOfBuffer) {
             if (_staleStreamTimeout === -1) {
                 _staleStreamTimeout = setTimeout(function () {
                     _stale = true;


### PR DESCRIPTION
On Android the stalled live error message is firing. It's possible this is because of missing buffered ranges. This check prevents that.

To follow up we may want to remove the `checkStaleStream()` call from "progress" events. The "stalled" event in Chrome (after playback has started) can be used as an indicator that the stream will stall.

#### Addresses Issue(s):

JW8-707 #2455
