### PR TITLE
Maintain width and height of nextup container with no thumbnail

### DIFF
--- a/src/css/controls/imports/nextup.less
+++ b/src/css/controls/imports/nextup.less
@@ -25,7 +25,7 @@
     box-shadow: 0 0 10px fade(@black, 50%);
     color: @inactive-color;
     display: inline-block;
-    max-width: 400px;
+    max-width: 280px;
     overflow: hidden;
     opacity: 0;
     position: relative;
@@ -38,6 +38,14 @@
 
     &:hover .jw-nextup-tooltip {
         color: @active-color;
+    }
+
+    &.jw-nextup-thumbnail-visible {
+        max-width: 400px;
+
+        .jw-nextup-thumbnail {
+            display: block;
+        }
     }
 }
 
@@ -53,10 +61,11 @@
 
 .jw-nextup-tooltip {
     display: flex;
+    height: 80px;
 }
 
 .jw-nextup-thumbnail {
-    .rect(120px, 80px);
+    width: 120px;
     background-position: center;
     background-size: cover;
     flex: 0 0 auto;
@@ -80,10 +89,6 @@
 
 .jw-nextup-header {
     font-weight: bold;
-}
-
-.jw-nextup-thumbnail-visible {
-    display: block;
 }
 
 .jw-nextup-title {

--- a/src/js/view/controls/nextuptooltip.js
+++ b/src/js/view/controls/nextuptooltip.js
@@ -100,7 +100,7 @@ export default class NextUpTooltip {
         setTimeout(() => {
             // Set thumbnail
             this.thumbnail = this.content.querySelector('.jw-nextup-thumbnail');
-            toggleClass(this.thumbnail, 'jw-nextup-thumbnail-visible', !!nextUpItem.image);
+            toggleClass(this.content, 'jw-nextup-thumbnail-visible', !!nextUpItem.image);
             if (nextUpItem.image) {
                 const thumbnailStyle = this.loadThumbnail(nextUpItem.image);
                 utils.style(this.thumbnail, thumbnailStyle);


### PR DESCRIPTION
### This PR will...

- Move the height of the thumbnail to the container
- Change the max width of the container depending on if there is a thumbnail
- Move the `.jw-nextup-thumbnail-visible` to the container so that the max width can be modified

### Why is this Pull Request needed?

So that whether there is a thumbnail or not, the width and height of the text area stays the same

#### Addresses Issue(s):

JW8-546

