### PR TITLE
Don't load preview images for autostarted videos

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -353,7 +353,7 @@ function View(_api, _model) {
 
     function redraw(model, visibility, lastVisibility) {
         if (visibility && !lastVisibility) {
-            _stateHandler(model);
+            _stateHandler(model, model.get('state'));
             _this.updateStyles();
         }
     }
@@ -664,8 +664,6 @@ function View(_api, _model) {
         if (!_this.isSetup) {
             return;
         }
-
-        newState = newState || model.get('state');
 
         if (oldState === STATE_ERROR) {
             const errorContainer = _playerElement.querySelector('.jw-error-msg');

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -688,6 +688,10 @@ function View(_api, _model) {
 
         switch (state) {
             case STATE_IDLE:
+                if (_model.get('autostart')) {
+                    break;
+                }
+                // falls through
             case STATE_ERROR:
             case STATE_COMPLETE:
                 // Set the poster image before playback starts (idle), when the playlist ends (complete),

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -353,7 +353,7 @@ function View(_api, _model) {
 
     function redraw(model, visibility, lastVisibility) {
         if (visibility && !lastVisibility) {
-            _stateUpdate(model.get('state'));
+            _stateHandler(model);
             _this.updateStyles();
         }
     }
@@ -665,6 +665,8 @@ function View(_api, _model) {
             return;
         }
 
+        newState = newState || model.get('state');
+
         if (oldState === STATE_ERROR) {
             const errorContainer = _playerElement.querySelector('.jw-error-msg');
             if (errorContainer) {
@@ -688,10 +690,6 @@ function View(_api, _model) {
 
         switch (state) {
             case STATE_IDLE:
-                if (_model.get('autostart')) {
-                    break;
-                }
-                // falls through
             case STATE_ERROR:
             case STATE_COMPLETE:
                 // Set the poster image before playback starts (idle), when the playlist ends (complete),


### PR DESCRIPTION
### This PR will...
Use the `_stateHandler` for loading the preview image when necessary.
### Why is this Pull Request needed?
This [change](https://github.com/jwplayer/jwplayer/pull/2552/files#diff-adecb551656b12ea38bd16aad3077585R350) - which first gets called when the player state is IDLE, even for autostarted players -  loads the poster image immediately. Before, the player would be in a buffering or playing state for an autostarted video because of the raf check in `_stateHandler`, which calls `_stateUpdate`. 
### Are there any points in the code the reviewer needs to double check?
No - the other changes in https://github.com/jwplayer/jwplayer/pull/2552 are still good.
### Are there any Pull Requests open in other repos which need to be merged with this?
No.
#### Addresses Issue(s):
JW8-1005

