### PR TITLE
Set playlist to an empty array before throwing load error

### DIFF
--- a/src/js/api/setup-steps.js
+++ b/src/js/api/setup-steps.js
@@ -19,6 +19,7 @@ export function loadPlaylist(_model) {
                 resolve();
             });
             playlistLoader.on(ERROR, err => {
+                _model.attributes.playlist = [];
                 _model.set('feedData', {
                     error: new Error(`Error loading playlist: ${err.message}`)
                 });


### PR DESCRIPTION
### This PR will...
Set the playlist to an empty array before the error event so the correct error msg is displayed when setup fails.
### Why is this Pull Request needed?
The `containsDrm` function expects the playlist to be an array in order to check if the playlist has drm sources.
### Are there any points in the code the reviewer needs to double check?
No.
### Are there any Pull Requests open in other repos which need to be merged with this?
No.
#### Addresses Issue(s):
JW8-974

