### PR TITLE
Do not toggle the state to idle before playback

### DIFF
--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -4,7 +4,7 @@ import getMediaElement from 'api/get-media-element';
 import cancelable from 'utils/cancelable';
 import MediaController from 'program/media-controller';
 
-import { ERROR, PLAYER_STATE, STATE_BUFFERING, STATE_IDLE } from 'events/events';
+import { ERROR, PLAYER_STATE, STATE_BUFFERING } from 'events/events';
 
 export default class ProgramController {
     constructor(model) {
@@ -113,8 +113,6 @@ export default class ProgramController {
 
         if (mediaController) {
             mediaController.stop();
-        } else {
-            model.set(PLAYER_STATE, STATE_IDLE);
         }
     }
 


### PR DESCRIPTION
Prevents the behavior where the player goes from buffering to idle and then back to buffering before playback. This regression was introduced recently with JW8-42. IDLE state should come from providers.

There may be a case where loading a new playlist results in the player stopping (autostart: false). Ideally this would be handled by the program controller after loading is complete and there is no `thenPlay` action to take.

If there is no mediaController, we are probably in an intermediary state we are trying to setup a provider - the should be a remain in a buffering state. Stop video is used to stop any active playback before going to another item.

Fixes:
[JW8-906] Breakpoint 1 player view (3 buttons) is seen momentarily before playback starts or is paused (for Safari)
