### PR TITLE
Adjust bottom on Ad Skip Button so it isn't obscured by a customized control bar

### DIFF
--- a/src/css/controls/imports/skipad.less
+++ b/src/css/controls/imports/skipad.less
@@ -6,7 +6,7 @@
     position: absolute;
     display: flex;
     right: 0.75em;
-    bottom: 3em;
+    bottom: 3.5em;
     padding: @ui-padding;
     border: 1px solid lighten(@black, 20%);
     background-color: @black;

--- a/src/css/controls/imports/skipad.less
+++ b/src/css/controls/imports/skipad.less
@@ -6,7 +6,7 @@
     position: absolute;
     display: flex;
     right: 0.75em;
-    bottom: 3.5em;
+    bottom: 56px;
     padding: @ui-padding;
     border: 1px solid lighten(@black, 20%);
     background-color: @black;


### PR DESCRIPTION
### This PR will...

Change the position of the skip ad overlay

### Why is this Pull Request needed?

On custom coloured control bars, the skip ad overlay rests on top of the control bar so there needs to be more space between the skip ad overlay and control bar. Adjusting the bottom by .5em fixes it.

#### Addresses Issue(s):

JW8-412

