### PR TITLE
Fix fullscreen on players with numeric ids

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -583,7 +583,7 @@ function View(_api, _model) {
     function _isNativeFullscreen() {
         if (fullscreenHelpers.supportsDomFullscreen()) {
             const fsElement = fullscreenHelpers.fullscreenElement();
-            return (fsElement && fsElement === _playerElement);
+            return !!(fsElement && fsElement === _playerElement);
         }
         // if player element view fullscreen not available, return video fullscreen state
         const provider = _model.getVideo();


### PR DESCRIPTION
### This PR will...

Fix return boolean regression in `_isNativeFullscreen` check.

### Why is this Pull Request needed?

When exiting fullscreen this method should return `false` but instead it returned `undefined` which prevented the player from resetting the DOM properly.

#### Addresses Issue(s):

JW8-1021

