### PR TITLE
Set BGL min start time to 1s to avoid ad performance degredation 

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -2,7 +2,7 @@ import { STATE_BUFFERING, STATE_COMPLETE, STATE_PAUSED,
     MEDIA_META, MEDIA_TIME, MEDIA_COMPLETE,
     PLAYLIST_ITEM, PLAYLIST_COMPLETE,
     INSTREAM_CLICK, AD_SKIPPED } from 'events/events';
-import { BACKGROUND_LOAD_OFFSET } from '../program/program-constants';
+import { BACKGROUND_LOAD_OFFSET, BACKGROUND_LOAD_MIN_OFFSET } from '../program/program-constants';
 import Promise from 'polyfills/promise';
 import Events from 'utils/backbone.events';
 import _ from 'utils/underscore';
@@ -207,6 +207,9 @@ var InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
             // If no skipoffset is set, default to background loading 5 seconds before the end
             _backgroundLoadPosition = item.duration - BACKGROUND_LOAD_OFFSET;
         }
+
+        // Ensure background loading doesn't degrade ad performance by starting too early
+        _backgroundLoadPosition = Math.max(_backgroundLoadPosition, BACKGROUND_LOAD_MIN_OFFSET);
 
         return playPromise;
     };

--- a/src/js/program/program-constants.js
+++ b/src/js/program/program-constants.js
@@ -2,3 +2,5 @@
 export const MEDIA_POOL_SIZE = 3;
 // The default number of seconds from the end of a video from which we should start background loading
 export const BACKGROUND_LOAD_OFFSET = 5;
+// The earliest time (in seconds) from the start of an ad background loading can begin
+export const BACKGROUND_LOAD_MIN_OFFSET = 1;


### PR DESCRIPTION
### Why is this Pull Request needed?
We want to avoid downloading in the background while an ad is trying to buffer enough content to ensure smooth playback

### Are there any points in the code the reviewer needs to double check?
Is 1s too soon?

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-1061

