### PR TITLE
Ensure an initial quality is set on html5 provider preload and load

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -465,9 +465,12 @@ function VideoProvider(_playerId, _playerConfig) {
 
     this.preload = function(item) {
         _setLevels(item.sources);
-        const preload = _levels[_currentQuality] ? _levels[_currentQuality].preload : 'metadata';
-        _setAttribute('preload', preload);
-        _setVideotagSource(_levels[_currentQuality]);
+        const source = _levels[_currentQuality];
+        const preload = source.preload || 'metadata';
+        if (preload !== 'none') {
+            _setAttribute('preload', preload);
+            _setVideotagSource(source);
+        }
     };
 
     this.load = function(item) {

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -449,8 +449,7 @@ function VideoProvider(_playerId, _playerConfig) {
     };
 
     this.init = function(item) {
-        _levels = item.sources;
-        _currentQuality = _pickInitialQuality(item.sources);
+        _setLevels(item.sources);
         const source = _levels[_currentQuality];
         _androidHls = isAndroidHls(source);        
         if (_androidHls) {
@@ -458,14 +457,15 @@ function VideoProvider(_playerId, _playerConfig) {
             _this.supportsPlaybackRate = false;
         }
         // the loadeddata event determines the mediaType for HLS sources
-        if (item.sources.length && item.sources[0].type !== 'hls') {
-            this.sendMediaType(item.sources);
+        if (_levels.length && _levels[0].type !== 'hls') {
+            this.sendMediaType(_levels);
         }
         visualQuality.reason = '';
     };
 
     this.preload = function(item) {
-        const preload = item.sources[_currentQuality] ? item.sources[_currentQuality].preload : 'metadata';
+        _setLevels(item.sources);
+        const preload = _levels[_currentQuality] ? _levels[_currentQuality].preload : 'metadata';
         _setAttribute('preload', preload);
         _setVideotagSource(_levels[_currentQuality]);
     };


### PR DESCRIPTION
### This PR will...

Ensure an initial quality is set in the html5 provider when `preload(item)` and `load(item)`are called. This fixes a bug where calling `stop()` on "ready" throws an exception.

Also make sure we never set the video preload attribute to none as that causes play promises to be unreliable on iOS with multiple video tags in the DOM.

### Why is this Pull Request needed?

In the html5 provider, the initial quality or source object is `_levels[_currentQuality]`. Calling `stop()` after the html5 has been inited will reset `_currentQuality` to `-1` indicating that the stream has ended or is stopped, and making `_levels[_currentQuality]` return `undefined`. Since init, preload and load all accept an item argument, they should all call `_setLevels(item.sources)` to ensure `_currentQuality` is set to `0` and the levels reflect the contents of the item passed to the last method called.

Harness setup:
```js
{
    events: {
        ready: function() { this.stop() }
    },
    file: "video.mp4",
}
```