### PR TITLE
Do not disable selected 'Unknown CC' after midroll on iOS

### DIFF
--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -49,9 +49,9 @@ function setTextTracks(tracks) {
         this._initTextTracks();
     } else {
         // Remove the 608 captions track that was mutated by the browser
+        this._unknownCount = 0;
         this._textTracks = _.reject(this._textTracks, function(track) {
             const trackId = track._id;
-            this._unknownCount = 0;
             if (this.renderNatively && trackId && trackId.indexOf('nativecaptions') === 0) {
                 delete this._tracksById[trackId];
                 return true;

--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -51,12 +51,12 @@ function setTextTracks(tracks) {
         // Remove the 608 captions track that was mutated by the browser
         this._textTracks = _.reject(this._textTracks, function(track) {
             const trackId = track._id;
+            this._unknownCount = 0;
             if (this.renderNatively && trackId && trackId.indexOf('nativecaptions') === 0) {
-                if (track.name.indexOf('Unknown') === 0 && this._unknownCount > 0) {
-                    this._unknownCount -= 1;
-                }
                 delete this._tracksById[trackId];
                 return true;
+            } else if (track.name.indexOf('Unknown') === 0) {
+                this._unknownCount++;
             }
         }, this);
 

--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -52,6 +52,9 @@ function setTextTracks(tracks) {
         this._textTracks = _.reject(this._textTracks, function(track) {
             const trackId = track._id;
             if (this.renderNatively && trackId && trackId.indexOf('nativecaptions') === 0) {
+                if (track.name.indexOf('Unknown') === 0 && this._unknownCount > 0) {
+                    this._unknownCount -= 1;
+                }
                 delete this._tracksById[trackId];
                 return true;
             }


### PR DESCRIPTION
### This PR will...

Correctly label captions with no name in the manifest so that it is persisted after a midroll on iOS and not turn off captions.

### Why is this Pull Request needed?

On iOS, we reload the captions after a midroll. The logic around giving captions with no labels a unique `Unknown CC...` label has a bug that caused it to not reset the count correctly. So after a midroll, `Unknown CC` became `Unknown CC [2]` which was not being matched to the caption name stored in local storage. Since there was no match, captions would default to `Off` and be disabled. 

#### Addresses Issue(s):

JW8-752
