### PR TITLE
Remove build number from pop up window on right click of beta players

### DIFF
--- a/src/js/view/controls/rightclick.js
+++ b/src/js/view/controls/rightclick.js
@@ -19,7 +19,6 @@ export default class RightClick {
     buildArray() {
         var semverParts = version.split('+');
         var majorMinorPatchPre = semverParts[0];
-        var isBeta = majorMinorPatchPre.indexOf('beta') > 0;
 
         var menu = {
             items: [{
@@ -29,18 +28,6 @@ export default class RightClick {
                 link: 'https://jwplayer.com/learn-more'
             }]
         };
-
-        var isPrerelease = majorMinorPatchPre.indexOf('-') > 0;
-        var versionMeta = semverParts[1];
-        if (isPrerelease && versionMeta) {
-            var pairs = versionMeta.split('.');
-            var titleString = isBeta ? pairs[0] : pairs[0] + '.' + pairs[1];
-
-            menu.items.push({
-                title: 'build: (' + titleString + ')',
-                link: '#'
-            });
-        }
 
         var provider = this.model.get('provider');
         if (provider && provider.name.indexOf('flash') >= 0) {

--- a/src/js/view/controls/rightclick.js
+++ b/src/js/view/controls/rightclick.js
@@ -19,6 +19,7 @@ export default class RightClick {
     buildArray() {
         var semverParts = version.split('+');
         var majorMinorPatchPre = semverParts[0];
+        var isBeta = majorMinorPatchPre.indexOf('beta') > 0;
 
         var menu = {
             items: [{
@@ -33,8 +34,10 @@ export default class RightClick {
         var versionMeta = semverParts[1];
         if (isPrerelease && versionMeta) {
             var pairs = versionMeta.split('.');
+            var titleString = isBeta ? pairs[0] : pairs[0] + '.' + pairs[1];
+
             menu.items.push({
-                title: 'build: (' + pairs[0] + '.' + pairs[1] + ')',
+                title: 'build: (' + titleString + ')',
                 link: '#'
             });
         }


### PR DESCRIPTION
### This PR will...
Remove the build number on beta players when the user right clicks the player and sees the pop up window.

### Why is this Pull Request needed?
The build number means nothing to do the user and should only be seen in development.

#### Addresses Issue(s):

JW8-525

