### PR TITLE
[Do not merge] Start BGL 2 seconds into the ad if skip offset is unknown

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -204,8 +204,8 @@ var InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
             _this.setupSkipButton(skipoffset, _options);
             _backgroundLoadPosition = skipoffset;
         } else {
-            // If no skipoffset is set, default to background loading 5 seconds before the end
-            _backgroundLoadPosition = item.duration - BACKGROUND_LOAD_OFFSET;
+            // If no skipoffset is set, default to background loading 5 seconds from the start
+            _backgroundLoadPosition = BACKGROUND_LOAD_OFFSET;
         }
 
         return playPromise;

--- a/src/js/program/program-constants.js
+++ b/src/js/program/program-constants.js
@@ -1,4 +1,4 @@
 // The number of tags allocated in the media pool
 export const MEDIA_POOL_SIZE = 3;
-// The default number of seconds from the end of a video from which we should start background loading
-export const BACKGROUND_LOAD_OFFSET = 5;
+// The default number of seconds from the start of a video from which we should start background loading
+export const BACKGROUND_LOAD_OFFSET = 2;


### PR DESCRIPTION
### Why is this Pull Request needed?
We don't always know when an ad will begin it's skip countdown (which is when we start BGL). This change makes it so that we always reliably BGL enough content to avoid buffering.

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

 JW8-1060

