### PR TITLE
Enable seeking event on ios fullscreen

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -62,6 +62,7 @@ function VideoProvider(_playerId, _playerConfig) {
         },
         
         timeupdate() {
+            _setPositionBeforeSeek(_videotag.currentTime);
             VideoEvents.timeupdate.call(_this);
             checkStaleStream();
             if (_this.state === STATE_PLAYING) {
@@ -115,7 +116,7 @@ function VideoProvider(_playerId, _playerConfig) {
         },
 
         seeking() {
-            var offset = _seekOffset !== null ? _seekOffset : _videotag.currentTime;
+            var offset = _seekOffset !== null ? _seekOffset : _this.getCurrentTime();
             _seekOffset = null;
             _delayedSeek = 0;
             _this.seeking = true;
@@ -123,6 +124,7 @@ function VideoProvider(_playerId, _playerConfig) {
                 position: _positionBeforeSeek,
                 offset: offset
             });
+            _setPositionBeforeSeek(offset);
         },
 
         webkitbeginfullscreen(e) {
@@ -275,6 +277,7 @@ function VideoProvider(_playerId, _playerConfig) {
     };
 
     function _checkDelayedSeek(duration) {
+        // Don't seek when _delayedSeek is set to -1 in _completeLoad
         if (_delayedSeek && _delayedSeek !== -1 && duration && duration !== Infinity) {
             _this.seek(_delayedSeek);
         }

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -254,7 +254,7 @@ function VideoProvider(_playerId, _playerConfig) {
 
     function _convertTime(position) {
         if (_this.getDuration() < 0) {
-            position = -(_getSeekableEnd() - position);
+            position -= _getSeekableEnd();
         }
         return position;
     }

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -119,11 +119,11 @@ function VideoProvider(_playerId, _playerConfig) {
             _seekOffset = null;
             _delayedSeek = 0;
             _this.seeking = true;
-            _this.trigger(events.JWPLAYER_MEDIA_SEEK, {
-                position: _position,
+            _this.trigger(MEDIA_SEEK, {
+                position: _positionBeforeSeek,
                 offset: offset
             });
-        }
+        },
 
         webkitbeginfullscreen(e) {
             _fullscreenState = true;
@@ -194,6 +194,7 @@ function VideoProvider(_playerId, _playerConfig) {
     let _canSeek = false; // true on valid time event
     let _delayedSeek = 0;
     let _seekOffset = null;
+    let _positionBeforeSeek = null;
     let _levels;
     let _currentQuality = -1;
     let _fullscreenState = false;
@@ -241,13 +242,20 @@ function VideoProvider(_playerId, _playerConfig) {
         }
     }
 
+    function _setPositionBeforeSeek(position) {
+        _positionBeforeSeek = _convertTime(position);
+    }
+
     _this.getCurrentTime = function() {
-        let currentTime = _videotag.currentTime;
-        if (_this.getDuration() < 0) {
-            currentTime = -(_getSeekableEnd() - currentTime);
-        }
-        return currentTime;
+        return _convertTime(_videotag.currentTime);
     };
+
+    function _convertTime(position) {
+        if (_this.getDuration() < 0) {
+            position = -(_getSeekableEnd() - position);
+        }
+        return position;
+    }
 
     _this.getDuration = function() {
         var duration = _videotag.duration;
@@ -468,7 +476,7 @@ function VideoProvider(_playerId, _playerConfig) {
                 if (isLiveNotDvr && end && (behindLiveEdge > 15 || behindLiveEdge < 0)) {
                     // resume playback at edge of live stream
                     _seekOffset = Math.max(end - 10, end - seekableDuration);
-                    _setPosition(_videotag.currentTime);
+                    _setPositionBeforeSeek(_videotag.currentTime);
                     _videotag.currentTime = _seekOffset;
                 }
 
@@ -490,7 +498,7 @@ function VideoProvider(_playerId, _playerConfig) {
             try {
                 _this.seeking = true;
                 _seekOffset = seekPos;
-                _setPosition(_videotag.currentTime);
+                _setPositionBeforeSeek(_videotag.currentTime);
                 _videotag.currentTime = seekPos;
             } catch (e) {
                 _this.seeking = false;


### PR DESCRIPTION
### This PR will...
listen to the html5 seeking event before firing our seek event instead of firing it when the seek command is executed.
### Why is this Pull Request needed?
To enable our seeking events to be fired when seeking in iOS's native player during fullscreen.
### Are there any points in the code the reviewer needs to double check?
1) I had to store the position in a 'positionBeforeSeek' variable to have an accurate initial position when seeking in iOS fullscreen. Storing the position was removed after version 7. Currently it is set as time updates and after seeking since scrubbing in ios fullscreen will fire multiple seek events.
2) this.seeking = true is set twice; do we need it to be set on the seek command ? It is also set twice in [v7's fix for this bug](https://github.com/jwplayer/jwplayer/blob/d30fee0e70ef211b4a0700787f65830fbe758892/src/js/providers/html5.js#L638)

#### Addresses Issue(s):
JW8-708

