### PR TITLE
Add hlsjs flag for Safari

### DIFF
--- a/src/js/playlist/playlist.js
+++ b/src/js/playlist/playlist.js
@@ -45,6 +45,7 @@ export function filterPlaylist(playlist, model, feedData) {
 function formatSources(item, model) {
     const sources = item.sources;
     const androidhls = model.get('androidhls');
+    const safariHls = model.get('safarihls');
     const itemDrm = item.drm || model.get('drm');
     const withCredentials = fallbackIfUndefined(item.withCredentials, model.get('withCredentials'));
     const hlsjsdefault = model.get('hlsjsdefault') !== false;
@@ -55,6 +56,9 @@ function formatSources(item, model) {
         }
         if (androidhls !== undefined && androidhls !== null) {
             originalSource.androidhls = androidhls;
+        }
+        if (safariHls !== undefined && safariHls !== null) {
+            originalSource.safariHls = safariHls;
         }
 
         if (originalSource.drm || itemDrm) {

--- a/src/js/playlist/playlist.js
+++ b/src/js/playlist/playlist.js
@@ -45,7 +45,7 @@ export function filterPlaylist(playlist, model, feedData) {
 function formatSources(item, model) {
     const sources = item.sources;
     const androidhls = model.get('androidhls');
-    const safariHls = model.get('safarihls');
+    const safariHlsjs = model.get('safarihlsjs');
     const itemDrm = item.drm || model.get('drm');
     const withCredentials = fallbackIfUndefined(item.withCredentials, model.get('withCredentials'));
     const hlsjsdefault = model.get('hlsjsdefault') !== false;
@@ -57,8 +57,8 @@ function formatSources(item, model) {
         if (androidhls !== undefined && androidhls !== null) {
             originalSource.androidhls = androidhls;
         }
-        if (safariHls !== undefined && safariHls !== null) {
-            originalSource.safariHls = safariHls;
+        if (safariHlsjs !== undefined && safariHlsjs !== null) {
+            originalSource.safarihlsjs = safariHlsjs;
         }
 
         if (originalSource.drm || itemDrm) {


### PR DESCRIPTION
### This PR will...

Check if the `safarihlsjs` flag is set in the model and add it as a flag in the source. This will allow `ProvidersSupported` to verify if it should use `hlsjs`

### Why is this Pull Request needed?

Since `ProvidersSupported` only takes in the `source` and not `model`, the flag needs to be passed through.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-commercial/pull/4370

#### Addresses Issue(s):

JW8-856

