### PR TITLE
Added conditional to CustomButton class for optional class

### DIFF
--- a/src/js/view/controls/components/custom-button.js
+++ b/src/js/view/controls/components/custom-button.js
@@ -20,7 +20,11 @@ export default class CustomButton {
 
     constructor(img, ariaText, callback, id, btnClass) {
         const buttonElement = document.createElement('div');
-        buttonElement.className = `jw-icon jw-icon-inline jw-button-color jw-reset ${btnClass}`;
+        if (btnClass) {
+            buttonElement.className = `jw-icon jw-icon-inline jw-button-color jw-reset ${btnClass}`;
+        } else {
+            buttonElement.className = `jw-icon jw-icon-inline jw-button-color jw-reset`;
+        }
         buttonElement.setAttribute('button', id);
         buttonElement.setAttribute('role', 'button');
         buttonElement.setAttribute('tabindex', '0');

--- a/src/js/view/controls/components/custom-button.js
+++ b/src/js/view/controls/components/custom-button.js
@@ -20,11 +20,7 @@ export default class CustomButton {
 
     constructor(img, ariaText, callback, id, btnClass) {
         const buttonElement = document.createElement('div');
-        if (btnClass) {
-            buttonElement.className = `jw-icon jw-icon-inline jw-button-color jw-reset ${btnClass}`;
-        } else {
-            buttonElement.className = 'jw-icon jw-icon-inline jw-button-color jw-reset';
-        }
+        buttonElement.className = `jw-icon jw-icon-inline jw-button-color jw-reset ${btnClass || ''}`;
         buttonElement.setAttribute('button', id);
         buttonElement.setAttribute('role', 'button');
         buttonElement.setAttribute('tabindex', '0');

--- a/src/js/view/controls/components/custom-button.js
+++ b/src/js/view/controls/components/custom-button.js
@@ -23,7 +23,7 @@ export default class CustomButton {
         if (btnClass) {
             buttonElement.className = `jw-icon jw-icon-inline jw-button-color jw-reset ${btnClass}`;
         } else {
-            buttonElement.className = `jw-icon jw-icon-inline jw-button-color jw-reset`;
+            buttonElement.className = 'jw-icon jw-icon-inline jw-button-color jw-reset';
         }
         buttonElement.setAttribute('button', id);
         buttonElement.setAttribute('role', 'button');


### PR DESCRIPTION
### This PR will...

Only add the optional btnClass for .addButton() if one is supplied.

### Why is this Pull Request needed?

Previously, if no class was passed to .addButton(), 'undefined' would be added as the class on the button.

### Are there any points in the code the reviewer needs to double check?

n/a

### Are there any Pull Requests open in other repos which need to be merged with this?

n/a

#### Addresses Issue(s):

JW8-985

