### PR TITLE
Add check for instream in addClickHandler

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -257,7 +257,9 @@ var InstreamAdapter = function(_controller, _model, _view) {
             _view.clickHandler().setAlternateClickHandlers(_clickHandler, _doubleClickHandler);
         }
 
-        _instream.on(MEDIA_META, this.metaHandler, this);
+        if (_instream) {
+            _instream.on(MEDIA_META, this.metaHandler, this);
+        }
     };
 
     this.skipAd = function(evt) {
@@ -285,11 +287,11 @@ var InstreamAdapter = function(_controller, _model, _view) {
 
         _model.set('adModel', null);
 
-        if (_instream) {
-            if (_view.clickHandler()) {
-                _view.clickHandler().revertAlternateClickHandlers();
-            }
+        if (_view.clickHandler()) {
+            _view.clickHandler().revertAlternateClickHandlers();
+        }
 
+        if (_instream) {
             // Sync player state with ad for model "change:state" events to trigger
             if (_instream._adModel) {
                 const adState = _instream._adModel.get('state');


### PR DESCRIPTION
### This PR will...
Add check for existence of ```_instream``` in ```addClickHandler```

### Why is this Pull Request needed?
DAI needs to use ```addClickHandler``` function for mobile click handlers to work properly. However, DAI does not call ```init``` on ```InstreamAdapter```, resulting ```_instream``` to be undefined.

#### Addresses Issue(s):
ADS-623


