### PR TITLE
Changed localization value for airplay from 'Airplay' to 'AirPlay'

### DIFF
--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -31,7 +31,7 @@ const Defaults = {
         prev: 'Previous',
         next: 'Next',
         cast: 'Chromecast',
-        airplay: 'Airplay',
+        airplay: 'AirPlay',
         fullscreen: 'Fullscreen',
         playlist: 'Playlist',
         hd: 'Quality',

--- a/test/manual/index.html
+++ b/test/manual/index.html
@@ -29,7 +29,7 @@
             prev: 'Précédent',
             next: 'Suivant',
             cast: 'Chromecast',
-            airplay: 'Airplay',
+            airplay: 'AirPlay',
             fullscreen: 'Plein écran',
             playlist: 'Liste de lecture',
             hd: 'Qualité',

--- a/test/manual/release.html
+++ b/test/manual/release.html
@@ -28,7 +28,7 @@
                 prev: 'Précédent',
                 next: 'Suivant',
                 cast: 'Chromecast',
-                airplay: 'Airplay',
+                airplay: 'AirPlay',
                 fullscreen: 'Plein écran',
                 playlist: 'Liste de lecture',
                 hd: 'Qualité',


### PR DESCRIPTION
### This PR will...

Change the localization value in Defaults for `airplay` from `Airplay` to `AirPlay`

### Why is this Pull Request needed?

`Airplay` was incorrectly being seen in the tooltip. Should be styled `AirPlay`.

### Are there any points in the code the reviewer needs to double check?

This also exists in things like class name such as `AirplayController` and other places that imports this. Maybe this can be addressed in the future if at all.

