### PR TITLE
Use padding instead of left/right for captions positioning

### DIFF
--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -51,7 +51,7 @@ const Defaults = {
         settings: 'Settings',
         unmute: 'Unmute'
     },
-    renderCaptionsNatively: true,
+    renderCaptionsNatively: false,
     nextUpDisplay: true
 };
 

--- a/src/js/polyfills/webvtt.js
+++ b/src/js/polyfills/webvtt.js
@@ -407,8 +407,8 @@ function CueStyleBox(window, cue) {
     var styles = {
         textShadow: '',
         position: 'relative',
-        left: 0,
-        right: 0,
+        'padding-left': 0,
+        'padding-right': 0,
         top: 0,
         bottom: 0,
         display: 'inline',
@@ -472,7 +472,7 @@ function CueStyleBox(window, cue) {
     // the right from there.
     if (cue.vertical === '') {
         this.applyStyles({
-            left: this.formatStyle(textPos, '%'),
+            'padding-left': this.formatStyle(textPos, '%'),
             width: this.formatStyle(cue.size, '%')
         });
         // Vertical box orientation; textPos is the distance from the top edge of the
@@ -489,8 +489,8 @@ function CueStyleBox(window, cue) {
         this.applyStyles({
             top: this.formatStyle(box.top, 'px'),
             bottom: this.formatStyle(box.bottom, 'px'),
-            left: this.formatStyle(box.left, 'px'),
-            right: this.formatStyle(box.right, 'px'),
+            'padding-left': this.formatStyle(box.left, 'px'),
+            'padding-right': this.formatStyle(box.right, 'px'),
             height: 'auto',
             width: this.formatStyle(box.width, 'px')
         });
@@ -626,8 +626,8 @@ BoxPosition.prototype.toCSSCompatValues = function (reference) {
     return {
         top: this.top - reference.top,
         bottom: reference.bottom - this.bottom,
-        left: this.left - reference.left,
-        right: reference.right - this.right,
+        'padding-left': this.left - reference.left,
+        'padding-left': reference.right - this.right,
         height: this.height,
         width: this.width
     };
@@ -643,8 +643,8 @@ BoxPosition.getSimpleBoxPosition = function (obj) {
     obj = obj.div ? obj.div.getBoundingClientRect() :
         obj.tagName ? obj.getBoundingClientRect() : obj;
     var ret = {
-        left: obj.left,
-        right: obj.right,
+        'padding-left': obj.left,
+        'padding-right': obj.right,
         top: obj.top || top,
         height: obj.height || height,
         bottom: obj.bottom || (top + (obj.height || height)),
@@ -781,12 +781,12 @@ function moveBoxToLinePosition(window, styleBox, containerBox, boxPositions, num
                 break;
             case 'rl':
                 styleBox.applyStyles({
-                    left: styleBox.formatStyle(linePos, '%')
+                    'padding-left': styleBox.formatStyle(linePos, '%')
                 });
                 break;
             case 'lr':
                 styleBox.applyStyles({
-                    right: styleBox.formatStyle(linePos, '%')
+                    'padding-right': styleBox.formatStyle(linePos, '%')
                 });
                 break;
             default:

--- a/src/js/polyfills/webvtt.js
+++ b/src/js/polyfills/webvtt.js
@@ -627,7 +627,7 @@ BoxPosition.prototype.toCSSCompatValues = function (reference) {
         top: this.top - reference.top,
         bottom: reference.bottom - this.bottom,
         'padding-left': this.left - reference.left,
-        'padding-left': reference.right - this.right,
+        'padding-right': reference.right - this.right,
         height: this.height,
         width: this.width
     };

--- a/src/js/polyfills/webvtt.js
+++ b/src/js/polyfills/webvtt.js
@@ -407,8 +407,8 @@ function CueStyleBox(window, cue) {
     var styles = {
         textShadow: '',
         position: 'relative',
-        'padding-left': 0,
-        'padding-right': 0,
+        paddingLeft: 0,
+        paddingRight: 0,
         top: 0,
         bottom: 0,
         display: 'inline',
@@ -472,7 +472,7 @@ function CueStyleBox(window, cue) {
     // the right from there.
     if (cue.vertical === '') {
         this.applyStyles({
-            'padding-left': this.formatStyle(textPos, '%'),
+            paddingLeft: this.formatStyle(textPos, '%'),
             width: this.formatStyle(cue.size, '%')
         });
         // Vertical box orientation; textPos is the distance from the top edge of the
@@ -489,8 +489,8 @@ function CueStyleBox(window, cue) {
         this.applyStyles({
             top: this.formatStyle(box.top, 'px'),
             bottom: this.formatStyle(box.bottom, 'px'),
-            'padding-left': this.formatStyle(box.left, 'px'),
-            'padding-right': this.formatStyle(box.right, 'px'),
+            paddingLeft: this.formatStyle(box.left, 'px'),
+            paddingRight: this.formatStyle(box.right, 'px'),
             height: 'auto',
             width: this.formatStyle(box.width, 'px')
         });
@@ -626,8 +626,8 @@ BoxPosition.prototype.toCSSCompatValues = function (reference) {
     return {
         top: this.top - reference.top,
         bottom: reference.bottom - this.bottom,
-        'padding-left': this.left - reference.left,
-        'padding-right': reference.right - this.right,
+        paddingLeft: this.left - reference.left,
+        paddingRight: reference.right - this.right,
         height: this.height,
         width: this.width
     };
@@ -643,8 +643,8 @@ BoxPosition.getSimpleBoxPosition = function (obj) {
     obj = obj.div ? obj.div.getBoundingClientRect() :
         obj.tagName ? obj.getBoundingClientRect() : obj;
     var ret = {
-        'padding-left': obj.left,
-        'padding-right': obj.right,
+        paddingLeft: obj.left,
+        paddingRight: obj.right,
         top: obj.top || top,
         height: obj.height || height,
         bottom: obj.bottom || (top + (obj.height || height)),
@@ -781,12 +781,12 @@ function moveBoxToLinePosition(window, styleBox, containerBox, boxPositions, num
                 break;
             case 'rl':
                 styleBox.applyStyles({
-                    'padding-left': styleBox.formatStyle(linePos, '%')
+                    paddingLeft: styleBox.formatStyle(linePos, '%')
                 });
                 break;
             case 'lr':
                 styleBox.applyStyles({
-                    'padding-right': styleBox.formatStyle(linePos, '%')
+                    paddingRight: styleBox.formatStyle(linePos, '%')
                 });
                 break;
             default:

--- a/src/js/view/captionsrenderer.js
+++ b/src/js/view/captionsrenderer.js
@@ -302,15 +302,21 @@ const CaptionsRenderer = function (_model) {
         this.selectCues(_captionsTrack, _timeEvent);
     }
 
-    function _itemReadyHandler() {
+    function _captionsListHandler(model, captionsList) {
+        if (captionsList.length === 1) {
+            // captionsList only contains 'off'
+            return;
+        }
+
         // don't load the polyfill or do unnecessary work if rendering natively
-        if (!_model.get('renderCaptionsNatively') && !_WebVTT) {
+        if (!model.get('renderCaptionsNatively') && !_WebVTT) {
             loadWebVttPolyfill().catch((error) => {
                 this.trigger(ERROR, {
                     message: 'Captions renderer failed to load',
                     reason: error
                 });
             });
+            model.off('change:captionsList', _captionsListHandler, this);
         }
     }
 
@@ -340,7 +346,7 @@ const CaptionsRenderer = function (_model) {
         this.selectCues(_captionsTrack, _timeEvent);
     }, this);
 
-    _model.on('itemReady', _itemReadyHandler, this);
+    _model.on('change:captionsList', _captionsListHandler, this);
 };
 
 Object.assign(CaptionsRenderer.prototype, Events);


### PR DESCRIPTION
### This PR will...

- Use `padding-left` and `padding-right` in lieu of `left` and`right`  css values for setting the position of captions.
- Disable native rendering in Chrome so that publishers can immediately take advantage of better window styling of captions.
- Wait until we've added a text track to the menu before loading the renderer.
### Why is this Pull Request needed?
When rendering captions natively in Chrome, window styles applied to VTTCues span the beginning of the cue to the end of the video container. Publishers expect the behavior to be similar to Safari, where the captions window margin is the same on the left and right, regardless of where the text within it is positioned.
### Are there any points in the code the reviewer needs to double check?
No.
### Are there any Pull Requests open in other repos which need to be merged with this?
No.
#### Addresses Issue(s):
JW8-475

