### PR TITLE
Fix tapping cast button on android

### DIFF
--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -305,6 +305,8 @@ export default class Controlbar {
 
         if (elements.cast && elements.cast.button) {
             new UI(elements.cast.element()).on('click tap enter', function(evt) {
+                // controlbar cast button needs to manually trigger a click
+                // on the native cast button for taps and enter key
                 if (evt.type !== 'click') {
                     elements.cast.button.click();
                 }

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -305,7 +305,7 @@ export default class Controlbar {
 
         if (elements.cast && elements.cast.button) {
             new UI(elements.cast.element()).on('click tap enter', function(evt) {
-                if (evt.type === 'enter') {
+                if (evt.type !== 'click') {
                     elements.cast.button.click();
                 }
                 this._model.set('castClicked', true);


### PR DESCRIPTION
### This PR will...

instead of triggering a `click` event just when hitting the `enter` key, it will also do so for `tap` events as well. This will allow tapping on Android devices to open the native Chromecast popup.

### Why is this Pull Request needed?

We wrap the native Chromecast button within our own button container. Since we are no longer support pointer events on Android, the native button expects a pointer event, so when it is tapped, the button container will trigger, in turn, a click event on the native button. 

#### Addresses Issue(s):

JW8-849