### PR TITLE
v7 Safari 11 click-to-play

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -360,6 +360,8 @@ define([
 
                 autostartFallbackOnItemReady();
 
+                _primeMediaElementForPlayback();
+
                 switch (typeof item) {
                     case 'string':
                         _loadPlaylist(item);
@@ -422,6 +424,8 @@ define([
                     _setItem(0);
                 }
 
+                _primeMediaElementForPlayback();
+
                 if (!_preplay) {
                     _preplay = true;
                     _this.triggerAfterReady(events.JWPLAYER_MEDIA_BEFOREPLAY, { playReason: _model.get('playReason') });
@@ -452,6 +456,20 @@ define([
                 if (status instanceof utils.Error) {
                     _this.triggerError(status);
                     _actionOnAttach = null;
+                }
+            }
+
+            function _inInteraction(event) {
+                return event && /^(?:mouse|pointer|touch|gesture|click|key)/.test(event.type);
+            }
+
+            function _primeMediaElementForPlayback() {
+                // If we're in a user-gesture event call load() on video to allow async playback
+                if (_inInteraction(window.event)) {
+                    const mediaElement = _this.currentContainer.querySelector('video, audio');
+                    if (mediaElement && _isIdle()) {
+                        mediaElement.load();
+                    }
                 }
             }
 

--- a/test/mock/video.js
+++ b/test/mock/video.js
@@ -1,10 +1,30 @@
 define([
     'test/underscore'
 ], function (_) {
+
+    var video = document.createElement('video');
+
+    // PhantomJS throws an error when video.load() is called
+    // Installing this polyfill before tests makes all calls to
+    // document.create('video') return the video instance in mock/video
+    // which performs noop functions when load, play and pause are called
+    try {
+        video.load();
+    } catch (error) {
+        console.error('video element load() not supported.');
+
+        var createElementNative = document.createElement;
+        document.createElement = function(name) {
+            if (name === 'video') {
+                return video;
+            }
+            return createElementNative.call(this, name);
+        };
+    }
+
     // override/polyfill HTMLVideoElement methods and properties
     // to keep results consistent across browsers in current tests
     // when running unit tests this file is loaded in place of src/utils/video
-    var video = document.createElement('video');
     video.load = _.noop;
     video.play = _.noop;
     video.pause = _.noop;
@@ -20,5 +40,6 @@ define([
             'video/webm'
         ], type);
     };
+
     return video;
 });


### PR DESCRIPTION
### This PR will...

Prime the video tag used by the html5 provider for playback with Safari 11's autoplay policy.

It also removes the use of the preload="none" attribute and value on the video element with the the html5 provider. 

### Why is this Pull Request needed?

Priming the video tag by calling `.load()` on user-gesture prevents Safari 11 from pausing video when the video src is changed by an ad plugin after a click event.

Removing preload="none" makes the video tag src setting behavior consistent, and prevents the loading of media in browsers that ignore this attribute; like Edge which always loads content when src is set. It's important that when we set the src, the "canplay" event fire for JW7 to start playback. The only happens when preload is not set to none now that we don't call `load()` unnecessarily.

#### Addresses Issue(s):

JW8-778
