### PR TITLE
Custom controlbar background shouldn't hide captions on mobile

### DIFF
--- a/src/css/controls/imports/controlbar.less
+++ b/src/css/controls/imports/controlbar.less
@@ -35,10 +35,6 @@
             color: @hover-color;
         }
     }
-
-    .jw-flag-touch & {
-        max-height: 88px;
-    }
 }
 
 .jw-button-container {

--- a/src/css/controls/imports/slider.less
+++ b/src/css/controls/imports/slider.less
@@ -160,11 +160,6 @@
         }
     }
 
-    .jw-flag-touch & {
-        align-items: flex-end;
-        padding-bottom: 5px;
-    }
-
     .jw-flag-touch &::before {
         height: 44px;
         width: 100%;

--- a/src/css/controls/imports/slider.less
+++ b/src/css/controls/imports/slider.less
@@ -161,8 +161,17 @@
     }
 
     .jw-flag-touch & {
-        .rect(100%, 44px);
         align-items: flex-end;
         padding-bottom: 5px;
+    }
+
+    .jw-flag-touch &::before {
+        height: 44px;
+        width: 100%;
+        content: "";
+        position: absolute;
+        display: block;
+        bottom: calc(100% - 17px);
+        left: 0;
     }
 }

--- a/src/js/view/utils/skin.js
+++ b/src/js/view/utils/skin.js
@@ -165,13 +165,6 @@ export function handleColorOverrides(playerId, skin) {
             ':not(.jw-state-idle) .jw-controlbar',
             '.jw-flag-audio-player .jw-controlbar'
         ], 'background', config.background, true);
-
-        // For touch devices, we want the height of the controlbar to be 88px so it would have a larger touch target
-        // (see https://github.com/jwplayer/jwplayer/blob/master/src/css/controls/imports/controlbar.less#L40)
-        // But we want the background color to only affect the area up to the time slider, which has a height of 61px.
-        // Using a sharp linear gradient to handle this, so need hard-code the transparent area to 27px (88px - 61px)
-        css(`#${playerId}.jw-flag-touch:not(.jw-flag-audio-player):not(.jw-state-idle) .jw-controlbar`,
-            `{background: linear-gradient(transparent 27px, ${config.background} 27px, ${config.background})}`);
     }
 
     function styleTimeslider(config) {

--- a/src/js/view/utils/skin.js
+++ b/src/js/view/utils/skin.js
@@ -165,6 +165,13 @@ export function handleColorOverrides(playerId, skin) {
             ':not(.jw-state-idle) .jw-controlbar',
             '.jw-flag-audio-player .jw-controlbar'
         ], 'background', config.background, true);
+
+        // For touch devices, we want the height of the controlbar to be 88px so it would have a larger touch target
+        // (see https://github.com/jwplayer/jwplayer/blob/master/src/css/controls/imports/controlbar.less#L40)
+        // But we want the background color to only affect the area up to the time slider, which has a height of 61px.
+        // Using a sharp linear gradient to handle this, so need hard-code the transparent area to 27px (88px - 61px)
+        css(`#${playerId}.jw-flag-touch:not(.jw-flag-audio-player):not(.jw-state-idle) .jw-controlbar`,
+            `{background: linear-gradient(transparent 27px, ${config.background} 27px, ${config.background})}`);
     }
 
     function styleTimeslider(config) {


### PR DESCRIPTION
### This PR will...

Only apply the custom controlbar background colour up to the time slider and not the entire touch target on mobile devices

### Why is this Pull Request needed?

So that the background colour does not obscure captions

#### Addresses Issue(s):

JW8-685

