### PR TITLE
Only trigger captionsList event once when item is ready

### DIFF
--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -66,11 +66,19 @@ const Captions = function(_model) {
                                 });
                         }
                     }
-                    _updateMenu();
                 }
+                _updateMenu();
             }, this);
 
-        _updateMenu();
+        _resetMenu();
+    }
+
+    function _resetMenu() {
+        // Update model without dispatching events _updateMenu()
+        const captionsMenu = _captionsMenu();
+        const attributes = _model.attributes;
+        attributes.captionsIndex = 0;
+        attributes.captionsList = captionsMenu;
     }
 
     function _updateMenu() {


### PR DESCRIPTION
### This PR will...

Reset captions in the model without triggering a captionsList event on playlistItem. The captionsList event will be triggered on itemReady and contain sideloaded tracks.

This fixes the `cucumber features/api/api_captions.feature` automated test (https://github.com/jwplayer/jwplayer-commercial/pull/4484) that has been failing since captions.js item handling was changed for background loading.

  