### PR TITLE
Add new API to replace one playlist item

### DIFF
--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -669,6 +669,18 @@ export default function Api(element) {
         },
 
         /**
+         * Stop any active playback, and loads a new playlist item to the given index of the current playlist item.
+         * @param {object} toLoad - The new playlist item to replace at index.
+         * @param {number} [index] - The index within the current playlist where the new playlist item goes into.
+         * Only applied when passing in a playlist or playlist items.
+         * @returns {Api}
+         */
+        loadAtIndex(toLoad, index) {
+            core.loadAtIndex(toLoad, index);
+            return this;
+        },
+
+        /**
          * Starts playback.
          * @param {object} [meta] - An optional argument used to specify cause.
          * @return {Api}

--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -27,6 +27,7 @@ const CoreShim = function(originalContainer) {
     this.apiQueue = new ApiQueueDecorator(this, [
         // These commands require a provider instance to be available
         'load',
+        'loadAtIndex',
         'play',
         'pause',
         'seek',

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -285,7 +285,14 @@ Object.assign(Controller.prototype, {
             });
         };
 
-        function _load(item, feedData) {
+        function _loadAtIndex(item, index) {
+            const feedData = _model.get('feedData');
+            const newPlaylist = _model.get('playlist');
+            newPlaylist[index] = item;
+            return _load(newPlaylist, feedData, index);
+        }
+
+        function _load(item, feedData, index = 0) {
 
             _this.trigger('destroyPlugin', {});
             _stop(true);
@@ -314,7 +321,7 @@ Object.assign(Controller.prototype, {
                     break;
                 }
                 case 'object':
-                    loadPromise = _updatePlaylist(item, feedData);
+                    loadPromise = _updatePlaylist(item, feedData, index);
                     break;
                 case 'number':
                     loadPromise = _setItem(item);
@@ -328,10 +335,10 @@ Object.assign(Controller.prototype, {
                 });
             });
 
-            loadPromise.then(checkAutoStartCancelable.async).catch(function() {});
+            return loadPromise.then(checkAutoStartCancelable.async).catch(function() {});
         }
 
-        function _updatePlaylist(data, feedData) {
+        function _updatePlaylist(data, feedData, itemIndex = 0) {
             const playlist = Playlist(data);
             try {
                 setPlaylist(_model, playlist, feedData);
@@ -340,7 +347,7 @@ Object.assign(Controller.prototype, {
                 _model.set('playlistItem', null);
                 return Promise.reject(error);
             }
-            return _setItem(0);
+            return _setItem(itemIndex);
         }
 
         function _loadPlaylist(toLoad) {
@@ -721,6 +728,7 @@ Object.assign(Controller.prototype, {
 
         /** Controller API / public methods **/
         this.load = _load;
+        this.loadAtIndex = _loadAtIndex;
         this.play = _play;
         this.pause = _pause;
         this.seek = _seek;

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -287,8 +287,10 @@ var InstreamAdapter = function(_controller, _model, _view) {
             }
 
             // Sync player state with ad for model "change:state" events to trigger
-            const adState = _instream._adModel.get('state');
-            _model.attributes.state = adState;
+            if (_instream._adModel) {
+                const adState = _instream._adModel.get('state');
+                _model.attributes.state = adState;
+            }
 
             _model.off(null, null, _instream);
             _instream.off(null, null, _this);


### PR DESCRIPTION
### This PR will...
Add a new API that replaces a playlist item at the given index, instead of replacing the whole playlist.

### Why is this Pull Request needed?
DAI playlist support needs this function so that the stream that we get from google DAI only replaces one playlist item.

#### Addresses Issue(s):
ADS-523
