### PR TITLE
Fire "itemReady" after provider.init()

### DIFF
--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -13,9 +13,6 @@ const Captions = function(_model) {
     // Listen for captions menu index changes from the view
     _model.on('change:captionsIndex', _captionsIndexHandler, this);
 
-    // Listen for item ready to determine which provider is in use
-    _model.on('itemReady', _itemReadyHandler, this);
-
     function _setSubtitlesTracks(tracks) {
         if (!tracks.length) {
             return;
@@ -42,36 +39,41 @@ const Captions = function(_model) {
         _tracks = [];
         _tracksById = {};
         _unknownCount = 0;
-    }
 
-    function _itemReadyHandler(item) {
-        // Clean up in case we're replaying
-        _itemHandler(_model, item);
-
+        const item = _model.get('playlistItem');
         const tracks = item.tracks;
         const len = tracks && tracks.length;
 
-        // Sideload tracks when not rendering natively
-        if (!_model.get('renderCaptionsNatively') && len) {
-            for (let i = 0; i < len; i++) {
-                /* eslint-disable no-loop-func */
-                const track = tracks[i];
-                if (_kindSupported(track.kind) && !_tracksById[track._id]) {
-                    _addTrack(track);
-                    loadFile(track,
-                        (vttCues) => {
-                            _addVTTCuesToTrack(track, vttCues);
-                        },
-                        (error) => {
-                            this.trigger(ERROR, {
-                                message: 'Captions failed to load',
-                                reason: error
-                            });
-                        });
+        // Update tracks once we know "renderCaptionsNatively" based on provider
+        _model.off('itemReady', null, this)
+            .once('itemReady', () => {
+                // Sideload tracks when not rendering natively
+                if (len && !_model.get('renderCaptionsNatively')) {
+                    for (let i = 0; i < len; i++) {
+                        /* eslint-disable no-loop-func */
+                        const track = tracks[i];
+                        if (_kindSupported(track.kind) && !_tracksById[track._id]) {
+                            _addTrack(track);
+                            loadFile(track,
+                                (vttCues) => {
+                                    _addVTTCuesToTrack(track, vttCues);
+                                },
+                                (error) => {
+                                    this.trigger(ERROR, {
+                                        message: 'Captions failed to load',
+                                        reason: error
+                                    });
+                                });
+                        }
+                        _updateMenu();
+                    }
                 }
-            }
-        }
+            }, this);
 
+        _updateMenu();
+    }
+
+    function _updateMenu() {
         const captionsMenu = _captionsMenu();
         _selectDefaultIndex();
         _setCaptionsList(captionsMenu);

--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -65,8 +65,8 @@ const Captions = function(_model) {
                                     });
                                 });
                         }
-                        _updateMenu();
                     }
+                    _updateMenu();
                 }
             }, this);
 

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -53,7 +53,6 @@ const Model = function() {
         this.set('item', index);
         this.set('minDvrWindow', item.minDvrWindow);
         this.set('playlistItem', item);
-        this.trigger('itemReady', item);
     };
 
     this.setMediaModel = function (mediaModel) {
@@ -256,7 +255,6 @@ const syncProviderProperties = (model, provider) => {
     model.set('supportsPlaybackRate', provider.supportsPlaybackRate);
     model.set('playbackRate', provider.getPlaybackRate());
     model.set('renderCaptionsNatively', provider.renderNatively);
-
 };
 
 function syncPlayerWithMediaModel(mediaModel) {

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -50,14 +50,15 @@ export default class ProgramController extends Eventable {
             // Buffer between item switches, but remain in the initial state (IDLE) while loading the first provider
             model.set(PLAYER_STATE, STATE_BUFFERING);
             if (casting || this.providerController.canPlay(mediaController.provider, source)) {
+                this.providerPromise = Promise.resolve(mediaController);
                 // We can reuse the current mediaController and do so synchronously
                 // Initialize the provider and mediaModel, sync it with the Model
                 // This sets up the mediaController and allows playback to begin
                 mediaController.activeItem = item;
                 this._setActiveMedia(mediaController);
-                this.providerPromise = Promise.resolve(mediaController);
                 // Initialize the provider last so it's setting properties on the (newly) active media model
                 mediaController.provider.init(item);
+                model.trigger('itemReady', item);
                 return this.providerPromise;
             }
 
@@ -77,6 +78,7 @@ export default class ProgramController extends Eventable {
                     this._setActiveMedia(nextMediaController);
                     // Initialize the provider last so it's setting properties on the (newly) active media model
                     nextMediaController.provider.init(item);
+                    model.trigger('itemReady', item);
                     return nextMediaController;
                 }
             });
@@ -201,6 +203,7 @@ export default class ProgramController extends Eventable {
         this._setActiveMedia(castMediaController);
         // Initialize the provider last so it's setting properties on the (newly) active media model
         castMediaController.provider.init(item);
+        model.trigger('itemReady', item);
     }
 
     /**


### PR DESCRIPTION
### This PR will...

Trigger "itemReady" at the point it was originally intended to be fired - when the provider is ready.

### Why is this Pull Request needed?

If you look at all the places where we listen for "itemReady", it is expected that there is a provider with a media element ready for playback. The most common use is for captions track logic that requires a media element and provider after "renderCaptionsNatively" has been sent, or we're casting.