### PR TITLE
Set the poster image when necessary

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -739,7 +739,6 @@ function View(_api, _model) {
         }
         replaceClass(_playerElement, /jw-state-\S+/, 'jw-state-' + state);
 
-        _model.off('change:playlistItem', setPosterImage);
         switch (state) {
             case STATE_IDLE:
             case STATE_ERROR:
@@ -748,7 +747,7 @@ function View(_api, _model) {
                 // or when an error is encountered. We don't get to the idle state between playlist items because of RAF
 
                 if (_model.mediaModel.get('mediaType') === 'video') {
-                    _model.change('playlistItem', setPosterImage);
+                    setPosterImage(_model);
                 }
 
                 if (_captionsRenderer) {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -668,10 +668,15 @@ function View(_api, _model) {
         _controls.userActive();
     }
 
-    function _onMediaTypeChange(model, val) {
+    function _onMediaTypeChange(mediaModel, val) {
         const isAudioFile = (val === 'audio');
         const provider = _model.getVideo();
         const isFlash = (provider && provider.getName().name.indexOf('flash') === 0);
+
+        // Set the poster image for each audio file encountered in a playlist
+        if (isAudioFile) {
+            setPosterImage(_model);
+        }
 
         toggleClass(_playerElement, 'jw-flag-media-audio', isAudioFile);
 
@@ -711,7 +716,7 @@ function View(_api, _model) {
         }
 
         cancelAnimationFrame(_stateClassRequestId);
-        if (_playerState === STATE_PLAYING || (_playerState === STATE_IDLE && _model.get('autostart'))) {
+        if (_playerState === STATE_PLAYING) {
             _stateUpdate(_playerState);
         } else {
             _stateClassRequestId = requestAnimationFrame(() => _stateUpdate(_playerState));
@@ -739,7 +744,13 @@ function View(_api, _model) {
             case STATE_IDLE:
             case STATE_ERROR:
             case STATE_COMPLETE:
-                _model.change('playlistItem', setPosterImage);                
+                // Set the poster image for videos before playback starts (idle), when the playlist ends (complete),
+                // or when an error is encountered. We don't get to the idle state between playlist items because of RAF
+
+                if (_model.mediaModel.get('mediaType') === 'video') {
+                    _model.change('playlistItem', setPosterImage);
+                }
+
                 if (_captionsRenderer) {
                     _captionsRenderer.hide();
                 }


### PR DESCRIPTION
### This PR will...
- Always set the poster image for audio streams
- Only set the poster image for videos when we're in the idle, error or complete state longer than it takes for RAF. This typically happens when playback starts (idle), after playback ends for the last item in a playlist (complete), or when we enter the error state. 
### Why is this Pull Request needed?
In states other than `playing`, we delay calling `_stateUpdate` until the next animation frame. This resulted in the poster image not being set for all audio items in a playlist when a player is set to autostart or between playlist items where the player is typically not in the `idle` state long enough. 
### Are there any points in the code the reviewer needs to double check?
No.
### Are there any Pull Requests open in other repos which need to be merged with this?
No.
#### Addresses Issue(s):
JW8-875
