### PR TITLE
v7 Cleanup karma test context

### DIFF
--- a/test-context.js
+++ b/test-context.js
@@ -1,8 +1,13 @@
+// Bundle files chunked by webpack
+require('polyfills/promise');
+require('polyfills/base64');
+require('polyfills/vtt');
+require('intersection-observer');
+require('parsers/captions/vttparser');
+require('view/controls/controls');
+require('providers/html5');
+require('providers/flash');
+require('providers/youtube');
+
 const testsContext = require.context('./test/unit', true);
 testsContext.keys().forEach(testsContext);
-
-const polyfillsContext = require.context('./src/js/polyfills', true);
-polyfillsContext.keys().forEach(polyfillsContext);
-
-// Mock require.ensure
-require('./test/mock/mock-ensure.js');


### PR DESCRIPTION
### This PR will...

Cleanup karma test context.

### Why is this Pull Request needed?

This makes tests for v7 easier to maintain by clearly showing dependencies used in tests and removing the need for a `require.ensure` polyfill.
