### PR TITLE
Get subtitleTracks even when the mediaController is backgrounded

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -149,11 +149,25 @@ Object.assign(Controller.prototype, {
                 const type = streamType(duration, minDvrWindow);
                 model.setStreamType(type);
             });
+
+            const mediaController = _programController.mediaController;
+            mediaController.off('subtitlesTracks', _onSubtitleTracks);
+            mediaController.on('subtitlesTracks', _onSubtitleTracks);
         });
 
         // Ensure captionsList event is raised after playlistItem
         _captions = new Captions(_model);
         _captions.on('all', _triggerAfterReady);
+
+        function _onSubtitleTracks(e) {
+            _captions.setSubtitlesTracks(e.tracks);
+            const defaultCaptionsIndex = _captions.getCurrentIndex();
+
+            // set the current captions if the default index isn't 0 or "Off"
+            if (defaultCaptionsIndex > 0) {
+                _setCurrentCaptions(defaultCaptionsIndex);
+            }
+        }
 
         function _triggerAfterReady(type, e) {
             _this.triggerAfterReady(type, e);
@@ -686,15 +700,6 @@ Object.assign(Controller.prototype, {
 
         function addProgramControllerListeners() {
             _programController.on('all', _triggerAfterReady, _this);
-            _programController.on('subtitlesTracks', (e) => {
-                _captions.setSubtitlesTracks(e.tracks);
-                const defaultCaptionsIndex = _captions.getCurrentIndex();
-
-                // set the current captions if the default index isn't 0 or "Off"
-                if (defaultCaptionsIndex > 0) {
-                    _setCurrentCaptions(defaultCaptionsIndex);
-                }
-            });
             _programController.on(MEDIA_COMPLETE, () => {
                 // Insert a small delay here so that other complete handlers can execute
                 resolved.then(_completeHandler);


### PR DESCRIPTION
### This PR will...

Listen for "subtitleTracks" on the active mediaController instead of the programController.

### Why is this Pull Request needed?

Because "subtitleTracks" must be handled in the controller even when the provider/mediaController that fired the event is backgrounded, for the captions menu and renderer to display 608 captions following a preroll.

### Other things to consider

Events received from the provider by a mediaController in the background should be queued, and dispatched once the provider is foregrounded. This would provide parity with the v8.0.x and single video tag behavior. This is not addressed here, instead I've created JW8-1043.

#### Addresses Issue(s):

JW8-1024


  