### PR TITLE
Set native captions tracks on attach media in html5 provider

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -446,6 +446,7 @@ define([
             if (sourceChanged || loadedSrc === 'none' || loadedSrc === 'started') {
                 _duration = duration;
                 _setVideotagSource(_levels[_currentQuality]);
+                _this.setupSideloadedTracks(_this._itemTracks);
                 if (previousSource && sourceChanged) {
                     _videotag.load();
                 }
@@ -572,6 +573,8 @@ define([
             if (source.preload !== 'none') {
                 _setVideotagSource(source);
             }
+
+            this.setupSideloadedTracks(item.tracks);
         };
 
         this.load = function(item) {
@@ -585,7 +588,6 @@ define([
                 _loading();
             }
             _completeLoad(item.starttime || 0, item.duration || 0);
-            this.setupSideloadedTracks(item.tracks);
         };
 
         this.play = function() {
@@ -767,6 +769,9 @@ define([
 
             // If there was a showing track, re-enable it
             this.enableTextTrack();
+            if (this.renderNatively) {
+                this.setTextTracks(this.video.textTracks);
+            }
             this.addTracksListener(_videotag.textTracks, 'change', this.textTrackChangeHandler);
         };
 


### PR DESCRIPTION
### This PR will...

- Reset text tracks player model on attachMedia
- Revert `setupSideloadedTracks` pushed to v7.12.x branch

### Why is this Pull Request needed?

Because ads plugins don't fully load the video and any 608 captions before the ad starts, textTracks need to be set on attach.

#### Addresses Issue(s):

JW8-797

