### PR TITLE
Lower volume threshold for showing max volume icon

### DIFF
--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -358,7 +358,7 @@ export default class Controlbar {
         if (this.elements.volumetooltip) {
             this.elements.volumetooltip.volumeSlider.render(muted ? 0 : vol);
             utils.toggleClass(this.elements.volumetooltip.element(), 'jw-off', muted);
-            utils.toggleClass(this.elements.volumetooltip.element(), 'jw-full', vol === 100 && !muted);
+            utils.toggleClass(this.elements.volumetooltip.element(), 'jw-full', vol >= 75 && !muted);
         }
     }
 


### PR DESCRIPTION
### This PR will...

Lower the volume threshold to 75% for showing the max volume icon when a user uses the volume tooltip to change the volume.

### Why is this Pull Request needed?

Consistency with design template

#### Addresses Issue(s):

JW8-403

