### PR TITLE
Cache custom button SVG elements

### DIFF
--- a/src/js/view/controls/components/custom-button.js
+++ b/src/js/view/controls/components/custom-button.js
@@ -2,6 +2,20 @@ import { style } from 'utils/css';
 import UI from 'utils/ui';
 import svgParse from 'utils/svgParser';
 
+let collection = {};
+
+function getCachedIcon(svg) {
+    if (!collection[svg]) {
+        const icons = Object.keys(collection);
+        if (icons.length > 10) {
+            delete collection[icons[0]];
+        }
+        const element = svgParse(svg);
+        collection[svg] = element;
+    }
+    return collection[svg].cloneNode(true);
+}
+
 export default class CustomButton {
 
     constructor(img, ariaText, callback, id, btnClass) {
@@ -16,7 +30,7 @@ export default class CustomButton {
 
         let iconElement;
         if (img && img.substring(0, 4) === '<svg') {
-            iconElement = svgParse(img);
+            iconElement = getCachedIcon(img);
         } else {
             iconElement = document.createElement('div');
             iconElement.className = 'jw-icon jw-button-image jw-button-color jw-reset';


### PR DESCRIPTION
### This PR will...

Keep a cache of SVG elements used as custom button icons (sharing, playlist/discovery), and clone cached nodes when a new button is created with a cached icon.

### Why is this Pull Request needed?

Each time plugins like sharing and related add custom SVG buttons to a control bar, SVG text must be parsed. Since they do this multiple times for each player on the page, this expensive operation uses CPU and memory that can affect page performance.

Caching the elements allows us to clone the parsed node for button icons that have already been parsed once, saving CPU and memory and improving page performance.

#### Addresses Issue(s):

JW8-928

