### PR TITLE
setActiveItem model change events

### DIFF
--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -226,7 +226,7 @@ const Model = function() {
         const duration = item ? seconds(item.duration) : 0;
         const mediaModel = this.mediaModel;
         this.set('playRejected', false);
-        this.set('itemMeta', {});
+        this.attributes.itemMeta = {};
         mediaModel.set('position', position);
         mediaModel.set('duration', duration);
     };

--- a/src/js/model/player-model.js
+++ b/src/js/model/player-model.js
@@ -5,6 +5,7 @@ export const INITIAL_PLAYER_STATE = {
     flashBlocked: false,
     item: 0,
     itemMeta: {},
+    playbackRate: 1,
     playRejected: false,
     state: STATE_IDLE
 };

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -316,9 +316,9 @@ class ProgramController extends Eventable {
         assignMediaContainer(model, mediaController);
         this.mediaController = mediaController;
 
-        model.setProvider(provider);
-        model.setMediaModel(mediaModel);
         model.set('mediaElement', mediaController.mediaElement);
+        model.setMediaModel(mediaModel);
+        model.setProvider(provider);
 
         forwardEvents(this, mediaController);
     }

--- a/test/mock/mock-provider.js
+++ b/test/mock/mock-provider.js
@@ -3,6 +3,7 @@ import VideoAttached from 'providers/video-attached-mixin';
 import Tracks from 'providers/tracks-mixin';
 import BackboneEvents from 'utils/backbone.events';
 import ProviderDefaults from 'providers/default';
+import sinon from 'sinon';
 
 
 class MockDefault {}
@@ -12,6 +13,10 @@ export default class MockProvider extends MockDefault {
     constructor(playerId, playerConfig, mediaElement) {
         super();
         this.video = mediaElement;
+        sinon.spy(this, 'init');
+        sinon.spy(this, 'load');
+        sinon.spy(this, 'play');
+        sinon.spy(this, 'pause');
     }
 
     getName() {


### PR DESCRIPTION
### This PR will...

Test and update model change events fired during program-controller `setActiveItem(index)`.

### Why is this Pull Request needed?

- Asserts that "itemReady" is called following provider.init()
- Asserts that provider.load() is not called
- Asserts expected update order
-- `playlistItem` is set first
-- `mediaElement `
-- `mediaModel`
-- `provider`
-- "itemReady" is triggered last
- Asserts that state is changed to buffering on second item
- `playbackRate` is defaulted to `1` to remove a "change" event on first item

