### PR TITLE
Update travis config to build using node v9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
-  - 8
-  - 5
+  - 9
 
 before_install:
   - npm config set loglevel warn


### PR DESCRIPTION
Use node 9 for better compatibility with CI tools like greenkeeper. Remove node 5 (leave that to Jenkins).