### PR TITLE
Improve view test code coverage

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -329,7 +329,10 @@ function View(_api, _model) {
                 ControlsLoader.load()
                     .then(function (Controls) {
                         ControlsModule = Controls;
-                        addControls();
+                        // Check that controls is still true after the loader promise resolves
+                        if (model.get('controls')) {
+                            addControls();
+                        }
                     })
                     .catch(function (reason) {
                         _this.trigger(ERROR, {
@@ -694,6 +697,7 @@ function View(_api, _model) {
         if (ErrorContainer.cloneIcon) {
             errorContainer.querySelector('.jw-icon').appendChild(ErrorContainer.cloneIcon('error'));
         }
+        _title.hide();
         _playerElement.appendChild(errorContainer.firstChild);
         toggleClass(_playerElement, 'jw-flag-audio-player', !!model.get('audioMode'));
     }

--- a/test/mock/mock-api.js
+++ b/test/mock/mock-api.js
@@ -1,4 +1,3 @@
-import _ from 'test/underscore';
 import Events from 'utils/backbone.events';
 import members from 'data/api-members';
 import methods from 'data/api-methods';
@@ -10,11 +9,11 @@ const MockApi = function() {
 
 const mockProto = {};
 
-_.each(methods, function(value, name) {
+Object.keys(methods).forEach(name => {
     mockProto[name] = noop;
 });
 
-_.each(chainable, function(value, name) {
+Object.keys(chainable).forEach(name => {
     mockProto[name] = noopChained;
 });
 

--- a/test/mock/mock-model.js
+++ b/test/mock/mock-model.js
@@ -5,7 +5,7 @@ import Events from 'utils/backbone.events';
 const MockModel = function() {};
 
 Object.assign(MockModel.prototype, SimpleModel, {
-    setup: function(configuration) {
+    setup(configuration) {
         const self = this;
         const playlistItem = Object.assign({
             file: '//playertest.longtailvideo.com/bunny.mp4',
@@ -34,7 +34,8 @@ Object.assign(MockModel.prototype, SimpleModel, {
                     file: 'http://content.bitsontherun.com/videos/q1fx20VZ-52qL9xLP.mp4',
                     image: 'http://content.bitsontherun.com/thumbs/3XnJSIm4-480.jpg'
                 }
-            ]
+            ],
+            playbackRateControls: true
         }, {});
 
         this.attributes = Object.assign({}, playerConfig, {
@@ -88,24 +89,26 @@ Object.assign(MockModel.prototype, SimpleModel, {
 
         this.attributes.provider = {
             name: 'html5',
-            getName: function() {
+            renderNatively: false,
+            supportsPlaybackRate: true,
+            getName() {
                 return {
                     name: 'html5'
                 };
             },
-            setContainer: function(/* element */) {
+            setContainer(/* element */) {
                 // element.appendChild(mediaElement[0]);
             },
-            setVisibility: function(state) {
+            setVisibility(state) {
                 mediaElement.style.visibility = state ? 'visible' : '';
                 mediaElement.style.opacity = state ? 1 : 0;
             },
-            seek: function(/* time */) {
+            seek(/* time */) {
                 // mediaElement[0].load();
                 // mediaElement[0].currentTime = time;
                 // mediaElement[0].pause();
             },
-            resize: function(width, height, stretching) {
+            resize(width, height, stretching) {
                 if (!width || !height || !mediaElement.videoWidth || !mediaElement.videoHeight) {
                     return false;
                 }
@@ -127,27 +130,32 @@ Object.assign(MockModel.prototype, SimpleModel, {
                 mediaElement.style.width = style.width;
                 mediaElement.style.height = style.height;
             },
-            setCurrentQuality: function(value) {
+            setCurrentQuality(value) {
                 self.mediaModel.set('currentLevel', value);
             },
-            setCurrentAudioTrack: function(value) {
+            setCurrentAudioTrack(value) {
                 self.mediaModel.set('currentAudioTrack', value);
             },
-            setControls: function() {}
+            setControls() {},
         };
     },
 
-    getVideo: function() {
+    getVideo() {
         return this.get('provider');
     },
 
-    autoStartOnMobile: function() {
+    autoStartOnMobile() {
         return false;
     },
 
-    setAutoStart: function() {
+    setAutoStart() {
         return false;
-    }
+    },
+
+    setPlaybackRate(rate) {
+        this.set('defaultPlaybackRate', rate);
+        this.set('playbackRate', rate);
+    },
 });
 
 // Represents the state of the provider/media element


### PR DESCRIPTION
### This PR will...

- Guard against `addControls` being called when `model.set('controls', false)` is done before controls are finished loading.
- Hide the player's title element when displaying an error, to fix the impact this element has on player size when new styles are injected by the error template (JW8-824)
- Update mock-model.js:
  - Added `setPlaybackRate()` and `playbackRateControls`

### Why is this Pull Request needed?

If `setControls` is toggled on and off synchronously before the controls are loaded, the promise that resolves should not add controls.

The player should not change size when in the error state. Our test configs are incomplete - see commercial changes (or add a title and description) to see reproduce the bug.

Mock-model is used by the view test and required updates.

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-commercial/pull/4325

#### Addresses Issue(s):

JW8-886, JW8-824 

