### PR TITLE
Handle provider loading play attempt errors

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -61,6 +61,7 @@ Object.assign(Controller.prototype, {
             resolved.then(_completeHandler);
         });
         _model.mediaController.on(MEDIA_ERROR, _this.triggerError, _this);
+        _model.on(ERROR, _this.triggerError, _this);
 
         // If we attempt to load flash, assume it is blocked if we don't hear back within a second
         _model.on('change:flashBlocked', function(model, isBlocked) {


### PR DESCRIPTION
### This PR will...

Handle the case where a provider fails to load when changing playlist items. 

An error event is triggered and "Could not play video: Network error" is displayed. Since this also breaks the play attempt, a "playAttemptFailed" event is triggered.

#### Addresses Issue(s):

JW8-711

