### PR TITLE
Stopped mouseover event from triggering when coming from nextUp

### DIFF
--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -129,7 +129,7 @@ const UI = function (elem, options) {
 
     // overHandler and outHandler not assigned in touch situations
     function overHandler(evt) {
-        if (evt.pointerType !== 'touch' && evt.fromElement.classList[0].indexOf('jw-nextup') === -1) {
+        if (evt.pointerType !== 'touch') {
             triggerEvent(OVER, evt);
         }
     }

--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -129,7 +129,7 @@ const UI = function (elem, options) {
 
     // overHandler and outHandler not assigned in touch situations
     function overHandler(evt) {
-        if (evt.pointerType !== 'touch') {
+        if (evt.pointerType !== 'touch' && evt.fromElement.classList[0].indexOf('jw-nextup') === -1) {
             triggerEvent(OVER, evt);
         }
     }

--- a/src/js/view/utils/clickhandler.js
+++ b/src/js/view/utils/clickhandler.js
@@ -23,8 +23,8 @@ export default class ClickHandler {
             move: function() {
                 this.trigger('move');
             },
-            over: function() {
-                this.trigger('over');
+            over: function(evt) {
+                this.trigger('over', evt);
             },
             out: function() {
                 this.trigger('out');

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -404,7 +404,11 @@ function View(_api, _model) {
             },
             doubleClick: () => _controls && api.setFullscreen(),
             move: () => _controls && _controls.userActive(),
-            over: () => _controls && _controls.userActive()
+            over: (evt) => {
+                if (_controls && (evt.sourceEvent.fromElement.classList.length === 0 || evt.sourceEvent.fromElement.classList[0].indexOf('jw-nextup') === -1)) {
+                    _controls.userActive();
+                }
+            }
         });
 
         return clickHandler;


### PR DESCRIPTION
### This PR will...

Stop the (mouse)OVER event from triggering when coming from any element within the nextup overlay

### Why is this Pull Request needed?

Without it, if the controls hide/user goes inactive while hovering the nextup overlay, a mouseover event will fire on the video element causing the controls to show again. This causes the illusion that the nextup display is flickering.

### Are there any points in the code the reviewer needs to double check?

Is this the best way of doing this?

### Are there any Pull Requests open in other repos which need to be merged with this?

No.

#### Addresses Issue(s):

JW8-1004

