### PR TITLE
Guard against undefined window.localStorage

### DIFF
--- a/src/js/model/storage.js
+++ b/src/js/model/storage.js
@@ -6,7 +6,7 @@ let storage = {
 };
 
 try {
-    storage = window.localStorage;
+    storage = window.localStorage || storage;
 } catch (e) {/* ignore */}
 
 function Storage(namespace, persistItems) {


### PR DESCRIPTION
According to #2538 there's a case where `window.localStorage` could be undefined which breaks player setup. We were only dealing with the case where accessing `window.localStorage` throws an error (Safari), but not where it's undefined.

Fixes #2538