### PR TITLE
Fix mute & volume double firing

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -91,6 +91,7 @@ Object.assign(Controller.prototype, {
         _model.on('change:castState', function(model, evt) {
             _this.trigger(CAST_SESSION, evt);
         });
+
         _model.on('change:fullscreen', function(model, bool) {
             _this.trigger(FULLSCREEN, {
                 fullscreen: bool
@@ -100,12 +101,14 @@ Object.assign(Controller.prototype, {
                 model.set('playOnViewable', false);
             }
         });
+
         _model.on('change:volume', function(model, vol) {
             _this.trigger(MEDIA_VOLUME, {
                 volume: vol
             });
         });
-        _model.on('change:mute change:autostartMuted', function(model) {
+
+        _model.on('change:mute', function(model) {
             _this.trigger(MEDIA_MUTE, {
                 mute: model.getMute()
             });
@@ -756,7 +759,7 @@ Object.assign(Controller.prototype, {
         };
         this.setMute = (mute) => {
             _model.setMute(mute);
-            updateProgramSoundSettings();
+            // updateProgramSoundSettings();
         };
         this.setPlaybackRate = (playbackRate) => {
             _model.setPlaybackRate(playbackRate); 

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -704,7 +704,6 @@ Object.assign(Controller.prototype, {
 
         function updateProgramSoundSettings() {
             _programController.mute = _model.getMute();
-            _programController.volume = _model.get('volume');
         }
 
         /** Controller API / public methods **/
@@ -759,7 +758,7 @@ Object.assign(Controller.prototype, {
         };
         this.setMute = (mute) => {
             _model.setMute(mute);
-            // updateProgramSoundSettings();
+            updateProgramSoundSettings();
         };
         this.setPlaybackRate = (playbackRate) => {
             _model.setPlaybackRate(playbackRate); 

--- a/src/js/program/ad-media-pool.js
+++ b/src/js/program/ad-media-pool.js
@@ -11,12 +11,6 @@ export default function AdMediaPool(mediaPool) {
         },
         recycle() {
             mediaPool.recycle(adElement);
-        },
-        syncVolume: function (volume) {
-            adElement.volume = volume / 100;
-        },
-        syncMute(mute) {
-            adElement.muted = mute;
         }
     };
 }

--- a/src/js/program/media-element-pool.js
+++ b/src/js/program/media-element-pool.js
@@ -20,16 +20,6 @@ export default function MediaElementPool() {
             if (mediaElement && !elements.some(element => element === mediaElement)) {
                 elements.push(mediaElement);
             }
-        },
-        syncVolume: function (volume) {
-            elements.forEach(e => {
-                e.volume = volume / 100;
-            });
-        },
-        syncMute(mute) {
-            elements.forEach(e => {
-                e.muted = mute;
-            });
         }
     };
 }

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -16,15 +16,10 @@ export default class ProgramController extends Eventable {
         this.backgroundMedia = null;
         this.mediaPool = mediaPool;
         this.mediaController = null;
+        this.mediaControllerListener = MediaControllerListener(model, this);
         this.model = model;
         this.providerController = ProviderController(model.getConfiguration());
         this.providerPromise = resolved;
-
-        const modelForward = MediaControllerListener(model);
-        this.mediaControllerListener = (type, data) => {
-            modelForward(type, data);
-            this.trigger(type, data);
-        };
     }
 
     /**
@@ -450,7 +445,7 @@ export default class ProgramController extends Eventable {
     /**
      * Attaches or detaches the current media
      * @param {boolean} shouldAttach
-     * @returns {undefined}
+     * @returns {void}
      */
     set attached(shouldAttach) {
         const { mediaController } = this;
@@ -496,12 +491,12 @@ export default class ProgramController extends Eventable {
 
     /**
      * Mutes or unmutes the activate media.
-     * Syncs across all media elements.
+     * Syncs both background and foreground media controllers.
      * @param {boolean} mute
      * @returns {void}
      */
     set mute(mute) {
-        const { backgroundMedia, mediaController, mediaPool } = this;
+        const { backgroundMedia, mediaController } = this;
 
         if (mediaController) {
             mediaController.mute = mute;
@@ -509,8 +504,6 @@ export default class ProgramController extends Eventable {
         if (backgroundMedia) {
             backgroundMedia.mute = mute;
         }
-
-        mediaPool.syncMute(mute);
     }
 
     /**
@@ -562,12 +555,12 @@ export default class ProgramController extends Eventable {
 
     /**
      * Sets the volume level.
-     * Syncs across all media elements.
+     * Syncs both background and foreground media controllers.
      * @param {number} volume
      * @returns {void}
      */
     set volume(volume) {
-        const { backgroundMedia, mediaController, mediaPool } = this;
+        const { backgroundMedia, mediaController } = this;
 
         if (mediaController) {
             mediaController.volume = volume;
@@ -575,8 +568,6 @@ export default class ProgramController extends Eventable {
         if (backgroundMedia) {
             backgroundMedia.volume = volume;
         }
-
-        mediaPool.syncVolume(volume);
     }
 }
 

--- a/src/js/program/program-listeners.js
+++ b/src/js/program/program-listeners.js
@@ -82,7 +82,7 @@ export function ProviderListener(mediaController) {
     };
 }
 
-export function MediaControllerListener(model) {
+export function MediaControllerListener(model, programController) {
     return function (type, data) {
         switch (type) {
             case 'flashThrottle': {
@@ -99,13 +99,13 @@ export function MediaControllerListener(model) {
                 break;
             case MEDIA_VOLUME:
                 model.set(type, data[type]);
-                break;
+                return;
             case MEDIA_MUTE:
                 if (!model.get('autostartMuted')) {
                     // Don't persist mute state with muted autostart
                     model.set(type, data[type]);
                 }
-                break;
+                return;
             case MEDIA_RATE_CHANGE: {
                 const rate = data.playbackRate;
                 // Check if its a generally usable rate.  Shaka changes rate to 0 when pause or buffering.
@@ -144,5 +144,7 @@ export function MediaControllerListener(model) {
                 break;
             default:
         }
+
+        programController.trigger(type, data);
     };
 }


### PR DESCRIPTION
### This PR will...
- Avoid firing mute and volume from the program controller
- Cleanup synchronization of mute and volume across media elements

### Why is this Pull Request needed?
- Mute and volume are already triggered through to the API via model change events. It makes more sense to drive these events from the model because they're "global" player properties, and we want to set them even if a provider does not exist.
- We don't need to synchronize media elements in the pool because volume and mute are set when the active provider is changed.

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-1009

