### PR TITLE
Use getBoundingClientRect on player element for right click menu position

### DIFF
--- a/src/js/view/controls/rightclick.js
+++ b/src/js/view/controls/rightclick.js
@@ -2,7 +2,7 @@ import rightclickTemplate from 'view/controls/templates/rightclick';
 import { cloneIcon } from 'view/controls/icons';
 import { version } from 'version';
 import { flashVersion } from 'utils/browser';
-import { createElement, emptyElement, addClass, removeClass } from 'utils/dom';
+import { createElement, emptyElement, addClass, removeClass, bounds } from 'utils/dom';
 import UI from 'utils/ui';
 
 function createDomElement(html) {
@@ -56,10 +56,10 @@ export default class RightClick {
     }
 
     getOffset(evt) {
-        var bounds = this.playerElement.getBoundingClientRect();
-        var x = evt.clientX - bounds.left;
-        var y = evt.clientY - bounds.top;
-        
+        var playerBounds = bounds(this.playerElement);
+        var x = evt.clientX - playerBounds.left;
+        var y = evt.clientY - playerBounds.top;
+
         return { x: x, y: y };
     }
 

--- a/src/js/view/controls/rightclick.js
+++ b/src/js/view/controls/rightclick.js
@@ -57,8 +57,8 @@ export default class RightClick {
 
     getOffset(evt) {
         var playerBounds = bounds(this.playerElement);
-        var x = evt.clientX - playerBounds.left;
-        var y = evt.clientY - playerBounds.top;
+        var x = evt.pageX - playerBounds.left;
+        var y = evt.pageY - playerBounds.top;
 
         return { x: x, y: y };
     }

--- a/src/js/view/controls/rightclick.js
+++ b/src/js/view/controls/rightclick.js
@@ -56,17 +56,10 @@ export default class RightClick {
     }
 
     getOffset(evt) {
-        var target = evt.target;
-        // offsetX is from the W3C standard, layerX is how Firefox does it
-        var x = evt.offsetX || evt.layerX;
-        var y = evt.offsetY || evt.layerY;
-        while (target !== this.playerElement) {
-            x += target.offsetLeft;
-            y += target.offsetTop;
-
-            target = target.parentNode;
-        }
-
+        var bounds = this.playerElement.getBoundingClientRect();
+        var x = evt.clientX - bounds.left;
+        var y = evt.clientY - bounds.top;
+        
         return { x: x, y: y };
     }
 


### PR DESCRIPTION
### This PR will...

Use getBoundingClientRect on player element to determine where the right click menu pops up on the player rather than traversing the DOM upwards until the player element is found. 

### Why is this Pull Request needed?
If the target  of the mouse event is too deeply nested, the right click menus left and top position isn't correct. It's better to base the position of the right click menu relative to the player rather than the events target. 

#### Addresses Issue(s):

JW8-632

