### PR TITLE
Add new adBreakStart and adBreakEnd events

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -662,6 +662,10 @@ Object.assign(Controller.prototype, {
             triggerAdvanceEvent(related, 'nextClick', () => related.next());
         }
 
+        function _forwardEvent(data) {
+            this.trigger(data.type, data);
+        }
+
         function triggerAdvanceEvent(related, evt, cb) {
             if (!related) {
                 return;
@@ -875,6 +879,8 @@ Object.assign(Controller.prototype, {
         this.createInstream = function() {
             this.instreamDestroy();
             this._instreamAdapter = new InstreamAdapter(this, _model, _view, mediaPool);
+            this._instreamAdapter.on('adBreakStart', _forwardEvent, this);
+            this._instreamAdapter.on('adBreakEnd', _forwardEvent, this);
             return this._instreamAdapter;
         };
 
@@ -887,6 +893,7 @@ Object.assign(Controller.prototype, {
         this.instreamDestroy = function() {
             if (_this._instreamAdapter) {
                 _this._instreamAdapter.destroy();
+                _this._instreamAdapter.off(null, null, _this);
                 _this._instreamAdapter = null;
             }
         };

--- a/src/js/utils/parser.js
+++ b/src/js/utils/parser.js
@@ -39,6 +39,22 @@ export function getAbsolutePath(path, base) {
     return protocol + domain + '/' + result.join('/');
 }
 
+export function getAdClient(client) {
+    if (client.indexOf('vast') >= 0) {
+        return 'vast';
+    }
+    if (client.indexOf('googima') >= 0) {
+        return 'googima';
+    }
+    if (client.indexOf('freewheel') >= 0) {
+        return 'freewheel';
+    }
+    if (client.indexOf('dai') >= 0) {
+        return 'dai';
+    }
+    return 'unknown';
+}
+
 export function isAbsolutePath(path) {
     return /^(?:(?:https?|file):)?\/\//.test(path);
 }


### PR DESCRIPTION
### This PR will...
Create new events called adBreakStart and adBreakEnd, which are fired whenever instream adapter's init and destroy functions are called. Rename the old 'adBreakEnd' used for vast to 'vastAdBreakEnd', so that we can use 'adBreakEnd' for the new event.

### Why is this Pull Request needed?
To track when ad break starts and end.

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-ads-vast/pull/304

#### Addresses Issue(s):

ADS-792
