### PR TITLE
Sync mute & volume when using a shared pool 

### DIFF
--- a/src/js/program/shared-media-pool.js
+++ b/src/js/program/shared-media-pool.js
@@ -1,5 +1,5 @@
 export default function SharedMediaPool(sharedElement, mediaPool) {
-    return {
+    return Object.assign({}, mediaPool, {
         prime() {
             sharedElement.load();
         },
@@ -11,10 +11,6 @@ export default function SharedMediaPool(sharedElement, mediaPool) {
         },
         recycle() {
             mediaPool.clean(sharedElement);
-        },
-        syncVolume() {
-        },
-        syncMute() {
         }
-    };
+    });
 }


### PR DESCRIPTION
### Why is this Pull Request needed?
Neither mediaController nor backgroundMedia is set when reading `mute` and `volume` off of `localStorage`. We need to ensure that the tag has these properties set before starting, so that ads begin with the proper settings.

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-1055

