### PR TITLE
Fix cue drawing when duration is set in the config

### DIFF
--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -130,7 +130,8 @@ const Config = function(options, persisted) {
             'file',
             'sources',
             'tracks',
-            'preload'
+            'preload',
+            'duration'
         ]);
 
         config.playlist = [ obj ];
@@ -141,6 +142,7 @@ const Config = function(options, persisted) {
     }
 
     config.qualityLabels = config.qualityLabels || config.hlslabels;
+    delete config.duration;
 
     return config;
 };

--- a/src/js/view/controls/components/chapters.mixin.js
+++ b/src/js/view/controls/components/chapters.mixin.js
@@ -48,7 +48,6 @@ const ChaptersMixin = {
         // We won't want to draw them until we have a duration
         const duration = this._model.get('duration');
         if (!duration || duration <= 0) {
-            this._model.player.once('change:duration', this.drawCues, this);
             return;
         }
 

--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -146,6 +146,7 @@ class TimeSlider extends Slider {
 
     onDuration(model, duration) {
         this.updateTime(model.get('position'), duration);
+        this.drawCues();
     }
 
     onStreamType(model, streamType) {


### PR DESCRIPTION
### Why is this Pull Request needed?
- In Freewheel, cues are set by the ad client before the ad begins. The Player will have the ad mediaModel set at this point (which doesn't have the duration we need). We must listen for any duration change (and not just `once`), so that after ad ends, the cues are given the correct duration from the item. 
- We should not set `duration` on the model in the case we're given a flattened config. Unless we delete it from the config, this will happen. We now pick it from the config into the playlist item.

### Are there any points in the code the reviewer needs to double check?
Am I deleting `config.duration` at the correct point?

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-1048

