### PR TITLE
Set visualQuality on loadeddata event in html5 provider

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -102,6 +102,7 @@ function VideoProvider(_playerId, _playerConfig) {
             VideoEvents.loadeddata.call(_this);
             _setAudioTracks(_videotag.audioTracks);
             _checkDelayedSeek(_this.getDuration());
+            checkVisualQuality();
         },
 
         canplay() {
@@ -235,8 +236,7 @@ function VideoProvider(_playerId, _playerConfig) {
 
     function checkVisualQuality() {
         const level = visualQuality.level;
-        if (level.width !== _videotag.videoWidth ||
-            level.height !== _videotag.videoHeight) {
+        if (level.width !== _videotag.videoWidth || level.height !== _videotag.videoHeight) {
             level.width = _videotag.videoWidth;
             level.height = _videotag.videoHeight;
             _setMediaType();

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -327,7 +327,11 @@ function VideoProvider(_playerId, _playerConfig) {
             }
         }
         visualQuality.reason = 'initial choice';
-        visualQuality.level = {};
+
+        if (!visualQuality.level.width || !visualQuality.level.height) {
+            visualQuality.level = {};
+        }
+
         return currentQuality;
     }
 


### PR DESCRIPTION
### This PR will...

Trigger the visualQuality event in the html5 provider when the video is preloaded. 

### Why is this Pull Request needed?

To improve analytics data for play events, we should call getVisualQuality() as soon as possible. We can get data such as width, height, reason, etc when the player is preloaded.

### Are there any points in the code the reviewer needs to double check?

visualQuality event triggers twice on videos with only one quality level: when the player is loaded and again when the you press play. Both times return the same info Need to add a check in checkVisualQuality() in html5.js to compare the last level with the new one to make sure we dont call event with the same info.

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-commercial/pull/4288
https://github.com/jwplayer/hls.js/pull/125

#### Addresses Issue(s):

JW8-823

