### PR TITLE
Avoid prematurely ending a live stream when no buffered ranges are present 

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -732,7 +732,8 @@ function VideoProvider(_playerId, _playerConfig) {
         var endOfBuffer = endOfRange(_videotag.buffered);
         var live = _this.isLive();
 
-        if (live && _lastEndOfBuffer === endOfBuffer) {
+        // Don't end if we have noting buffered yet, or cannot get any information about the buffer
+        if (live && endOfBuffer && _lastEndOfBuffer === endOfBuffer) {
             if (_staleStreamTimeout === -1) {
                 _staleStreamTimeout = setTimeout(function () {
                     _stale = true;


### PR DESCRIPTION
### Why is this Pull Request needed?
Android native HLS player does not report any buffered ranges when live, which breaks existing logic around stale streams

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-707

