### PR TITLE
Fix the forwarding of initial provider events like "mediaType"

### DIFF
--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -200,7 +200,6 @@ export default class MediaController extends Eventable {
     }
 
     set activeItem(item) {
-        const { provider } = this;
         const mediaModel = this.mediaModel = new MediaModel();
         const position = item ? seconds(item.starttime) : 0;
         const duration = item ? seconds(item.duration) : 0;
@@ -209,8 +208,6 @@ export default class MediaController extends Eventable {
         mediaModelState.position = position;
         mediaModelState.duration = duration;
 
-        // Initialize the provider last so it's setting properties on the (newly) active media model
-        provider.init(item);
         this.item = item;
     }
 

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -56,6 +56,8 @@ export default class ProgramController extends Eventable {
                 mediaController.activeItem = item;
                 this._setActiveMedia(mediaController);
                 this.providerPromise = Promise.resolve(mediaController);
+                // Initialize the provider last so it's setting properties on the (newly) active media model
+                mediaController.provider.init(item);
                 return this.providerPromise;
             }
 
@@ -73,6 +75,8 @@ export default class ProgramController extends Eventable {
                     const nextMediaController = new MediaController(nextProvider, model);
                     nextMediaController.activeItem = item;
                     this._setActiveMedia(nextMediaController);
+                    // Initialize the provider last so it's setting properties on the (newly) active media model
+                    nextMediaController.provider.init(item);
                     return nextMediaController;
                 }
             });
@@ -195,6 +199,8 @@ export default class ProgramController extends Eventable {
         const castMediaController = new MediaController(castProvider, model);
         castMediaController.activeItem = item;
         this._setActiveMedia(castMediaController);
+        // Initialize the provider last so it's setting properties on the (newly) active media model
+        castMediaController.provider.init(item);
     }
 
     /**
@@ -587,7 +593,7 @@ function removeEventForwarding(programController, mediaController) {
 }
 
 function forwardEvents(programController, mediaController) {
-    mediaController.off('all', programController.mediaControllerListener, programController);
+    removeEventForwarding(programController, mediaController);
     mediaController.on('all', programController.mediaControllerListener, programController);
 }
 


### PR DESCRIPTION
### This PR will...

Call `provider.init` after program controller's `_setActiveMedia` so that initial provider events like "mediaType" are forwarded from the program controller.

### Why is this Pull Request needed?

Fixes a regression where the player api was no longer emitting "mediaType" events.

#### Addresses Issue(s):

JW8-998
