### PR TITLE
Check if device is touchScreen

### DIFF
--- a/src/js/environment/environment.js
+++ b/src/js/environment/environment.js
@@ -10,6 +10,7 @@ import {
     isAndroidNative,
     isIOS,
     isMobile,
+    isTouchScreen,
     isOSX,
     isIPad,
     isIPod,
@@ -65,6 +66,12 @@ export const OS = {};
  * @property {boolean} iframe - Is the session in an iframe?
  */
 export const Features = {};
+
+/**
+ * @typedef {object} HardwareCapabilities
+ * @property {boolean} touchScreen - Is the browser being rendered on a touch screen device?
+ */
+export const Hardware = {};
 
 const isWindows = () => {
     return userAgent.indexOf('Windows') > -1;
@@ -155,6 +162,13 @@ Object.defineProperties(Features, {
     },
     iframe: {
         get: memoize(isIframe),
+        enumerable: true
+    }
+});
+
+Object.defineProperties(Hardware, {
+    touchScreen: {
+        get: memoize(isTouchScreen),
         enumerable: true
     }
 });

--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -70,6 +70,10 @@ export function isMobile() {
     return isIOS() || isAndroid();
 }
 
+export function isTouchScreen() {
+    return 'ontouchstart' in window || navigator.msMaxTouchPoints;
+}
+
 export function isIframe() {
     try {
         return window.self !== window.top;

--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -71,7 +71,8 @@ export function isMobile() {
 }
 
 export function isTouchScreen() {
-    return 'ontouchstart' in window || navigator.msMaxTouchPoints;
+    // Note: does not work for FireFox on Surface.
+    return isMobile() || 'ontouchstart' in window || navigator.msMaxTouchPoints || navigator.maxTouchPoints;
 }
 
 export function isIframe() {

--- a/test/unit/api-test.js
+++ b/test/unit/api-test.js
@@ -241,7 +241,7 @@ describe('Api', function() {
         const api = new Api(container);
 
         expect(api.qoe(), '.qoe()').to.have.keys(['setupTime', 'firstFrame', 'player', 'item']);
-        expect(api.getEnvironment(), '.getEnvironment()').to.have.keys(['Browser', 'OS', 'Features']);
+        expect(api.getEnvironment(), '.getEnvironment()').to.have.keys(['Browser', 'OS', 'Features', 'Hardware']);
         expect(api.getContainer(), '.getContainer()').to.equal(container, 'returns the player DOM element before setup');
         expect(api.getConfig(), '.getConfig()').to.eql({});
         expect(api.getAudioTracks(), '.getAudioTracks()').to.equal(null);
@@ -289,7 +289,7 @@ describe('Api', function() {
         api.setup({});
 
         expect(api.qoe(), '.qoe()').to.have.keys(['setupTime', 'firstFrame', 'player', 'item']);
-        expect(api.getEnvironment(), '.getEnvironment()').to.have.keys(['Browser', 'OS', 'Features']);
+        expect(api.getEnvironment(), '.getEnvironment()').to.have.keys(['Browser', 'OS', 'Features', 'Hardware']);
         expect(api.getContainer(), '.getContainer()').to.equal(container, 'returns the player DOM element before setup');
         expect(api.getConfig(), '.getConfig()').to.not.be.empty;
         expect(api.getAudioTracks(), '.getAudioTracks()').to.equal(null);


### PR DESCRIPTION
### This PR will...
Add a section in the environment module indicating if a device supports touchScreen 
### Why is this Pull Request needed?
our mobile check excludes microsoft touch devices and therefore we need a better indicator to determine if swiping will be supported in related
### Are there any points in the code the reviewer needs to double check?
this check does not work for FireFox on microsoft touch screen devices.
### Are there any Pull Requests open in other repos which need to be merged with this?
blocker for [related PR](https://github.com/jwplayer/jwplayer-plugin-related/pull/186)
#### Addresses Issue(s):
JW8-942

