### PR TITLE
Fix for resuming after instream mid-roll

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -60,7 +60,7 @@ var InstreamAdapter = function(_controller, _model, _view) {
     this.init = function(sharedVideoTag) {
         // Keep track of the original player state
         const mediaElement = sharedVideoTag || _model.get('mediaElement');
-        _oldpos = _model.get('position');
+        _oldpos = _controller.get('position');
         _olditem = _model.get('playlist')[_model.get('item')];
 
         _instream.on('all', _instreamForward, this);


### PR DESCRIPTION
Position has been removed from the player model. This uses the controller to get it from the active media-model.
