### PR TITLE
Keep logo above autostart mute button

### DIFF
--- a/src/css/controls/states.less
+++ b/src/css/controls/states.less
@@ -72,7 +72,7 @@
         }
 
         .jw-logo-bottom-left,
-        .jw-logo-bottom-right {
+        &:not(.jw-flag-autostart) .jw-logo-bottom-right {
             bottom: 0;
         }
     }


### PR DESCRIPTION
### This PR will...

Keep the bottom right logo above the autostart mute icon on mobile

### Why is this Pull Request needed?

When the player is in the inactive state, the logo and mute icon overlap

#### Addresses Issue(s):

JW8-593

