### PR TITLE
Update cues after instream mode

### DIFF
--- a/src/js/model/player-model.js
+++ b/src/js/model/player-model.js
@@ -3,7 +3,6 @@ import { STATE_IDLE } from 'events/events';
 export const INITIAL_PLAYER_STATE = {
     audioMode: false,
     flashBlocked: false,
-    instream: null,
     item: 0,
     itemMeta: {},
     playRejected: false,

--- a/src/js/view/controls/components/chapters.mixin.js
+++ b/src/js/view/controls/components/chapters.mixin.js
@@ -1,4 +1,3 @@
-import _ from 'utils/underscore';
 import utils from 'utils/helpers';
 import srt from 'parsers/captions/srt';
 
@@ -33,8 +32,8 @@ const ChaptersMixin = {
 
     chaptersLoaded: function (evt) {
         const data = srt(evt.responseText);
-        if (_.isArray(data)) {
-            _.each(data, this.addCue, this);
+        if (Array.isArray(data)) {
+            data.forEach((obj) => this.addCue(obj));
             this.drawCues();
         }
     },
@@ -53,7 +52,7 @@ const ChaptersMixin = {
             return;
         }
 
-        _.each(this.cues, (cue) => {
+        this.cues.forEach((cue) => {
             cue.align(duration);
             cue.el.addEventListener('mouseover', () => {
                 this.activeCue = cue;
@@ -66,7 +65,7 @@ const ChaptersMixin = {
     },
 
     resetChapters: function() {
-        _.each(this.cues, (cue) => {
+        this.cues.forEach((cue) => {
             if (cue.el.parentNode) {
                 cue.el.parentNode.removeChild(cue.el);
             }

--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -91,6 +91,7 @@ class TimeSlider extends Slider {
 
         this._model
             .on('duration', this.onDuration, this)
+            .on('change:cues', this.addCues, this)
             .change('playlistItem', this.onPlaylistItem, this)
             .change('position', this.onPosition, this)
             .change('buffer', this.onBuffer, this)
@@ -175,6 +176,7 @@ class TimeSlider extends Slider {
             return;
         }
         this.reset();
+        this.addCues(model.get('cues'));
 
         var tracks = playlistItem.tracks;
         _.each(tracks, function (track) {
@@ -224,12 +226,12 @@ class TimeSlider extends Slider {
         // With touch events, we never will get the hover events on the cues that cause cues to be active.
         // Therefore use the info we about the scroll position to detect if there is a nearby cue to be active.
         if (UI.getPointerType(evt.sourceEvent) === 'touch') {
-            this.activeCue = _.reduce(this.cues, function(closeCue, cue) {
+            this.activeCue = this.cues.reduce((closeCue, cue) => {
                 if (Math.abs(position - (parseInt(cue.pct) / 100 * railBounds.width)) < this.mobileHoverDistance) {
                     return cue;
                 }
                 return closeCue;
-            }.bind(this), undefined);
+            }, undefined);
         }
 
         if (this.activeCue) {
@@ -271,8 +273,18 @@ class TimeSlider extends Slider {
         utils.removeClass(this.timeTip.el, 'jw-open');
     }
 
+    addCues(model, cues) {
+        if (cues && cues.length) {
+            cues.forEach((ele) => {
+                this.addCue(ele);
+            });
+            this.drawCues();
+        } else {
+            this.resetChapters();
+        }
+    }
+
     reset() {
-        this.resetChapters();
         this.resetThumbnails();
         this.timeTip.resetWidth();
         this.textLength = 0;

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -263,7 +263,6 @@ export default class Controlbar {
         _model.change('position', this.onElapsed, this);
         _model.change('fullscreen', this.onFullscreen, this);
         _model.change('streamType', this.onStreamTypeChange, this);
-        _model.change('cues', this.addCues, this);
         _model.change('altText', this.setAltText, this);
         _model.change('customButtons', this.updateButtons, this);
         _model.change('state', () => {
@@ -419,21 +418,6 @@ export default class Controlbar {
         this.elements.alt.textContent = altText;
     }
 
-    addCues(model, cues) {
-        if (!this.elements.time) {
-            return;
-        }
-        if (cues && cues.length) {
-            _.each(cues, function (ele) {
-                this.elements.time.addCue(ele);
-            }, this);
-        } else {
-            this.elements.time.resetChapters();
-        }
-
-        this.elements.time.drawCues();
-    }
-
     // Close menus if it has no event.  Otherwise close all but the event's target.
     closeMenus(evt) {
         _.each(this.menus, function (ele) {
@@ -558,18 +542,6 @@ export default class Controlbar {
                 buttonContainer.removeChild(buttonElement);
             }
         }
-    }
-
-    syncPlaybackTime(model) {
-        // When resuming playback mode, trigger a change so that the slider immediately resumes it's original position
-        const timeSlider = this.elements.time;
-        if (!timeSlider) {
-            return;
-        }
-
-        timeSlider.onPosition(model, model.get('position'));
-        timeSlider.onDuration(model, model.get('duration'));
-        timeSlider.onStreamType(model, model.get('streamType'));
     }
 
     toggleCaptionsButtonState(active) {

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -435,12 +435,11 @@ export default class Controls {
         }
     }
 
-    setupInstream(model) {
+    setupInstream() {
         this.instreamState = true;
         // Call Controls.userActivity to display the UI temporarily for the start of the ad
         this.userActive();
         this.addBackdrop();
-        this.controlbar.syncPlaybackTime(model);
         if (this.settingsMenu) {
             this.settingsMenu.close();
         }
@@ -450,7 +449,6 @@ export default class Controls {
     destroyInstream(model) {
         this.instreamState = null;
         this.addBackdrop();
-        this.controlbar.syncPlaybackTime(model);
         if (model.get('autostartMuted')) {
             utils.addClass(this.playerContainer, 'jw-flag-autostart');
         }

--- a/src/js/view/view-model.js
+++ b/src/js/view/view-model.js
@@ -90,13 +90,15 @@ export default class ViewModel extends SimpleModelExtendable {
             instreamModel.change('mediaModel', (model, mediaModel) => {
                 this.mediaModel = mediaModel;
             }, this);
+
+            dispatchDiffChangeEvents(this, instreamModel.attributes, this._model.attributes);
         } else {
             this._model.change('mediaModel', (model, mediaModel) => {
                 this.mediaModel = mediaModel;
             }, this);
-        }
 
-        dispatchDiffChangeEvents(this, instreamModel ? instreamModel.attributes : {}, this._model.attributes);
+            dispatchDiffChangeEvents(this, this._model.attributes, previousInstream ? previousInstream.attributes : {});
+        }
     }
 
     get(attr) {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -464,7 +464,7 @@ function View(_api, _model) {
         controls.on('all', _this.trigger, _this);
 
         if (_model.get('instream')) {
-            _controls.setupInstream(_model);
+            _controls.setupInstream();
         }
 
         const overlaysElement = _playerElement.querySelector('.jw-overlays');
@@ -729,7 +729,7 @@ function View(_api, _model) {
         removeClass(_playerElement, 'jw-flag-live');
 
         if (_controls) {
-            _controls.setupInstream(_model);
+            _controls.setupInstream();
         }
     };
 

--- a/test/data/model-properties.js
+++ b/test/data/model-properties.js
@@ -64,6 +64,7 @@ export const adModelProperties = {
 export const addedProperties = {
     playlistItem: {},
     provider: {},
+    instream: {},
 };
 
 export default {
@@ -88,7 +89,6 @@ export default {
     width: 640,
     height: 360,
     audioMode: false,
-    instream: null,
     state: '',
     playlist: [{}],
     item: 0,


### PR DESCRIPTION
### This PR will...

- Remove default `instream` model property so that it's on set in the player model and never set in the instream model
- Remove `_` from chapters.mixin.js
- Move cues logic from controlbar to timeslider
- Remove a redundant call to `resetChapters`
- Remove controls `syncPlaybackTime` since the view-model "diff" functionality handles changes between instream and player model properties
- Fix view-model instream/player "diff" functionality so that it runs properly when exiting instream

### Why is this Pull Request needed?

Fixes the display of instream cues after a preroll.

#### Addresses Issue(s):

JW8-915

