### PR TITLE
Improve criteria for determining if a tag is backgrounded 

### DIFF
--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -175,8 +175,13 @@ export default class MediaController extends Eventable {
     }
 
     get background() {
-        // A backgrounded provider is attached to a video tag, but has no parent container (i.e. not in the DOM)
-        return !this.container && this.attached;
+        const { container, provider } = this;
+        // A backgrounded provider is attached to a video tag
+        if (!this.attached) {
+            return false;
+        }
+        // A backgrounded provider does not have a parent container, or has one, but without the media tag as a child
+        return !container || (container && !container.contains(provider.video));
     }
 
     get container() {


### PR DESCRIPTION
### Why is this Pull Request needed?
To ensure that we're not removing a video tag from a container which is not it's parent. This can be the case with the Hlsjs provider, which sometimes swaps video tags in and out of the container itself.

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-1019

