### PR TITLE
v7 Safari 11 play fix

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -387,8 +387,8 @@ define([
                 });
                 loader.on(events.JWPLAYER_ERROR, function(evt) {
                     evt.message = 'Error loading playlist: ' + evt.message;
-                    this.triggerError(evt);
-                }, this);
+                    _this.triggerError(evt);
+                }, _this);
                 loader.load(toLoad);
             }
 

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -424,8 +424,6 @@ define([
                     _setItem(0);
                 }
 
-                _primeMediaElementForPlayback();
-
                 if (!_preplay) {
                     _preplay = true;
                     _this.triggerAfterReady(events.JWPLAYER_MEDIA_BEFOREPLAY, { playReason: _model.get('playReason') });
@@ -907,6 +905,7 @@ define([
 
             this.createInstream = function() {
                 this.instreamDestroy();
+                _primeMediaElementForPlayback();
                 this._instreamAdapter = new InstreamAdapter(this, _model, _view);
                 return this._instreamAdapter;
             };

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -304,6 +304,8 @@ define([
         }
 
         function _pauseHandler() {
+            clearTimeouts();
+
             // Sometimes the browser will fire "complete" and then a "pause" event
             if (_this.state === states.COMPLETE) {
                 return;
@@ -407,6 +409,13 @@ define([
             if (promise && promise.catch) {
                 promise.catch(function(err) {
                     if (_videotag.paused) {
+                        // Send a time update to update ads UI
+                        // `isDurationChange` prevents this from propigating an "adTime" event
+                        _this.trigger(events.JWPLAYER_MEDIA_TIME, {
+                            position: _position,
+                            duration: _duration,
+                            isDurationChange: true
+                        });
                         _this.setState(states.PAUSED);
                     }
                     // User gesture required to start playback


### PR DESCRIPTION
### This PR will...

JW8-778 - When calling `api.play()`, only prime the video tag if we're entering instream mode.
JW8-784 - Fix a JavaScript exception preventing proper handling of playlist load errors.
JW8-784 - Dispatch a time event when play promise fails to update ads UI. Changes the controlbar text from "Loading Ad" to "This ad will end in X seconds"


### Why is this Pull Request needed?

This prevents us from calling `video.load()` after media has preloaded successfully and is about to be played.

