### PR TITLE
Modularize Provider Creation Flow

### DIFF
--- a/src/js/api/set-playlist.js
+++ b/src/js/api/set-playlist.js
@@ -16,12 +16,4 @@ const setPlaylist = function(model, playlist, feedData = {}) {
     }
 };
 
-export function loadProvidersForPlaylist(model) {
-    const playlist = model.get('playlist');
-    const providersManager = model.getProviders();
-    const providersNeeded = providersManager.required(playlist);
-
-    return providersManager.load(providersNeeded);
-}
-
 export default setPlaylist;

--- a/src/js/providers/provider-controller.js
+++ b/src/js/providers/provider-controller.js
@@ -1,0 +1,53 @@
+import Providers from 'providers/providers';
+
+export default function ProviderController(initialConfig) {
+    let config = initialConfig;
+    let providers = new Providers(config);
+
+    return {
+        choose(source) {
+            return providers.choose(source).provider;
+        },
+        make(id, source) {
+            const Provider = this.choose(source);
+            if (!Provider) {
+                return null;
+            }
+            return new Provider(id, config);
+        },
+        loadProviders(playlist) {
+            return providers.load(providers.required(playlist));
+        },
+        allProviders() {
+            return providers;
+        },
+        updateConfig(updatedConfig) {
+            providers = new Providers(updatedConfig);
+            config = updatedConfig;
+        },
+        sync(model, provider) {
+            syncProviderToModel(model, provider);
+            syncModelToProvider(model, provider);
+        }
+    };
+}
+
+const syncProviderToModel = (model, provider) => {
+    provider.volume(model.get('volume'));
+    // Mute the video if autostarting on mobile, except for Android SDK. Otherwise, honor the model's mute value
+    const isAndroidSdk = model.get('sdkplatform') === 1;
+    provider.mute((model.autoStartOnMobile() && !isAndroidSdk) || model.get('mute'));
+    if (model.get('instreamMode') === true) {
+        provider.instreamMode = true;
+    }
+};
+
+const syncModelToProvider = (model, provider) => {
+    if (provider.getName().name.indexOf('flash') === -1) {
+        model.set('flashThrottle', undefined);
+        model.set('flashBlocked', false);
+    }
+    // Set playbackRate because provider support for playbackRate may have changed and not sent an update
+    model.set('playbackRate', provider.getPlaybackRate());
+    model.set('renderCaptionsNatively', provider.renderNatively);
+};

--- a/src/js/providers/providers.js
+++ b/src/js/providers/providers.js
@@ -40,11 +40,14 @@ Object.assign(Providers.prototype, {
             let loadProvider = false;
             for (let i = playlist.length; i--;) {
                 const item = playlist[i];
-                const supported = this.providerSupports(provider, item.sources[0]);
-                if (supported) {
-                    playlist.splice(i, 1);
+                const source = item.sources[0];
+                if (source) {
+                    const supported = this.providerSupports(provider, item.sources[0]);
+                    if (supported) {
+                        playlist.splice(i, 1);
+                    }
+                    loadProvider = loadProvider || supported;
                 }
-                loadProvider = loadProvider || supported;
             }
             return loadProvider;
         });


### PR DESCRIPTION
### This PR will...
Split out provider loading, creation, changing, and synchronization into discrete steps which can be called outside of changing a provider.

The bulk of this work separates provider control into a promise chain. The chain roughly goes:

Load providers -> check providers -> change provider OR reload current provider

But we need to prime the next video tag (if necessary) synchronously, so that's found outside of it. The code right now looks a little bit messy but that's fine - we'll be migrating this logic into a new module soon. The `provider-controller` looks a bit slim so I may delete it, but it's purpose was to remove the other provider modules from the Model.

### Why is this Pull Request needed?
In the near future we'll need to be able to do some of these steps, but not all of them at once. Refactoring out the methods will give us the flexibility to background load a provider without changing the active one.

### Are there any points in the code the reviewer needs to double check?
Everything

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/4272

#### Addresses Issue(s):

JW8-42

