### PR TITLE
Customize Related Autoplay Progress Bar

### DIFF
--- a/src/js/view/utils/skin.js
+++ b/src/js/view/utils/skin.js
@@ -175,7 +175,8 @@ export function handleColorOverrides(playerId, skin) {
 
         addStyle([
             '.jw-progress',
-            '.jw-knob'
+            '.jw-knob',
+            'jw-related-autoplay-progress'
         ], 'background-color', config.progress);
 
         addStyle([


### PR DESCRIPTION
### What does this Pull Request do?

The progress bar at the bottom of the related overlay for small breakpoints should be customizable the same way as the ads progress bar.

### Why is this Pull Request needed?

To have consistent custom styling across the player.

### Other PRs:

https://github.com/jwplayer/jwplayer-plugin-related/pull/179

#### Addresses Issue(s):

JW8-905