### PR TITLE
Clear cuepoints when empty array is passed in

### DIFF
--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -426,12 +426,18 @@ export default class Controlbar {
     }
 
     addCues(model, cues) {
-        if (this.elements.time) {
+        if (!this.elements.time) {
+            return;
+        }
+        if (cues && cues.length) {
             _.each(cues, function (ele) {
                 this.elements.time.addCue(ele);
             }, this);
-            this.elements.time.drawCues();
+        } else {
+            this.elements.time.resetChapters();
         }
+
+        this.elements.time.drawCues();
     }
 
     // Close menus if it has no event.  Otherwise close all but the event's target.


### PR DESCRIPTION

### This PR will...
Allow ```setCues``` api to clear cue points if empty array ```[]``` is passed in.

### Why is this Pull Request needed?
There is a public api ```setCues``` to add cue points, but there is no way to remove the cue points. This will allow cue points to be removed. Clearing cue points is needed for DAI, as we get cue point changed event whenever an ad ends. Putting same cue points places them at random location. 

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):
ADS-643

