### PR TITLE
Fix instream ad pod options

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -170,7 +170,7 @@ var InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
         let playlist = item;
         if (_.isArray(item)) {
             _array = item;
-            _arrayOptions = options;
+            _arrayOptions = options || _arrayOptions;
             item = _array[_arrayIndex];
             if (_arrayOptions) {
                 options = _arrayOptions[_arrayIndex];


### PR DESCRIPTION
### This PR will...

Don't reset instream options after the first ad pod.

### Why is this Pull Request needed?

Ad pod playback depends on instream options (skip button message) being available for each item.

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-commercial/pull/4428

#### Addresses Issue(s):

JW8-1002
