### PR TITLE
Always pass playlist to update playlist

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -308,14 +308,14 @@ Object.assign(Controller.prototype, {
                     });
                     updatePlaylistCancelable = cancelable((data) => {
                         if (data) {
-                            return _this.updatePlaylist(data.playlist, data);
+                            return _this.updatePlaylist(Playlist(data.playlist), data);
                         }
                     });
                     loadPromise = loadPlaylistPromise.then(updatePlaylistCancelable.async);
                     break;
                 }
                 case 'object':
-                    loadPromise = _this.updatePlaylist(item, feedData);
+                    loadPromise = _this.updatePlaylist(Playlist(item), feedData);
                     break;
                 case 'number':
                     loadPromise = _setItem(item);
@@ -817,8 +817,7 @@ Object.assign(Controller.prototype, {
             }
         };
 
-        this.updatePlaylist = function(data, feedData) {
-            const playlist = Playlist(data);
+        this.updatePlaylist = function(playlist, feedData) {
             try {
                 setPlaylist(_model, playlist, feedData);
             } catch (error) {


### PR DESCRIPTION
### This PR will...

Always pass a normalized playlist to `updatePlaylist`.

### Why is this Pull Request needed?

This simplifies logic in the extension of `updatePlaylist` added in https://github.com/jwplayer/jwplayer-commercial/pull/4382. The playlist argument will always be an array and any items and their sources will be normalized. 

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-commercial/pull/4382

#### Addresses Issue(s):

JW8-757

