### PR TITLE
Support querying and setup of multiple elements without ids

### DIFF
--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -40,6 +40,7 @@ function coreFactory(api, element) {
 function resetPlayer(api, core) {
     api.off();
     core.playerDestroy();
+    core.getContainer().removeAttribute('data-jwplayer-id');
 }
 
 /**
@@ -67,13 +68,14 @@ export default function Api(element) {
 
     // `uniqueId` should start at 1
     const uniqueId = ++instancesCreated;
-    const playerId = element.id;
+    const playerId = element.id || `player-${uniqueId}`;
     const qoeTimer = new Timer();
     const pluginsMap = {};
 
     let core = coreFactory(this, element);
 
     qoeTimer.tick('init');
+    element.setAttribute('data-jwplayer-id', playerId);
 
     Object.defineProperties(this, /** @lends Api.prototype */ {
         /**

--- a/src/js/jwplayer.js
+++ b/src/js/jwplayer.js
@@ -33,7 +33,7 @@ const jwplayer = function(query) {
         player = instances[query];
     } else if (query.nodeType) {
         domElement = query;
-        player = playerById(domElement.id);
+        player = playerById(domElement.id || domElement.getAttribute('data-jwplayer-id'));
     }
     // found player
     if (player) {


### PR DESCRIPTION
### This PR will...

Support querying and setup of multiple elements without ids.

The data attribute "data-jwplayer-id" is assigned to elements queried with jwplayer(domElememt) which do not have an id. The attribute is removed when jwplayer().remove() is called, and it is not present on the player element after setup, because the player always assigns an id to elements it creates.

### Why is this Pull Request needed?

Our API supports querying of a single element without an id. This extends to support multiple elements:

```js
const element1 = document.createElement('div');
const element2 = document.createElement('div');

document.body.appendChild(element1);
document.body.appendChild(element2);

jwplayer(element1).setup({ file: 'video.mp4' });
jwplayer(element2).setup({ file: 'video.mp4' });

jwplayer(element1).play();
jwplayer(element2).seek(30);
```

Here's an example that generates three elements to setup players with provided by @trinonsense 
 in #2382 https://codepen.io/trinonsense/pen/KXzVNZ Currently only one player is setup.

#### Addresses Issue(s):

JW8-801
Fixes #2382 