### PR TITLE
Prevent hover state on buffer icon  for custom skins

### DIFF
--- a/src/js/view/utils/skin.js
+++ b/src/js/view/utils/skin.js
@@ -142,13 +142,14 @@ export function handleColorOverrides(playerId, skin) {
             addStyle([
                 // Toggle and menu button active colors
                 '.jw-button-color.jw-toggle:not(.jw-icon-cast)',
+                '.jw-button-color:hover:not(.jw-icon-cast)',
                 '.jw-button-color:focus:not(.jw-icon-cast)',
                 '.jw-button-color.jw-toggle.jw-off:hover:not(.jw-icon-cast)'
             ], 'color', config.iconsActive);
 
             addStyle([
-                ':not(.jw-state-buffering) .jw-button-color:hover:not(.jw-icon-cast)'
-            ], 'color', config.iconsActive, true);
+                '.jw-svg-icon-buffer',
+            ], 'fill', config.icons);
 
             // Chromecast overrides
             // Can't use addStyle since it will camel case the style name

--- a/src/js/view/utils/skin.js
+++ b/src/js/view/utils/skin.js
@@ -142,10 +142,13 @@ export function handleColorOverrides(playerId, skin) {
             addStyle([
                 // Toggle and menu button active colors
                 '.jw-button-color.jw-toggle:not(.jw-icon-cast)',
-                '.jw-button-color:hover:not(.jw-icon-cast)',
                 '.jw-button-color:focus:not(.jw-icon-cast)',
                 '.jw-button-color.jw-toggle.jw-off:hover:not(.jw-icon-cast)'
             ], 'color', config.iconsActive);
+
+            addStyle([
+                ':not(.jw-state-buffering) .jw-button-color:hover:not(.jw-icon-cast)'
+            ], 'color', config.iconsActive, true);
 
             // Chromecast overrides
             // Can't use addStyle since it will camel case the style name


### PR DESCRIPTION
### This PR will...

Prevent hover state from being triggered when the user has a custom player skin and hovers on the buffer icon when the player is buffering.

### Why is this Pull Request needed?

Buffer icon should remain stateless when hovered on.

#### Addresses Issue(s):

JW8-659

