### PR TITLE
Rename or remove transient and duplicate model properties

### DIFF
--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -21,6 +21,7 @@ const CoreShim = function(originalContainer) {
     this._events = {};
     this.modelShim = new ModelShim();
     this.modelShim._qoeItem = new Timer();
+    this.mediaShim = {};
     this.setup = new Setup(this.modelShim);
     this.currentContainer =
         this.originalContainer = originalContainer;
@@ -72,6 +73,12 @@ Object.assign(CoreShim.prototype, {
         ]);
         const persisted = storage && storage.getAllItems();
         model.attributes = model.attributes || {};
+
+        this.mediaShim = {
+            position: 0,
+            duration: 0,
+            buffer: 0,
+        };
 
         // Assigning config properties to the model needs to be synchronous for chained get API methods
         const configuration = Config(options, persisted);
@@ -148,13 +155,16 @@ Object.assign(CoreShim.prototype, {
 
     // These methods read from the model
     get(property) {
+        if (property in this.mediaShim) {
+            return this.mediaShim[property];
+        }
         return this.modelShim.get(property);
     },
     getItemQoe() {
         return this.modelShim._qoeItem;
     },
     getConfig() {
-        return Object.assign({}, this.modelShim.attributes);
+        return Object.assign({}, this.modelShim.attributes, this.mediaShim);
     },
     getCurrentCaptions() {
         return this.get('captionsIndex');

--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -6,7 +6,7 @@ import loadPlugins from 'plugins/plugins';
 import Timer from 'api/timer';
 import Storage from 'model/storage';
 import SimpleModel from 'model/simplemodel';
-import { INITIAL_PLAYER_STATE } from 'model/player-model';
+import { INITIAL_PLAYER_STATE, INITIAL_MEDIA_STATE } from 'model/player-model';
 import { SETUP_ERROR, STATE_ERROR } from 'events/events';
 import Events from 'utils/backbone.events';
 import loadCoreBundle from 'api/core-loader';
@@ -74,11 +74,7 @@ Object.assign(CoreShim.prototype, {
         const persisted = storage && storage.getAllItems();
         model.attributes = model.attributes || {};
 
-        this.mediaShim = {
-            position: 0,
-            duration: 0,
-            buffer: 0,
-        };
+        Object.assign(this.mediaShim, INITIAL_MEDIA_STATE);
 
         // Assigning config properties to the model needs to be synchronous for chained get API methods
         const configuration = Config(options, persisted);

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -87,12 +87,6 @@ Object.assign(Controller.prototype, {
 
         _model.on('change:state', changeStateEvent, this);
 
-        _model.on('change:duration', function(model, duration) {
-            const minDvrWindow = model.get('minDvrWindow');
-            const type = streamType(duration, minDvrWindow);
-            model.setStreamType(type);
-        });
-
         _model.on('change:castState', function(model, evt) {
             _this.trigger(CAST_SESSION, evt);
         });
@@ -139,12 +133,17 @@ Object.assign(Controller.prototype, {
             });
         });
 
-        _model.on('change:mediaModel', function(model) {
+        _model.on('change:mediaModel', function(model, mediaModel) {
             model.set('errorEvent', undefined);
-            model.mediaModel.change(PLAYER_STATE, function(mediaModel, state) {
+            mediaModel.change('mediaState', function(changedMediaModel, state) {
                 if (!model.get('errorEvent')) {
                     model.set(PLAYER_STATE, normalizeState(state));
                 }
+            });
+            mediaModel.on('change:duration', function(changedMediaModel, duration) {
+                const minDvrWindow = model.get('minDvrWindow');
+                const type = streamType(duration, minDvrWindow);
+                model.setStreamType(type);
             });
         });
 

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -18,6 +18,7 @@ import { streamType } from 'providers/utils/stream-type';
 import Promise, { resolved } from 'polyfills/promise';
 import cancelable from 'utils/cancelable';
 import _ from 'utils/underscore';
+import { INITIAL_MEDIA_STATE } from 'model/player-model';
 import { PLAYER_STATE, STATE_BUFFERING, STATE_IDLE, STATE_COMPLETE, STATE_PAUSED, STATE_PLAYING, STATE_ERROR, STATE_LOADING,
     STATE_STALLED, MEDIA_BEFOREPLAY, PLAYLIST_LOADED, ERROR, PLAYLIST_COMPLETE, CAPTIONS_CHANGED, READY,
     MEDIA_ERROR, MEDIA_COMPLETE, CAST_SESSION, FULLSCREEN, PLAYLIST_ITEM, MEDIA_VOLUME, MEDIA_MUTE, PLAYBACK_RATE_CHANGED,
@@ -596,24 +597,9 @@ Object.assign(Controller.prototype, {
         }
 
         function _getVisualQuality() {
-            if (this._model.mediaModel) {
-                return this._model.mediaModel.get('visualQuality');
-            }
-            // if quality is not implemented in the provider,
-            // return quality info based on current level
-            const qualityLevels = _getQualityLevels();
-            if (qualityLevels) {
-                const levelIndex = _getCurrentQuality();
-                const level = qualityLevels[levelIndex];
-                if (level) {
-                    return {
-                        level: Object.assign({
-                            index: levelIndex
-                        }, level),
-                        mode: '',
-                        reason: ''
-                    };
-                }
+            const mediaModel = this._model.get('mediaModel');
+            if (mediaModel) {
+                return mediaModel.get('visualQuality');
             }
             return null;
         }
@@ -888,6 +874,13 @@ Object.assign(Controller.prototype, {
         _view.setup();
     },
     get(property) {
+        if (property in INITIAL_MEDIA_STATE) {
+            const mediaModel = this._model.get('mediaModel');
+            if (mediaModel) {
+                return mediaModel.get(property);
+            }
+            return INITIAL_MEDIA_STATE[property];
+        }
         return this._model.get(property);
     },
     getContainer() {

--- a/src/js/controller/instream-html5.js
+++ b/src/js/controller/instream-html5.js
@@ -175,9 +175,9 @@ const InstreamHtml5 = function(_controller, _model) {
 
         const adMediaModelContext = _adModel.mediaModel;
         provider.on(PLAYER_STATE, (event) => {
-            adMediaModelContext.set(PLAYER_STATE, event.newstate);
+            adMediaModelContext.set('mediaState', event.newstate);
         });
-        adMediaModelContext.on('change:' + PLAYER_STATE, (changeAdModel, state) => {
+        adMediaModelContext.on('change:mediaState', (changeAdModel, state) => {
             stateHandler(state);
         });
         provider.attachMedia();

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -1,6 +1,6 @@
 import { Browser, OS } from 'environment/environment';
 import SimpleModel from 'model/simplemodel';
-import { INITIAL_PLAYER_STATE } from 'model/player-model';
+import { INITIAL_PLAYER_STATE, INITIAL_MEDIA_STATE } from 'model/player-model';
 import { STATE_IDLE } from 'events/events';
 import _ from 'utils/underscore';
 import ProviderController from 'providers/provider-controller';
@@ -26,9 +26,9 @@ const Model = function() {
     this.getConfiguration = function() {
         const config = this.clone();
         const mediaModelAttributes = config.mediaModel.attributes;
-        config.position = mediaModelAttributes.position;
-        config.duration = mediaModelAttributes.duration;
-        config.buffer = mediaModelAttributes.buffer;
+        Object.keys(INITIAL_MEDIA_STATE).forEach(key => {
+            config[key] = mediaModelAttributes[key];
+        });
         delete config.instream;
         delete config.mediaModel;
         return config;
@@ -278,14 +278,12 @@ const MediaModel = Model.MediaModel = function() {
 
 Object.assign(MediaModel.prototype, SimpleModel, {
     srcReset() {
-        const attributes = this.attributes;
-        attributes.position = 0;
-        attributes.duration = 0;
-        attributes.buffer = 0;
-        attributes.setup = false;
-        attributes.started = false;
-        attributes.preloaded = false;
-        attributes.visualQuality = null;
+        Object.assign(this.attributes, INITIAL_MEDIA_STATE, {
+            setup: false,
+            started: false,
+            preloaded: false,
+            visualQuality: null,
+        });
     }
 });
 

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -25,6 +25,10 @@ const Model = function() {
 
     this.getConfiguration = function() {
         const config = this.clone();
+        const mediaModelAttributes = config.mediaModel.attributes;
+        config.position = mediaModelAttributes.position;
+        config.duration = mediaModelAttributes.duration;
+        config.buffer = mediaModelAttributes.buffer;
         delete config.instream;
         delete config.mediaModel;
         return config;
@@ -230,10 +234,11 @@ const Model = function() {
     this.resetItem = function (item) {
         const position = item ? seconds(item.starttime) : 0;
         const duration = item ? seconds(item.duration) : 0;
+        const mediaModel = this.mediaModel;
         this.set('playRejected', false);
         this.set('itemMeta', {});
-        this.set('position', position);
-        this.set('duration', duration);
+        mediaModel.set('position', position);
+        mediaModel.set('duration', duration);
     };
 };
 
@@ -260,20 +265,23 @@ const syncProviderProperties = (model, provider) => {
 
 function syncPlayerWithMediaModel(mediaModel) {
     // Sync player state with mediaModel state
-    const mediaState = mediaModel.get('state');
-    mediaModel.trigger('change:state', mediaModel, mediaState, mediaState);
+    const mediaState = mediaModel.get('mediaState');
+    mediaModel.trigger('change:mediaState', mediaModel, mediaState, mediaState);
 }
 
 // Represents the state of the provider/media element
 const MediaModel = Model.MediaModel = function() {
     this.attributes = {
-        state: STATE_IDLE
+        mediaState: STATE_IDLE
     };
 };
 
 Object.assign(MediaModel.prototype, SimpleModel, {
     srcReset() {
         const attributes = this.attributes;
+        attributes.position = 0;
+        attributes.duration = 0;
+        attributes.buffer = 0;
         attributes.setup = false;
         attributes.started = false;
         attributes.preloaded = false;

--- a/src/js/controller/qoe.js
+++ b/src/js/controller/qoe.js
@@ -71,7 +71,7 @@ const initQoe = function(initialModel, programController) {
     function onMediaModel(model, mediaModel, oldMediaModel) {
         // finish previous item
         if (model._qoeItem && oldMediaModel) {
-            model._qoeItem.end(oldMediaModel.get('state'));
+            model._qoeItem.end(oldMediaModel.get('mediaState'));
         }
         // reset item level qoe
         model._qoeItem = new Timer();
@@ -86,11 +86,11 @@ const initQoe = function(initialModel, programController) {
             return time;
         };
         model._qoeItem.tick(PLAYLIST_ITEM);
-        model._qoeItem.start(mediaModel.get('state'));
+        model._qoeItem.start(mediaModel.get('mediaState'));
 
         trackFirstFrame(model, programController);
 
-        mediaModel.on('change:state', function (changeMediaModel, newstate, oldstate) {
+        mediaModel.on('change:mediaState', function (changeMediaModel, newstate, oldstate) {
             if (newstate !== oldstate) {
                 model._qoeItem.end(oldstate);
                 model._qoeItem.start(newstate);

--- a/src/js/events/change-state-event.js
+++ b/src/js/events/change-state-event.js
@@ -21,7 +21,7 @@ export default function ChangeStateEvent(model, newstate, oldstate) {
             type: eventType,
             newstate: newstate,
             oldstate: oldstate,
-            reason: model.mediaModel.get('state')
+            reason: model.mediaModel.get('mediaState')
         };
         // add reason for play/pause events
         if (eventType === 'play') {

--- a/src/js/model/player-model.js
+++ b/src/js/model/player-model.js
@@ -6,8 +6,5 @@ export const INITIAL_PLAYER_STATE = {
     item: 0,
     itemMeta: {},
     playRejected: false,
-    state: STATE_IDLE,
-    duration: 0,
-    position: 0,
-    buffer: 0
+    state: STATE_IDLE
 };

--- a/src/js/model/player-model.js
+++ b/src/js/model/player-model.js
@@ -8,3 +8,9 @@ export const INITIAL_PLAYER_STATE = {
     playRejected: false,
     state: STATE_IDLE
 };
+
+export const INITIAL_MEDIA_STATE = {
+    position: 0,
+    duration: 0,
+    buffer: 0,
+};

--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -136,7 +136,7 @@ export default class MediaController extends Eventable {
             model.set('playRejected', true);
             const videoTagPaused = provider && provider.video && provider.video.paused;
             if (videoTagPaused) {
-                mediaModel.set(PLAYER_STATE, STATE_PAUSED);
+                mediaModel.set('mediaState', STATE_PAUSED);
             }
             this.trigger(MEDIA_PLAY_ATTEMPT_FAILED, {
                 error,
@@ -216,8 +216,8 @@ export default class MediaController extends Eventable {
 
 function syncPlayerWithMediaModel(mediaModel) {
     // Sync player state with mediaModel state
-    const mediaState = mediaModel.get('state');
-    mediaModel.trigger('change:state', mediaModel, mediaState, mediaState);
+    const mediaState = mediaModel.get('mediaState');
+    mediaModel.trigger('change:mediaState', mediaModel, mediaState, mediaState);
 }
 
 function addProviderListeners(mediaController) {

--- a/src/js/program/provider-listener.js
+++ b/src/js/program/provider-listener.js
@@ -53,10 +53,10 @@ export default function ProviderListener(mediaController) {
                     mediaController.thenPlayPromise.cancel();
                     mediaModel.srcReset();
                 }
-                // Always fire change:state to keep player model in sync
-                const previousState = mediaModel.attributes[PLAYER_STATE];
-                mediaModel.attributes[PLAYER_STATE] = data.newstate;
-                mediaModel.trigger('change:' + PLAYER_STATE, mediaModel, data.newstate, previousState);
+                // Always fire change:mediaState to keep player model in sync
+                const previousState = mediaModel.attributes.mediaState;
+                mediaModel.attributes.mediaState = data.newstate;
+                mediaModel.trigger('change:mediaState', mediaModel, data.newstate, previousState);
             }
                 // This "return" is important because
                 //  we are choosing to not propagate model event.
@@ -67,24 +67,21 @@ export default function ProviderListener(mediaController) {
                 mediaModel.srcReset();
                 break;
             case MEDIA_BUFFER:
-                model.set('buffer', data.bufferPercent);
+                mediaModel.set('buffer', data.bufferPercent);
             /* falls through */
             case MEDIA_META: {
                 const duration = data.duration;
                 if (_isNumber(duration) && !_isNaN(duration)) {
                     mediaModel.set('duration', duration);
-                    model.set('duration', duration);
                 }
                 Object.assign(model.get('itemMeta'), data.metadata);
                 break;
             }
             case MEDIA_TIME: {
                 mediaModel.set('position', data.position);
-                model.set('position', data.position);
                 const duration = data.duration;
                 if (_isNumber(duration) && !_isNaN(duration)) {
                     mediaModel.set('duration', duration);
-                    model.set('duration', duration);
                 }
                 model.trigger(type, data);
                 break;

--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -90,7 +90,7 @@ class TimeSlider extends Slider {
         super.setup.apply(this, arguments);
 
         this._model
-            .on('duration', this.onDuration, this)
+            .on('change:duration', this.onDuration, this)
             .on('change:cues', this.addCues, this)
             .change('playlistItem', this.onPlaylistItem, this)
             .change('position', this.onPosition, this)
@@ -134,7 +134,6 @@ class TimeSlider extends Slider {
     dragEnd() {
         super.dragEnd.apply(this, arguments);
         this._model.set('scrubbing', false);
-        this.dragJustReleased = true;
     }
 
     onBuffer(model, pct) {
@@ -142,11 +141,6 @@ class TimeSlider extends Slider {
     }
 
     onPosition(model, position) {
-        if (this.dragJustReleased) {
-            // prevents firing an outdated position and causing the timeslider to jump back and forth
-            this.dragJustReleased = false;
-            return;
-        }
         this.updateTime(position, model.get('duration'));
     }
 

--- a/test/data/model-properties.js
+++ b/test/data/model-properties.js
@@ -14,7 +14,6 @@ export const optionalProperties = {
     hideAdsControls: null,
     mediaModel: {},
     flashThrottle: null,
-    playRejected: false,
     androidhls: true,
     hlsjsdefault: true,
     drm: null,

--- a/test/unit/model-qoe-test.js
+++ b/test/unit/model-qoe-test.js
@@ -16,29 +16,29 @@ describe('Model QoE', function() {
         initQoe(model, program);
         const qoeItem = model._qoeItem;
 
-        mediaModel.set('state', STATE_IDLE);
+        mediaModel.set('mediaState', STATE_IDLE);
         program.trigger(MEDIA_PLAY_ATTEMPT);
-        mediaModel.set('state', STATE_LOADING);
-        mediaModel.set('state', STATE_PLAYING);
+        mediaModel.set('mediaState', STATE_LOADING);
+        mediaModel.set('mediaState', STATE_PLAYING);
 
         // FIXME: PROVIDER_FIRST_FRAME triggers MEDIA_FIRST_FRAME : we only need one event
         program.trigger(PROVIDER_FIRST_FRAME);
 
-        expect(!!qoeItem, 'qoeItem is defined').to.be.true;
+        expect(!!qoeItem, 'qoeItem is defined').to.equal(true);
 
         const loadTime = qoeItem.between(MEDIA_PLAY_ATTEMPT, MEDIA_FIRST_FRAME);
-        expect(validateMeasurement(loadTime), 'time to first frame is a valid number').to.be.true;
+        expect(validateMeasurement(loadTime), 'time to first frame is a valid number').to.equal(true);
 
         const qoeDump = qoeItem.dump();
         expect(qoeDump.counts.idle).to.equal(1, 'one idle event');
         expect(qoeDump.counts.loading).to.equal(1, 'one loading event');
         expect(qoeDump.counts.playing).to.equal(1, 'one playing event');
-        expect(validateMeasurement(qoeDump.sums.idle), 'idle sum is a valid number').to.be.true;
-        expect(validateMeasurement(qoeDump.sums.loading), 'loading sum is a valid number').to.be.true;
-        expect(validateMeasurement(qoeDump.sums.playing), 'playing sum is a valid number').to.be.true;
-        expect(validateMeasurement(qoeDump.events.playlistItem, startTime), 'playlistItem epoch time is ok').to.be.true;
-        expect(validateMeasurement(qoeDump.events.playAttempt, startTime), 'playAttempt epoch time is ok').to.be.true;
-        expect(validateMeasurement(qoeDump.events.firstFrame, startTime), 'firstFrame epoch time is ok').to.be.true;
+        expect(validateMeasurement(qoeDump.sums.idle), 'idle sum is a valid number').to.equal(true);
+        expect(validateMeasurement(qoeDump.sums.loading), 'loading sum is a valid number').to.equal(true);
+        expect(validateMeasurement(qoeDump.sums.playing), 'playing sum is a valid number').to.equal(true);
+        expect(validateMeasurement(qoeDump.events.playlistItem, startTime), 'playlistItem epoch time is ok').to.equal(true);
+        expect(validateMeasurement(qoeDump.events.playAttempt, startTime), 'playAttempt epoch time is ok').to.equal(true);
+        expect(validateMeasurement(qoeDump.events.firstFrame, startTime), 'firstFrame epoch time is ok').to.equal(true);
     });
 
     it('removes media controller event listeners', function() {
@@ -53,8 +53,8 @@ describe('Model QoE', function() {
 
         let qoeDump = qoeItem.dump();
         expect(validateMeasurement(qoeDump.events.playAttempt, startTime), 'play attempt event was fired ' +
-            JSON.stringify(qoeDump.events) + ' startTime: ' + startTime).to.be.true;
-        expect(validateMeasurement(qoeDump.events.firstFrame, startTime), 'first frame event was fired').to.be.true;
+            JSON.stringify(qoeDump.events) + ' startTime: ' + startTime).to.equal(true);
+        expect(validateMeasurement(qoeDump.events.firstFrame, startTime), 'first frame event was fired').to.equal(true);
 
         // test that listeners are removed by testing that tick events are no longer changed
         qoeItem.tick('playAttempt');
@@ -81,13 +81,13 @@ describe('Model QoE', function() {
         const mediaModel = model.mediaModel;
         const qoeItem = model._qoeItem;
 
-        mediaModel.set('state', STATE_LOADING);
-        mediaModel.set('state', STATE_PLAYING);
-        mediaModel.set('state', STATE_STALLED);
-        mediaModel.set('state', STATE_PLAYING);
+        mediaModel.set('mediaState', STATE_LOADING);
+        mediaModel.set('mediaState', STATE_PLAYING);
+        mediaModel.set('mediaState', STATE_STALLED);
+        mediaModel.set('mediaState', STATE_PLAYING);
 
         const qoeDump = qoeItem.dump();
-        expect(validateMeasurement(qoeDump.sums.stalled), 'stalled sum is a valid number').to.be.true;
+        expect(validateMeasurement(qoeDump.sums.stalled), 'stalled sum is a valid number').to.equal(true);
     });
 
     it('uses one qoe item per playlist item', function() {
@@ -103,17 +103,17 @@ describe('Model QoE', function() {
         const secondQoeItem = model._qoeItem;
 
         program.trigger(MEDIA_PLAY_ATTEMPT);
-        mediaModel.set('state', STATE_LOADING);
+        mediaModel.set('mediaState', STATE_LOADING);
 
-        expect(firstQoeItem !== secondQoeItem, 'qoe items are unique between playlistItem changes').to.be.true;
+        expect(firstQoeItem !== secondQoeItem, 'qoe items are unique between playlistItem changes').to.equal(true);
 
         const firstQoeDump = firstQoeItem.dump();
         const secondQoeDump = secondQoeItem.dump();
 
-        expect(firstQoeDump.events.playAttempt === undefined, 'play attempt is was not tracked for first unplayed item').to.be.true;
-        expect(secondQoeDump.events.playAttempt !== undefined, 'play attempt is was tracked for second item').to.be.true;
-        expect(firstQoeDump.counts.loading === undefined, 'loading was not tracked for first unplayed item').to.be.true;
-        expect(secondQoeDump.counts.loading === 1, 'loading was tracked for second item').to.be.true;
+        expect(firstQoeDump.events.playAttempt === undefined, 'play attempt is was not tracked for first unplayed item').to.equal(true);
+        expect(secondQoeDump.events.playAttempt !== undefined, 'play attempt is was tracked for second item').to.equal(true);
+        expect(firstQoeDump.counts.loading === undefined, 'loading was not tracked for first unplayed item').to.equal(true);
+        expect(secondQoeDump.counts.loading === 1, 'loading was tracked for second item').to.equal(true);
     });
 
     function validateMeasurement(value, min) {


### PR DESCRIPTION
### This PR will...

- Remove `position`, `duration` and `buffer` from the player model, and only write these in the media-model.
- Rename media-model `state` to `mediaState` so that it does not collide with `state` in the player (or view) model.

### Why is this Pull Request needed?

This places transient state that is reset between playlist items and ad breaks in the media-model. We can worry less about state from previous items affecting the current player state since each item gets it's own media-model.

### Are there any Pull Requests open in other repos which need to be merged with this?

Test updates https://github.com/jwplayer/jwplayer-commercial/pull/4376

#### Addresses Issue(s):

JW8-806

