### PR TITLE
Update intersection-observer polyfill to 0.4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5163,9 +5163,9 @@
       "dev": true
     },
     "intersection-observer": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.4.0.tgz",
-      "integrity": "sha512-hBECeRcNPMrQP02IlicMCDiL19KQweoWukv35juIVehB2lE+spel5UyfTux/YCkXaR8Zz0jq3xMZeWYZBAU2SA==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.4.3.tgz",
+      "integrity": "sha512-sRobbVo/+DVGkbco/UkuREmXSr5ypWeQ7S7tYDhzIIP3NFtAHLkkFYdivFAIgNe4sfDYBFAjxEgUyxiEmA/dgQ==",
       "dev": true
     },
     "invariant": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "grunt-karma": "2.0.0",
     "grunt-postcss": "0.8.0",
     "import-loader": "1.0.1",
-    "intersection-observer": "0.4.0",
+    "intersection-observer": "0.4.3",
     "istanbul-instrumenter-loader": "3.0.0",
     "jquery": "3.2.1",
     "jsdoc": "3.5.5",


### PR DESCRIPTION
### This PR will...

Update intersection-observer polyfill to 0.4.3

### Why is this Pull Request needed?

The feature check in 0.4.0 fails to detect that IntersectionObserver is available because it looks at a local reference to `IntersectionObserverEntry`, instead of the global on `window`.

This isn't a problem in our player since the player has it's own check for loading the polyfill code. It only surfaced as a problem in one of our commercial tests which uses the polyfill directly in Chrome.
