### PR TITLE
Do not null model-shim on destroy

### DIFF
--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -137,7 +137,6 @@ Object.assign(CoreShim.prototype, {
         this.off();
         this._events =
             this._model =
-            this.modelShim =
             this.originalContainer =
             this.apiQueue =
             this.setup = null;


### PR DESCRIPTION
Fixes exception in async plugin setup (calling `api.getConfig()`) `after api.remove()`.
