### PR TITLE
load DRM Item: Make updatePlaylist public

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -308,14 +308,14 @@ Object.assign(Controller.prototype, {
                     });
                     updatePlaylistCancelable = cancelable((data) => {
                         if (data) {
-                            return _updatePlaylist(data.playlist, data);
+                            return _this.updatePlaylist(data.playlist, data);
                         }
                     });
                     loadPromise = loadPlaylistPromise.then(updatePlaylistCancelable.async);
                     break;
                 }
                 case 'object':
-                    loadPromise = _updatePlaylist(item, feedData);
+                    loadPromise = _this.updatePlaylist(item, feedData);
                     break;
                 case 'number':
                     loadPromise = _setItem(item);
@@ -330,18 +330,6 @@ Object.assign(Controller.prototype, {
             });
 
             loadPromise.then(checkAutoStartCancelable.async).catch(function() {});
-        }
-
-        function _updatePlaylist(data, feedData) {
-            const playlist = Playlist(data);
-            try {
-                setPlaylist(_model, playlist, feedData);
-            } catch (error) {
-                _model.set('item', 0);
-                _model.set('playlistItem', null);
-                return Promise.reject(error);
-            }
-            return _setItem(0);
         }
 
         function _loadPlaylist(toLoad) {
@@ -827,6 +815,18 @@ Object.assign(Controller.prototype, {
             if (provider) {
                 provider.setControls(mode);
             }
+        };
+
+        this.updatePlaylist = function(data, feedData) {
+            const playlist = Playlist(data);
+            try {
+                setPlaylist(_model, playlist, feedData);
+            } catch (error) {
+                _model.set('item', 0);
+                _model.set('playlistItem', null);
+                return Promise.reject(error);
+            }
+            return _setItem(0);
         };
 
         this.playerDestroy = function () {


### PR DESCRIPTION
### This PR will...

-Made the updatePlaylist method public

If the `.load()` API is called, with an object that contains a DRM block, this will probe to identify the supported DRM key systems. Once the probe promise completes, the loading of the item continues.

### Why is this Pull Request needed?

to ensure that we are able to load and play DRM items using the `load` API.

### Othe PRs:

https://github.com/jwplayer/jwplayer-commercial/pull/4382

#### Addresses Issue(s):

JW8-757