### PR TITLE
[ADS-812] Remove Google IMA specific CSS.

### DIFF
--- a/src/css/controls/flags/ads.less
+++ b/src/css/controls/flags/ads.less
@@ -99,29 +99,6 @@
     }
 }
 
-.jwplayer.jw-flag-ads-googleima {
-    &.jw-flag-touch {
-        .jw-controlbar {
-            font-size: 1em;
-        }
-
-        .jw-display-icon-display,
-        .jw-display-icon-display .jw-icon-display {
-            pointer-events: none;
-        }
-    }
-
-    &.jw-flag-small-player {
-        .jw-controlbar .jw-icon {
-            height: 30px;
-        }
-
-        .jw-icon-fullscreen {
-            display: none;
-        }
-    }
-}
-
 .jwplayer.jw-flag-ads-vpaid,
 .jwplayer.jw-flag-touch.jw-flag-ads-vpaid {
     .jw-display-container,


### PR DESCRIPTION
### This PR will...
Remove Google IMA-specific CSS.

### Why is this Pull Request needed?
This CSS is specific to the jwplayer-ads-googima plugin, and should live there.

### Are there any Pull Requests open in other repos which need to be merged with this?
jwplayer/jwplayer-ads-googima#297

#### Addresses Issue(s):
ADS-812