### PR TITLE
Improve muted autoplay mobile controls

### DIFF
--- a/src/css/controls/flags/user-inactive.less
+++ b/src/css/controls/flags/user-inactive.less
@@ -39,3 +39,7 @@
         }
     }
 }
+
+.jwplayer.jw-flag-user-inactive .jw-autostart-mute {
+    display: flex;
+}

--- a/src/css/controls/flags/user-inactive.less
+++ b/src/css/controls/flags/user-inactive.less
@@ -40,6 +40,6 @@
     }
 }
 
-.jwplayer.jw-state-playing.jw-flag-user-inactive .jw-autostart-mute {
+.jw-state-playing.jw-flag-user-inactive .jw-autostart-mute {
     display: flex;
 }

--- a/src/css/controls/flags/user-inactive.less
+++ b/src/css/controls/flags/user-inactive.less
@@ -40,6 +40,6 @@
     }
 }
 
-.jwplayer.jw-flag-user-inactive .jw-autostart-mute {
+.jwplayer.jw-state-playing.jw-flag-user-inactive .jw-autostart-mute {
     display: flex;
 }

--- a/src/css/controls/imports/autostartmute.less
+++ b/src/css/controls/imports/autostartmute.less
@@ -3,7 +3,7 @@
 .jw-autostart-mute {
     position: absolute;
     bottom: 0;
-    right: 0;
+    right: 14px;
     height: @mobile-touch-target;
     width: @mobile-touch-target;
     background-color: rgba(33, 33, 33, 0.4);

--- a/src/css/controls/imports/autostartmute.less
+++ b/src/css/controls/imports/autostartmute.less
@@ -3,7 +3,7 @@
 .jw-autostart-mute {
     position: absolute;
     bottom: 0;
-    right: 14px;
+    right: 12px;
     height: @mobile-touch-target;
     width: @mobile-touch-target;
     background-color: rgba(33, 33, 33, 0.4);

--- a/src/css/controls/imports/autostartmute.less
+++ b/src/css/controls/imports/autostartmute.less
@@ -2,7 +2,7 @@
 
 .jw-autostart-mute {
     position: absolute;
-    bottom: 0.5em;
+    bottom: 4em;
     right: 0.5em;
     height: @mobile-touch-target;
     width: @mobile-touch-target;

--- a/src/css/controls/imports/autostartmute.less
+++ b/src/css/controls/imports/autostartmute.less
@@ -2,11 +2,11 @@
 
 .jw-autostart-mute {
     position: absolute;
-    bottom: 0.5em;
-    right: 0.5em;
+    bottom: 0;
+    right: 0;
     height: @mobile-touch-target;
     width: @mobile-touch-target;
-    background-color: @background-color;
+    background-color: rgba(33, 33, 33, 0.4);
     padding: 5px 4px 5px 6px;
     display: none;
 }

--- a/src/css/controls/imports/autostartmute.less
+++ b/src/css/controls/imports/autostartmute.less
@@ -2,12 +2,13 @@
 
 .jw-autostart-mute {
     position: absolute;
-    bottom: 4em;
+    bottom: 0.5em;
     right: 0.5em;
     height: @mobile-touch-target;
     width: @mobile-touch-target;
     background-color: @background-color;
     padding: 5px 4px 5px 6px;
+    display: none;
 }
 
 .jwplayer.jw-flag-autostart:not(.jw-flag-media-audio) {

--- a/src/css/controls/imports/controlbar.less
+++ b/src/css/controls/imports/controlbar.less
@@ -136,7 +136,6 @@
 }
 
 .jw-flag-ads-vpaid,
-.jw-flag-autostart,
 .jw-flag-user-inactive.jw-state-playing,
 .jw-flag-user-inactive.jw-state-buffering {
     &:not(.jw-flag-media-audio):not(.jw-flag-audio-player):not(.jw-flag-ads-vpaid-controls):not(.jw-flag-casting) {

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -409,7 +409,9 @@ export default class Controls {
                 timeout || ACTIVE_TIMEOUT);
         }
         if (!this.showing) {
-            if (this.mute.element().style.display === '') {
+            const mute = this.mute;
+
+            if (mute && mute.element().style.display === '') {
                 utils.removeClass(this.playerContainer, 'jw-flag-autostart');
             }
             utils.removeClass(this.playerContainer, 'jw-flag-user-inactive');
@@ -424,7 +426,9 @@ export default class Controls {
             return;
         }
 
-        if (this.mute.element().style.display === '') {
+        const mute = this.mute;
+
+        if (mute && mute.element().style.display === '') {
             utils.addClass(this.playerContainer, 'jw-flag-autostart');
         }
 

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -384,7 +384,7 @@ export default class Controls {
         this.controlbar.renderVolume(mute, model.get('volume'));
         this.mute.hide();
         utils.removeClass(this.playerContainer, 'jw-flag-autostart');
-        utils.removeClass(this.playerContainer, 'jw-flag-user-inactive');
+        this.userActive();
     }
 
     addActiveListeners(element) {
@@ -409,11 +409,6 @@ export default class Controls {
                 timeout || ACTIVE_TIMEOUT);
         }
         if (!this.showing) {
-            const mute = this.mute;
-
-            if (mute && mute.element().style.display === '') {
-                utils.removeClass(this.playerContainer, 'jw-flag-autostart');
-            }
             utils.removeClass(this.playerContainer, 'jw-flag-user-inactive');
             this.showing = true;
             this.trigger('userActive');
@@ -425,13 +420,6 @@ export default class Controls {
         if (this.settingsMenu.visible) {
             return;
         }
-
-        const mute = this.mute;
-
-        if (mute && mute.element().style.display === '') {
-            utils.addClass(this.playerContainer, 'jw-flag-autostart');
-        }
-
         this.showing = false;
         utils.addClass(this.playerContainer, 'jw-flag-user-inactive');
         this.trigger('userInactive');

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -384,6 +384,7 @@ export default class Controls {
         this.controlbar.renderVolume(mute, model.get('volume'));
         this.mute.hide();
         utils.removeClass(this.playerContainer, 'jw-flag-autostart');
+        utils.removeClass(this.playerContainer, 'jw-flag-user-inactive');
     }
 
     addActiveListeners(element) {
@@ -408,6 +409,9 @@ export default class Controls {
                 timeout || ACTIVE_TIMEOUT);
         }
         if (!this.showing) {
+            if (this.mute.element().style.display === '') {
+                utils.removeClass(this.playerContainer, 'jw-flag-autostart');
+            }
             utils.removeClass(this.playerContainer, 'jw-flag-user-inactive');
             this.showing = true;
             this.trigger('userActive');
@@ -418,6 +422,10 @@ export default class Controls {
         clearTimeout(this.activeTimeout);
         if (this.settingsMenu.visible) {
             return;
+        }
+
+        if (this.mute.element().style.display === '') {
+            utils.addClass(this.playerContainer, 'jw-flag-autostart');
         }
 
         this.showing = false;


### PR DESCRIPTION
### This PR will...

Display controbar immediately when the player autostarts and is muted. Tapping the player will display the control bar while the mute icon is shown. Also changed bottom property of jw-autostart-mute class so the control bar is fully visible while the user is tapping on the player and controlbar shows.

### Why is this Pull Request needed?

Controls should be visible immediately on the player without interacting with it

#### Addresses Issue(s):

JW8-290
