### PR TITLE
Remove behavior that seeks on "seeked" event while scrubbing

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -128,8 +128,8 @@ function VideoProvider(_playerId, _playerConfig) {
             _videotag.removeEventListener('waiting', setLoadingState);
             _videotag.addEventListener('waiting', setLoadingState);
             _this.trigger(MEDIA_SEEK, {
-                position: position,
-                offset: offset
+                position,
+                offset
             });
         },
 

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -119,17 +119,18 @@ function VideoProvider(_playerId, _playerConfig) {
         },
 
         seeking() {
-            var offset = _seekOffset !== null ? _seekOffset : _this.getCurrentTime();
+            const offset = _seekOffset !== null ? _seekOffset : _this.getCurrentTime();
+            const position = _positionBeforeSeek;
+            _setPositionBeforeSeek(offset);
             _seekOffset = null;
             _delayedSeek = 0;
             _this.seeking = true;
-            _this.trigger(MEDIA_SEEK, {
-                position: _positionBeforeSeek,
-                offset: offset
-            });
-            _setPositionBeforeSeek(offset);
             _videotag.removeEventListener('waiting', setLoadingState);
             _videotag.addEventListener('waiting', setLoadingState);
+            _this.trigger(MEDIA_SEEK, {
+                position: position,
+                offset: offset
+            });
         },
 
         seeked() {

--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -136,14 +136,6 @@ class TimeSlider extends Slider {
         this.dragJustReleased = true;
     }
 
-    // Event Listeners
-    onSeeked () {
-        // When we are done scrubbing there will be a final seeked event
-        if (this._model.get('scrubbing')) {
-            this.performSeek();
-        }
-    }
-
     onBuffer(model, pct) {
         this.updateBuffer(pct);
     }
@@ -183,8 +175,6 @@ class TimeSlider extends Slider {
             return;
         }
         this.reset();
-
-        model.on('seeked', this.onSeeked, this);
 
         var tracks = playlistItem.tracks;
         _.each(tracks, function (track) {

--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -6,7 +6,6 @@ import Slider from 'view/controls/components/slider';
 import Tooltip from 'view/controls/components/tooltip';
 import ChaptersMixin from 'view/controls/components/chapters.mixin';
 import ThumbnailsMixin from 'view/controls/components/thumbnails.mixin';
-import { MEDIA_SEEKED } from 'events/events';
 
 class TimeTip extends Tooltip {
 


### PR DESCRIPTION
### This PR will...

Remove a listener that caused seek to be called on "seeked" events. It also moves logic that handles the buffering state in the html5 provider to run before the "seek" event is fired.

### Why is this Pull Request needed?

The seeked listener was used early in JW7 to ensure seeking to the final dragging point on the time slider. It is no longer needed, probably hasn't worked until we recently forwarded provider events through the model, and now causes many redundant calls to seek while scrubbing.

Moving the logic in html5 is a best practice. State can change during event propagation so you want to handle as much logic as possible before events are dispatched - dispatching events last in a function unless there is an important reason to do otherwise.

#### Addresses Issue(s):

JW8-914

