### PR TITLE
Set correct default values for cues

### DIFF
--- a/src/js/parsers/captions/vttcue.js
+++ b/src/js/parsers/captions/vttcue.js
@@ -73,12 +73,11 @@ if (!VTTCue) {
         let _region = null;
         let _vertical = '';
         let _snapToLines = true;
-        let _line = 'auto';
+        let _line = autoKeyword;
         let _lineAlign = 'start';
-        let _position = 50;
-        let _positionAlign = 'middle';
-        let _size = 50;
-        let _align = 'middle';
+        let _position = autoKeyword;
+        let _size = 100;
+        let _align = 'center';
 
         Object.defineProperty(cue, 'id', {
             enumerable: true,
@@ -216,21 +215,6 @@ if (!VTTCue) {
                     throw new Error('Position must be between 0 and 100.');
                 }
                 _position = value;
-                this.hasBeenReset = true;
-            }
-        });
-
-        Object.defineProperty(cue, 'positionAlign', {
-            enumerable: true,
-            get: function () {
-                return _positionAlign;
-            },
-            set: function (value) {
-                const setting = findAlignSetting(value);
-                if (!setting) {
-                    throw new SyntaxError('An invalid or illegal string was specified.');
-                }
-                _positionAlign = setting;
                 this.hasBeenReset = true;
             }
         });

--- a/src/js/polyfills/webvtt.js
+++ b/src/js/polyfills/webvtt.js
@@ -453,7 +453,7 @@ function CueStyleBox(window, cue) {
             break;
         case 'middle':
         case 'center':
-            textPos = cue.position - (cue.size / 2);
+            textPos = (cue.position === 'auto' ? 50 : cue.position) - (cue.size / 2);
             break;
         case 'end':
         case 'right':


### PR DESCRIPTION
### What does this Pull Request do?
- Set the correct defaults for cues. 
- Remove unused positionAlign property.
- Normalize `textPos` value when rendering VTTCues based on the `cue.position` value if text is centered
### Why is this Pull Request needed?
In IE/Edge, where the `VTTCue` interface is polyfilled, cues were being created with the following defaults:
```
position: 50,
size: 50
```
This caused incorrect positioning of 608 captions that should be centered on the screen. The default value for these properties in browsers where the VTTCue interface exists is:
```
position: 'auto',
size: 100
```

Additionally, browsers expect the `align` value to be `'center'`  (except Safari, where it is `'middle'`), which is what is in the [WebVTT spec](https://www.w3.org/TR/webvtt1/#webvtt-cue-center-alignment). `VTTCue` isn't polyfilled in Safari anyway, so it's unaffected by this change.
### Are there any points in the code the reviewer needs to double check?
No.
### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/hls.js/pull/128
#### Addresses Issue(s):
JW8-205


