### PR TITLE
Remove "mobilecontrols" from the model

### DIFF
--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -10,7 +10,6 @@ const Defaults = {
     controls: true,
     displaytitle: true,
     displaydescription: true,
-    mobilecontrols: false,
     defaultPlaybackRate: 1,
     playbackRateControls: false,
     playbackRates: [0.5, 1, 1.25, 1.5, 2],

--- a/test/data/model-properties.js
+++ b/test/data/model-properties.js
@@ -94,6 +94,5 @@ export default {
     buffer: 0,
     itemMeta: {},
     castAvailable: false,
-    mobilecontrols: false,
     qualityLabels: undefined,
 };

--- a/test/mock/mock-model.js
+++ b/test/mock/mock-model.js
@@ -46,7 +46,6 @@ Object.assign(MockModel.prototype, SimpleModel, {
             controls: true,
             displaytitle: true,
             displaydescription: true,
-            mobilecontrols: false,
             repeat: false,
             castAvailable: false,
             stretching: 'uniform',


### PR DESCRIPTION
This property has already been removed from master and does not do anything in v8.0. This change is necessary to merge v8.0.x fixes into master without triggering a failure in `getConfig()` unit tests (https://github.com/jwplayer/jwplayer/pull/2545).
