### PR TITLE
Remove playback rate menu from unsupported streams

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -201,6 +201,7 @@ function VideoProvider(_playerId, _playerConfig) {
 
     this.isSDK = !!_playerConfig.sdkplatform;
     this.video = _videotag;
+    this.supportsPlaybackRate = true;
 
     _setupListeners(MediaEvents, _videotag);
 

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -193,7 +193,6 @@ function VideoProvider(_playerId, _playerConfig) {
     let _lastEndOfBuffer = null;
     let _androidHls = false;
 
-
     function _setAttribute(name, value) {
         _videotag.setAttribute(name, value || '');
     }

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -193,6 +193,7 @@ function VideoProvider(_playerId, _playerConfig) {
     let _lastEndOfBuffer = null;
     let _androidHls = false;
 
+
     function _setAttribute(name, value) {
         _videotag.setAttribute(name, value || '');
     }
@@ -339,7 +340,6 @@ function VideoProvider(_playerId, _playerConfig) {
     }
 
     function _setVideotagSource(source) {
-        _androidHls = isAndroidHls(source);
         _audioTracks = null;
         _currentAudioTrackIndex = -1;
         if (!visualQuality.reason) {
@@ -347,10 +347,7 @@ function VideoProvider(_playerId, _playerConfig) {
             visualQuality.level = {};
         }
         _canSeek = false;
-        if (_androidHls) {
-            // Playback rate is broken on Android HLS
-            _this.supportsPlaybackRate = false;
-        }
+
 
         var sourceElement = document.createElement('source');
         sourceElement.src = source.file;
@@ -420,6 +417,12 @@ function VideoProvider(_playerId, _playerConfig) {
     this.init = function(item) {
         _levels = item.sources;
         _currentQuality = _pickInitialQuality(item.sources);
+        const source = _levels[_currentQuality];
+        _androidHls = isAndroidHls(source);        
+        if (_androidHls) {
+            // Playback rate is broken on Android HLS
+            _this.supportsPlaybackRate = false;
+        }
         // the loadeddata event determines the mediaType for HLS sources
         if (item.sources.length && item.sources[0].type !== 'hls') {
             this.sendMediaType(item.sources);

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -347,7 +347,6 @@ function VideoProvider(_playerId, _playerConfig) {
         }
         _canSeek = false;
 
-
         var sourceElement = document.createElement('source');
         sourceElement.src = source.file;
         var sourceChanged = (_videotag.src !== sourceElement.src);

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -201,7 +201,6 @@ function VideoProvider(_playerId, _playerConfig) {
 
     this.isSDK = !!_playerConfig.sdkplatform;
     this.video = _videotag;
-    this.supportsPlaybackRate = true;
 
     _setupListeners(MediaEvents, _videotag);
 

--- a/src/js/view/controls/settings-menu.js
+++ b/src/js/view/controls/settings-menu.js
@@ -184,10 +184,7 @@ export function setupSubmenuListeners(settingsMenu, controlbar, model, api) {
         }
     });
 
-    model.on('change:streamType', (changedModel, newStreamType, previousStreamType) => {
-        if (newStreamType === previousStreamType) {
-            return;
-        } 
+    model.on('change:streamType', (changedModel, newStreamType) => {  
         setupPlaybackRatesMenu(model, model.get('playbackRates'));
     });
 

--- a/src/js/view/controls/settings-menu.js
+++ b/src/js/view/controls/settings-menu.js
@@ -127,15 +127,14 @@ export function setupSubmenuListeners(settingsMenu, controlbar, model, api) {
             removePlaybackRatesSubmenu(settingsMenu);
             return;
         }
-        if (!settingsMenu.getSubmenu('playbackRates')) {
-            addPlaybackRatesSubmenu(
-                settingsMenu,
-                playbackRates,
-                model.setPlaybackRate.bind(model),
-                model.get('playbackRate'),
-                model.get('localization').playbackRates
-            );
-        }
+
+        addPlaybackRatesSubmenu(
+            settingsMenu,
+            playbackRates,
+            model.setPlaybackRate.bind(model),
+            model.get('playbackRate'),
+            model.get('localization').playbackRates
+        );
     };
 
     model.change('mediaModel', (newModel, mediaModel) => {

--- a/src/js/view/controls/settings-menu.js
+++ b/src/js/view/controls/settings-menu.js
@@ -195,7 +195,4 @@ export function setupSubmenuListeners(settingsMenu, controlbar, model, api) {
         onPlaybackRatesChange(model, model.get('playbackRates'));
     });
 
-    model.on('change:playlistItem', (changedModel, playlistItem) => {
-        onPlaybackRatesChange(model, model.get('playbackRates')); 
-    });
 }

--- a/src/js/view/controls/settings-menu.js
+++ b/src/js/view/controls/settings-menu.js
@@ -110,10 +110,6 @@ export function setupSubmenuListeners(settingsMenu, controlbar, model, api) {
         controlbarButton.show();
     };
 
-    const onPlaybackRatesChange = (changedModel, playbackRates) => {
-        setupPlaybackRatesMenu(changedModel, playbackRates)
-    };
-
     const setupPlaybackRatesMenu = (changedModel, playbackRates) => {
         const provider = model.getVideo();
         const showPlaybackRateControls = 
@@ -162,7 +158,7 @@ export function setupSubmenuListeners(settingsMenu, controlbar, model, api) {
     }, this);
 
     // Playback Rates
-    model.change('playbackRates', onPlaybackRatesChange, this);
+    model.change('playbackRates', setupPlaybackRatesMenu, this);
     model.change('playbackRate', (changedModel, playbackRate) => {
         const rates = model.get('playbackRates');
         if (rates) {
@@ -184,7 +180,7 @@ export function setupSubmenuListeners(settingsMenu, controlbar, model, api) {
             const mediaModel = model.get('mediaModel');
             onAudiotracksChanged(mediaModel, mediaModel, mediaModel.get('audioTracks'));
             onQualitiesChanged(model, mediaModel.get('levels'));
-            onPlaybackRatesChange(model, model.get('playbackRates'));
+            setupPlaybackRatesMenu(model, model.get('playbackRates'));
         }
     });
 
@@ -192,7 +188,7 @@ export function setupSubmenuListeners(settingsMenu, controlbar, model, api) {
         if (newStreamType === previousStreamType) {
             return;
         } 
-        onPlaybackRatesChange(model, model.get('playbackRates'));
+        setupPlaybackRatesMenu(model, model.get('playbackRates'));
     });
 
 }

--- a/src/js/view/controls/settings-menu.js
+++ b/src/js/view/controls/settings-menu.js
@@ -160,8 +160,12 @@ export function setupSubmenuListeners(settingsMenu, controlbar, model, api) {
     model.change('playbackRates', onPlaybackRatesChange, this);
     model.change('playbackRate', (changedModel, playbackRate) => {
         const rates = model.get('playbackRates');
-        if (rates) {
+        const provider = model.getVideo();
+        if (rates && provider.supportsPlaybackRate) {
             activateSubmenuItem('playbackRates', rates.indexOf(playbackRate));
+        }
+        if (!provider.supportsPlaybackRate) {
+            removePlaybackRatesSubmenu(settingsMenu);
         }
     }, this);
 
@@ -180,6 +184,23 @@ export function setupSubmenuListeners(settingsMenu, controlbar, model, api) {
             onAudiotracksChanged(mediaModel, mediaModel, mediaModel.get('audioTracks'));
             onQualitiesChanged(model, mediaModel.get('levels'));
             onPlaybackRatesChange(model, model.get('playbackRates'));
+        }
+    });
+
+    model.on('change:streamType', (changedModel, newStreamType, previousStreamType) => {
+        if (newStreamType === previousStreamType) {
+            return;
+        }
+        if (newStreamType === 'LIVE') {
+            removePlaybackRatesSubmenu(settingsMenu);
+        } else {
+            addPlaybackRatesSubmenu(
+                settingsMenu,
+                model.get('playbackRates'),
+                model.setPlaybackRate.bind(model),
+                model.get('playbackRate'),
+                model.get('localization').playbackRates
+            );
         }
     });
 }

--- a/src/js/view/controls/settings-menu.js
+++ b/src/js/view/controls/settings-menu.js
@@ -111,9 +111,14 @@ export function setupSubmenuListeners(settingsMenu, controlbar, model, api) {
     };
 
     const onPlaybackRatesChange = (changedModel, playbackRates) => {
+        setupPlaybackRatesMenu(changedModel, playbackRates)
+    };
+
+    const setupPlaybackRatesMenu = (changedModel, playbackRates) => {
         const provider = model.getVideo();
-        const showPlaybackRateControls = provider &&
-            provider.supportsPlaybackRate &&
+        const showPlaybackRateControls = 
+            provider &&
+            provider.supportsPlaybackRate && 
             model.get('streamType') !== 'LIVE' &&
             model.get('playbackRateControls') &&
             playbackRates.length > 1;
@@ -122,14 +127,15 @@ export function setupSubmenuListeners(settingsMenu, controlbar, model, api) {
             removePlaybackRatesSubmenu(settingsMenu);
             return;
         }
-
-        addPlaybackRatesSubmenu(
-            settingsMenu,
-            playbackRates,
-            model.setPlaybackRate.bind(model),
-            model.get('playbackRate'),
-            model.get('localization').playbackRates
-        );
+        if (!settingsMenu.getSubmenu('playbackRates')) {
+            addPlaybackRatesSubmenu(
+                settingsMenu,
+                playbackRates,
+                model.setPlaybackRate.bind(model),
+                model.get('playbackRate'),
+                model.get('localization').playbackRates
+            );
+        }
     };
 
     model.change('mediaModel', (newModel, mediaModel) => {
@@ -160,12 +166,8 @@ export function setupSubmenuListeners(settingsMenu, controlbar, model, api) {
     model.change('playbackRates', onPlaybackRatesChange, this);
     model.change('playbackRate', (changedModel, playbackRate) => {
         const rates = model.get('playbackRates');
-        const provider = model.getVideo();
-        if (rates && provider.supportsPlaybackRate) {
+        if (rates) {
             activateSubmenuItem('playbackRates', rates.indexOf(playbackRate));
-        }
-        if (!provider.supportsPlaybackRate) {
-            removePlaybackRatesSubmenu(settingsMenu);
         }
     }, this);
 
@@ -190,17 +192,11 @@ export function setupSubmenuListeners(settingsMenu, controlbar, model, api) {
     model.on('change:streamType', (changedModel, newStreamType, previousStreamType) => {
         if (newStreamType === previousStreamType) {
             return;
-        }
-        if (newStreamType === 'LIVE') {
-            removePlaybackRatesSubmenu(settingsMenu);
-        } else {
-            addPlaybackRatesSubmenu(
-                settingsMenu,
-                model.get('playbackRates'),
-                model.setPlaybackRate.bind(model),
-                model.get('playbackRate'),
-                model.get('localization').playbackRates
-            );
-        }
+        } 
+        onPlaybackRatesChange(model, model.get('playbackRates'));
+    });
+
+    model.on('change:playlistItem', (changedModel, playlistItem) => {
+        onPlaybackRatesChange(model, model.get('playbackRates')); 
     });
 }

--- a/src/js/view/controls/settings-menu.js
+++ b/src/js/view/controls/settings-menu.js
@@ -184,7 +184,7 @@ export function setupSubmenuListeners(settingsMenu, controlbar, model, api) {
         }
     });
 
-    model.on('change:streamType', (changedModel, newStreamType) => {  
+    model.on('change:streamType', () => {  
         setupPlaybackRatesMenu(model, model.get('playbackRates'));
     });
 


### PR DESCRIPTION
### This PR will...

Removes playback rate controls from native Android HLS streams.

### Why is this Pull Request needed?

Playback rate controls were displaying on Android HLS streams, which do not support playback rate changes. 

### Are there any points in the code the reviewer needs to double check?

N/A

### Are there any Pull Requests open in other repos which need to be merged with this?

Yes - PR #4199 in jwplayer-commercial. https://github.com/jwplayer/jwplayer-commercial/pull/4199 

#### Addresses Issue(s):

JW8-652
