### PR TITLE
Show controls when navigating via keyboard

### DIFF
--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -46,6 +46,8 @@ export default class Controls {
         this.enabled = true;
         this.instreamState = null;
         this.keydownCallback = null;
+        this.keyupCallback = null;
+        this.blurCallback = null;
         this.mute = null;
         this.nextUpToolTip = null;
         this.playerContainer = playerContainer;
@@ -140,7 +142,7 @@ export default class Controls {
             }
 
             // Trigger userActive so that a dismissive click outside the player can hide the controlbar
-            this.userActive();
+            this.userActive(null, visible || isKeyEvent);
             lastState = state;
 
             const settingsButton = this.controlbar.elements.settingsButton;
@@ -198,24 +200,11 @@ export default class Controls {
                 return true;
             }
 
-            // keep controls active when navigating inside the player
-            if (!this.instreamState) {
-                const container = this.playerContainer;
-                const fullscreenButton = this.controlbar.elements.fullscreen;
-                const insideContainer = container !== evt.target && container.contains(evt.target);
-                const isTab = evt.keyCode === 9;
-
-                // check if we tab after fullscreen or shift-tab from player
-                const exitingContainer =
-                    (isTab && evt.shiftKey && evt.target === container) ||
-                    (isTab && evt.target === fullscreenButton.element());
-
-                this.userActive(null, insideContainer && !exitingContainer);
-            }
-
             switch (evt.keyCode) {
                 case 27: // Esc
                     api.setFullscreen(false);
+                    this.playerContainer.blur();
+                    this.userInactive();
                     break;
                 case 13: // enter
                 case 32: // space
@@ -271,21 +260,28 @@ export default class Controls {
         this.playerContainer.addEventListener('keydown', handleKeydown);
         this.keydownCallback = handleKeydown;
 
-        // If not mobile, show controls after closing overlay
-        if (!OS.mobile) {
-            const blurHandler = (evt) => {
-                const insidePlayer = evt.currentTarget.contains(evt.relatedTarget);
-                const overlayClosed =
-                    evt.currentTarget.classList.contains('jw-flag-overlay-open-related') ||
-                    settingsMenu.element().contains(evt.target);
+        // keep controls active when navigating inside the player
+        const handleKeyup = (evt) => {
+            if (!this.instreamState) {
+                const isTab = evt.keyCode === 9;
+                if (isTab) {
+                    const insideContainer = this.playerContainer.contains(evt.target);
+                    this.userActive(null, insideContainer);
+                }
+            }
+        };
+        this.playerContainer.addEventListener('keyup', handleKeyup);
+        this.keyupCallback = handleKeyup;
 
-                // show controls if inside the player and after overlay is closed
-                this.userActive(null, insidePlayer || overlayClosed);
-            };
-
-            this.playerContainer.addEventListener('blur', blurHandler, true);
-            this.blurCallback = blurHandler;
-        }
+        // Hide controls when focus leaves the player
+        const blurCallback = (evt) => {
+            const insideContainer = this.playerContainer.contains(evt.relatedTarget);
+            if (!insideContainer) {
+                this.userInactive();
+            }
+        };
+        this.playerContainer.addEventListener('blur', blurCallback, true);
+        this.blurCallback = blurCallback;
 
         // Show controls when enabled
         this.userActive();
@@ -321,6 +317,10 @@ export default class Controls {
 
         if (this.keydownCallback) {
             this.playerContainer.removeEventListener('keydown', this.keydownCallback);
+        }
+
+        if (this.keyupCallback) {
+            this.playerContainer.removeEventListener('keyup', this.keyupCallback);
         }
 
         if (this.blurCallback) {

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -399,7 +399,7 @@ export default class Controls {
         }
     }
 
-    userActive(timeout = ACTIVE_TIMEOUT, isKeyDown) {
+    userActive(timeout, isKeyDown) {
         clearTimeout(this.activeTimeout);
 
         if (!isKeyDown) {

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -198,7 +198,7 @@ export default class Controls {
                 return true;
             }
 
-            // On keypress show the controlbar for a few seconds;
+            // keep controls active when navigating inside the player
             if (!this.instreamState) {
                 const fullscreenButton = this.controlbar.elements.fullscreen;
                 const insideContainer = this.playerContainer.contains(evt.target);
@@ -207,7 +207,6 @@ export default class Controls {
                     (evt.keyCode === 9 && evt.shiftKey && evt.target === this.playerContainer) ||
                     (evt.keyCode === 9 && evt.target === fullscreenButton.element());
 
-                // keep controlbar open if inside the player via key events
                 this.userActive(null, insideContainer && !exitingContainer);
             }
 
@@ -269,6 +268,7 @@ export default class Controls {
         this.playerContainer.addEventListener('keydown', handleKeydown);
         this.keydownCallback = handleKeydown;
 
+        // If not mobile, show controls after closing overlay
         if (!OS.mobile) {
             const blurHandler = (evt) => {
                 const insidePlayer = evt.currentTarget.contains(evt.relatedTarget);
@@ -276,7 +276,6 @@ export default class Controls {
                     evt.currentTarget.classList.contains('jw-flag-overlay-open-related') ||
                     settingsMenu.element().contains(evt.target);
 
-                console.log('blur', insidePlayer, overlayOpen);
                 this.userActive(null, insidePlayer || overlayOpen);
             };
 

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -200,11 +200,12 @@ export default class Controls {
 
             // keep controls active when navigating inside the player
             if (!this.instreamState) {
+                const container = this.playerContainer;
                 const fullscreenButton = this.controlbar.elements.fullscreen;
-                const insideContainer = this.playerContainer.contains(evt.target);
+                const insideContainer = container !== evt.target && container.contains(evt.target);
 
                 const exitingContainer =
-                    (evt.keyCode === 9 && evt.shiftKey && evt.target === this.playerContainer) ||
+                    (evt.keyCode === 9 && evt.shiftKey && evt.target === container) ||
                     (evt.keyCode === 9 && evt.target === fullscreenButton.element());
 
                 this.userActive(null, insideContainer && !exitingContainer);

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -203,10 +203,12 @@ export default class Controls {
                 const container = this.playerContainer;
                 const fullscreenButton = this.controlbar.elements.fullscreen;
                 const insideContainer = container !== evt.target && container.contains(evt.target);
+                const isTab = evt.keyCode === 9;
 
+                // check if we tab after fullscreen or shift-tab from player
                 const exitingContainer =
-                    (evt.keyCode === 9 && evt.shiftKey && evt.target === container) ||
-                    (evt.keyCode === 9 && evt.target === fullscreenButton.element());
+                    (isTab && evt.shiftKey && evt.target === container) ||
+                    (isTab && evt.target === fullscreenButton.element());
 
                 this.userActive(null, insideContainer && !exitingContainer);
             }
@@ -273,11 +275,12 @@ export default class Controls {
         if (!OS.mobile) {
             const blurHandler = (evt) => {
                 const insidePlayer = evt.currentTarget.contains(evt.relatedTarget);
-                const overlayOpen =
+                const overlayClosed =
                     evt.currentTarget.classList.contains('jw-flag-overlay-open-related') ||
                     settingsMenu.element().contains(evt.target);
 
-                this.userActive(null, insidePlayer || overlayOpen);
+                // show controls if inside the player and after overlay is closed
+                this.userActive(null, insidePlayer || overlayClosed);
             };
 
             this.playerContainer.addEventListener('blur', blurHandler, true);

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -225,8 +225,6 @@ function View(_api, _model) {
         focusHelper = flagNoFocus(_playerElement);
         fullscreenHelpers = requestFullscreenHelper(_playerElement, document, _fullscreenChangeHandler);
 
-        _playerElement.addEventListener('focus', onFocus);
-
         _model.on('change:errorEvent', _errorHandler);
         _model.on('change:hideAdsControls', function (model, val) {
             toggleClass(_playerElement, 'jw-flag-ads-hide-controls', val);
@@ -758,13 +756,6 @@ function View(_api, _model) {
         }
     }
 
-    function onFocus() {
-        // On tab-focus, show the control bar for a few seconds
-        if (_controls && !_instreamModel && !_isMobile) {
-            _controls.userActive(null, true);
-        }
-    }
-
     const settingsMenuVisible = () => {
         const settingsMenu = _controls && _controls.settingsMenu;
         return !!(settingsMenu && settingsMenu.visible);
@@ -863,7 +854,6 @@ function View(_api, _model) {
         this.off();
         cancelAnimationFrame(_resizeContainerRequestId);
         clearTimeout(_resizeMediaTimeout);
-        _playerElement.removeEventListener('focus', onFocus);
         if (focusHelper) {
             focusHelper.destroy();
             focusHelper = null;


### PR DESCRIPTION
### This PR will...

Keep controls visible when navigating the player using the keyboard, but will fade out when clicking or tabbing out of the player.

### Why is this Pull Request needed?

To be able to continue navigating the player while using keys without the controls fading out and focus is lost

#### Addresses Issue(s):

JW8-603

