### PR TITLE
Prevent firefox window event exception

### DIFF
--- a/src/js/view/controls/components/settings/menu.js
+++ b/src/js/view/controls/components/settings/menu.js
@@ -53,6 +53,7 @@ export function SettingsMenu(onVisibility, onSubmenuAdded, onMenuEmpty) {
             addDocumentListeners(documentClickHandler);
 
             if (isDefault) {
+                // TODO: remove window.event; instead, pass the event from the button interaction or use 'keyup' in controls.js
                 if (!window.event || !window.event.pointerType) {
                     active.categoryButtonElement.focus();
                 }

--- a/src/js/view/controls/components/settings/menu.js
+++ b/src/js/view/controls/components/settings/menu.js
@@ -53,7 +53,7 @@ export function SettingsMenu(onVisibility, onSubmenuAdded, onMenuEmpty) {
             addDocumentListeners(documentClickHandler);
 
             if (isDefault) {
-                if (!window.event.pointerType) {
+                if (!window.event || !window.event.pointerType) {
                     active.categoryButtonElement.focus();
                 }
             } else {


### PR DESCRIPTION
### This PR will...
check if window event exists before getting its pointer type. I chose to always focus the default element on firefox instead of never focusing it because I believe focusing is necessary for accessibility ( @hghazzi please correct me if i'm wrong) and the only reason we don't focus on click is to avoid the tooltip popping up.
### Why is this Pull Request needed?
To prevent a firefox exception
### Are there any points in the code the reviewer needs to double check?
n/a
### Are there any Pull Requests open in other repos which need to be merged with this?
n/a
#### Addresses Issue(s):
JW8-732

