### PR TITLE
Add hlsjs flag for Safari (v8.0.x)

### DIFF
--- a/src/js/playlist/playlist.js
+++ b/src/js/playlist/playlist.js
@@ -45,6 +45,7 @@ export function filterPlaylist(playlist, model, feedData) {
 function formatSources(item, model) {
     const sources = item.sources;
     const androidhls = model.get('androidhls');
+    const safariHlsjs = model.get('safarihlsjs');
     const itemDrm = item.drm || model.get('drm');
     const withCredentials = fallbackIfUndefined(item.withCredentials, model.get('withCredentials'));
     const hlsjsdefault = model.get('hlsjsdefault') !== false;
@@ -55,6 +56,10 @@ function formatSources(item, model) {
         }
         if (androidhls !== undefined && androidhls !== null) {
             originalSource.androidhls = androidhls;
+        }
+
+        if (safariHlsjs !== undefined && safariHlsjs !== null) {
+            originalSource.safarihlsjs = safariHlsjs;
         }
 
         if (originalSource.drm || itemDrm) {

--- a/test/unit/playlist-filtering-test.js
+++ b/test/unit/playlist-filtering-test.js
@@ -34,7 +34,7 @@ function testSource(sourceName, desiredType, isAndroidHls) {
     const pl = Playlist(Playlists[sourceName]);
     const filtered = filterPlaylist(pl, model);
 
-    expect(sourcesMatch(filtered)).to.be.true;
+    expect(sourcesMatch(filtered), `Comparing ${sourceName} ${desiredType}`).to.equal(true);
 }
 
 describe('playlist.filterSources', function() {

--- a/test/unit/providers-test.js
+++ b/test/unit/providers-test.js
@@ -1,7 +1,5 @@
-import Providers from 'providers/providers';
-import ProvidersSupported from 'providers/providers-supported';
+import Providers, { Loaders } from 'providers/providers';
 import Source from 'playlist/source';
-import { Features } from 'environment/environment';
 import _ from 'underscore/underscore';
 
 const getName = function getName(provider) {
@@ -15,13 +13,6 @@ const getName = function getName(provider) {
 };
 
 describe('Providers', function() {
-
-    it('should be prioritized', function() {
-        const providerMap = ProvidersSupported.reduce(function(providers, provider, index) {
-            providers[getName(provider)] = index;
-            return providers;
-        }, {});
-    });
 
     it('should choose html5 by default', function() {
         const htmlSources = {
@@ -47,6 +38,10 @@ describe('Providers', function() {
     });
 
     it('should not choose a provider for hls and dash streams', function() {
+        if (!Loaders || (Loaders.hlsjs || Loaders.shaka)) {
+            // Exit if Loaders were extended with hls and dash providers or is not exported in this project
+            return;
+        }
         const unsupportedSources = {
             hls: {
                 file: 'http://playertest.longtailvideo.com/adaptive/bipbop/bipbopall.hls',


### PR DESCRIPTION
### This PR will...

- Check if the `safarihlsjs` flag is set in the model and add it as a flag in the source. This will allow `ProvidersSupported` to verify if it should use `hlsjs`
-Remove redundant edition checks

### Why is this Pull Request needed?

Since `ProvidersSupported` only takes in the `source` and not `model`, the flag needs to be passed through.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-commercial/pull/4370

#### Addresses Issue(s):

JW8-856 & JW8-806