### PR TITLE
Reset text tracks player model on attachMedia

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -159,6 +159,9 @@ function VideoProvider(_playerId, _playerConfig) {
             _videotag.loop = false;
             // If there was a showing track, re-enable it
             this.enableTextTrack();
+            if (this.renderNatively) {
+                this.setTextTracks(this.video.textTracks);
+            }
             this.addTracksListener(_videotag.textTracks, 'change', this.textTrackChangeHandler);
         },
         stalledHandler(checkStartTime) {


### PR DESCRIPTION
### This PR will...

Restore the captions menu for embedded text tracks (608/VTT tracks) on iOS after an ad.

### Why is this Pull Request needed?

When IMA plays an ad without using our video tag, we no longer need to reload the video src. Our tracks code expected that it would and only reset the tracks state if it did. Calling `setTextTracks` on attach synchs up the player model and view with the video tag's tracks.

#### Addresses Issue(s):

JW8-684

