### PR TITLE
Add player only view-model

### DIFF
--- a/src/js/view/captionsrenderer.js
+++ b/src/js/view/captionsrenderer.js
@@ -22,7 +22,9 @@ const _defaults = {
     windowOpacity: 0
 };
 
-const CaptionsRenderer = function (_model) {
+const CaptionsRenderer = function (viewModel) {
+
+    const _model = viewModel.player;
 
     let _options;
     let _captionsTrack;

--- a/src/js/view/controls/components/chapters.mixin.js
+++ b/src/js/view/controls/components/chapters.mixin.js
@@ -48,7 +48,7 @@ const ChaptersMixin = {
         // We won't want to draw them until we have a duration
         const duration = this._model.get('duration');
         if (!duration || duration <= 0) {
-            this._model.once('change:duration', this.drawCues, this);
+            this._model.player.once('change:duration', this.drawCues, this);
             return;
         }
 

--- a/src/js/view/controls/nextuptooltip.js
+++ b/src/js/view/controls/nextuptooltip.js
@@ -30,21 +30,22 @@ export default class NextUpTooltip {
         this.closeButton.setAttribute('aria-label', this.nextUpClose);
         this.tooltip = this.content.querySelector('.jw-nextup-tooltip');
 
-        const model = this._model;
+        const viewModel = this._model;
+        const playerViewModel = viewModel.player;
         // Next Up is hidden until we get a valid NextUp item from the nextUp event
         this.enabled = false;
 
         // Events
-        model.on('change:nextUp', this.onNextUp, this);
+        viewModel.on('change:nextUp', this.onNextUp, this);
 
         // Listen for duration changes to determine the offset from the end for when next up should be shown
-        model.change('duration', this.onDuration, this);
+        playerViewModel.change('duration', this.onDuration, this);
         // Listen for position changes so we can show the tooltip when the offset has been crossed
-        model.change('position', this.onElapsed, this);
+        playerViewModel.change('position', this.onElapsed, this);
 
-        model.change('streamType', this.onStreamType, this);
+        playerViewModel.change('streamType', this.onStreamType, this);
 
-        model.change('state', function(stateChangeModel, state) {
+        playerViewModel.change('state', function(stateChangeModel, state) {
             if (state === 'complete') {
                 this.toggle(false);
             }

--- a/src/js/view/controls/settings-menu.js
+++ b/src/js/view/controls/settings-menu.js
@@ -54,7 +54,9 @@ export function createSettingsMenu(controlbar, onVisibility) {
 }
 
 
-export function setupSubmenuListeners(settingsMenu, controlbar, model, api) {
+export function setupSubmenuListeners(settingsMenu, controlbar, viewModel, api) {
+    const model = viewModel.player;
+
     const activateSubmenuItem = (submenuName, itemIndex) => {
         const submenu = settingsMenu.getSubmenu(submenuName);
         if (submenu) {

--- a/src/js/view/title.js
+++ b/src/js/view/title.js
@@ -1,7 +1,7 @@
 import { style } from 'utils/css';
 
 const Title = function(_model) {
-    this.model = _model;
+    this.model = _model.player;
 };
 
 Object.assign(Title.prototype, {

--- a/test/unit/controls/settings-menu-test.js
+++ b/test/unit/controls/settings-menu-test.js
@@ -81,7 +81,9 @@ describe('SettingsMenu', function() {
                 };
             };
 
-            SettingsMenu.setupSubmenuListeners(settingsMenu, controlbar, viewModel);
+            SettingsMenu.setupSubmenuListeners(settingsMenu, controlbar, {
+                player: viewModel
+            });
         });
 
         it('should setup qualities element on levels change', function() {

--- a/test/unit/simplemodel-test.js
+++ b/test/unit/simplemodel-test.js
@@ -1,4 +1,3 @@
-import _ from 'utils/underscore';
 import sinon from 'sinon';
 import SimpleModel from 'model/simplemodel';
 

--- a/test/unit/view-model.js
+++ b/test/unit/view-model.js
@@ -189,9 +189,7 @@ describe('ViewModel', function() {
         instreamMediaModel.set('d', 30);
 
         viewModel.trigger('viewModelEvent');
-
-        expect(playerViewModel).to.be.an.instanceof(ViewModel);
-
+        
         assert(modelSpy.calledOnce, 'Player-model listeners called');
         assert(mediaModelSpy.calledOnce, 'Player media-model listeners called');
 

--- a/test/unit/view-model.js
+++ b/test/unit/view-model.js
@@ -1,0 +1,254 @@
+import sinon from 'sinon';
+import ViewModel from 'view/view-model';
+import Model from 'controller/model';
+
+describe('ViewModel', function() {
+
+    it('is a class', function() {
+        const model = new Model();
+        const viewModel = new ViewModel(model);
+
+        expect(ViewModel).to.be.a('function');
+        expect(viewModel.constructor).to.be.a('function');
+    });
+
+    it('forwards events from the player model', function() {
+        const model = new Model();
+        const viewModel = new ViewModel(model);
+
+        const modelSpy = sinon.spy();
+
+        viewModel.on('change:duration', modelSpy);
+        model.set('duration', 30);
+
+        assert(modelSpy.calledOnce, 'Player model event listener called');
+        assert(modelSpy.firstCall.calledWith(viewModel, 30), 'Player model change event listener receives correct arguments');
+    });
+
+    it('forwards events from the media model', function() {
+        const model = new Model();
+        const mediaModel = model.get('mediaModel');
+        const viewModel = new ViewModel(model);
+        // Activate media-model in view-model
+        model.attributes.mediaModel = null;
+        model.setMediaModel(mediaModel);
+
+        const modelSpy = sinon.spy();
+
+        viewModel.on('change:duration', modelSpy);
+        mediaModel.set('duration', 30);
+
+        assert(modelSpy.calledOnce, 'Media model event listener called');
+        assert(modelSpy.firstCall.calledWith(viewModel, 30), 'Media model change event listener receives correct arguments');
+    });
+
+    it('forwards events from the instream model', function() {
+        const model = new Model();
+        const viewModel = new ViewModel(model);
+        const instream = {
+            _adModel: new Model()
+        };
+
+        const instreamChangeModeSpy = sinon.spy();
+        const instreamModelSpy = sinon.spy();
+
+        viewModel.on('instreamMode', instreamChangeModeSpy);
+        viewModel.on('change:duration', instreamModelSpy);
+
+        // Activate instream mode
+        model.set('instream', instream);
+        instream._adModel.set('duration', 30);
+
+        assert(instreamChangeModeSpy.calledOnce, '"instreamMode" event listener called when instream is added');
+        assert(instreamModelSpy.calledOnce, 'Instream-model event listener called');
+        assert(instreamModelSpy.firstCall.calledWith(viewModel, 30), 'Instream-model change event listener receives correct arguments');
+
+        // Deactivate instream mode
+        model.set('instream', null);
+        instream._adModel.set('duration', 60);
+
+        assert(instreamChangeModeSpy.calledTwice, '"instreamMode" event listener called when instream is removed');
+        assert(instreamModelSpy.calledOnce, 'Instream-model event listener not called after instream is removed');
+    });
+
+    it('forwards events from instream\'s media model', function() {
+        const model = new Model();
+        const viewModel = new ViewModel(model);
+        const instream = {
+            _adModel: new Model()
+        };
+
+        const instreamModelSpy = sinon.spy();
+        viewModel.on('change:duration', instreamModelSpy);
+
+        // Activate instream mode
+        model.set('instream', instream);
+        instream._adModel.get('mediaModel').set('duration', 30);
+
+        assert(instreamModelSpy.calledOnce, 'Instream media-model event listener called');
+        assert(instreamModelSpy.firstCall.calledWith(viewModel, 30), 'Instream media-model change event listener receives correct arguments');
+
+        // Deactivate instream mode
+        model.set('instream', null);
+        instream._adModel.get('mediaModel').set('duration', 60);
+
+        assert(instreamModelSpy.calledOnce, 'Instream media-model event listener not called after instream is removed');
+    });
+
+    it('gets attributes from the most specific model', function() {
+        const model = new Model();
+        const mediaModel = model.get('mediaModel');
+        const viewModel = new ViewModel(model);
+        const instream = {
+            _adModel: new Model()
+        };
+        const instreamMediaModel = instream._adModel.get('mediaModel');
+
+        model.set('attr', 'model');
+        model.set('model-attr', 'model');
+        mediaModel.set('attr', 'media-model');
+        instream._adModel.set('attr', 'instream-model');
+        instream._adModel.set('model-attr', 'instream-model');
+        instreamMediaModel.set('attr', 'instream-media-model');
+
+        expect(viewModel.get('attr'), 'Media-model is not active until it is changed on the model').to.equal('model');
+
+        // Activate media-model in view-model
+        model.attributes.mediaModel = null;
+        model.setMediaModel(mediaModel);
+
+        expect(viewModel.get('attr'), 'Media-model attribute is returned').to.equal('media-model');
+        expect(viewModel.get('model-attr'), 'Attributes only on the model are returned').to.equal('model');
+
+        // Activate instream mode
+        model.set('instream', instream);
+
+        expect(viewModel.get('attr'), 'Instream media-model attribute is returned').to.equal('instream-media-model');
+        expect(viewModel.get('model-attr'), 'Attributes only on instream are returned').to.equal('instream-model');
+    });
+
+    it('set attributes on the player model only', function() {
+        const model = new Model();
+        const mediaModel = model.get('mediaModel');
+        const viewModel = new ViewModel(model);
+        const instream = {
+            _adModel: new Model()
+        };
+        const instreamMediaModel = instream._adModel.get('mediaModel');
+
+        viewModel.set('attr', 100);
+
+        expect(viewModel.get('attr'), 'Attributes set on the view-model can be retrieved from the view-model').to.equal(100);
+        expect(model.get('attr'), 'Attributes set on the view-model are set on the model').to.equal(100);
+        expect(mediaModel.get('attr'), 'Attributes set on the view-model are not set on the media-model').to.be.an('undefined');
+
+        // Activate instream mode
+        model.set('instream', instream);
+
+        expect(viewModel.get('attr'), 'Attributes set on the view-model can be retrieved from the view-model in instream mode').to.equal(100);
+
+        expect(instream._adModel.get('attr'), 'Attributes set on the view-model are not set on the instream-model').to.be.an('undefined');
+        expect(instreamMediaModel.get('attr'), 'Attributes set on the view-model are not set on the instrean media-model').to.be.an('undefined');
+    });
+
+    it('has a player only sub view-model', function() {
+        const model = new Model();
+        const mediaModel = model.get('mediaModel');
+        const instream = {
+            _adModel: new Model()
+        };
+        const instreamMediaModel = instream._adModel.get('mediaModel');
+        const viewModel = new ViewModel(model);
+        const playerViewModel = viewModel.player;
+
+        const modelSpy = sinon.spy();
+        const mediaModelSpy = sinon.spy();
+        const instreamChangeModeSpy = sinon.spy();
+        const instreamModelSpy = sinon.spy();
+        const instreamMediaModelSpy = sinon.spy();
+        const viewModelSpy = sinon.spy();
+
+        playerViewModel.on('change:a', modelSpy);
+        playerViewModel.on('change:b', mediaModelSpy);
+        playerViewModel.on('change:c', instreamModelSpy);
+        playerViewModel.on('change:d', instreamMediaModelSpy);
+        playerViewModel.on('viewModelEvent', viewModelSpy);
+        playerViewModel.on('instreamMode', instreamChangeModeSpy);
+
+        // Activate media-model in view-model
+        model.attributes.mediaModel = null;
+        model.setMediaModel(mediaModel);
+
+        model.set('a', 30);
+        mediaModel.set('b', 30);
+
+        // Activate instream mode
+        model.set('instream', instream);
+
+        instream._adModel.set('c', 30);
+        instreamMediaModel.set('d', 30);
+
+        viewModel.trigger('viewModelEvent');
+
+        expect(playerViewModel).to.be.an.instanceof(ViewModel);
+
+        assert(modelSpy.calledOnce, 'Player-model listeners called');
+        assert(mediaModelSpy.calledOnce, 'Player media-model listeners called');
+
+        assert(viewModelSpy.notCalled, 'View-model listeners not called');
+        assert(instreamChangeModeSpy.notCalled, '"instreamMode" view-model listener not called');
+        assert(instreamModelSpy.notCalled, 'Instream-model listeners not called');
+        assert(instreamMediaModelSpy.notCalled, 'Instream media-model listeners not called');
+    });
+
+    it('removes listeners when destroyed', function() {
+        const model = new Model();
+        const mediaModel = model.get('mediaModel');
+        const viewModel = new ViewModel(model);
+        const instream = {
+            _adModel: new Model()
+        };
+        const instreamMediaModel = instream._adModel.get('mediaModel');
+
+        const modelSpy = sinon.spy();
+        const mediaModelSpy = sinon.spy();
+        const instreamChangeModeSpy = sinon.spy();
+        const instreamModelSpy = sinon.spy();
+        const instreamMediaModelSpy = sinon.spy();
+        const viewModelSpy = sinon.spy();
+
+        viewModel.on('test-model', modelSpy);
+        viewModel.on('test-media', mediaModelSpy);
+        viewModel.on('test-instream-model', instreamModelSpy);
+        viewModel.on('test-instream-media-model', instreamMediaModelSpy);
+        viewModel.on('test-view-model', viewModelSpy);
+        viewModel.on('instreamMode', instreamChangeModeSpy);
+
+        viewModel.destroy();
+
+        model.trigger('test-model');
+        mediaModel.trigger('test-media');
+        viewModel.trigger('test-view-model');
+
+        // Activate instream mode
+        model.set('instream', instream);
+
+        instream._adModel.trigger('test-instream-model');
+        instreamMediaModel.trigger('test-instream-media-model');
+        viewModel.trigger('test-view-model');
+
+        assert(modelSpy.notCalled, 'Model listeners removed');
+        assert(mediaModelSpy.notCalled, 'Media-model listeners removed');
+        assert(instreamChangeModeSpy.notCalled, '"instreamMode" view-model listener removed');
+        assert(instreamModelSpy.notCalled, 'Instream-model listeners removed');
+        assert(instreamMediaModelSpy.notCalled, 'Instream media-model listeners removed');
+        assert(viewModelSpy.notCalled, 'View-model listeners removed');
+    });
+
+    it('implements getVideo', function() {
+        const model = new Model();
+        const viewModel = new ViewModel(model);
+
+        expect(viewModel.getVideo).to.be.a('function');
+    });
+});


### PR DESCRIPTION
Adds a player-only sub view-model used by components that should only get state from the player (never from instream).

This is used primarily by settings-menu and next-up components. It prevents a bug where next-up is displayed after prerolls because of duration changes between instream and player state.

Also adds unit tests for view-model.

#### Addresses Issue(s):

JW8-807
