### PR TITLE
Fix for instream ad pod support

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -98,12 +98,7 @@ var InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
 
     function _loadNextItem() {
         _arrayIndex++;
-        var item = _array[_arrayIndex];
-        var options;
-        if (_arrayOptions) {
-            options = _arrayOptions[_arrayIndex];
-        }
-        _this.loadItem(item, options);
+        _this.loadItem(_array);
     }
 
     function _instreamForward(type, data) {


### PR DESCRIPTION
### This PR will...

Maintain the intream playlist while playing ad pods.

### Why is this Pull Request needed?

Instream used to setup playback after the first ad pod, by cludging a single item into the instream model's playlist property. Now with background loading the ad program controller requires a playlist with more than one item when `setActiveItem(index)` is called with an `index` greater than `0`.  That wasn't happening which caused an exception on the second ad pod.

This cleans up the `_loadNextItem` method nicely, and fixes the regression in ad pod behavior.

### Are there any points in the code the reviewer needs to double check?

For each ad pod item, the playlist is being updated. This may not be necessary and could trigger unwanted instream "playlist" events that previously were only fired at the start of instream playback.

#### Addresses Issue(s):

JW8-997
