### PR TITLE
pass event instead of window.event in menu.js

### DIFF
--- a/src/js/view/controls/components/button.js
+++ b/src/js/view/controls/components/button.js
@@ -14,9 +14,8 @@ export default function (icon, apiAction, ariaText, svgIcons) {
     element.style.display = 'none';
 
     if (apiAction) {
-        // Don't send the event to the handler so we don't have unexpected results. (e.g. play)
-        new UI(element).on('click tap enter', function() {
-            apiAction();
+        new UI(element).on('click tap enter', function(event) {
+            apiAction(event);
         });
     }
 

--- a/src/js/view/controls/components/settings/menu.js
+++ b/src/js/view/controls/components/settings/menu.js
@@ -46,15 +46,14 @@ export function SettingsMenu(onVisibility, onSubmenuAdded, onMenuEmpty) {
     topbarElement.appendChild(closeButton.element());
 
     const instance = {
-        open(isDefault) {
+        open(isDefault, event) {
             visible = true;
-            onVisibility(visible);
+            onVisibility(visible, event);
             settingsMenuElement.setAttribute('aria-expanded', 'true');
             addDocumentListeners(documentClickHandler);
 
             if (isDefault) {
-                // TODO: remove window.event; instead, pass the event from the button interaction or use 'keyup' in controls.js
-                if (!window.event || !window.event.pointerType) {
+                if (event && event.type === 'enter') {
                     active.categoryButtonElement.focus();
                 }
             } else {

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -143,13 +143,13 @@ export default class Controlbar {
             _api.next();
         }, next, cloneIcons('next'));
 
-        const settingsButton = button('jw-icon-settings jw-settings-submenu-button', () => {
-            this.trigger('settingsInteraction', 'quality', true);
+        const settingsButton = button('jw-icon-settings jw-settings-submenu-button', (event) => {
+            this.trigger('settingsInteraction', 'quality', true, event);
         }, localization.settings, cloneIcons('settings'));
         settingsButton.element().setAttribute('aria-haspopup', 'true');
 
-        const captionsButton = button('jw-icon-cc jw-settings-submenu-button', () => {
-            this.trigger('settingsInteraction', 'captions', false);
+        const captionsButton = button('jw-icon-cc jw-settings-submenu-button', (event) => {
+            this.trigger('settingsInteraction', 'captions', false, event);
         }, localization.cc, cloneIcons('cc-off,cc-on'));
         captionsButton.element().setAttribute('aria-haspopup', 'true');
 

--- a/src/js/view/controls/settings-menu.js
+++ b/src/js/view/controls/settings-menu.js
@@ -21,7 +21,7 @@ export function createSettingsMenu(controlbar, onVisibility) {
 
     const settingsMenu = SettingsMenu(onVisibility, onSubmenuAdded, onMenuEmpty);
 
-    controlbar.on('settingsInteraction', (submenuName, isDefault) => {
+    controlbar.on('settingsInteraction', (submenuName, isDefault, event) => {
         const submenu = settingsMenu.getSubmenu(submenuName);
         if (!submenu && !isDefault) {
             // Do nothing if activating an invalid submenu
@@ -46,7 +46,7 @@ export function createSettingsMenu(controlbar, onVisibility) {
                 // Activate the first submenu if clicking the default button
                 settingsMenu.activateFirstSubmenu();
             }
-            settingsMenu.open(isDefault);
+            settingsMenu.open(isDefault, event);
         }
     });
 


### PR DESCRIPTION
### This PR will...

Remove the check for window.event and pass in the event from the element event listener in button.js to menu.js to determine if the tooltip should be focused or not.

### Why is this Pull Request needed?
Window.event doesn't exist in Firefox and Safari. Passing in the initial event from the button makes it easier to determine if the event type is appropriate to show the tooltip .

### Are there any points in the code the reviewer needs to double check?
Passing in the event to the apiAction in button.js

#### Addresses Issue(s):
JW8-741

