### PR TITLE
Only forward provider "mediaType" event when type is changed

### DIFF
--- a/src/js/program/program-listeners.js
+++ b/src/js/program/program-listeners.js
@@ -14,9 +14,10 @@ export function ProviderListener(mediaController) {
 
         switch (type) {
             case MEDIA_TYPE:
-                if (mediaModel.get(MEDIA_TYPE) !== data.mediaType) {
-                    mediaModel.set(MEDIA_TYPE, data.mediaType);
+                if (mediaModel.get(MEDIA_TYPE) === data.mediaType) {
+                    return;
                 }
+                mediaModel.set(MEDIA_TYPE, data.mediaType);
                 break;
             case MEDIA_VISUAL_QUALITY:
                 mediaModel.set(MEDIA_VISUAL_QUALITY, Object.assign({}, data));

--- a/test/unit/program-controller-test.js
+++ b/test/unit/program-controller-test.js
@@ -34,7 +34,8 @@ const providerEvents = [
         type: 'subtitleTracks'
     },
     {
-        type: 'mediaType'
+        type: 'mediaType',
+        mediaType: 'video'
     },
     {
         type: 'bufferChange'


### PR DESCRIPTION
The player API should only emit one event per "mediaType" change ("video" or "audio").

This fixes an issue where a provider might trigger more than one "mediaType": "video" update, and each update was being forwarded through the api.

#### Addresses Issue(s):

JW8-1043

