### PR TITLE
Set poster image on audio only streams where autostart is true

### DIFF
--- a/src/js/view/preview.js
+++ b/src/js/view/preview.js
@@ -6,7 +6,7 @@ const Preview = function(_model) {
 };
 
 function validState(state) {
-    return state === 'complete' || state === 'idle' || state === 'error';
+    return state === 'complete' || state === 'idle' || state === 'error' || state === 'buffering';
 }
 
 Object.assign(Preview.prototype, {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -679,6 +679,12 @@ function View(_api, _model) {
         // Put the preview element before the media element in order to display browser captions
         // otherwise keep it on top of the media element to display captions with the captions renderer
         _playerElement.insertBefore(_preview.el, element);
+
+        if (isAudioFile && _model.get('autostart')) {
+            setPosterImage(_model);
+        }
+
+
     }
 
     function _errorHandler(model, evt) {
@@ -711,7 +717,7 @@ function View(_api, _model) {
         }
 
         cancelAnimationFrame(_stateClassRequestId);
-        if (_playerState === STATE_PLAYING || (_playerState === STATE_IDLE && _model.get('autostart'))) {
+        if (_playerState === STATE_PLAYING) {
             _stateUpdate(_playerState);
         } else {
             _stateClassRequestId = requestAnimationFrame(() => _stateUpdate(_playerState));

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -683,8 +683,6 @@ function View(_api, _model) {
         if (isAudioFile && _model.get('autostart')) {
             setPosterImage(_model);
         }
-
-
     }
 
     function _errorHandler(model, evt) {


### PR DESCRIPTION
### This PR will...

Prevent poster images from being loaded on video streams where autostart is true.

### Why is this Pull Request needed?

Poster images should only be loaded for audio only streams where autostart is true.

### Are there any points in the code the reviewer needs to double check?

Had to set "buffering" as a valid state in the validState method in preview.js because thats the earliest the isAudioFile variable is set to true in the _onMediaTypeChange method and the setImage method in preview.js will exit if the state of the player isnt valid.

#### Addresses Issue(s):

JW8-875
