### PR TITLE
Avoid prematurely reading attached off of mediaController 

### DIFF
--- a/src/js/program/provider-listener.js
+++ b/src/js/program/provider-listener.js
@@ -7,7 +7,7 @@ import { PLAYER_STATE, STATE_IDLE, MEDIA_VOLUME, MEDIA_MUTE,
 
 export default function ProviderListener(mediaController) {
     return function (type, data) {
-        const { provider, mediaModel, model, attached } = mediaController;
+        const { provider, mediaModel, model } = mediaController;
         const event = Object.assign({}, data, {
             type: type
         });
@@ -103,7 +103,7 @@ export default function ProviderListener(mediaController) {
             case MEDIA_COMPLETE:
                 mediaController.beforeComplete = true;
                 mediaController.trigger(MEDIA_BEFORECOMPLETE, event);
-                if (attached) {
+                if (mediaController.attached) {
                     mediaController._playbackComplete();
                 }
                 return;


### PR DESCRIPTION
### Why is this Pull Request needed?
`attached` can be changed async, so we should read it off at the last minute

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-922

