### PR TITLE
Hide display icons on mobile when menu is open

### DIFF
--- a/src/css/controls/imports/settings-menu.less
+++ b/src/css/controls/imports/settings-menu.less
@@ -129,7 +129,8 @@
 
 .jw-settings-open {
     .jw-breakpoint-2 &,
-    .jw-flag-small-player & {
+    .jw-flag-small-player &,
+    .jw-flag-touch & {
         .jw-display-container {
             display: none;
         }


### PR DESCRIPTION
### This PR will...

no longer show display icons on touch devices when the settings menu is open

### Why is this Pull Request needed?

to not have the menu overlap over the display icons

#### Addresses Issue(s):

JW8-542
