### PR TITLE
Program Controller

### DIFF
--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -113,7 +113,7 @@ Object.assign(CoreShim.prototype, {
             storage.track(coreModel);
 
             // Set the active playlist item after plugins are loaded and the view is setup
-            return coreModel.setItemIndex(coreModel.get('item'));
+            return this.setItemIndex(coreModel.get('item'));
         }).then(() => {
             if (!this.setup) {
                 return;

--- a/src/js/api/set-playlist.js
+++ b/src/js/api/set-playlist.js
@@ -16,12 +16,4 @@ const setPlaylist = function(model, playlist, feedData = {}) {
     }
 };
 
-export function loadProvidersForPlaylist(model) {
-    const playlist = model.get('playlist');
-    const providersManager = model.getProviders();
-    const providersNeeded = providersManager.required(playlist);
-
-    return providersManager.load(providersNeeded);
-}
-
 export default setPlaylist;

--- a/src/js/api/setup-steps.js
+++ b/src/js/api/setup-steps.js
@@ -39,9 +39,8 @@ function filterPlaylist(_model) {
         // Filter the playlist and update the model's 'playlist'
         setPlaylist(_model, _model.get('playlist'), _model.get('feedData'));
 
-        // Adaptation of { loadProvidersForPlaylist } from 'api/set-playlist'
-        // Only loads first provider, if not included in the core bundle
-        // And does not call `model.setProvider` once the provider is loaded
+        // Loads the first provider if not included in the core bundle
+        // A provider loaded this way will not be set upon completion
         const playlist = _model.get('playlist');
         const providersManager = _model.getProviders();
         const firstProviderNeeded = providersManager.required([playlist[0]]);

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -733,11 +733,11 @@ Object.assign(Controller.prototype, {
         this.setConfig = (newConfig) => setConfig(_this, newConfig);
         this.setItemIndex = _setItem;
 
-        // Program passthroughs
-        this.playVideo = _programController.playVideo.bind(_programController);
-        this.stopVideo = _programController.stopVideo.bind(_programController);
-        this.castVideo = _programController.castVideo.bind(_programController);
-        this.stopCast = _programController.stopCast.bind(_programController);
+        // Program Controller passthroughs
+        this.playVideo = (playReason) => _programController.playVideo(playReason);
+        this.stopVideo = () => _programController.stopVideo();
+        this.castVideo = (castProvider, item) => _programController.castVideo(castProvider, item);
+        this.stopCast = () => _programController.stopCast();
 
         // Model passthroughs
         this.setVolume = _model.setVolume.bind(_model);

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -529,8 +529,10 @@ Object.assign(Controller.prototype, {
             const length = playlist.length;
 
             // If looping past the end, or before the beginning
-            index = parseInt(index, 10) || 0;
-            index = (index + length) % length;
+            index = (parseInt(index, 10) || 0) % length;
+            if (index < 0) {
+                index += length;
+            }
 
             const item = playlist[index];
             return _programController.setActiveItem(item, index);

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -633,7 +633,6 @@ Object.assign(Controller.prototype, {
             return _programController.audioTracks;
         }
 
-        // TODO mediaController
         function _setCurrentCaptions(index) {
             index = parseInt(index, 10) || 0;
 

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -198,7 +198,7 @@ var InstreamAdapter = function(_controller, _model, _view) {
 
         adModel.set('skipButton', false);
 
-        const playPromise = _instream.load(item);
+        const playPromise = _instream.load(item, _arrayIndex);
 
         const skipoffset = item.skipoffset || _options.skipoffset;
         if (skipoffset) {
@@ -301,13 +301,13 @@ var InstreamAdapter = function(_controller, _model, _view) {
             _controller.attachMedia();
 
             if (_oldpos === null) {
-                _model.stopVideo();
+                _controller.stopVideo();
             } else {
                 const mediaModelContext = _model.mediaModel;
                 const item = Object.assign({}, _olditem);
                 item.starttime = _oldpos;
                 _model.attributes.playlistItem = item;
-                _model.playVideo().catch(function(error) {
+                _controller.playVideo().catch(function(error) {
                     if (mediaModelContext === _model.mediaModel) {
                         _model.mediaController.trigger('error', {
                             message: error.message

--- a/src/js/controller/instream-html5.js
+++ b/src/js/controller/instream-html5.js
@@ -4,11 +4,13 @@ import { OS } from 'environment/environment';
 import Events from 'utils/backbone.events';
 import changeStateEvent from 'events/change-state-event';
 import Model from 'controller/model';
+import ProgramController from 'program/program-controller';
 
 const InstreamHtml5 = function(_controller, _model) {
     var _adModel;
     var _currentProvider;
     var _this = Object.assign(this, Events);
+    let _programController;
 
     // Listen for player resize events
     _controller.on(FULLSCREEN, function(data) {
@@ -54,25 +56,22 @@ const InstreamHtml5 = function(_controller, _model) {
         mediaElement.addEventListener('abort', _this.srcReset);
         mediaElement.addEventListener('emptied', _this.srcReset);
         this._adModel = _adModel;
+        _programController = new ProgramController(_adModel);
     };
 
     /** Load an instream item and initialize playback **/
-    _this.load = function() {
+    _this.load = function(item, index) {
         // Let the player media model know we're using it's video tag
         _this.srcReset();
 
         // Make sure it chooses a provider
-        _adModel.stopVideo();
-        _adModel.setItemIndex(0).then(() => {
-            if (!_adModel) {
-                return;
-            }
-            _checkProvider(_adModel.getVideo());
-        });
+        _programController.stopVideo();
         _checkProvider();
-
-        // Load the instream item
-        return _adModel.playVideo();
+        _programController.setActiveItem(item, index)
+            .then(() => {
+                _checkProvider(_adModel.getVideo());
+            });
+        return _programController.playVideo();
     };
 
     _this.applyProviderListeners = function(provider) {
@@ -142,18 +141,12 @@ const InstreamHtml5 = function(_controller, _model) {
 
     /** Start instream playback **/
     _this.instreamPlay = function() {
-        if (!_adModel.getVideo()) {
-            return;
-        }
-        _adModel.getVideo().play();
+        _programController.playVideo();
     };
 
     /** Pause instream playback **/
     _this.instreamPause = function() {
-        if (!_adModel.getVideo()) {
-            return;
-        }
-        _adModel.getVideo().pause();
+        _programController.pause();
     };
 
 

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -1,45 +1,37 @@
 import { Browser, OS } from 'environment/environment';
 import SimpleModel from 'model/simplemodel';
 import { INITIAL_PLAYER_STATE } from 'model/player-model';
-import Providers from 'providers/providers';
-import { loadProvidersForPlaylist } from 'api/set-playlist';
-import getMediaElement from 'api/get-media-element';
 import initQoe from 'controller/qoe';
-import { PLAYER_STATE, STATE_IDLE, STATE_BUFFERING, STATE_PAUSED, STATE_COMPLETE, MEDIA_VOLUME, MEDIA_MUTE,
+import { PLAYER_STATE, STATE_IDLE, STATE_COMPLETE, MEDIA_VOLUME, MEDIA_MUTE,
     MEDIA_TYPE, PROVIDER_CHANGED, AUDIO_TRACKS, AUDIO_TRACK_CHANGED,
-    MEDIA_PLAY_ATTEMPT, MEDIA_PLAY_ATTEMPT_FAILED, MEDIA_RATE_CHANGE,
-    MEDIA_BUFFER, MEDIA_TIME, MEDIA_LEVELS, MEDIA_LEVEL_CHANGED, MEDIA_ERROR, ERROR,
+    MEDIA_RATE_CHANGE, MEDIA_BUFFER, MEDIA_TIME, MEDIA_LEVELS, MEDIA_LEVEL_CHANGED, MEDIA_ERROR,
     MEDIA_BEFORECOMPLETE, MEDIA_COMPLETE, MEDIA_META } from 'events/events';
-import { seconds } from 'utils/strings';
 import _ from 'utils/underscore';
 import Events from 'utils/backbone.events';
-import { resolved } from 'polyfills/promise';
 import cancelable from 'utils/cancelable';
+import ProviderController from 'providers/provider-controller';
+import { seconds } from 'utils/strings';
 
 // Represents the state of the player
 const Model = function() {
     const _this = this;
-    let _providers;
+    let providerController;
     let _provider;
     let _beforecompleted = false;
-    let _attached = true;
     let thenPlayPromise = cancelable(function() {});
-    let providerPromise = resolved;
 
     this.mediaController = Object.assign({}, Events);
     this.mediaModel = new MediaModel();
 
     initQoe(this);
 
+    this.set('attached', true);
     this.set('mediaModel', this.mediaModel);
 
     this.setup = function(config) {
-
         Object.assign(this.attributes, config, INITIAL_PLAYER_STATE);
-
-        this.updateProviders();
+        providerController = ProviderController(this.getConfiguration());
         this.setAutoStart();
-
         return this;
     };
 
@@ -49,11 +41,7 @@ const Model = function() {
         return config;
     };
 
-    this.updateProviders = function() {
-        _providers = new Providers(this.getConfiguration());
-    };
-
-    function _videoEventHandler(type, data) {
+    this.videoEventHandler = function(type, data) {
         const event = Object.assign({}, data, {
             type: type
         });
@@ -96,6 +84,7 @@ const Model = function() {
                 return;
             case PLAYER_STATE: {
                 if (data.newstate === STATE_IDLE) {
+                    // TODO: cancel promise in PC
                     thenPlayPromise.cancel();
                     mediaModel.srcReset();
                 }
@@ -103,13 +92,13 @@ const Model = function() {
                 const previousState = mediaModel.attributes[PLAYER_STATE];
                 mediaModel.attributes[PLAYER_STATE] = data.newstate;
                 mediaModel.trigger('change:' + PLAYER_STATE, mediaModel, data.newstate, previousState);
-
             }
                 // This "return" is important because
                 //  we are choosing to not propagate this event.
                 //  Instead letting the master controller do so
                 return;
             case MEDIA_ERROR:
+                // TODO: cancel promise in PC
                 thenPlayPromise.cancel();
                 mediaModel.srcReset();
                 break;
@@ -149,7 +138,7 @@ const Model = function() {
             case MEDIA_COMPLETE:
                 _beforecompleted = true;
                 this.mediaController.trigger(MEDIA_BEFORECOMPLETE, event);
-                if (_attached) {
+                if (this.get('attached')) {
                     this.playbackComplete();
                 }
                 return;
@@ -171,7 +160,7 @@ const Model = function() {
         }
 
         this.mediaController.trigger(type, event);
-    }
+    };
 
     this.setQualityLevel = function(quality, levels) {
         if (quality > -1 && levels.length > 1) {
@@ -185,6 +174,25 @@ const Model = function() {
         this.set('qualityLabel', label);
     };
 
+    this.setActiveItem = function (item, index) {
+        this.resetItem(item);
+        this.attributes.playlistItem = null;
+        this.set('item', index);
+        this.set('minDvrWindow', item.minDvrWindow);
+        this.set('playlistItem', item);
+        this.trigger('itemReady', item);
+    };
+
+    this.setMediaModel = function (mediaModel) {
+        if (this.mediaModel) {
+            this.mediaModel.off();
+        }
+
+        this.mediaModel = mediaModel;
+        this.set('mediaModel', mediaModel);
+        syncPlayerWithMediaModel(mediaModel);
+    };
+
     this.setCurrentAudioTrack = function(currentTrack, tracks) {
         if (currentTrack > -1 && tracks.length > 0 && currentTrack < tracks.length) {
             this.mediaModel.set('currentAudioTrack', parseInt(currentTrack));
@@ -196,86 +204,8 @@ const Model = function() {
         _provider.setContainer(container);
     };
 
-    this.changeVideoProvider = function(Provider) {
-        this.off('change:mediaContainer', this.onMediaContainer);
-
-        if (_provider) {
-            _provider.off(null, null, this);
-            if (_provider.getContainer()) {
-                _provider.remove();
-            }
-            delete _provider.instreamMode;
-        }
-
-        if (!Provider) {
-            this.resetProvider();
-            this.set('provider', undefined);
-            return;
-        }
-
-        _provider = new Provider(_this.get('id'), _this.getConfiguration());
-
-        var container = this.get('mediaContainer');
-        if (container) {
-            _provider.setContainer(container);
-        } else {
-            this.once('change:mediaContainer', this.onMediaContainer);
-        }
-
-        if (_provider.getName().name.indexOf('flash') === -1) {
-            this.set('flashThrottle', undefined);
-            this.set('flashBlocked', false);
-        }
-
-        _provider.volume(_this.get('volume'));
-
-        // Mute the video if autostarting on mobile, except for Android SDK. Otherwise, honor the model's mute value
-        const isAndroidSdk = _this.get('sdkplatform') === 1;
-        _provider.mute((this.autoStartOnMobile() && !isAndroidSdk) || _this.get('mute'));
-
-        _provider.on('all', _videoEventHandler, this);
-
-        // Attempt setting the playback rate to be the user selected value
-        this.setPlaybackRate(this.get('defaultPlaybackRate'));
-
-        // Set playbackRate because provider support for playbackRate may have changed and not sent an update
-        this.set('playbackRate', _provider.getPlaybackRate());
-
-        if (this.get('instreamMode') === true) {
-            _provider.instreamMode = true;
-        }
-
-        this.set('renderCaptionsNatively', _provider.renderNatively);
-    };
-
     this.checkComplete = function() {
         return _beforecompleted;
-    };
-
-    this.detachMedia = function() {
-        thenPlayPromise.cancel();
-        _attached = false;
-        if (_provider) {
-            _provider.off('all', _videoEventHandler, this);
-            _provider.detachMedia();
-        }
-    };
-
-    this.attachMedia = function() {
-        _attached = true;
-        if (_provider) {
-            _provider.off('all', _videoEventHandler, this);
-            _provider.on('all', _videoEventHandler, this);
-        }
-        if (_beforecompleted) {
-            this.playbackComplete();
-        }
-        if (_provider) {
-            _provider.attachMedia();
-        }
-
-        // Restore the playback rate to the provider in case it changed while detached and we reused a video tag.
-        this.setPlaybackRate(this.get('defaultPlaybackRate'));
     };
 
     this.playbackComplete = function() {
@@ -304,114 +234,8 @@ const Model = function() {
         }
     };
 
-    // Give the option for a provider to be forced
-    this.chooseProvider = function(source) {
-        // if _providers.choose is null, something went wrong in filtering
-        return _providers.choose(source).provider;
-    };
-
-    this.setItemIndex = function(index) {
-        const playlist = this.get('playlist');
-        const length = playlist.length;
-
-        // If looping past the end, or before the beginning
-        index = parseInt(index, 10) || 0;
-        index = (index + length) % length;
-
-        this.set('item', index);
-        return this.setActiveItem(playlist[index]);
-    };
-
-    this.setActiveItem = function(item) {
-        thenPlayPromise.cancel();
-        // Item is actually changing
-        this.mediaModel.off();
-        this.mediaModel = new MediaModel();
-        resetItem(this, item);
-        this.set('minDvrWindow', item.minDvrWindow);
-        this.set('mediaModel', this.mediaModel);
-        this.attributes.playlistItem = null;
-        this.set('playlistItem', item);
-        providerPromise = this.setProvider(item);
-        return providerPromise;
-    };
-
-    function resetItem(model, item) {
-        const position = item ? seconds(item.starttime) : 0;
-        const duration = item ? seconds(item.duration) : 0;
-        const mediaModelState = model.mediaModel.attributes;
-        model.mediaModel.srcReset();
-        mediaModelState.position = position;
-        mediaModelState.duration = duration;
-
-        model.set('playRejected', false);
-        model.set('itemMeta', {});
-        model.set('position', position);
-        model.set('duration', duration);
-    }
-
-    this.setProvider = function(item) {
-        const source = item && item.sources && item.sources[0];
-        if (source === undefined) {
-            // source is undefined when resetting index with empty playlist
-            throw new Error('No media');
-        }
-
-        const Provider = this.chooseProvider(source);
-        // If we are changing video providers
-        if (!Provider || !(_provider && _provider instanceof Provider)) {
-            // Replace the video tag for the next provider
-            if (_provider) {
-                replaceMediaElement(this);
-            }
-            this.changeVideoProvider(Provider);
-        }
-
-        if (!_provider) {
-            this.set(PLAYER_STATE, STATE_BUFFERING);
-            const mediaModelContext = this.mediaModel;
-            return loadProvidersForPlaylist(this).then(() => {
-                if (mediaModelContext === this.mediaModel) {
-                    syncPlayerWithMediaModel(mediaModelContext);
-                    // Verify that we have a provider class for this source
-                    if (this.chooseProvider(source)) {
-                        return this.setProvider(item);
-                    }
-                }
-            });
-        }
-
-        // this allows the providers to preload
-        if (_provider.init) {
-            _provider.init(item);
-        }
-
-        // Set the Provider after calling init because some Provider properties are only set afterwards
-        this.set('provider', _provider.getName());
-
-        // Listening for change:item won't suffice when loading the same index or file
-        // We also can't listen for change:mediaModel because it triggers whether or not
-        //  an item was actually loaded
-        this.trigger('itemReady', item);
-        return resolved;
-    };
-
-    function replaceMediaElement(model) {
-        // Replace click-to-play media element, and call .load() to unblock user-gesture to play requirement
-        const lastMediaElement = model.attributes.mediaElement;
-        const mediaElement =
-            model.attributes.mediaElement = getMediaElement();
-        mediaElement.volume = lastMediaElement.volume;
-        mediaElement.muted = lastMediaElement.muted;
-        mediaElement.load();
-    }
-
     this.getProviders = function() {
-        return _providers;
-    };
-
-    this.resetProvider = function() {
-        _provider = null;
+        return providerController.allProviders();
     };
 
     this.setVolume = function(volume) {
@@ -452,8 +276,18 @@ const Model = function() {
         }
     };
 
+    this.setProvider = function (provider) {
+        _provider = provider;
+        syncProviderProperties(this, provider);
+    };
+
+    this.resetProvider = function () {
+        _provider = null;
+        this.set('provider', undefined);
+    };
+
     this.setPlaybackRate = function(playbackRate) {
-        if (!_attached || !_.isNumber(playbackRate)) {
+        if (!this.get('attached') || !_.isNumber(playbackRate)) {
             return;
         }
 
@@ -469,138 +303,6 @@ const Model = function() {
         if (_provider && _provider.setPlaybackRate) {
             _provider.setPlaybackRate(playbackRate);
         }
-    };
-
-    function loadAndPlay(model, item) {
-        thenPlayPromise.cancel();
-
-        const mediaModelContext = model.mediaModel;
-
-        mediaModelContext.set('setup', true);
-        if (_provider) {
-            return playWithProvider(item);
-        }
-
-        thenPlayPromise = cancelable(() => {
-            if (mediaModelContext === model.mediaModel) {
-                return playWithProvider(item);
-            }
-            throw new Error('Playback cancelled.');
-        });
-        return providerPromise.catch(error => {
-            thenPlayPromise.cancel();
-            // Required provider was not loaded
-            model.trigger(ERROR, {
-                message: `Could not play video: ${error.message}`,
-                error: error
-            });
-            // Fail the playPromise to trigger "playAttemptFailed"
-            throw error;
-        }).then(thenPlayPromise.async);
-    }
-
-    function playWithProvider(item) {
-        // Calling load() on Shaka may return a player setup promise
-        const providerSetupPromise = _provider.load(item);
-        if (providerSetupPromise) {
-            thenPlayPromise = cancelable(() => {
-                return _provider.play() || resolved;
-            });
-            return providerSetupPromise.then(thenPlayPromise.async);
-        }
-        return _provider.play() || resolved;
-    }
-
-    function playAttempt(model, playPromise, playReason) {
-        const mediaModelContext = model.mediaModel;
-        const itemContext = model.get('playlistItem');
-
-        model.mediaController.trigger(MEDIA_PLAY_ATTEMPT, {
-            item: itemContext,
-            playReason: playReason
-        });
-
-        // Immediately set player state to buffering if these conditions are met
-        const videoTagUnpaused = _provider && _provider.video && !_provider.video.paused;
-        if (videoTagUnpaused) {
-            model.set(PLAYER_STATE, STATE_BUFFERING);
-        }
-
-        playPromise.then(() => {
-            if (!mediaModelContext.get('setup')) {
-                // Exit if model state was reset
-                return;
-            }
-            mediaModelContext.set('started', true);
-            if (mediaModelContext === model.mediaModel) {
-                syncPlayerWithMediaModel(mediaModelContext);
-            }
-        }).catch(error => {
-            model.set('playRejected', true);
-            const videoTagPaused = _provider && _provider.video && _provider.video.paused;
-            if (videoTagPaused) {
-                mediaModelContext.set(PLAYER_STATE, STATE_PAUSED);
-            }
-            model.mediaController.trigger(MEDIA_PLAY_ATTEMPT_FAILED, {
-                error: error,
-                item: itemContext,
-                playReason: playReason
-            });
-        });
-    }
-
-    function syncPlayerWithMediaModel(mediaModel) {
-        // Sync player state with mediaModel state
-        const mediaState = mediaModel.get('state');
-        mediaModel.trigger('change:state', mediaModel, mediaState, mediaState);
-    }
-
-    this.stopVideo = function() {
-        thenPlayPromise.cancel();
-        const item = this.get('playlist')[this.get('item')];
-        this.attributes.playlistItem = item;
-        resetItem(this, item);
-        if (_provider) {
-            _provider.stop();
-        }
-    };
-
-    this.preloadVideo = function() {
-        const item = this.get('playlistItem');
-        // Only attempt to preload if media is attached and hasn't been loaded
-        if (this.get('state') === 'idle' && _attached && _provider &&
-            item.preload !== 'none' &&
-            this.get('autostart') === false &&
-            !this.mediaModel.get('setup') &&
-            !this.mediaModel.get('preloaded')) {
-            this.mediaModel.set('preloaded', true);
-            _provider.preload(item);
-        }
-    };
-
-    this.playVideo = function(playReason) {
-        const item = this.get('playlistItem');
-        if (!item) {
-            return;
-        }
-
-        if (!playReason) {
-            playReason = this.get('playReason');
-        }
-
-        let playPromise;
-
-        this.set('playRejected', false);
-        if (!this.mediaModel.get('setup')) {
-            playPromise = loadAndPlay(this, item);
-            playAttempt(this, playPromise, playReason);
-        } else {
-            playPromise = _provider.play() || resolved;
-            if (!this.mediaModel.get('started')) {
-                playAttempt(this, playPromise, playReason);
-            }
-        }
-        return playPromise;
     };
 
     this.persistCaptionsTrack = function() {
@@ -623,10 +325,6 @@ const Model = function() {
          */
         if (trackIndex && tracks && trackIndex <= tracks.length && tracks[trackIndex - 1].data) {
             this.set('captionsTrack', tracks[trackIndex - 1]);
-        }
-
-        if (_provider && _provider.setSubtitlesTrack) {
-            _provider.setSubtitlesTrack(trackIndex);
         }
     };
 
@@ -670,7 +368,47 @@ const Model = function() {
         }
         this.set('playOnViewable', autoStartOnMobile || this.get('autostart') === 'viewable');
     };
+
+    this.resetItem = function (item) {
+        const position = item ? seconds(item.starttime) : 0;
+        const duration = item ? seconds(item.duration) : 0;
+        this.set('playRejected', false);
+        this.set('itemMeta', {});
+        this.set('position', position);
+        this.set('duration', duration);
+    };
+
+    this.setThenPlayPromise = function (promise) {
+        thenPlayPromise.cancel();
+        thenPlayPromise = promise;
+    };
 };
+
+const syncProviderProperties = (model, provider) => {
+    model.set('provider', provider.getName());
+
+    provider.volume(model.get('volume'));
+    // Mute the video if autostarting on mobile, except for Android SDK. Otherwise, honor the model's mute value
+    const isAndroidSdk = model.get('sdkplatform') === 1;
+    provider.mute((model.autoStartOnMobile() && !isAndroidSdk) || model.get('mute'));
+    if (model.get('instreamMode') === true) {
+        provider.instreamMode = true;
+    }
+
+    if (provider.getName().name.indexOf('flash') === -1) {
+        model.set('flashThrottle', undefined);
+        model.set('flashBlocked', false);
+    }
+    // Set playbackRate because provider support for playbackRate may have changed and not sent an update
+    model.set('playbackRate', provider.getPlaybackRate());
+    model.set('renderCaptionsNatively', provider.renderNatively);
+};
+
+function syncPlayerWithMediaModel(mediaModel) {
+    // Sync player state with mediaModel state
+    const mediaState = mediaModel.get('state');
+    mediaModel.trigger('change:state', mediaModel, mediaState, mediaState);
+}
 
 // Represents the state of the provider/media element
 const MediaModel = Model.MediaModel = function() {
@@ -691,4 +429,5 @@ Object.assign(MediaModel.prototype, SimpleModel, {
 
 Object.assign(Model.prototype, SimpleModel);
 
+export { MediaModel };
 export default Model;

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -84,7 +84,6 @@ const Model = function() {
                 return;
             case PLAYER_STATE: {
                 if (data.newstate === STATE_IDLE) {
-                    // TODO: cancel promise in PC
                     thenPlayPromise.cancel();
                     mediaModel.srcReset();
                 }
@@ -98,7 +97,6 @@ const Model = function() {
                 //  Instead letting the master controller do so
                 return;
             case MEDIA_ERROR:
-                // TODO: cancel promise in PC
                 thenPlayPromise.cancel();
                 mediaModel.srcReset();
                 break;

--- a/src/js/events/events.js
+++ b/src/js/events/events.js
@@ -398,3 +398,4 @@ export const INSTREAM_CLICK = 'instreamClick';
  * Triggered when the player is resized to a width in a different breakpoint category.
 */
 export const BREAKPOINT = 'breakpoint';
+

--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -1,0 +1,216 @@
+import cancelable from 'utils/cancelable';
+import { resolved } from 'polyfills/promise';
+import { MediaModel } from 'controller/model';
+import { seconds } from 'utils/strings';
+
+import { MEDIA_PLAY_ATTEMPT, MEDIA_PLAY_ATTEMPT_FAILED, PLAYER_STATE,
+    STATE_PAUSED, STATE_BUFFERING, STATE_IDLE } from 'events/events';
+
+export default class MediaController {
+    constructor(provider, model) {
+        this.provider = provider;
+        this.model = model;
+        this.mediaModel = null;
+        this.attached = true;
+    }
+
+    init(item) {
+        const { model, provider } = this;
+        provider.init(item);
+        provider.setState(STATE_IDLE);
+        const mediaModel = this.mediaModel = new MediaModel();
+        const position = item ? seconds(item.starttime) : 0;
+        const duration = item ? seconds(item.duration) : 0;
+        const mediaModelState = mediaModel.attributes;
+        mediaModel.srcReset();
+        mediaModelState.position = position;
+        mediaModelState.duration = duration;
+        model.setProvider(provider);
+        model.setMediaModel(mediaModel);
+    }
+
+    reset() {
+        this.mediaModel = null;
+    }
+
+    play(item, playReason) {
+        const { model, mediaModel, provider } = this;
+
+        if (!playReason) {
+            playReason = model.get('playReason');
+        }
+
+        model.set('playRejected', false);
+        let playPromise = resolved;
+        if (mediaModel.get('setup')) {
+            playPromise = provider.play();
+        } else {
+            playPromise = loadAndPlay(item, provider, model);
+            mediaModel.set('setup', true);
+            if (!mediaModel.get('started')) {
+                playAttempt(playPromise, model, playReason, provider);
+            }
+        }
+        return playPromise;
+    }
+
+    stop() {
+        const { provider } = this;
+        provider.stop();
+    }
+
+    pause() {
+        this.provider.pause();
+    }
+
+    preload(item) {
+        const { mediaModel, provider } = this;
+        mediaModel.set('preloaded', true);
+        provider.preload(item);
+    }
+
+    destroy() {
+        const { provider, model } = this;
+
+        provider.off(null, null, model);
+        if (provider.getContainer()) {
+            provider.remove();
+        }
+        delete provider.instreamMode;
+        this.provider = null;
+    }
+
+    attach() {
+        const { model, provider } = this;
+        this.attached = true;
+        model.set('attached', true);
+
+        provider.off('all', model.videoEventHandler, model);
+        provider.on('all', model.videoEventHandler, model);
+
+        if (model.checkComplete) {
+            model.playbackComplete();
+        }
+
+        provider.attachMedia();
+
+        // Restore the playback rate to the provider in case it changed while detached and we reused a video tag.
+        model.setPlaybackRate(model.get('defaultPlaybackRate'));
+    }
+
+    detach() {
+        const { model, provider } = this;
+        this.attached = false;
+        model.set('attached', false);
+
+        model.setThenPlayPromise(cancelable(() => {}));
+        provider.off('all', model.videoEventHandler, model);
+        provider.detachMedia();
+    }
+
+    get audioTrack() {
+        return this.provider.getCurrentAudioTrack();
+    }
+
+    get quality() {
+        return this.provider.getCurrentQuality();
+    }
+
+    get audioTracks() {
+        return this.provider.getAudioTracks();
+    }
+
+    get preloaded() {
+        return this.mediaModel.get('preloaded');
+    }
+
+    get qualities() {
+        return this.provider.getQualityLevels();
+    }
+
+    get setup() {
+        return this.mediaModel && this.mediaModel.get('setup');
+    }
+
+    set audioTrack(index) {
+        this.provider.setCurrentAudioTrack(index);
+    }
+
+    set controls(mode) {
+        this.provider.setControls(mode);
+    }
+
+    set position(pos) {
+        this.provider.seek(pos);
+    }
+
+    set quality(index) {
+        this.provider.setCurrentQuality(index);
+    }
+
+    set subtitles(index) {
+        if (this.provider.setSubtitlesTrack) {
+            this.provider.setSubtitlesTrack(index);
+        }
+    }
+}
+
+function loadAndPlay(item, provider, model) {
+    // Calling load() on Shaka may return a player setup promise
+    const providerSetupPromise = provider.load(item);
+    if (providerSetupPromise) {
+        const thenPlayPromise = cancelable(() => {
+            return provider.play() || resolved;
+        });
+        model.setThenPlayPromise(thenPlayPromise);
+        return providerSetupPromise.then(thenPlayPromise.async);
+    }
+    return provider.play() || resolved;
+}
+
+// Executes the playPromise
+function playAttempt(playPromise, model, playReason, provider) {
+    const mediaModelContext = model.mediaModel;
+    const itemContext = model.get('playlistItem');
+
+    model.mediaController.trigger(MEDIA_PLAY_ATTEMPT, {
+        item: itemContext,
+        playReason: playReason
+    });
+
+    // Immediately set player state to buffering if these conditions are met
+    const videoTagUnpaused = provider && provider.video && !provider.video.paused;
+    if (videoTagUnpaused) {
+        model.set(PLAYER_STATE, STATE_BUFFERING);
+    }
+
+    playPromise.then(() => {
+        if (!mediaModelContext.get('setup')) {
+            // Exit if model state was reset
+            return;
+        }
+        mediaModelContext.set('started', true);
+        if (mediaModelContext === model.mediaModel) {
+            syncPlayerWithMediaModel(mediaModelContext);
+        }
+    }).catch(error => {
+        model.set('playRejected', true);
+        const videoTagPaused = provider && provider.video && provider.video.paused;
+        if (videoTagPaused) {
+            mediaModelContext.set(PLAYER_STATE, STATE_PAUSED);
+        }
+        model.mediaController.trigger(MEDIA_PLAY_ATTEMPT_FAILED, {
+            error: error,
+            item: itemContext,
+            playReason: playReason
+        });
+    });
+}
+
+function syncPlayerWithMediaModel(mediaModel) {
+    // Sync player state with mediaModel state
+    const mediaState = mediaModel.get('state');
+    mediaModel.trigger('change:state', mediaModel, mediaState, mediaState);
+}
+
+

--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -4,7 +4,7 @@ import { MediaModel } from 'controller/model';
 import { seconds } from 'utils/strings';
 
 import { MEDIA_PLAY_ATTEMPT, MEDIA_PLAY_ATTEMPT_FAILED, PLAYER_STATE,
-    STATE_PAUSED, STATE_BUFFERING, STATE_IDLE } from 'events/events';
+    STATE_PAUSED, STATE_BUFFERING } from 'events/events';
 
 export default class MediaController {
     constructor(provider, model) {
@@ -17,7 +17,6 @@ export default class MediaController {
     init(item) {
         const { model, provider } = this;
         provider.init(item);
-        provider.setState(STATE_IDLE);
         const mediaModel = this.mediaModel = new MediaModel();
         const position = item ? seconds(item.starttime) : 0;
         const duration = item ? seconds(item.duration) : 0;

--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -17,7 +17,6 @@ export default class MediaController {
     init(item) {
         this.reset();
         const { model, provider, mediaModel } = this;
-        provider.init(item);
         const position = item ? seconds(item.starttime) : 0;
         const duration = item ? seconds(item.duration) : 0;
         const mediaModelState = mediaModel.attributes;
@@ -26,6 +25,8 @@ export default class MediaController {
         mediaModelState.duration = duration;
         model.setProvider(provider);
         model.setMediaModel(mediaModel);
+        // Initialize the provider last so it's setting properties on the (newly) active media model
+        provider.init(item);
     }
 
     reset() {

--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -60,7 +60,8 @@ export default class MediaController {
     }
 
     pause() {
-        this.provider.pause();
+        const { provider } = this;
+        provider.pause();
     }
 
     preload(item) {

--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -45,8 +45,8 @@ export default class MediaController {
         if (mediaModel.get('setup')) {
             playPromise = provider.play();
         } else {
-            playPromise = loadAndPlay(item, provider, model);
             mediaModel.set('setup', true);
+            playPromise = loadAndPlay(item, provider, model);
             if (!mediaModel.get('started')) {
                 playAttempt(playPromise, model, playReason, provider);
             }

--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -87,7 +87,7 @@ export default class MediaController {
         provider.off('all', model.videoEventHandler, model);
         provider.on('all', model.videoEventHandler, model);
 
-        if (model.checkComplete) {
+        if (model.checkComplete()) {
             model.playbackComplete();
         }
 

--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -8,16 +8,16 @@ import { MEDIA_PLAY_ATTEMPT, MEDIA_PLAY_ATTEMPT_FAILED, PLAYER_STATE,
 
 export default class MediaController {
     constructor(provider, model) {
-        this.provider = provider;
-        this.model = model;
-        this.mediaModel = null;
         this.attached = true;
+        this.mediaModel = new MediaModel();
+        this.model = model;
+        this.provider = provider;
     }
 
     init(item) {
-        const { model, provider } = this;
+        this.reset();
+        const { model, provider, mediaModel } = this;
         provider.init(item);
-        const mediaModel = this.mediaModel = new MediaModel();
         const position = item ? seconds(item.starttime) : 0;
         const duration = item ? seconds(item.duration) : 0;
         const mediaModelState = mediaModel.attributes;
@@ -29,7 +29,7 @@ export default class MediaController {
     }
 
     reset() {
-        this.mediaModel = null;
+        this.mediaModel = new MediaModel();
     }
 
     play(item, playReason) {

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -1,0 +1,314 @@
+import ProviderController from 'providers/provider-controller';
+import { resolved } from 'polyfills/promise';
+import getMediaElement from 'api/get-media-element';
+import cancelable from 'utils/cancelable';
+import MediaController from 'program/media-controller';
+
+import { ERROR, PLAYER_STATE, STATE_BUFFERING, STATE_IDLE } from 'events/events';
+
+export default class ProgramController {
+    constructor(model) {
+        this.mediaController = null;
+        this.model = model;
+        this.providerController = ProviderController(model.getConfiguration());
+        this.providerPromise = resolved;
+    }
+
+    setActiveItem(item, index) {
+        const { mediaController, model } = this;
+
+        model.setActiveItem(item, index);
+
+        const source = item && item.sources && item.sources[0];
+        if (source === undefined) {
+            return Promise.reject('No media');
+        }
+
+        if (mediaController) {
+            // Buffer between item switches, but remain in the initial state (IDLE) while loading the first provider
+            model.set(PLAYER_STATE, STATE_BUFFERING);
+            if (!this.providerController.canPlay(mediaController.provider, source)) {
+                // If we can't play the source with the current provider, reset the current one and
+                // prime the next tag within the gesture
+                this._destroyActiveMedia();
+            } else {
+                // We can reuse the current mediaController
+                // Reset it so that a play call before the providerPromise resolves doesn't cause problems
+                // Any play calls will wait for the mediaController to setup again before calling play
+                this.mediaController.reset();
+            }
+        }
+
+        const mediaModelContext = model.mediaModel;
+        this.providerPromise = this._loadProviderConstructor(source)
+            .then((ProviderConstructor) => {
+                // Don't do anything if we've tried to load another provider while this promise was resolving
+                if (mediaModelContext === model.mediaModel) {
+                    let nextProvider = mediaController && mediaController.provider;
+                    // Make a new provider if we don't already have one
+                    if (!nextProvider) {
+                        nextProvider = new ProviderConstructor(model.get('id'), model.getConfiguration());
+                        this._changeVideoProvider(nextProvider);
+                    }
+                    // Initialize the provider and mediaModel, sync it with the Model
+                    // This sets up the mediaController and allows playback to begin
+                    this.mediaController.init(item);
+                    return this.mediaController;
+                }
+            });
+        return this.providerPromise;
+    }
+
+    playVideo(playReason) {
+        const { mediaController, model } = this;
+        const item = model.get('playlistItem');
+        let playPromise;
+
+        if (!item) {
+            return;
+        }
+
+        if (!playReason) {
+            playReason = model.get('playReason');
+        }
+
+        // Setup means that we've already started playback on the current item; all we need to do is resume it
+        if (mediaController) {
+            playPromise = mediaController.play(item, playReason);
+        } else {
+            // Wait for the provider to load before starting initial playback
+            // Make the subsequent promise cancelable so that we can avoid playback when no longer wanted
+            const thenPlayPromise = cancelable((nextMediaController) => {
+                nextMediaController.play(item, playReason);
+            });
+            model.setThenPlayPromise(thenPlayPromise);
+            playPromise = this.providerPromise.then(thenPlayPromise.async);
+        }
+
+        return playPromise;
+    }
+
+    stopVideo() {
+        const { mediaController, model } = this;
+
+        const item = model.get('playlist')[model.get('item')];
+        model.attributes.playlistItem = item;
+        model.resetItem(item);
+
+        if (mediaController) {
+            mediaController.stop();
+        } else {
+            model.set(PLAYER_STATE, STATE_IDLE);
+        }
+    }
+
+    preloadVideo() {
+        const { mediaController, model } = this;
+        if (!mediaController) {
+            return;
+        }
+
+        const item = model.get('playlistItem');
+        if (!item || (item && item.preload === 'none')) {
+            return;
+        }
+
+        // Only attempt to preload if media hasn't been loaded and we haven't started, and it's attached
+        if (model.get('state') === 'idle'
+            && model.get('autostart') === false
+            && mediaController.attached
+            && !mediaController.setup
+            && !mediaController.preloaded) {
+            mediaController.preload(item);
+        }
+    }
+
+    pause() {
+        const { mediaController } = this;
+        if (!mediaController) {
+            return;
+        }
+
+        mediaController.pause();
+    }
+
+    castVideo(castProvider, item) {
+        this._changeVideoProvider(castProvider);
+        this.mediaController.init(item);
+    }
+
+    stopCast() {
+        this.stopVideo();
+        this.mediaController = null;
+    }
+
+    _changeVideoProvider(nextProvider) {
+        const { model } = this;
+        model.off('change:mediaContainer', model.onMediaContainer);
+
+        const container = model.get('mediaContainer');
+        if (container) {
+            nextProvider.setContainer(container);
+        } else {
+            model.once('change:mediaContainer', model.onMediaContainer);
+        }
+
+        // TODO: Split into the mediaController
+        nextProvider.on('all', model.videoEventHandler, model);
+        // Attempt setting the playback rate to be the user selected value
+        model.setPlaybackRate(model.get('defaultPlaybackRate'));
+
+        this.mediaController = new MediaController(nextProvider, model);
+    }
+
+    _loadProviderConstructor(source) {
+        const { model, mediaController, providerController } = this;
+
+        let ProviderConstructor = providerController.choose(source);
+        if (ProviderConstructor) {
+            return Promise.resolve(ProviderConstructor);
+        }
+
+        return providerController.loadProviders(model.get('playlist'))
+            .then(() => {
+                ProviderConstructor = providerController.choose(source);
+                // The provider we need couldn't be loaded
+                if (!ProviderConstructor) {
+                    if (mediaController) {
+                        mediaController.destroy();
+                        model.resetProvider();
+                        this.mediaController = null;
+                    }
+                    const message = 'Could not load provider for playlist';
+                    model.trigger(ERROR, {
+                        message
+                    });
+                    throw Error(message);
+                }
+                return ProviderConstructor;
+            });
+    }
+
+    _destroyActiveMedia() {
+        const { model } = this;
+
+        this.mediaController.destroy();
+        this.mediaController = null;
+        model.resetProvider();
+        replaceMediaElement(model);
+    }
+
+    get activeProvider() {
+        const { mediaController } = this;
+        if (!mediaController) {
+            return null;
+        }
+
+        return mediaController.provider;
+    }
+
+    get audioTrack() {
+        const { mediaController } = this;
+        if (!mediaController) {
+            return -1;
+        }
+
+        return mediaController.audioTrack;
+    }
+
+    get audioTracks() {
+        const { mediaController } = this;
+        if (!mediaController) {
+            return;
+        }
+
+        return mediaController.audioTracks;
+    }
+
+    get quality() {
+        if (!this.mediaController) {
+            return -1;
+        }
+
+        return this.mediaController.quality;
+    }
+
+    get qualities() {
+        const { mediaController } = this;
+        if (!mediaController) {
+            return null;
+        }
+
+        return mediaController.qualities;
+    }
+
+    set attached(value) {
+        const { mediaController } = this;
+        if (!mediaController) {
+            return;
+        }
+
+        if (value) {
+            mediaController.attach();
+        } else {
+            mediaController.detach();
+        }
+    }
+
+    set audioTrack(index) {
+        const { mediaController } = this;
+        if (!mediaController) {
+            return;
+        }
+
+        mediaController.audioTrack = parseInt(index, 10) || 0;
+    }
+
+    set controls(mode) {
+        const { mediaController } = this;
+        if (!mediaController) {
+            return;
+        }
+
+        mediaController.controls = mode;
+    }
+
+    set position(pos) {
+        const { mediaController } = this;
+        if (!mediaController) {
+            return;
+        }
+
+        mediaController.position = pos;
+    }
+
+    set quality(index) {
+        const { mediaController } = this;
+        if (!mediaController) {
+            return;
+        }
+
+        mediaController.currentQuality = parseInt(index, 10) || 0;
+    }
+
+    set subtitles(index) {
+        const { mediaController } = this;
+        if (!mediaController) {
+            return;
+        }
+
+        mediaController.subtitles = index;
+    }
+}
+
+function replaceMediaElement(model) {
+    // Replace click-to-play media element, and call .load() to unblock user-gesture to play requirement
+    const lastMediaElement = model.attributes.mediaElement;
+    const mediaElement =
+        model.attributes.mediaElement = getMediaElement();
+    mediaElement.volume = lastMediaElement.volume;
+    mediaElement.muted = lastMediaElement.muted;
+    mediaElement.load();
+}
+
+

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -169,7 +169,6 @@ export default class ProgramController {
             model.once('change:mediaContainer', model.onMediaContainer);
         }
 
-        // TODO: Split into the mediaController
         nextProvider.on('all', model.videoEventHandler, model);
         // Attempt setting the playback rate to be the user selected value
         model.setPlaybackRate(model.get('defaultPlaybackRate'));

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -73,7 +73,7 @@ export default class ProgramController {
         }
 
         // Setup means that we've already started playback on the current item; all we need to do is resume it
-        if (mediaController) {
+        if (mediaController && mediaController.setup) {
             playPromise = mediaController.play(item, playReason);
         } else {
             // Wait for the provider to load before starting initial playback

--- a/src/js/providers/provider-controller.js
+++ b/src/js/providers/provider-controller.js
@@ -9,7 +9,6 @@ export default function ProviderController(initialConfig) {
             return providers.choose(source).provider;
         },
         canPlay(_provider, source) {
-            // TODO: Make new method to determine if the current provider can play a source
             const ProviderConstructor = this.choose(source);
             return ProviderConstructor && (_provider && _provider instanceof ProviderConstructor);
         },

--- a/src/js/providers/provider-controller.js
+++ b/src/js/providers/provider-controller.js
@@ -1,0 +1,30 @@
+import Providers from 'providers/providers';
+
+export default function ProviderController(initialConfig) {
+    let config = initialConfig;
+    let providers = new Providers(config);
+
+    return {
+        choose(source) {
+            return providers.choose(source).provider;
+        },
+        canPlay(_provider, source) {
+            // TODO: Make new method to determine if the current provider can play a source
+            const ProviderConstructor = this.choose(source);
+            return ProviderConstructor && (_provider && _provider instanceof ProviderConstructor);
+        },
+        make(id, source) {
+            const Provider = this.choose(source);
+            if (!Provider) {
+                return null;
+            }
+            return new Provider(id, config);
+        },
+        loadProviders(playlist) {
+            return providers.load(providers.required(playlist));
+        },
+        allProviders() {
+            return providers;
+        }
+    };
+}

--- a/src/js/providers/providers.js
+++ b/src/js/providers/providers.js
@@ -42,7 +42,7 @@ Object.assign(Providers.prototype, {
                 const item = playlist[i];
                 const source = item.sources[0];
                 if (source) {
-                    const supported = this.providerSupports(provider, item.sources[0]);
+                    const supported = this.providerSupports(provider, source);
                     if (supported) {
                         playlist.splice(i, 1);
                     }

--- a/src/js/providers/providers.js
+++ b/src/js/providers/providers.js
@@ -40,11 +40,14 @@ Object.assign(Providers.prototype, {
             let loadProvider = false;
             for (let i = playlist.length; i--;) {
                 const item = playlist[i];
-                const supported = this.providerSupports(provider, item.sources[0]);
-                if (supported) {
-                    playlist.splice(i, 1);
+                const source = item.sources[0];
+                if (source) {
+                    const supported = this.providerSupports(provider, item.sources[0]);
+                    if (supported) {
+                        playlist.splice(i, 1);
+                    }
+                    loadProvider = loadProvider || supported;
                 }
-                loadProvider = loadProvider || supported;
             }
             return loadProvider;
         });


### PR DESCRIPTION
### This PR will...
Builds on top of https://github.com/jwplayer/jwplayer/pull/2512, but goes further. This PR takes the Provider loading/switching logic out of the Model and into the Program Controller. It manages the provider promise. Additionally, this PR introduces the Media controller, which is responsible for controlling the provider. It manages the play promise.

The bulk of this work separates provider control into a promise chain. The chain roughly goes:

Load providers -> check providers -> change provider OR reload current provider

But we need to prime the next video tag (if necessary) synchronously, so that's found outside of it. The code right now looks a little bit messy but that's fine - we'll be migrating this logic into a new module soon. The `provider-controller` looks a bit slim so I may delete it, but it's purpose was to remove the other provider modules from the Model.

### Why is this Pull Request needed?
The Program Controller will be doing the background loading work in the future. In order to background load, we need to be able to load a Provider independent of setting it as active. While the current iteration of this module does not do that, it makes it much more straightforward - the promise chains needed to load and have been separated. Playback was tangled up as a child of loading - in order to flatten it out (and thus making the promise chain extensible) I separated playback logic into the Media Controller.


### Are there any points in the code the reviewer needs to double check?
Everything

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/4299

#### Addresses Issue(s):

JW8-42

