### PR TITLE
A/B Test Recs Localization

### DIFF
--- a/src/assets/SVG/more-videos.svg
+++ b/src/assets/SVG/more-videos.svg
@@ -1,0 +1,1 @@
+<svg class="jw-svg-icon jw-svg-icon-more-videos" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 240"><path d="M25,109.8h48.8V51.2H25V109.8z M25,191.2h48.8v-58.6H25V191.2z M96.6,191.2h48.8v-58.6H96.6V191.2z M168.2,191.2H217v-58.6 h-48.8V191.2z M96.6,109.8h48.8V51.2H96.6V109.8z M168.2,51.2v58.6H217V51.2H168.2z"/></svg>

--- a/src/css/controls/imports/controlbar.less
+++ b/src/css/controls/imports/controlbar.less
@@ -108,6 +108,27 @@
     }
 }
 
+.jw-more-videos {
+    position: absolute;
+    top: (@mobile-touch-target * -1);
+    left: 0;
+    margin: 0;
+    width: auto;
+    padding: 0 12px;
+
+    .jw-text {
+        height: @mobile-touch-target;
+        line-height: @mobile-touch-target;
+        padding-left: 6px;
+        color: @inactive-color;
+    }
+
+    &:hover .jw-text,
+    &:focus .jw-text {
+        color: @active-color;
+    }
+}
+
 .jw-icon-inline.jw-icon-volume {
     display: none;
 }

--- a/src/js/view/controls/components/custom-button.js
+++ b/src/js/view/controls/components/custom-button.js
@@ -15,7 +15,9 @@ export default class CustomButton {
         }
 
         let iconElement;
