### PR TITLE
Show live button in controlbar only mode

### DIFF
--- a/src/css/controls/flags/audioplayer.less
+++ b/src/css/controls/flags/audioplayer.less
@@ -42,14 +42,17 @@
         .jw-icon-next,
         .jw-icon-rewind,
         .jw-icon-cast,
+        .jw-icon-live,
         .jw-icon-airplay,
+        .jw-logo-button,
         .jw-text-elapsed,
         .jw-text-duration {
             display: flex;
             flex: 0 0 auto;
         }
 
-        .jw-text-duration {
+        .jw-text-duration,
+        .jw-text-countdown {
             padding-right: 10px;
         }
 


### PR DESCRIPTION
### This PR will...

- Show the live icon for livestreams in controlbar only mode 
- Show the controlbar logo in controlbar only mode 
- Fix right padding for small controlbar only players

### Why is this Pull Request needed?

- To show the correct icons for the player based on the stream and config. 
- When showing the countdown timer, additional padding is needed

#### Addresses Issue(s):

JW8-744

