### PR TITLE
Casting: Persist media position on connect & disconnect

### DIFF
--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -215,17 +215,13 @@ export default class ProgramController extends Eventable {
      * @returns {undefined}
      */
     stopCast() {
-        const { mediaController, model } = this;
+        const { model } = this;
         const index = model.get('item');
         const item = model.get('playlist')[index];
 
         item.starttime = model.mediaModel.get('position');
-        model.resetItem(item);
 
-        if (mediaController) {
-            mediaController.stop();
-            this.mediaController = null;
-        }
+        this.stopVideo();
 
         this.setActiveItem(index);
     }

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -198,12 +198,16 @@ export default class ProgramController extends Eventable {
     castVideo(castProvider, item) {
         const { model } = this;
 
+        const playlistItem = Object.assign({}, item);
+        playlistItem.starttime = model.mediaModel.get('position');
+
         const castMediaController = new MediaController(castProvider, model);
-        castMediaController.activeItem = item;
+        castMediaController.activeItem = playlistItem;
         this._setActiveMedia(castMediaController);
         // Initialize the provider last so it's setting properties on the (newly) active media model
-        castMediaController.provider.init(item);
-        model.trigger('itemReady', item);
+        castMediaController.provider.init(playlistItem);
+        model.trigger('itemReady', playlistItem);
+
     }
 
     /**
@@ -211,8 +215,19 @@ export default class ProgramController extends Eventable {
      * @returns {undefined}
      */
     stopCast() {
-        this.stopVideo();
-        this.mediaController = null;
+        const { mediaController, model } = this;
+        const index = model.get('item');
+        const item = model.get('playlist')[index];
+
+        item.starttime = model.mediaModel.get('position');
+        model.attributes.playlistItem = item;
+
+        if (mediaController) {
+            mediaController.stop();
+            this.mediaController = null;
+        }
+
+        model.setActiveItem(index);
     }
 
     /**

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -220,7 +220,6 @@ export default class ProgramController extends Eventable {
         const item = model.get('playlist')[index];
 
         item.starttime = model.mediaModel.get('position');
-        model.attributes.playlistItem = item;
         model.resetItem(item);
 
         if (mediaController) {

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -221,13 +221,12 @@ export default class ProgramController extends Eventable {
 
         item.starttime = model.mediaModel.get('position');
         model.attributes.playlistItem = item;
+        model.resetItem(item);
 
         if (mediaController) {
             mediaController.stop();
             this.mediaController = null;
         }
-
-        model.setActiveItem(index);
     }
 
     /**

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -227,6 +227,8 @@ export default class ProgramController extends Eventable {
             mediaController.stop();
             this.mediaController = null;
         }
+
+        this.setActiveItem(index);
     }
 
     /**


### PR DESCRIPTION
### This PR will...

Before connecting and disconnecting from the chromecast device during playback, the current position needs to be persisted. Now that the position is maintained in the media model, we get and set the start time based on that value.

It will also move the logic within the chromecast controller to now be in the program controller.

### Why is this Pull Request needed?

So when we connect or disconnect, the media continues to play and does not start from the beginning

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-commercial/pull/4463

#### Addresses Issue(s):

JW8-986