### PR TITLE
Display buffer icon in Safari when seeking outside of buffer

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -55,67 +55,6 @@ function VideoProvider(_playerId, _playerConfig) {
 
     const _this = this;
 
-    // karim >
-
-    function observe(media) {
-        const observer = new MutationObserver(function(mutations) {
-            mutations.forEach(function(mutation) {
-                console.warn('mutation', mutation);
-            });
-        });
-        observer.observe(media, {
-            attributes: true
-        });
-        const load = media.load;
-        const pause = media.pause;
-        const play = media.play;
-        media.load = function() {
-            console.error('media.load()');
-            return load.call(this);
-        };
-        media.pause = function() {
-            console.error('media.pause()');
-            return pause.call(this);
-        };
-        media.play = function() {
-            console.error('media.play()');
-            return play.call(this);
-        };
-        function videoEventHandler(e) {
-            console.warn('>> "' + e.type + '"');
-        }
-        function videoEventHandlerSpecial(e) {
-            console.error('>> "' + e.type + '"');
-        }
-        media.addEventListener('loadstart', videoEventHandler);
-        media.addEventListener('progress', videoEventHandler);
-        media.addEventListener('suspend', videoEventHandler);
-        media.addEventListener('abort', videoEventHandler);
-        media.addEventListener('error', videoEventHandler);
-        media.addEventListener('emptied', videoEventHandler);
-        media.addEventListener('stalled', videoEventHandler);
-        media.addEventListener('loadedmetadata', videoEventHandler);
-        media.addEventListener('loadeddata', videoEventHandler);
-        media.addEventListener('canplay', videoEventHandler);
-        media.addEventListener('canplaythrough', videoEventHandler);
-        media.addEventListener('playing', videoEventHandler);
-        media.addEventListener('waiting', videoEventHandler);
-        media.addEventListener('seeking', videoEventHandlerSpecial);
-        media.addEventListener('seeked', videoEventHandlerSpecial);
-        media.addEventListener('ended', videoEventHandler);
-        media.addEventListener('durationchange', videoEventHandler);
-        media.addEventListener('timeupdate', videoEventHandler);
-        media.addEventListener('play', videoEventHandler);
-        media.addEventListener('pause', videoEventHandler);
-        media.addEventListener('ratechange', videoEventHandler);
-        media.addEventListener('resize', videoEventHandler);
-        media.addEventListener('volumechange', videoEventHandler);
-    }
-
-//    observe(media);
-
-    // < karim
-
     const MediaEvents = {
         progress() {
             VideoEvents.progress.call(_this);
@@ -123,6 +62,9 @@ function VideoProvider(_playerId, _playerConfig) {
         },
         
         timeupdate() {
+            if (_positionBeforeSeek === _videotag.currentTime) {
+                return;
+            }
             _setPositionBeforeSeek(_videotag.currentTime);
             VideoEvents.timeupdate.call(_this);
             checkStaleStream();
@@ -191,7 +133,6 @@ function VideoProvider(_playerId, _playerConfig) {
 
         seeked() {
             VideoEvents.seeked.call(_this);
-//            _videotag.removeEventListener('waiting', () => _this.setState(STATE_BUFFERING));
             _videotag.removeEventListener('waiting', setBufferingState);
         },
 
@@ -330,7 +271,6 @@ function VideoProvider(_playerId, _playerConfig) {
         }
 
         if (outOfBufferRange) {
-            console.error('outOfBufferRange');
             _videotag.addEventListener('waiting', setBufferingState);
         }
     }

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -124,8 +124,6 @@ function VideoProvider(_playerId, _playerConfig) {
         
         timeupdate() {
             _setPositionBeforeSeek(_videotag.currentTime);
-//            _videotag.removeEventListener('waiting', () => console.log('we are waiting'));
-//            _videotag.removeEventListener('waiting', () => _this.setState(STATE_BUFFERING));
             VideoEvents.timeupdate.call(_this);
             checkStaleStream();
             if (_this.state === STATE_PLAYING) {
@@ -193,7 +191,8 @@ function VideoProvider(_playerId, _playerConfig) {
 
         seeked() {
             VideoEvents.seeked.call(_this);
-            _videotag.removeEventListener('waiting', () => _this.setState(STATE_BUFFERING));
+//            _videotag.removeEventListener('waiting', () => _this.setState(STATE_BUFFERING));
+            _videotag.removeEventListener('waiting', setBufferingState);
         },
 
         webkitbeginfullscreen(e) {
@@ -331,16 +330,13 @@ function VideoProvider(_playerId, _playerConfig) {
         }
 
         if (outOfBufferRange) {
-//            _videotag.addEventListener('waiting', () => console.log('we are waiting'));
             console.error('outOfBufferRange');
-            _videotag.addEventListener('waiting', () => _this.setState(STATE_BUFFERING));
-//            _this.setState(STATE_BUFFERING);
-//            _videotag.addEventListener('waiting', _this.setState(STATE_BUFFERING));
+            _videotag.addEventListener('waiting', setBufferingState);
         }
     }
 
     function setBufferingState() {
-        _this.setState(STATE_BUFFERING)
+        _this.setState(STATE_BUFFERING);
     }
 
     function _setPositionBeforeSeek(position) {

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -125,6 +125,7 @@ function VideoProvider(_playerId, _playerConfig) {
                 offset: offset
             });
             _setPositionBeforeSeek(offset);
+            _checkForBuffering(offset);
         },
 
         webkitbeginfullscreen(e) {
@@ -241,6 +242,17 @@ function VideoProvider(_playerId, _playerConfig) {
             level.label = _levels[_currentQuality].label;
             _this.trigger('visualQuality', visualQuality);
             visualQuality.reason = '';
+        }
+    }
+
+    function _checkForBuffering(position) {
+        if (_videotag.buffered.length <= 0) {
+            return;
+        }
+
+        const buffered = _videotag.buffered.find(bufferRange => bufferRange.start <= position && bufferRange.end >= position);
+        if (!buffered) {
+            this.addEventListener('waiting', () => console.log('we are waiting'));
         }
     }
 

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -201,7 +201,7 @@ function VideoProvider(_playerId, _playerConfig) {
     const _videotag = _this.video = _playerConfig.mediaElement;
     const visualQuality = { level: {} };
     const _staleStreamDuration = 3 * 10 * 1000;
-    observe(_videotag);
+
     let _canSeek = false; // true on valid time event
     let _delayedSeek = 0;
     let _seekOffset = null;

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -258,19 +258,17 @@ function VideoProvider(_playerId, _playerConfig) {
         if (bufferedRange.length <= 0) {
             return;
         }
-        let outOfBufferRange = position > bufferedRange.end(bufferedRange.length - 1);
-        let inBuffer;
-        if (!outOfBufferRange) {
+        let withinBuffer;
+        if (position <= bufferedRange.end(bufferedRange.length - 1)) {
             for (let i = 0; i < bufferedRange.length; i++) {
-                inBuffer = position > bufferedRange.start(i) && position < bufferedRange.end(i);
-                if (inBuffer) {
-                    outOfBufferRange = false;
+                withinBuffer = position > bufferedRange.start(i) && position < bufferedRange.end(i);
+                if (withinBuffer) {
                     break;
                 }
             }
         }
 
-        if (outOfBufferRange) {
+        if (!withinBuffer) {
             _videotag.addEventListener('waiting', setBufferingState);
         }
     }

--- a/src/js/providers/video-attached-mixin.js
+++ b/src/js/providers/video-attached-mixin.js
@@ -49,7 +49,6 @@ const VideoAttachedMixin = {
         if (this.atEdgeOfLiveStream()) {
             this.setPlaybackRate(1);
         }
-
         this.setState(STATE_STALLED);
     },
 

--- a/src/js/providers/video-listener-mixin.js
+++ b/src/js/providers/video-listener-mixin.js
@@ -1,4 +1,4 @@
-import { STATE_IDLE, STATE_COMPLETE, STATE_STALLED, STATE_LOADING, STATE_PLAYING, STATE_PAUSED,
+import { STATE_IDLE, STATE_COMPLETE, STATE_STALLED, STATE_LOADING, STATE_PLAYING, STATE_PAUSED, STATE_BUFFERING,
     PROVIDER_FIRST_FRAME, CLICK, MEDIA_BUFFER_FULL, MEDIA_RATE_CHANGE, MEDIA_ERROR,
     MEDIA_BUFFER, MEDIA_META, MEDIA_TIME, MEDIA_SEEKED, MEDIA_VOLUME, MEDIA_MUTE, MEDIA_COMPLETE
 } from 'events/events';
@@ -37,6 +37,9 @@ const VideoListenerMixin = {
 
     timeupdate() {
         this.stopStallCheck();
+        if (this.seeking) {
+            return;
+        }
         var height = this.video.videoHeight;
         if (height !== this._helperLastVideoHeight) {
             if (this.adaptation) {
@@ -56,7 +59,7 @@ const VideoListenerMixin = {
             return;
         }
 
-        if (!this.video.paused && (this.state === STATE_STALLED || this.state === STATE_LOADING)) {
+        if (!this.video.paused && (this.state === STATE_STALLED || this.state === STATE_LOADING || this.state === STATE_BUFFERING)) {
             this.startStallCheck();
             this.setState(STATE_PLAYING);
         }
@@ -105,7 +108,7 @@ const VideoListenerMixin = {
     },
 
     playing() {
-        this.setState(STATE_PLAYING);
+//        this.setState(STATE_PLAYING);
         this.trigger(PROVIDER_FIRST_FRAME);
     },
 

--- a/src/js/providers/video-listener-mixin.js
+++ b/src/js/providers/video-listener-mixin.js
@@ -108,7 +108,6 @@ const VideoListenerMixin = {
     },
 
     playing() {
-//        this.setState(STATE_PLAYING);
         this.trigger(PROVIDER_FIRST_FRAME);
     },
 

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -695,12 +695,8 @@ function View(_api, _model) {
     }
 
     function _stateHandler(model, newState, oldState) {
-//        console.warn('newState: ' + newState);
         if (!_model.get('viewSetup')) {
             return;
-        }
-        if (newState === 'buffering') {
-            console.log('karim');
         }
 
 

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -695,9 +695,14 @@ function View(_api, _model) {
     }
 
     function _stateHandler(model, newState, oldState) {
+//        console.warn('newState: ' + newState);
         if (!_model.get('viewSetup')) {
             return;
         }
+        if (newState === 'buffering') {
+            console.log('karim');
+        }
+
 
         _playerState = model.get('state');
 

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -699,7 +699,6 @@ function View(_api, _model) {
             return;
         }
 
-
         _playerState = model.get('state');
 
         instreamStateUpdate(_playerState);


### PR DESCRIPTION
### This PR will...
- listen for 'waiting' to trigger buffer state, if seeking outside the buffered area
- ignore timeupdates when seeking
- ignore timeupdates if time does not change
- prevent setting playing state on playing event; playing event means play was requested, not that playback is actually occurring. 
### Why is this Pull Request needed?
To display buffer icon when seeking outside of buffer area in safari for HLS Streams
### Are there any points in the code the reviewer needs to double check?
- removed setting the playing state on the playing event because it gets triggered when play is requested, not when able. For example, it gets triggered before seek is complete, see attachment:
<img width="221" alt="screen shot 2017-10-26 at 4 56 22 pm" src="https://user-images.githubusercontent.com/12138319/32126655-d5d88330-bb3f-11e7-977c-67fd738ef599.png">
- does not work for mp4s on Firefox since waiting event is never triggered, see attachment:
![screen shot 2017-10-27 at 5 30 01 pm](https://user-images.githubusercontent.com/12138319/32126679-00c4ed9a-bb40-11e7-9a51-e8121d8e20ed.png)
- removed playing since it does not mean playback is occurring and gets fired while seeking, see attachment: 
![screen shot 2017-10-27 at 5 33 28 pm](https://user-images.githubusercontent.com/12138319/32127039-167af376-bb42-11e7-9677-35c1b6478bdb.png)

#### Addresses Issue(s):
JW8-725

