### PR TITLE
Reposition text track display back into container

### DIFF
--- a/src/js/polyfills/webvtt.js
+++ b/src/js/polyfills/webvtt.js
@@ -643,8 +643,8 @@ BoxPosition.getSimpleBoxPosition = function (obj) {
     obj = obj.div ? obj.div.getBoundingClientRect() :
         obj.tagName ? obj.getBoundingClientRect() : obj;
     var ret = {
-        paddingLeft: obj.left,
-        paddingRight: obj.right,
+        left: obj.left,
+        right: obj.right,
         top: obj.top || top,
         height: obj.height || height,
         bottom: obj.bottom || (top + (obj.height || height)),


### PR DESCRIPTION
### This PR will...

Use `left/right` instead of `paddingLeft/paddingRight` to correctly calculate the position `jw-text-track-display` container. This will ensure that it is always within `jw-text-track-container` when captions should be at the very bottom of the container (`line:100%`).

### Why is this Pull Request needed?

https://github.com/jwplayer/jwplayer/pull/2499 replaces `left/right` with `paddingLeft/paddingRight` to fix the captions window positioning. For `getSimpleBoxPosition`, it should not have changed, since it caused a miscalculation when captions were set to `line:100%`

#### Addresses Issue(s):

JW8-836

