### PR TITLE
Fix instream getMediaElement for iOS

### DIFF
--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -20,6 +20,11 @@ export default class ProgramController extends Eventable {
         this.model = model;
         this.providerController = ProviderController(model.getConfiguration());
         this.providerPromise = resolved;
+
+        if (!Features.backgroundLoading) {
+            // If background loading is not supported, set the shared media element
+            model.set('mediaElement', this.mediaPool.getPrimedElement());
+        }
     }
 
     /**
@@ -262,13 +267,11 @@ export default class ProgramController extends Eventable {
      */
     primeMediaElements() {
         if (!Features.backgroundLoading) {
-            // If background loading is supported, the model will always contain the shared media element
+            // If background loading is not supported, the model will always contain the shared media element
             // Prime it so that playback after changing the active item does not require further gestures
             const { model } = this;
             const mediaElement = model.get('mediaElement');
-            if (mediaElement) {
-                mediaElement.load();
-            }
+            mediaElement.load();
         }
         this.mediaPool.prime();
     }
@@ -414,6 +417,12 @@ export default class ProgramController extends Eventable {
      * @returns {Element|undefined}
      */
     get primedElement() {
+        if (!Features.backgroundLoading) {
+            // If background loading is not supported, the model will always contain the shared media element
+            // Prime it so that playback after changing the active item does not require further gestures
+            const { model } = this;
+            return model.get('mediaElement');
+        }
         return this.mediaPool.getPrimedElement();
     }
 


### PR DESCRIPTION
### This PR will...

Set 'mediaElement' on the model when program-controller is instantiated when background loading is not supported. Always prime/return 'mediaElement' when background loading is not supported.

### Why is this Pull Request needed?

This is for ads to get the same media element on iOS when background loading is not supported.

### What about the pool?

This could be addressed in the media pool(s), but that would require more changes and could introduce new regressions.

#### Addresses Issue(s):

JW8-1011

