### PR TITLE
Set default video attributes in the media pool

### DIFF
--- a/src/js/program/media-element-pool.js
+++ b/src/js/program/media-element-pool.js
@@ -4,6 +4,9 @@ export default function MediaElementPool() {
     for (let i = 0; i < maxPrimedTags; i++) {
         const mediaElement = document.createElement('video');
         mediaElement.className = 'jw-video jw-reset';
+        mediaElement.setAttribute('disableRemotePlayback', '');
+        mediaElement.setAttribute('webkit-playsinline', '');
+        mediaElement.setAttribute('playsinline', '');
         elements.push(mediaElement);
     }
 

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -221,21 +221,11 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
     let _lastEndOfBuffer = null;
     let _androidHls = false;
 
-    function _setAttribute(name, value) {
-        _videotag.setAttribute(name, value || '');
-    }
-
-    _videotag.className = 'jw-video jw-reset';
-
     this.isSDK = !!_playerConfig.sdkplatform;
     this.video = _videotag;
     this.supportsPlaybackRate = true;
 
     _setupListeners(MediaEvents, _videotag);
-
-    _setAttribute('disableRemotePlayback', '');
-    _setAttribute('webkit-playsinline');
-    _setAttribute('playsinline');
 
     function checkVisualQuality() {
         const level = visualQuality.level;
@@ -475,7 +465,7 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
         const source = _levels[_currentQuality];
         const preload = source.preload || 'metadata';
         if (preload !== 'none') {
-            _setAttribute('preload', preload);
+            _videotag.setAttribute('preload', preload);
             _setVideotagSource(source);
         }
     };


### PR DESCRIPTION
Since these attributes are required on video elements we pass to vast, and also required on Android Chrome when using hls.js, I'm moving them from html5 to the media pool so that they're always present.