### PR TITLE
Show poster image for autostarted audio files

### DIFF
--- a/src/js/view/preview.js
+++ b/src/js/view/preview.js
@@ -20,9 +20,7 @@ Object.assign(Preview.prototype, {
             image.onload = null;
         }
         this.image = null;
-        if (!validState(this.model.get('state'))) {
-            return;
-        }
+
         this.model.off('change:state', null, this);
         var backgroundImage = '';
         if (typeof img === 'string') {


### PR DESCRIPTION
### This PR will...
Remove the `validState` check so that the image can be set for audio streams after the `mediaType` is determined. 
### Why is this Pull Request needed?
When autostarting, the `mediaType` is not determined until the player is in a `buffering` state. The `validState` check was used to prevent loading the poster image while the player was buffering or playing. This will never happen for videos since `setPosterImage` is only called in `_stateUpdate` when the player is in the `idle`, `error` or `complete` state.  However, it was preventing the poster from being set for audio streams. I considered removing it altogether, but I think it's still beneficial to keep it around so that we don't attempt to set the poster image unnecessarily when the player is resized.
### Are there any points in the code the reviewer needs to double check?
No.
### Are there any Pull Requests open in other repos which need to be merged with this?
No.
#### Addresses Issue(s):
JW8-891

