### PR TITLE
Enable reusing getConfig test in Commercial

### DIFF
--- a/test/unit/api-get-config-test.js
+++ b/test/unit/api-get-config-test.js
@@ -7,7 +7,7 @@ import {
 } from 'mock/video-element-polyfill';
 import _ from 'underscore';
 
-describe('Api.getConfig', function() {
+const getConfigTest = function(modelProperties) {
 
     before(installVideoPolyfill);
 
@@ -51,7 +51,9 @@ describe('Api.getConfig', function() {
             }
         });
     });
-});
+};
+
+describe('Api.getConfig', () => getConfigTest(modelProperties));
 
 function getTypeOf(value) {
     if (value === null) {
@@ -68,3 +70,5 @@ function getTypeOf(value) {
     }
     return typeof value;
 }
+
+export default getConfigTest;

--- a/test/unit/api-get-config-test.js
+++ b/test/unit/api-get-config-test.js
@@ -7,7 +7,7 @@ import {
 } from 'mock/video-element-polyfill';
 import _ from 'underscore';
 
-const getConfigTest = function(modelProperties) {
+const testGetConfig = function(modelProperties) {
 
     before(installVideoPolyfill);
 
@@ -53,7 +53,7 @@ const getConfigTest = function(modelProperties) {
     });
 };
 
-describe('Api.getConfig', () => getConfigTest(modelProperties));
+describe('Api.getConfig', () => testGetConfig(modelProperties));
 
 function getTypeOf(value) {
     if (value === null) {
@@ -71,4 +71,4 @@ function getTypeOf(value) {
     return typeof value;
 }
 
-export default getConfigTest;
+export default testGetConfig;


### PR DESCRIPTION
### This PR will...
make getConfig test reusable
### Why is this Pull Request needed?
to reuse this test in commercial
### Are there any points in the code the reviewer needs to double check?
This works, but I'm not sure if it's the best approach to making a test reusable
### Are there any Pull Requests open in other repos which need to be merged with this?
Needed for https://github.com/jwplayer/jwplayer-commercial/pull/4314
#### Addresses Issue(s):
JW8-819

