### PR TITLE
Reset the current text track index when tracks are cleared

### DIFF
--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -366,6 +366,7 @@ function clearTracks() {
     this._cuesByTrackId = null;
     this._metaCuesByTextTime = null;
     this._unknownCount = 0;
+    this._currentTextTrackIndex = -1;
     this._activeCuePosition = null;
     if (this.renderNatively) {
         // Removing listener first to ensure that removing cues does not trigger it unnecessarily


### PR DESCRIPTION
### This PR will...
Reset the current text track index when tracks are cleared so that the index is determined by looking at the label in local storage or the default track.
### Why is this Pull Request needed?
By not resetting `_currentTextTrackIndex` between playlist items in Shaka, the player was not showing English captions for the next playlist item due to differing indices with the previous item. The player should not assume that the index is the same and instead rely on the caption label to determine if there's an available captions track in the same language as the viewer's previous selection.
### Are there any points in the code the reviewer needs to double check?
No.
### Are there any Pull Requests open in other repos which need to be merged with this?
No.
#### Addresses Issue(s):
JW8-895

