### PR TITLE
Fix exception calling clearCueData before _cachedVTTCues is set

### DIFF
--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -376,8 +376,9 @@ function clearTracks() {
 
 // Clear track cues to prevent duplicates
 function clearCueData(trackId) {
-    if (this._cachedVTTCues[trackId]) {
-        this._cachedVTTCues[trackId] = {};
+    const cachedVTTCues = this._cachedVTTCues;
+    if (cachedVTTCues && cachedVTTCues[trackId]) {
+        cachedVTTCues[trackId] = {};
         if (this._tracksById) {
             this._tracksById[trackId].data = [];
         }


### PR DESCRIPTION
Guard against an exception that is thrown when `clearCueData` is called while `_cachedVTTCues` is `null`.