### PR TITLE
Reverted default align value. alignSetting expects it to be 'middle'

### DIFF
--- a/src/js/parsers/captions/vttcue.js
+++ b/src/js/parsers/captions/vttcue.js
@@ -77,7 +77,7 @@ if (!VTTCue) {
         let _lineAlign = 'start';
         let _position = autoKeyword;
         let _size = 100;
-        let _align = 'center';
+        let _align = 'middle';
 
         Object.defineProperty(cue, 'id', {
             enumerable: true,


### PR DESCRIPTION
### What does this Pull Request do?
Revert the default align value since alignSetting expects it to be 'middle'.
### Why is this Pull Request needed?
Changing align to middle caused exceptions when parsing captions.
### Are there any points in the code the reviewer needs to double check?
No.
### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/hls.js/pull/129
#### Addresses Issue(s):
JW8-205

