### PR TITLE
Fix fullscreen on players with numeric ids

### DIFF
--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -2,7 +2,7 @@ import _ from 'utils/underscore';
 import { loadFrom, getScriptPath } from 'utils/playerutils';
 import { serialize } from 'utils/parser';
 
-/* global __webpack_public_path__:true*/
+/* global __webpack_public_path__:true */
 /* eslint camelcase: 0 */
 // Defaults
 const Defaults = {
@@ -54,8 +54,11 @@ const Defaults = {
 };
 
 function _deserialize(options) {
-    _.each(options, function(val, key) {
-        options[key] = serialize(val);
+    Object.keys(options).forEach((key) => {
+        if (key === 'id') {
+            return;
+        }
+        options[key] = serialize(options[key]);
     });
 }
 

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -583,7 +583,7 @@ function View(_api, _model) {
     function _isNativeFullscreen() {
         if (fullscreenHelpers.supportsDomFullscreen()) {
             const fsElement = fullscreenHelpers.fullscreenElement();
-            return !!(fsElement && fsElement.id === _model.get('id'));
+            return (fsElement && fsElement === _playerElement);
         }
         // if player element view fullscreen not available, return video fullscreen state
         const provider = _model.getVideo();


### PR DESCRIPTION
### This PR will...

- Prevent the type of "id" from being converted to a number or boolean
- Compare element instances when checking for native fullscreen.

### Why is this Pull Request needed?

The player id should always be a string that strictly equals the id of it's parent element. This will ensure `jwplayer().id` and `jwplayer().getConfig().id` do not get parsed into a number when the value is a numeric string shorter than 6 character (something the player has always done for properties like "width", "height" and "controls").

When going fullscreen `_isNativeFullscreen ` checks to see if the player element is equal to `document.fullscreenElement()`, but it did this using element id comparison. When that failed because of the config issue above, an exit fullscreen request is made so that the media element can go fullscreen instead (for iOS). All that resulted in issue  #2618). Comparing element instances directly removes all dependencies on player and element ids

#### Things to look out for

Let's make sure that the id check wasn't required in any of the browsers that we currently support (Example: What if IE11 or Edge return a different object instance from `document.fullscreenElement()` for the same element? Not sure it's possible, but I have the feeling we wrote it that way for a browser issue like that 4 years ago.)

#### Addresses Issue(s):

Fixes #2618

