### PR TITLE
Use date util in clock.js

### DIFF
--- a/src/js/utils/clock.js
+++ b/src/js/utils/clock.js
@@ -1,11 +1,12 @@
-const Date = window.Date;
+import { now as getTime } from 'utils/date';
+
 const performance = window.performance || {
     timing: {}
 };
-const startDate = performance.timing.navigationStart || (new Date().getTime());
+const startDate = performance.timing.navigationStart || getTime();
 
 if (!('now' in performance)) {
-    performance.now = () => (new Date().getTime()) - startDate;
+    performance.now = () => (getTime() - startDate);
 }
 
 export function now() {


### PR DESCRIPTION
### This PR will...

Use 'utils/date' `now()` in clock.js instead of `new Date().getTime()`.

### Why is this Pull Request needed?

The date util uses `Date.now` or falls back to `new Date().getTime`.