### PR TITLE
Prevent controls from being re-added after instream mode

### DIFF
--- a/src/js/view/view-model.js
+++ b/src/js/view/view-model.js
@@ -96,8 +96,9 @@ export default class ViewModel extends SimpleModelExtendable {
             this._model.change('mediaModel', (model, mediaModel) => {
                 this.mediaModel = mediaModel;
             }, this);
-
-            dispatchDiffChangeEvents(this, this._model.attributes, previousInstream ? previousInstream.attributes : {});
+            
+            const mergedAttributes = Object.assign({}, previousInstream ? previousInstream.attributes : {}, this._model.attributes);
+            dispatchDiffChangeEvents(this, this._model.attributes, mergedAttributes);
         }
     }
 


### PR DESCRIPTION
### This PR will...

Prevent change events after instream for attributes that only exist in the player model (e.g. "controls"). Use a merged set of attributes to compare state changes between instream and player model.

### Why is this Pull Request needed?

This prevents change events from player model attributes that have not changed.

#### Addresses Issue(s):

JW8-924

