### PR TITLE
Synchronously reuse provider

### DIFF
--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -29,10 +29,6 @@ export default class MediaController {
         provider.init(item);
     }
 
-    reset() {
-        this.mediaModel = new MediaModel();
-    }
-
     play(item, playReason) {
         const { model, mediaModel, provider } = this;
 

--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -15,8 +15,8 @@ export default class MediaController {
     }
 
     init(item) {
-        this.reset();
-        const { model, provider, mediaModel } = this;
+        const { model, provider } = this;
+        const mediaModel = this.mediaModel = new MediaModel();
         const position = item ? seconds(item.starttime) : 0;
         const duration = item ? seconds(item.duration) : 0;
         const mediaModelState = mediaModel.attributes;

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -32,10 +32,12 @@ export default class ProgramController {
                 // prime the next tag within the gesture
                 this._destroyActiveMedia();
             } else {
-                // We can reuse the current mediaController
-                // Reset it so that a play call before the providerPromise resolves doesn't cause problems
-                // Any play calls will wait for the mediaController to setup again before calling play
-                this.mediaController.reset();
+                // We can reuse the current mediaController and do so synchronously
+                // Initialize the provider and mediaModel, sync it with the Model
+                // This sets up the mediaController and allows playback to begin
+                this.mediaController.init(item);
+                this.providerPromise = Promise.resolve(this.mediaController);
+                return this.providerPromise;
             }
         }
 
@@ -44,14 +46,8 @@ export default class ProgramController {
             .then((ProviderConstructor) => {
                 // Don't do anything if we've tried to load another provider while this promise was resolving
                 if (mediaModelContext === model.mediaModel) {
-                    let nextProvider = mediaController && mediaController.provider;
-                    // Make a new provider if we don't already have one
-                    if (!nextProvider) {
-                        nextProvider = new ProviderConstructor(model.get('id'), model.getConfiguration());
-                        this._changeVideoProvider(nextProvider);
-                    }
-                    // Initialize the provider and mediaModel, sync it with the Model
-                    // This sets up the mediaController and allows playback to begin
+                    const nextProvider = new ProviderConstructor(model.get('id'), model.getConfiguration());
+                    this._changeVideoProvider(nextProvider);
                     this.mediaController.init(item);
                     return this.mediaController;
                 }


### PR DESCRIPTION
### This PR will...
Synchronously reuse a provider when able

### Why is this Pull Request needed?
To avoid a race condition in Hlsjs and Shaka when initializing a provider after the first time. These providers may destroy and recreate their own video tag via the `remove()` method in the `video-actions-mixin`. This remove calls `stop()`, which sets the provider state to `IDLE`, which causes the `thenPlayPromise` to be cancelled. This cancellation results in subsequent items not autostarting when going to the next video.

### Are there any points in the code the reviewer needs to double check?
Do you think this is a bandaid or a proper solution? We must have listeners attached before calling `init()`, which was my first solution. I'm not sure what side effects removing `stop()` from `remove()` would have. 

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):
JW8-893
