### PR TITLE
Restore view-model state after instream

### DIFF
--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -263,8 +263,10 @@ export default class Controlbar {
         _model.change('fullscreen', this.onFullscreen, this);
         _model.change('streamType', this.onStreamTypeChange, this);
         _model.change('dvrLive', (model, dvrLive) => {
-            // update live icon and displayed time when DVR stream enters or exits live edge
-            utils.toggleClass(this.elements.live.element(), 'jw-dvr-live', dvrLive);
+            if (dvrLive !== undefined) {
+                // update live icon and displayed time when DVR stream enters or exits live edge
+                utils.toggleClass(this.elements.live.element(), 'jw-dvr-live', dvrLive);
+            }
         });
         _model.change('altText', this.setAltText, this);
         _model.change('customButtons', this.updateButtons, this);
@@ -430,7 +432,6 @@ export default class Controlbar {
         this.elements.rewind.toggle(streamType !== 'LIVE');
         this.elements.live.toggle(streamType === 'LIVE' || streamType === 'DVR');
         this.elements.duration.style.display = streamType === 'DVR' ? 'none' : '';
-        model.set('dvrLive', false);
         const duration = model.get('duration');
         this.onDuration(model, duration);
     }

--- a/src/js/view/view-model.js
+++ b/src/js/view/view-model.js
@@ -129,7 +129,7 @@ export default class ViewModel extends PlayerViewModel {
                 this.mediaModel = mediaModel;
             }, this);
 
-            const mergedAttributes = Object.assign({}, previousInstream.attributes, this._model.attributes);
+            const mergedAttributes = Object.assign({}, this._model.attributes, previousInstream.attributes);
             dispatchDiffChangeEvents(this, this._model.attributes, mergedAttributes);
         }
     }

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -724,7 +724,6 @@ function View(_api, _model) {
 
     const setupInstream = function() {
         addClass(_playerElement, 'jw-flag-ads');
-        removeClass(_playerElement, 'jw-flag-live');
 
         if (_controls) {
             _controls.setupInstream();


### PR DESCRIPTION
### This PR will...

- Fix view-model diff of instream-model -> player-model transition
- Remove "DVR" and "Live" streamType CSS class hacks.

### Why is this Pull Request needed?

These changes ensure that all player state is restored after ad playback. The view-model should properly handle changes between streamTypes (VOD, Live, DVR) when entering and existing instream mode.

#### Addresses Issue(s):

JW8-976