-        if (img && img.substring(0, 4) === '<svg') {
+        if (img instanceof SVGSVGElement) {
+            iconElement = img;
+        } else if (img && img.substring(0, 4) === '<svg') {
             iconElement = svgParse(img);
         } else {
             iconElement = document.createElement('div');

--- a/src/js/view/controls/components/custom-button.js
+++ b/src/js/view/controls/components/custom-button.js
@@ -15,7 +15,7 @@ export default class CustomButton {
         }
 
         let iconElement;
-        if (img instanceof SVGSVGElement) {
+        if (img instanceof SVGElement) {
             iconElement = img;
         } else if (img && img.substring(0, 4) === '<svg') {
             iconElement = svgParse(img);

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -39,9 +39,8 @@ function div(classes) {
 }
 
 function isRecsUpDisplay(abConfig) {
-    const tests = abConfig ? abConfig.tests : null;
-
-    if (tests && tests.discoverIcon && tests.discoverIcon) {
+    if (abConfig && abConfig.tests && abConfig.tests.discoverIcon) {
+        const tests = abConfig.tests;
         for (let i = 0; i < tests.discoverIcon.length; i++) {
             const test = tests.discoverIcon[i];
             if (test.type === 'discoverIcon') {
@@ -49,7 +48,6 @@ function isRecsUpDisplay(abConfig) {
             }
         }
     }
-
     return false;
 }
 

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -568,8 +568,6 @@ export default class Controlbar {
             const isSmallPlayer = getBreakpoint(model.get('containerWidth')) < 2;
             const isAddMore = isRecsUpDisplay(model.get('ab')) && buttonProps.btnClass === 'jw-related-btn';
 
-            console.log('Related', model.get('related'), isAddMore);
-
             buttonProps.img = isAddMore ? cloneIcons('more-videos')[0] : buttonProps.img;
             if (isAddMore && !isSmallPlayer) {
                 this.addMoreVideos(buttonProps);

--- a/src/js/view/controls/icons.js
+++ b/src/js/view/controls/icons.js
@@ -5,7 +5,6 @@ import PLAY_ICON from 'assets/SVG/play.svg';
 import PAUSE_ICON from 'assets/SVG/pause.svg';
 import REWIND_ICON from 'assets/SVG/rewind-10.svg';
 import NEXT_ICON from 'assets/SVG/next.svg';
-// import STOP_ICON from 'assets/SVG/stop.svg';
 import VOLUME_ICON_0 from 'assets/SVG/volume-0.svg';
 import VOLUME_ICON_50 from 'assets/SVG/volume-50.svg';
 import VOLUME_ICON_100 from 'assets/SVG/volume-100.svg';
@@ -18,14 +17,11 @@ import LIVE_ICON from 'assets/SVG/live.svg';
 import PLAYBACK_RATE_ICON from 'assets/SVG/playback-rate.svg';
 import SETTINGS_ICON from 'assets/SVG/settings.svg';
 import AUDIO_TRACKS_ICON from 'assets/SVG/audio-tracks.svg';
-// import QUALITY_ICON_25 from 'assets/SVG/quality-25.svg';
-// import QUALITY_ICON_50 from 'assets/SVG/quality-50.svg';
-// import QUALITY_ICON_75 from 'assets/SVG/quality-75.svg';
 import QUALITY_ICON from 'assets/SVG/quality-100.svg';
 import FULLSCREEN_EXIT_ICON from 'assets/SVG/fullscreen-not.svg';
 import FULLSCREEN_ENTER_ICON from 'assets/SVG/fullscreen.svg';
 import CLOSE_ICON from 'assets/SVG/close.svg';
-// import ARROW_ICON from 'assets/SVG/arror.svg';
+import MORE_VIDEOS_ICON from 'assets/SVG/more-videos.svg';
 import JW_LOGO from 'assets/SVG/jw-logo.svg';
 import svgParse from 'utils/svgParser';
 
@@ -91,5 +87,6 @@ function parseCollection() {
         FULLSCREEN_ENTER_ICON +
         CLOSE_ICON +
         JW_LOGO +
+        MORE_VIDEOS_ICON +
         '</xml>');
 }

--- a/src/js/view/utils/skin.js
+++ b/src/js/view/utils/skin.js
@@ -122,6 +122,7 @@ export function handleColorOverrides(playerId, skin) {
                 // controlbar button colors
                 '.jw-button-color:not(.jw-icon-cast)',
                 '.jw-button-color.jw-toggle.jw-off:not(.jw-icon-cast)',
+                '.jw-more-videos .jw-text',
             ], 'color', config.icons);
 
             addStyle([
@@ -144,7 +145,9 @@ export function handleColorOverrides(playerId, skin) {
                 '.jw-button-color.jw-toggle:not(.jw-icon-cast)',
                 '.jw-button-color:hover:not(.jw-icon-cast)',
                 '.jw-button-color:focus:not(.jw-icon-cast)',
-                '.jw-button-color.jw-toggle.jw-off:hover:not(.jw-icon-cast)'
+                '.jw-button-color.jw-toggle.jw-off:hover:not(.jw-icon-cast)',
+                '.jw-more-videos:hover .jw-text',
+                '.jw-more-videos:focus .jw-text',
             ], 'color', config.iconsActive);
 
             addStyle([

--- a/test/unit/skin-test.js
+++ b/test/unit/skin-test.js
@@ -76,7 +76,8 @@ describe('Skin Customization', function() {
 
             expect(cssUtils.css.args[1]).to.eql([
                 '#id .jw-button-color:not(.jw-icon-cast), ' +
-                '#id .jw-button-color.jw-toggle.jw-off:not(.jw-icon-cast)',
+                '#id .jw-button-color.jw-toggle.jw-off:not(.jw-icon-cast), ' +
+                '#id .jw-more-videos .jw-text',
                 { color: 'blue' },
                 'id'
             ]);


### PR DESCRIPTION
### This PR will...

- Take the selected variant in the `playerConfig.ab` block and either display the discovery icon inside or above the controlbar
- Adds the new `More Videos` svg icon.

### Why is this Pull Request needed?

- For the first step of the new Recs Display UI, we can now A/B test the position of the discovery icon, making it clearer and more visible to users when the controlbar is showing.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/ab-test/pull/19

#### Addresses Issue(s):

JW8-1014