### PR TITLE
Add playlistItem event listener in preview.js

### DIFF
--- a/src/js/view/preview.js
+++ b/src/js/view/preview.js
@@ -12,8 +12,6 @@ function validState(state) {
 Object.assign(Preview.prototype, {
     setup: function(element) {
         this.el = element;
-
-        this.model.on('change:playlistItem', this.playlistItem, this);
     },
     setImage: function(img) {
         // Remove onload function from previous image
@@ -66,13 +64,6 @@ Object.assign(Preview.prototype, {
                 backgroundSize: backgroundSize
             });
         }
-    },
-    playlistItem: function(model, item) {
-        if (!item) {
-            return;
-        }
-        
-        this.setImage(item.image);
     },
     element: function() {
         return this.el;

--- a/src/js/view/preview.js
+++ b/src/js/view/preview.js
@@ -12,6 +12,8 @@ function validState(state) {
 Object.assign(Preview.prototype, {
     setup: function(element) {
         this.el = element;
+
+        this.model.on('change:playlistItem', this.playlistItem, this);
     },
     setImage: function(img) {
         // Remove onload function from previous image
@@ -64,6 +66,13 @@ Object.assign(Preview.prototype, {
                 backgroundSize: backgroundSize
             });
         }
+    },
+    playlistItem: function(model, item) {
+        if (!item) {
+            return;
+        }
+        
+        this.setImage(item.image);
     },
     element: function() {
         return this.el;

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -734,16 +734,15 @@ function View(_api, _model) {
         }
         replaceClass(_playerElement, /jw-state-\S+/, 'jw-state-' + state);
 
+        _model.off('change:playlistItem', setPosterImage);
         switch (state) {
             case STATE_IDLE:
             case STATE_ERROR:
-            case STATE_COMPLETE: {
-                const playlistItem = _model.get('playlistItem');
-                _preview.setImage(playlistItem && playlistItem.image);
+            case STATE_COMPLETE:
+                _model.change('playlistItem', setPosterImage);                
                 if (_captionsRenderer) {
                     _captionsRenderer.hide();
                 }
-            }
                 break;
             default:
                 if (_captionsRenderer) {
@@ -754,6 +753,11 @@ function View(_api, _model) {
                 }
                 break;
         }
+    }
+
+    function setPosterImage(model) {
+        const playlistItem = model.get('playlistItem');
+        _preview.setImage(playlistItem && playlistItem.image);
     }
 
     const settingsMenuVisible = () => {


### PR DESCRIPTION
### This PR will...

Change the preview image when a new playlist is loaded via the load api when the player state is idle.

### Why is this Pull Request needed?

The preview image would only change if a new playlist was loaded while the video was playing, paused, or buffering, but not when the player state is idle.

### Are there any points in the code the reviewer needs to double check?

The setImage function in preview.js may be called multiple times now because of my event listener in the setup function. May need to put a conditional in my new function to make sure the setImage function doesn't fire if the preview image on the new item is the same is old one (by the time my function is hit, the image on the item and the model are the same)

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-803

