### PR TITLE
HTML5 Provider getVisualQuality() fixes

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -22,7 +22,7 @@ import { INITIAL_MEDIA_STATE } from 'model/player-model';
 import { PLAYER_STATE, STATE_BUFFERING, STATE_IDLE, STATE_COMPLETE, STATE_PAUSED, STATE_PLAYING, STATE_ERROR, STATE_LOADING,
     STATE_STALLED, MEDIA_BEFOREPLAY, PLAYLIST_LOADED, ERROR, PLAYLIST_COMPLETE, CAPTIONS_CHANGED, READY,
     MEDIA_ERROR, MEDIA_COMPLETE, CAST_SESSION, FULLSCREEN, PLAYLIST_ITEM, MEDIA_VOLUME, MEDIA_MUTE, PLAYBACK_RATE_CHANGED,
-    CAPTIONS_LIST, CONTROLS, RESIZE } from 'events/events';
+    CAPTIONS_LIST, CONTROLS, RESIZE, MEDIA_VISUAL_QUALITY } from 'events/events';
 import ProgramController from 'program/program-controller';
 import initQoe from 'controller/qoe';
 
@@ -599,7 +599,7 @@ Object.assign(Controller.prototype, {
         function _getVisualQuality() {
             const mediaModel = this._model.get('mediaModel');
             if (mediaModel) {
-                return mediaModel.get('visualQuality');
+                return mediaModel.get(MEDIA_VISUAL_QUALITY);
             }
             return null;
         }

--- a/src/js/events/events.js
+++ b/src/js/events/events.js
@@ -310,6 +310,11 @@ export const MEDIA_LEVELS = 'levels';
 export const MEDIA_LEVEL_CHANGED = 'levelsChanged';
 
 /**
+ * Fired when the visual quality of media is updated.
+ */
+export const MEDIA_VISUAL_QUALITY = 'visualQuality';
+
+/**
  * Fired when controls are enabled or disabled by a script.
 */
 export const CONTROLS = 'controls';

--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -5,8 +5,9 @@ import { resolved } from 'polyfills/promise';
 import { MediaModel } from 'controller/model';
 import { seconds } from 'utils/strings';
 import {
-    MEDIA_PLAY_ATTEMPT, MEDIA_PLAY_ATTEMPT_FAILED, PLAYER_STATE,
-    STATE_PAUSED, STATE_BUFFERING, MEDIA_COMPLETE, STATE_COMPLETE
+    MEDIA_PLAY_ATTEMPT, MEDIA_PLAY_ATTEMPT_FAILED, MEDIA_COMPLETE,
+    PLAYER_STATE, STATE_PAUSED, STATE_BUFFERING, STATE_COMPLETE,
+    MEDIA_VISUAL_QUALITY
 } from 'events/events';
 
 export default class MediaController extends Eventable {
@@ -130,6 +131,11 @@ export default class MediaController extends Eventable {
             }
             mediaModel.set('started', true);
             if (mediaModel === model.mediaModel) {
+                // Start firing visualQuality once playback has started
+                mediaModel.off(MEDIA_VISUAL_QUALITY, null, this);
+                mediaModel.change(MEDIA_VISUAL_QUALITY, (changedMediaModel, eventData) => {
+                    this.trigger(MEDIA_VISUAL_QUALITY, eventData);
+                }, this);
                 syncPlayerWithMediaModel(mediaModel);
             }
         }).catch(error => {

--- a/src/js/program/provider-listener.js
+++ b/src/js/program/provider-listener.js
@@ -2,7 +2,7 @@ import { _isNaN, _isNumber } from 'utils/underscore';
 import { PLAYER_STATE, STATE_IDLE, MEDIA_VOLUME, MEDIA_MUTE,
     MEDIA_TYPE, PROVIDER_CHANGED, AUDIO_TRACKS, AUDIO_TRACK_CHANGED,
     MEDIA_RATE_CHANGE, MEDIA_BUFFER, MEDIA_TIME, MEDIA_LEVELS, MEDIA_LEVEL_CHANGED, MEDIA_ERROR,
-    MEDIA_BEFORECOMPLETE, MEDIA_COMPLETE, MEDIA_META, MEDIA_SEEK, MEDIA_SEEKED,
+    MEDIA_BEFORECOMPLETE, MEDIA_COMPLETE, MEDIA_META, MEDIA_SEEK, MEDIA_SEEKED, MEDIA_VISUAL_QUALITY,
     NATIVE_FULLSCREEN } from 'events/events';
 
 export default function ProviderListener(mediaController) {
@@ -47,6 +47,9 @@ export default function ProviderListener(mediaController) {
                     mediaModel.set(MEDIA_TYPE, data.mediaType);
                     mediaController.trigger(type, event);
                 }
+                return;
+            case MEDIA_VISUAL_QUALITY:
+                mediaModel.set(MEDIA_VISUAL_QUALITY, Object.assign({}, data));
                 return;
             case PLAYER_STATE: {
                 if (data.newstate === STATE_IDLE) {
@@ -113,9 +116,6 @@ export default function ProviderListener(mediaController) {
                 break;
             case 'subtitlesTrackChanged':
                 model.persistVideoSubtitleTrack(data.currentTrack, data.tracks);
-                break;
-            case 'visualQuality':
-                mediaModel.set('visualQuality', Object.assign({}, data));
                 break;
             case MEDIA_SEEK:
             case MEDIA_SEEKED:

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -1,7 +1,7 @@
 import { qualityLevel } from 'providers/data-normalizer';
 import { Browser, OS } from 'environment/environment';
 import { isAndroidHls } from 'providers/html5-android-hls';
-import { STATE_IDLE, STATE_PLAYING, MEDIA_META, MEDIA_ERROR,
+import { STATE_IDLE, MEDIA_META, MEDIA_ERROR, MEDIA_VISUAL_QUALITY, MEDIA_TYPE,
     MEDIA_LEVELS, MEDIA_LEVEL_CHANGED, MEDIA_SEEK, STATE_LOADING } from 'events/events';
 import VideoEvents from 'providers/video-listener-mixin';
 import VideoAction from 'providers/video-actions-mixin';
@@ -67,10 +67,12 @@ function VideoProvider(_playerId, _playerConfig) {
                 VideoEvents.timeupdate.call(_this);
             }
             checkStaleStream();
-            if (_this.state === STATE_PLAYING) {
+            if (Browser.ie) {
                 checkVisualQuality();
             }
         },
+
+        resize: checkVisualQuality,
 
         ended() {
             _currentQuality = -1;
@@ -89,6 +91,7 @@ function VideoProvider(_playerId, _playerConfig) {
                 width: _videotag.videoWidth
             };
             _this.trigger(MEDIA_META, metadata);
+            checkVisualQuality();
         },
 
         durationchange() {
@@ -102,7 +105,6 @@ function VideoProvider(_playerId, _playerConfig) {
             VideoEvents.loadeddata.call(_this);
             _setAudioTracks(_videotag.audioTracks);
             _checkDelayedSeek(_this.getDuration());
-            checkVisualQuality();
         },
 
         canplay() {
@@ -249,7 +251,7 @@ function VideoProvider(_playerId, _playerConfig) {
             visualQuality.bitrate = 0;
             level.index = _currentQuality;
             level.label = _levels[_currentQuality].label;
-            _this.trigger('visualQuality', visualQuality);
+            _this.trigger(MEDIA_VISUAL_QUALITY, visualQuality);
             visualQuality.reason = '';
         }
     }
@@ -767,7 +769,7 @@ function VideoProvider(_playerId, _playerConfig) {
             if (_videotag.videoHeight === 0) {
                 mediaType = 'audio';
             }
-            _this.trigger('mediaType', { mediaType: mediaType });
+            _this.trigger(MEDIA_TYPE, { mediaType: mediaType });
         }
     }
 

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -10,7 +10,8 @@ import { normalizeSkin, handleColorOverrides } from 'view/utils/skin';
 import { Browser, OS, Features } from 'environment/environment';
 import * as ControlsLoader from 'controller/controls-loader';
 import {
-    STATE_BUFFERING, STATE_IDLE, STATE_COMPLETE, STATE_PAUSED, STATE_PLAYING, STATE_ERROR, RESIZE, BREAKPOINT, DISPLAY_CLICK, LOGO_CLICK, ERROR, NATIVE_FULLSCREEN } from 'events/events';
+    STATE_BUFFERING, STATE_IDLE, STATE_COMPLETE, STATE_PAUSED, STATE_PLAYING, STATE_ERROR,
+    RESIZE, BREAKPOINT, DISPLAY_CLICK, LOGO_CLICK, ERROR, NATIVE_FULLSCREEN, MEDIA_VISUAL_QUALITY } from 'events/events';
 import Events from 'utils/backbone.events';
 import {
     addClass,
@@ -212,7 +213,7 @@ function View(_api, _model) {
         // Native fullscreen (coming through from the provider)
         _model.on(NATIVE_FULLSCREEN, _fullscreenChangeHandler);
 
-        _model.on('change:visualQuality', () => {
+        _model.on(`change:${MEDIA_VISUAL_QUALITY}`, () => {
             _resizeMedia();
         });
 


### PR DESCRIPTION
### This PR will...

Update the "visualQuality" in the mediaModel as soon as possible from the html5 provider. Only fire "visualQuality" events once playback has begun. 

### Why is this Pull Request needed?

So that `api.getVisualQuality()` will always return results on "play" - also on "playAttempt" provided metadata was loaded.

#### Addresses Issue(s):

JW8-823

