### PR TITLE
Prime the media element used by instream on iOS

### DIFF
--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -986,5 +986,5 @@ Object.assign(Api.prototype, /** @lends Api.prototype */ {
      * Pauses or toggles ad playback. Implemented by ad plugins.
      * @param {boolean} toggle - Specifies whether ad playback should be paused or resumed.
      */
-    pauseAd(toggle) {}, // eslint-disable-line,
+    pauseAd(toggle) {}, // eslint-disable-line
 });

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -293,7 +293,9 @@ Object.assign(Controller.prototype, {
             checkAutoStartCancelable = cancelable(_checkAutoStart);
             updatePlaylistCancelable.cancel();
 
-            _programController.primeMediaElements();
+            if (_inInteraction(window.event)) {
+                _programController.primeMediaElements();
+            }
 
             let loadPromise;
 
@@ -399,7 +401,9 @@ Object.assign(Controller.prototype, {
                 if (_interruptPlay) {
                     _interruptPlay = false;
                     _actionOnAttach = null;
-                    _programController.primeMediaElements();
+                    if (_inInteraction(window.event)) {
+                        _programController.primeMediaElements();
+                    }
                     return resolved;
                 }
             }

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -58,9 +58,9 @@ var InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
 
     this.type = 'instream';
 
-    this.init = function(sharedVideoTag) {
+    this.init = function() {
         // Keep track of the original player state
-        _adProgram.setup(sharedVideoTag);
+        _adProgram.setup();
 
         _oldpos = _controller.get('position');
         _adProgram.on('all', _instreamForward, this);

--- a/src/js/program/ad-media-pool.js
+++ b/src/js/program/ad-media-pool.js
@@ -4,13 +4,12 @@ export default function AdMediaPool(adElement) {
     let elements = [adElement];
 
     return Object.assign({}, mediaPool, {
-        prime() {},
+        prime() {
+            elements[0].load();
+        },
         recycle() {},
         getPrimedElement() {
             return elements[0];
-        },
-        changePrimedElement(newElement) {
-            elements[0] = newElement;
         }
     });
 }

--- a/src/js/program/ad-program-controller.js
+++ b/src/js/program/ad-program-controller.js
@@ -24,7 +24,7 @@ export default class AdProgramController extends ProgramController {
         }
     }
 
-    setup(sharedTag) {
+    setup() {
         const { model, mediaPool, playerModel } = this;
         const playerAttributes = playerModel.attributes;
         const mediaModelContext = playerModel.mediaModel;
@@ -55,21 +55,13 @@ export default class AdProgramController extends ProgramController {
 
 
         if (!Features.backgroundLoading) {
-            let mediaElement;
-            if (sharedTag) {
-                mediaElement = sharedTag;
-                mediaPool.changePrimedElement(sharedTag);
-            } else {
-                mediaElement = mediaPool.getPrimedElement();
+            const mediaElement = mediaPool.getPrimedElement();
+            if (!mediaElement.paused) {
+                mediaElement.pause();
             }
-            if (mediaElement) {
-                if (!mediaElement.paused) {
-                    mediaElement.pause();
-                }
-                mediaElement.playbackRate = mediaElement.defaultPlaybackRate = 1;
-                model.mediaElement = mediaElement;
-                model.mediaSrc = mediaElement.src;
-            }
+            mediaElement.playbackRate = mediaElement.defaultPlaybackRate = 1;
+            model.mediaElement = mediaElement;
+            model.mediaSrc = mediaElement.src;
         }
     }
 

--- a/src/js/program/media-element-pool.js
+++ b/src/js/program/media-element-pool.js
@@ -2,14 +2,14 @@ export default function MediaElementPool() {
     const maxPrimedTags = 3;
     const elements = [];
     for (let i = 0; i < maxPrimedTags; i++) {
-        elements.push(document.createElement('video'));
+        const mediaElement = document.createElement('video');
+        mediaElement.className = 'jw-video jw-reset';
+        elements.push(mediaElement);
     }
 
     return {
         prime() {
-            elements.forEach(element => {
-                primeMediaElementForPlayback(element);
-            });
+            elements.forEach(primeMediaElementForPlayback);
         },
         getPrimedElement() {
             if (elements.length) {
@@ -32,12 +32,9 @@ export default function MediaElementPool() {
     };
 }
 
-function primeMediaElementForPlayback() {
-    const mediaElement = document.createElement('video');
-    mediaElement.className = 'jw-video jw-reset';
+function primeMediaElementForPlayback(mediaElement) {
     // If we're in a user-gesture event call load() on video to allow async playback
     if (!mediaElement.src) {
         mediaElement.load();
     }
-    return mediaElement;
 }

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -6,8 +6,7 @@ import { MediaControllerListener } from 'program/program-listeners';
 import Eventable from 'utils/eventable';
 
 import { ERROR, PLAYER_STATE, STATE_BUFFERING } from 'events/events';
-import {Features} from '../environment/environment';
-import mediaparser from '../parsers/mediaparser';
+import { Features } from '../environment/environment';
 
 export default class ProgramController extends Eventable {
     constructor(model, mediaPool) {
@@ -218,6 +217,13 @@ export default class ProgramController extends Eventable {
     }
 
     primeMediaElements() {
+        if (!Features.backgroundLoading) {
+            const { model } = this;
+            const mediaElement = model.get('mediaElement');
+            if (mediaElement) {
+                mediaElement.load();
+            }
+        }
         this.mediaPool.prime();
     }
 


### PR DESCRIPTION
### This PR will...

Prime model "mediaElement" when not background loading at the same time we prime elements in the pool, so that it is primed when we play a preroll.

Also removes "sharedVideoTag" are from instream (no longer in use), and cleans up `pool.prime()` implementation.

### Why is this Pull Request needed?

This allows us to remove code from ads plugins that attempts to prime video elements for playback https://github.com/jwplayer/jwplayer-ads-vast/pull/294

#### Addresses Issue(s):

JW8-770

