### PR TITLE
Remove background opacity from submenus

### DIFF
--- a/src/js/view/utils/skin.js
+++ b/src/js/view/utils/skin.js
@@ -215,12 +215,6 @@ export function handleColorOverrides(playerId, skin) {
             '.jw-nextup',
             '.jw-settings-submenu',
         ], 'background', config.background);
-
-        if (config.background) {
-            addStyle([
-                '.jw-settings-submenu'
-            ], 'opacity', 0.7);
-        }
     }
 
     function styleTooltips(config) {

--- a/src/js/view/utils/skin.js
+++ b/src/js/view/utils/skin.js
@@ -213,7 +213,7 @@ export function handleColorOverrides(playerId, skin) {
 
         addStyle([
             '.jw-nextup',
-            '.jw-settings-submenu',
+            '.jw-settings-menu',
         ], 'background', config.background);
     }
 


### PR DESCRIPTION
### This PR will...

Remove the opacity that was being applied to the background color of the submenus

### Why is this Pull Request needed?

Since the opacity of the menu will never be transparent, we should be settings it bu default

#### Addresses Issue(s):

JW8-739
