### PR TITLE
[AB-1254] Fixed an issue where autostart would be muted in the SDK for Android

### DIFF
--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -229,8 +229,9 @@ const Model = function() {
 
         _provider.volume(_this.get('volume'));
 
-        // Mute the video if autostarting on mobile. Otherwise, honor the model's mute value
-        _provider.mute(_this.autoStartOnMobile() || _this.get('mute'));
+        // Mute the video if autostarting on mobile, except for Android SDK. Otherwise, honor the model's mute value
+        const isAndroidSdk = _this.get('sdkplatform') === 1;
+        _provider.mute((this.autoStartOnMobile() && !isAndroidSdk) || _this.get('mute'));
 
         _provider.on('all', _videoEventHandler, this);
 
@@ -655,7 +656,8 @@ const Model = function() {
         }
 
         const autoStartOnMobile = this.autoStartOnMobile();
-        if (autoStartOnMobile) {
+        const isAndroidSdk = _this.get('sdkplatform') === 1;
+        if (autoStartOnMobile && !isAndroidSdk) {
             this.set('autostartMuted', true);
         }
         this.set('playOnViewable', autoStartOnMobile || this.get('autostart') === 'viewable');


### PR DESCRIPTION
### This PR will... 

Autostart unmuted (unless mute requested) in the SDK for Android.

### Why is this Pull Request needed?

Regression where autostart playback would be muted in the SDK for Android.

### Are there any points in the code the reviewer needs to double check?

@karimJWP is autostart disallowed in iOS apps?  This will only autostart unmuted for Android.

### Are there any Pull Requests open in other repos which need to be merged with this?

No

#### Addresses Issue(s):

[AB-1254]

