### PR TITLE
Make the hlsjsdefault flag be true by default

### DIFF
--- a/src/js/playlist/playlist.js
+++ b/src/js/playlist/playlist.js
@@ -47,7 +47,7 @@ function formatSources(item, model) {
     const androidhls = model.get('androidhls');
     const itemDrm = item.drm || model.get('drm');
     const withCredentials = fallbackIfUndefined(item.withCredentials, model.get('withCredentials'));
-    const hlsjsdefault = model.get('hlsjsdefault');
+    const hlsjsdefault = model.get('hlsjsdefault') !== false;
 
     return sources.map(function(originalSource) {
         if (originalSource !== Object(originalSource)) {

--- a/src/js/providers/html5-android-hls.js
+++ b/src/js/providers/html5-android-hls.js
@@ -7,7 +7,7 @@ export function isAndroidHls(source) {
         }
 
         // Allow Android hls playback on versions 4.1 and above, excluding Firefox (which does not support HLS in any version)
-        return !Browser.firefox && parseFloat(OS.version.version) >= 4.1;
+        return !Browser.firefox && parseFloat(OS.version.version) >= 4.4;
     }
     return null;
 }


### PR DESCRIPTION
### This PR will...

If `hlsjsdefault` is not explicitly set to false in the config, it will use the `hls.js` provider for Android devices.

### Why is this Pull Request needed?

To support the larger set that HLS provides compared to simply using the native HTML player on Android devices.

### Are there any points in the code the reviewer needs to double check?

We will want to run the Android cucumber tests and do extensive manual testing to verify that `hls.js` is robust enough to now be used.

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-commercial/pull/4268

#### Addresses Issue(s):

JW8-264