### PR TITLE
Remove QoE timer clock interval throttling to match v8

### DIFF
--- a/src/js/utils/clock.js
+++ b/src/js/utils/clock.js
@@ -1,44 +1,17 @@
-define([], function() {
+const Date = window.Date;
+const performance = window.performance || {
+    timing: {}
+};
+const startDate = performance.timing.navigationStart || (new Date().getTime());
 
-    const performance = window.performance;
+if (!('now' in performance)) {
+    performance.now = () => (new Date().getTime()) - startDate;
+}
 
-    const supportsPerformance = !!(performance && performance.now);
-    
-    const MAX_INTERVAL = 10000;
+export function now() {
+    return performance.now();
+}
 
-    const getTime = function() {
-        if (supportsPerformance) {
-            return performance.now();
-        }
-        return new Date().getTime();
-    };
-
-    const Clock = function() {
-        const started = getTime();
-        let updated = started;
-
-        const updateClock = function() {
-            let delta = getTime() - updated;
-            if (delta > MAX_INTERVAL) {
-                delta = MAX_INTERVAL;
-            } else if (delta < 0) {
-                delta = 0;
-            }
-            updated += delta;
-        };
-        setInterval(updateClock, 1000);
-
-        Object.defineProperty(this, 'currentTime', {
-            get: function() {
-                updateClock();
-                return updated - started;
-            }
-        });
-    };
-
-    Clock.prototype.now = function() {
-        return this.currentTime;
-    };
-
-    return new Clock();
-});
+export function dateTime() {
+    return startDate + performance.now();
+}

--- a/src/js/utils/timer.js
+++ b/src/js/utils/timer.js
@@ -1,8 +1,21 @@
-define([
-    'utils/clock',
-    'utils/underscore'
-], function(clock, _) {
+import { dateTime } from 'utils/clock';
 
+/**
+ * QoE metrics returned by `jwplayer()._qoe.dump()`.
+ * {@link Api#qoe jwplayer().qoe():PlayerQoE} returns these for the player and the current playlist item.
+ * @typedef {object} TimerMetrics
+ * @property {object} counts - Lists event counts by event name
+ * @property {object} events - Lists last event timestamps (epoch ms) by event name
+ * @property {object} sums - Lists total event/state duration by event/state name
+ */
+
+define([
+    'utils/underscore',
+], function(_) {
+    /**
+     * The Timer used to measure player and playlist item QoE
+     * @class Timer
+     */
     const Timer = function() {
         const startTimes = {};
         const sum = {};
@@ -10,30 +23,48 @@ define([
 
         const ticks = {};
 
-        const started = Math.max(1, new Date().getTime());
-
+        /** @lends Timer */
         return {
             // Profile methods
+            /**
+             * Start timing a method. Increment {@link TimerMetrics} count.
+             * If the method was already started, but not finished, it's start will be reset.
+             * @memberOf Timer
+             * @instance
+             * @param {string} methodName - The method or player state name.
+             */
             start: function(methodName) {
-                startTimes[methodName] = started + clock.now();
+                startTimes[methodName] = dateTime();
                 counts[methodName] = counts[methodName] + 1 || 1;
             },
+            /**
+             * Finish timing a method. The time since `start` is added to {@link TimerMetrics#sums} sums.
+             * @memberOf Timer
+             * @instance
+             * @param {string} methodName - The method or player state name.
+             */
             end: function(methodName) {
                 if (!startTimes[methodName]) {
                     return;
                 }
-                const now = started + clock.now();
+                const now = dateTime();
                 const e = now - startTimes[methodName];
                 delete startTimes[methodName];
                 sum[methodName] = sum[methodName] + e || e;
             },
+            /**
+             * Output the timer metrics.
+             * @memberOf Timer
+             * @instance
+             * @returns {TimerMetrics}
+             */
             dump: function() {
                 // Add running sum of latest method
                 // This lets `jwplayer().qoe().item.sums` return a tally of running playing/paused time
                 const runningSums = _.extend({}, sum);
                 for (const methodName in startTimes) {
                     if (Object.prototype.hasOwnProperty.call(startTimes, methodName)) {
-                        const now = started + clock.now();
+                        const now = dateTime();
                         const e = now - startTimes[methodName];
                         runningSums[methodName] = runningSums[methodName] + e || e;
                     }
@@ -46,9 +77,34 @@ define([
             },
 
             // Profile events
+            /**
+             * Add or update an event timestamp. The timestamp "tick" is added to {@link TimerMetrics#events} events.
+             * @memberOf Timer
+             * @instance
+             * @param {string} event - The event name.
+             */
             tick: function(event) {
-                ticks[event] = started + clock.now();
+                ticks[event] = dateTime();
             },
+
+            /**
+             * Remove an event timestamp. The timestamp "tick" is removed from {@link TimerMetrics#events} events.
+             * @memberOf Timer
+             * @instance
+             * @param {string} event - The event name.
+             */
+            clear: function(event) {
+                delete ticks[event];
+            },
+
+            /**
+             * Get the difference between two events.
+             * @memberOf Timer
+             * @instance
+             * @param left - The first event name.
+             * @param right - The second event name.
+             * @returns {number|null}
+             */
             between: function(left, right) {
                 if (ticks[right] && ticks[left]) {
                     return ticks[right] - ticks[left];


### PR DESCRIPTION
### This PR will...

Update v7's clock to match v8's. These changes reflect the updates made in https://github.com/jwplayer/jwplayer/pull/2347 to QoE timing.

### Why is this Pull Request needed?

This will make comparisons of QoE measurements between 7 and 8 more accurate.

#### Addresses Issue(s):

JW8-799

