### PR TITLE
Clean media elements when recycling

### DIFF
--- a/src/js/program/media-element-pool.js
+++ b/src/js/program/media-element-pool.js
@@ -13,6 +13,7 @@ export default function MediaElementPool() {
         },
         getPrimedElement() {
             if (elements.length) {
+                // Shift over pop so that we cycle through elements instead of reusing the same one
                 return elements.shift();
             }
             return null;

--- a/src/js/program/media-element-pool.js
+++ b/src/js/program/media-element-pool.js
@@ -18,6 +18,7 @@ export default function MediaElementPool() {
         },
         recycle(mediaElement) {
             if (mediaElement && !elements.some(element => element === mediaElement)) {
+                clean(mediaElement);
                 elements.push(mediaElement);
             }
         },
@@ -38,5 +39,20 @@ function primeMediaElementForPlayback(mediaElement) {
     // If we're in a user-gesture event call load() on video to allow async playback
     if (!mediaElement.src) {
         mediaElement.load();
+    }
+}
+
+// Try to clean the media element so that we don't see frames of the previous video when reusing a tag
+function clean(mediaElement) {
+    // We don't want to call load again if the media element is already clean
+    if (!mediaElement.src) {
+        return;
+    }
+
+    mediaElement.removeAttribute('src');
+    try {
+        mediaElement.load();
+    } catch (e) {
+        // Calling load may throw an exception, but does not result in an error state
     }
 }

--- a/src/js/program/media-element-pool.js
+++ b/src/js/program/media-element-pool.js
@@ -13,8 +13,9 @@ export default function MediaElementPool() {
         },
         getPrimedElement() {
             if (elements.length) {
-                return elements.pop();
+                return elements.shift();
             }
+            return null;
         },
         recycle(mediaElement) {
             if (mediaElement && !elements.some(element => element === mediaElement)) {
@@ -27,9 +28,9 @@ export default function MediaElementPool() {
                 e.volume = volume / 100;
             });
         },
-        syncMute(mute) {
+        syncMute(muted) {
             elements.forEach(e => {
-                e.muted = mute;
+                e.muted = muted;
             });
         }
     };

--- a/test/unit/media-pool-tests.js
+++ b/test/unit/media-pool-tests.js
@@ -1,0 +1,50 @@
+import MediaPool from 'program/media-element-pool';
+
+describe('Media Element Pool', function () {
+    let mediaPool = null;
+    beforeEach(function () {
+        mediaPool = new MediaPool();
+    });
+
+    it('starts with 3 empty media elements', function () {
+        for (let i = 0; i < 3; i++) {
+            const element = mediaPool.getPrimedElement();
+            expect(element).to.not.equal(null);
+            expect(element.nodeName).to.equal('VIDEO');
+            expect(element.src).to.equal('');
+            expect(element.className).to.equal('jw-video jw-reset');
+        }
+        expect(mediaPool.getPrimedElement()).to.equal(null);
+    });
+
+    it('primes elements by calling load', function () {
+        const spies = [];
+        for (let i = 0; i < 3; i++) {
+            const element = mediaPool.getPrimedElement();
+            mediaPool.recycle(element);
+            const spy = sinon.spy();
+            element.load = spy;
+            spies.push(spy);
+        }
+
+        mediaPool.prime();
+        expect(spies.length).to.equal(3);
+        spies.forEach(s => {
+            expect(s.calledOnce).to.equal(true);
+        });
+    });
+
+    it('synchronizes volume across the pool', function () {
+       mediaPool.syncVolume(50);
+       for (let i = 0; i < 3; i++) {
+           expect(mediaPool.getPrimedElement().volume).to.equal(0.5);
+       }
+    });
+
+    it('synchronizes mute across the pool', function () {
+        mediaPool.syncMute(true);
+        for (let i = 0; i < 3; i++) {
+            expect(mediaPool.getPrimedElement().muted).to.equal(true);
+        }
+    });
+});

--- a/test/unit/media-pool-tests.js
+++ b/test/unit/media-pool-tests.js
@@ -11,7 +11,8 @@ describe('Media Element Pool', function () {
             const element = mediaPool.getPrimedElement();
             expect(element).to.not.equal(null);
             expect(element.nodeName).to.equal('VIDEO');
-            expect(element.src).to.equal('');
+            // src is undefined when running in PhantomJS
+            expect(element.src || '').to.equal('');
             expect(element.className).to.equal('jw-video jw-reset');
         }
         expect(mediaPool.getPrimedElement()).to.equal(null);


### PR DESCRIPTION
### This PR will...
- Remove the `src` attribute and call `load` when recycling
- Add unit tests
- `unshift` over `pop` so that we cycle through media elements
-- `push` and `pop` both operate on the last element; repeated use may mean we only the same one or two elements

### Why is this Pull Request needed?
To prevent frames from the previous video flashing at the beginning of a new one

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-1006

