### PR TITLE
Base skin unit tests on DOM modification rather than spying on css util methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3052,6 +3052,12 @@
       "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
       "dev": true
     },
+    "fast-diff": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
+      "dev": true
+    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "eslint": "4.4.0",
     "eslint-plugin-no-for-of-loops": "1.0.0",
     "esprima": "4.0.0",
+    "fast-diff": "1.1.2",
     "file-loader": "0.11.2",
     "grunt": "1.0.1",
     "grunt-cli": "1.2.0",

--- a/src/js/view/utils/skin.js
+++ b/src/js/view/utils/skin.js
@@ -1,7 +1,10 @@
 import { prefix } from 'utils/strings';
 import { css, getRgba } from 'utils/css';
 
-export function normalizeSkin(skinConfig = {}) {
+export function normalizeSkin(skinConfig) {
+    if (!skinConfig) {
+        skinConfig = {};
+    }
 
     const active = skinConfig.active;
     const inactive = skinConfig.inactive;
@@ -105,8 +108,9 @@ export function handleColorOverrides(playerId, skin) {
     if (skin.tooltips) {
         styleTooltips(skin.tooltips);
     }
-
-    insertGlobalColorClasses(skin.menus);
+    if (skin.menus) {
+        insertGlobalColorClasses(skin.menus);
+    }
 
     function styleControlbar(config) {
 
@@ -248,15 +252,15 @@ export function handleColorOverrides(playerId, skin) {
 
     // Set global colors, used by related plugin
     // If a color is undefined simple-style-loader won't add their styles to the dom
-    function insertGlobalColorClasses(config = {}) {
+    function insertGlobalColorClasses(config) {
         if (config.textActive) {
             const activeColorSet = {
                 color: config.textActive,
                 borderColor: config.textActive,
                 stroke: config.textActive
             };
-            css('#' + playerId + ' .jw-color-active', activeColorSet, playerId);
-            css('#' + playerId + ' .jw-color-active-hover:hover', activeColorSet, playerId);
+            css(`#${playerId} .jw-color-active`, activeColorSet, playerId);
+            css(`#${playerId} .jw-color-active-hover:hover`, activeColorSet, playerId);
         }
         if (config.text) {
             const inactiveColorSet = {
@@ -264,8 +268,8 @@ export function handleColorOverrides(playerId, skin) {
                 borderColor: config.text,
                 stroke: config.text
             };
-            css('#' + playerId + ' .jw-color-inactive', inactiveColorSet, playerId);
-            css('#' + playerId + ' .jw-color-inactive-hover:hover', inactiveColorSet, playerId);
+            css(`#${playerId} .jw-color-inactive`, inactiveColorSet, playerId);
+            css(`#${playerId} .jw-color-inactive-hover:hover`, inactiveColorSet, playerId);
         }
     }
 }


### PR DESCRIPTION
### This PR will...

Replace the use of sinon in our skin customization tests with code that looks for diffs in the player style sheet elements.

### Why is this Pull Request needed?

Testing that skin customization results in only our css utils running or not does not assert affect on the DOM. These changes do not affect coverage of our code. They make the tests better reflect the intent of the assertions, and remove the expectation that a certain utility interface is used to make the style changes (with the exception of style sheet element attributes added by simple-style-loader).

There is some cleanup on the skin module itself, and changes to the tests "beforeEach" and "after" handlers to remove styles added by simple-style-loader.
