### PR TITLE
Set initial view properties on model

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -164,10 +164,8 @@ Object.assign(Controller.prototype, {
             });
         }
 
-        viewModel.on('change:viewSetup', (changedViewModel, viewSetup) => {
-            if (viewSetup) {
-                showView(this, _view.element());
-            }
+        viewModel.on('viewSetup', (viewElement) => {
+            showView(this, viewElement);
         });
 
         this.playerReady = function() {

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -324,7 +324,7 @@ var InstreamAdapter = function(_controller, _model, _view) {
     };
 
     this.setText = function(text) {
-        _view.setAltText(text ? text : '');
+        _view.setAltText(text || '');
     };
 
     // This method is triggered by plugins which want to hide player controls

--- a/src/js/view/view-model.js
+++ b/src/js/view/view-model.js
@@ -20,6 +20,13 @@ export default class ViewModel extends SimpleModelExtendable {
         this._instreamModel = null;
         this._mediaModel = null;
 
+        Object.assign(playerModel.attributes, {
+            altText: '',
+            fullscreen: false,
+            logoWidth: 0,
+            scrubbing: false
+        });
+
         playerModel.on('all', (type, objectOrEvent, value, previousValue) => {
             this.trigger(type, objectOrEvent, value, previousValue);
         }, this);

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -255,7 +255,7 @@ function View(_api, _model) {
         viewsManager.add(this);
 
         this.isSetup = true;
-        _model.set('viewSetup', true);
+        _model.trigger('viewSetup', _playerElement);
 
         const inDOM = document.body.contains(_playerElement);
         if (inDOM) {
@@ -664,7 +664,7 @@ function View(_api, _model) {
     }
 
     function _stateHandler(model, newState, oldState) {
-        if (!_model.get('viewSetup')) {
+        if (!_this.isSetup) {
             return;
         }
 


### PR DESCRIPTION
### This PR will...

- Set initial view properties on model
- Replace "viewSetup" model property with "viewSetup" event from viewModel

### Why is this Pull Request needed?

- Sets "altText" to empty so that `undefined` is not rendered in the controlbar on IE11 (JW8-908)
- Removes "viewSetup" from model state (not useful in `getConfig()` and was only used to get an event from the view without forwarding through the API)
- Restores other model defaults used by the view that were removed by recent view-model changes:

```js
altText: '',
fullscreen: false,
logoWidth: 0,
scrubbing: false
```
#### Addresses Issue(s):

JW8-908
