### PR TITLE
Sync model volume and mute on initial setup 

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -63,6 +63,7 @@ Object.assign(Controller.prototype, {
         _view.on('all', _triggerAfterReady, _this);
 
         const _programController = new ProgramController(_model, mediaPool);
+        syncInitialModelState();
         addProgramControllerListeners();
         initQoe(_model, _programController);
 
@@ -700,6 +701,12 @@ Object.assign(Controller.prototype, {
                 resolved.then(_completeHandler);
             });
             _programController.on(MEDIA_ERROR, _this.triggerError, _this);
+        }
+
+        function syncInitialModelState() {
+            // Mute the video if autostarting on mobile, except for Android SDK. Otherwise, honor the model's mute value
+            _programController.mute = (_model.autoStartOnMobile() && !_model.get('sdkplatform')) || _model.get('mute');
+            _programController.volume = _model.get('volume');
         }
 
         function updateProgramSoundSettings() {

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -234,11 +234,6 @@ const Model = function() {
 
 const syncProviderProperties = (model, provider) => {
     model.set('provider', provider.getName());
-
-    provider.volume(model.get('volume'));
-    // Mute the video if autostarting on mobile, except for Android SDK. Otherwise, honor the model's mute value
-    const isAndroidSdk = model.get('sdkplatform') === 1;
-    provider.mute((model.autoStartOnMobile() && !isAndroidSdk) || model.get('mute'));
     if (model.get('instreamMode') === true) {
         provider.instreamMode = true;
     }


### PR DESCRIPTION
### Why is this Pull Request needed?
We want to set `mute` and `volume` across all media elements on initial setup; previously, only the active element had these properties set.

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-1045 JW8-1046

