### PR TITLE
Sync mute directly from player model attributes

### DIFF
--- a/src/js/program/ad-program-controller.js
+++ b/src/js/program/ad-program-controller.js
@@ -42,7 +42,7 @@ export default class AdProgramController extends ProgramController {
             instreamMode: true,
             edition: playerAttributes.edition,
             mediaContext: mediaModelContext,
-            mute: playerModel.getMute(),
+            mute: playerAttributes.mute,
             streamType: 'VOD',
             autostartMuted: playerAttributes.autostartMuted,
             autostart: playerAttributes.autostart,


### PR DESCRIPTION
### Why is this Pull Request needed?
Syncing from `getMute()` instead of the `mute` attribute caused a difference between the playerModel and instreamModel, which when set, generated a `change:mute` event, resulting in `unmuteAutoplay` to be called.

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-1023

