### PR TITLE
Trigger _stateUpdate in _stateHandler if state is idle and autostart

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -711,7 +711,7 @@ function View(_api, _model) {
         }
 
         cancelAnimationFrame(_stateClassRequestId);
-        if (_playerState === STATE_PLAYING) {
+        if (_playerState === STATE_PLAYING || (_playerState === STATE_IDLE && _model.get('autostart'))) {
             _stateUpdate(_playerState);
         } else {
             _stateClassRequestId = requestAnimationFrame(() => _stateUpdate(_playerState));


### PR DESCRIPTION
### This PR will...

Show poster images on audio streams that auto start.

### Why is this Pull Request needed?

setPosterImage wasn't being called when autostart was set to true because the stream was never in the valid states to set the poster image (idle, complete)

#### Addresses Issue(s):

JW8-859


