### PR TITLE
Fix handling of playlist loading 404 errors

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -306,7 +306,9 @@ Object.assign(Controller.prototype, {
                         });
                     });
                     updatePlaylistCancelable = cancelable((data) => {
-                        return _updatePlaylist(data.playlist, data);
+                        if (data) {
+                            return _updatePlaylist(data.playlist, data);
+                        }
                     });
                     loadPromise = loadPlaylistPromise.then(updatePlaylistCancelable.async);
                     break;


### PR DESCRIPTION
### This PR will...

Prevent a Javascript error in async handling of playlist loading when loading the playlist fails.

### Why is this Pull Request needed?

We catch load promise errors outside of the switch statement where the result of loading the playlist is used to update the player. If an error occurs, data will be undefined. That's OK within this callback.

#### Addresses Issue(s):

JW8-788

