### PR TITLE
Show the selected captions track when playback starts and after a midroll

### DIFF
--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -16,16 +16,11 @@ const Captions = function(_model) {
     // Listen for item ready to determine which provider is in use
     _model.on('itemReady', _itemReadyHandler, this);
 
-    // Listen for provider subtitle tracks
-    //   ignoring provider "subtitlesTrackChanged" since index should be managed here
-    _model.on('subtitlesTracks', _subtitlesTracksHandler, this);
-
-    function _subtitlesTracksHandler(e) {
-        if (!e.tracks.length) {
+    function _setSubtitlesTracks(tracks) {
+        if (!tracks.length) {
             return;
         }
 
-        const tracks = e.tracks || [];
         for (let i = 0; i < tracks.length; i++) {
             _addTrack(tracks[i]);
         }
@@ -35,7 +30,7 @@ const Captions = function(_model) {
 
         const captionsMenu = _captionsMenu();
         _selectDefaultIndex();
-        this.setCaptionsList(captionsMenu);
+        _setCaptionsList(captionsMenu);
     }
 
     let _tracks = [];
@@ -79,7 +74,7 @@ const Captions = function(_model) {
 
         const captionsMenu = _captionsMenu();
         _selectDefaultIndex();
-        this.setCaptionsList(captionsMenu);
+        _setCaptionsList(captionsMenu);
     }
 
     function _kindSupported(kind) {
@@ -162,16 +157,18 @@ const Captions = function(_model) {
         }
     }
 
+    function _setCaptionsList (captionsMenu) {
+        _model.set('captionsList', captionsMenu);
+    }
+
+    this.setSubtitlesTracks = _setSubtitlesTracks;
+
     this.getCurrentIndex = function() {
         return _model.get('captionsIndex');
     };
 
     this.getCaptionsList = function() {
         return _model.get('captionsList');
-    };
-
-    this.setCaptionsList = function(captionsMenu) {
-        _model.set('captionsList', captionsMenu);
     };
 
     this.destroy = function() {

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -694,6 +694,15 @@ Object.assign(Controller.prototype, {
 
         function addProgramControllerListeners() {
             _programController.on('all', _triggerAfterReady, _this);
+            _programController.on('subtitlesTracks', (e) => {
+                _captions.setSubtitlesTracks(e.tracks);
+                const defaultCaptionsIndex = _captions.getCurrentIndex();
+
+                // set the current captions if the default index isn't 0 or "Off"
+                if (defaultCaptionsIndex > 0) {
+                    _setCurrentCaptions(defaultCaptionsIndex);
+                }
+            });
             _programController.on(MEDIA_COMPLETE, () => {
                 // Insert a small delay here so that other complete handlers can execute
                 resolved.then(_completeHandler);


### PR DESCRIPTION
### This PR will...
- Set the captions track when the initial index > 0
- Make `setCaptionsList` private since it's only used in `captions.js`.

### Why is this Pull Request needed?
The model no longer controls syncing up the provider with the default captions track. This is now the responsibility of the controller. As such, the controller should `setCurrentCaptions` when the provider notifies the program controller that subtitles exist.
### Are there any points in the code the reviewer needs to double check?
No
### Are there any Pull Requests open in other repos which need to be merged with this?
No
#### Addresses Issue(s):
JW8-934

