### PR TITLE
Synchronously start playback when provider is instantiated

### DIFF
--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -69,7 +69,7 @@ export default class ProgramController {
         }
 
         // Setup means that we've already started playback on the current item; all we need to do is resume it
-        if (mediaController && mediaController.setup) {
+        if (mediaController && mediaController.provider) {
             playPromise = mediaController.play(item, playReason);
         } else {
             // Wait for the provider to load before starting initial playback


### PR DESCRIPTION
### This PR will...

Don't create `thenPlayPromise` when we already have a provider instance.

### Why is this Pull Request needed?

So that playback is started and then seek called when seeking from the idle state.

#### Addresses Issue(s):

JW8-894
