### PR TITLE
Always set the preview image in the idle state

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -743,12 +743,9 @@ function View(_api, _model) {
             case STATE_IDLE:
             case STATE_ERROR:
             case STATE_COMPLETE:
-                // Set the poster image for videos before playback starts (idle), when the playlist ends (complete),
+                // Set the poster image before playback starts (idle), when the playlist ends (complete),
                 // or when an error is encountered. We don't get to the idle state between playlist items because of RAF
-
-                if (_model.mediaModel.get('mediaType') === 'video') {
-                    setPosterImage(_model);
-                }
+                setPosterImage(_model);
 
                 if (_captionsRenderer) {
                     _captionsRenderer.hide();


### PR DESCRIPTION
### This PR will...
Set the preview image in the idle, error and complete states regardless of media type.
### Why is this Pull Request needed?
The media type may be `undefined` when the player is idle, resulting in the poster image not being set.
### Are there any points in the code the reviewer needs to double check?
No. This restores previous behavior. The change was an optimization to reduce attempts to set the preview image. In the case of audio, `setPosterImage` may get called twice, but that's ok.
### Are there any Pull Requests open in other repos which need to be merged with this?
No.
#### Addresses Issue(s):
JW8-989

