### PR TITLE
Fix instream playlist item replacement

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -269,6 +269,9 @@ var InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
 
     this.replacePlaylistItem = function(item) {
         _model.set('playlistItem', item);
+        if (_adProgram) {
+            _adProgram.srcReset();
+        }
     };
 
     this.destroy = function() {

--- a/src/js/program/ad-program-controller.js
+++ b/src/js/program/ad-program-controller.js
@@ -150,8 +150,14 @@ export default class AdProgramController extends ProgramController {
     srcReset() {
         const { playerModel } = this;
         const mediaModel = playerModel.get('mediaModel');
+        const provider = playerModel.getVideo();
 
         mediaModel.srcReset();
+
+        // Set hlsjs.src to null so that it reloads it's item source
+        if (provider) {
+            provider.src = null;
+        }
     }
 
     _nativeFullscreenHandler(evt) {

--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -62,9 +62,9 @@ export default class MediaController extends Eventable {
     }
 
     destroy() {
-        const { provider, model } = this;
-
-        provider.off(null, null, model);
+        const { provider, mediaModel } = this;
+        mediaModel.off();
+        provider.off();
         this.detach();
         if (provider.getContainer()) {
             provider.remove();


### PR DESCRIPTION
### This PR will...

- Fix `srcReset` with the hlsjs provider, so that playlist item sources can be replaced by instream.
- Remove all listeners from mediaModel and provider when mediaController is destroyed

### Why is this Pull Request needed?

When `hlsjs.init(item)` is used to preload media, subsequent calls to `hlsjs.load(item)` ignore and changes to the item. When `srcReset` was called, then the provider should be updated so that the new source is loaded.

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-ads-dai/pull/24
https://github.com/jwplayer/jwplayer-commercial/pull/4450

#### Addresses Issue(s):

ADS-788
