### PR TITLE
Show the selected captions track when playback starts and after a midroll

### DIFF
--- a/src/js/view/utils/submenu-factory.js
+++ b/src/js/view/utils/submenu-factory.js
@@ -46,6 +46,12 @@ export function addCaptionsSubmenu(settingsMenu, captionsList, action, initialSe
     });
 
     const captionsSubmenu = makeSubmenu(settingsMenu, CAPTIONS_SUBMENU, captionsContentItems, cloneIcon('cc-off'), tooltipText);
+
+    // Set the current captions track if the initial index isn't 'Off'
+    if (initialSelectionIndex > 0) {
+        action(initialSelectionIndex);
+    }
+
     captionsSubmenu.activateItem(initialSelectionIndex);
 }
 


### PR DESCRIPTION
### This PR will...
Set the captions track in the provider when the initial index > 0. This occurs when captionsIndex is persisted in local storage or after a midroll.

### Why is this Pull Request needed?
When the menu is setup, `captionsSubmenu.activateItem(initialSelectionIndex);` simply selects the correct captions sub-menu item, but there was nothing telling the provider that it should prepare a captions track to be displayed if one should be selected. The callback [here](#diff-9cb89dfb63ccc7e459e527fcc5a13102R41) takes care of the case where there's a user selection from the settings menu, but this does not get fired when the menu is first setup if `localStorage.captionsIndex > 0`. This also caused captions to not show after a midroll.
### Are there any points in the code the reviewer needs to double check?
No
### Are there any Pull Requests open in other repos which need to be merged with this?
No
#### Addresses Issue(s):
JW8-934

