### PR TITLE
Fix issues with getting state from adModel

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -291,8 +291,10 @@ var InstreamAdapter = function(_controller, _model, _view) {
             }
 
             // Sync player state with ad for model "change:state" events to trigger
-            const adState = _instream._adModel.get('state');
-            _model.attributes.state = adState;
+            if (_instream._adModel) {
+                const adState = _instream._adModel.get('state');
+                _model.attributes.state = adState;
+            }
 
             _model.off(null, null, _instream);
             _instream.off(null, null, _this);


### PR DESCRIPTION
### This PR will...
Add check on whether if ```_instream._adModel``` before getting ```_instream._adModel.get('state')```

### Why is this Pull Request needed?
For DAI, ```_instream._adModel``` does not exist and causes console error when calling ```get('state')```

#### Addresses Issue(s):
ADS-646


