### PR TITLE
Always keep display icon centered

### DIFF
--- a/src/js/view/controls/next-display-icon.js
+++ b/src/js/view/controls/next-display-icon.js
@@ -9,7 +9,6 @@ export default class NextDisplayIcon {
 
         model.change('nextUp', function(nextUpChangeModel, nextUp) {
             element.style.visibility = nextUp ? '' : 'hidden';
-            element.style.opacity = nextUp ? 1 : 0;
         });
 
         this.el = element;

--- a/src/js/view/controls/next-display-icon.js
+++ b/src/js/view/controls/next-display-icon.js
@@ -8,7 +8,8 @@ export default class NextDisplayIcon {
         });
 
         model.change('nextUp', function(nextUpChangeModel, nextUp) {
-            element.style.display = nextUp ? '' : 'none';
+            element.style.visibility = nextUp ? '' : 'hidden';
+            element.style.opacity = nextUp ? 1 : 0;
         });
 
         this.el = element;


### PR DESCRIPTION
### This PR will...

toggle `visibility` styles of the next display icon instead of `display` to hide it if there are no more playlist items

### Why is this Pull Request needed?

If there are no more playlist items, the next up display icon should not show at breakpoint 1, but the positions of the play and rewind display icons should not change

#### Addresses Issue(s):

JW8-730

