### PR TITLE
Program controller listener tests

### DIFF
--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -34,12 +34,6 @@ const Model = function() {
         return config;
     };
 
-    this.setQualityLevel = function(quality, levels) {
-        if (quality > -1 && levels.length > 1) {
-            this.mediaModel.set('currentLevel', parseInt(quality));
-        }
-    };
-
     this.persistQualityLevel = function(quality, levels) {
         var currentLevel = levels[quality] || {};
         var label = currentLevel.label;
@@ -64,12 +58,6 @@ const Model = function() {
         this.mediaModel = mediaModel;
         this.set('mediaModel', mediaModel);
         syncPlayerWithMediaModel(mediaModel);
-    };
-
-    this.setCurrentAudioTrack = function(currentTrack, tracks) {
-        if (currentTrack > -1 && tracks.length > 0 && currentTrack < tracks.length) {
-            this.mediaModel.set('currentAudioTrack', parseInt(currentTrack));
-        }
     };
 
     this.destroy = function() {

--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -66,6 +66,7 @@ export default class MediaController extends Eventable {
 
     destroy() {
         const { provider, mediaModel } = this;
+        this.off();
         mediaModel.off();
         provider.off();
         this.eventQueue.destroy();
@@ -83,10 +84,10 @@ export default class MediaController extends Eventable {
 
         // Restore the playback rate to the provider in case it changed while detached and we reused a video tag.
         model.setPlaybackRate(model.get('defaultPlaybackRate'));
-        this.eventQueue.flush();
         provider.attachMedia();
         this.attached = true;
         model.set('attached', true);
+        this.eventQueue.flush();
 
         if (this.beforeComplete) {
             this._playbackComplete();

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -251,7 +251,6 @@ class ProgramController extends Eventable {
             this._destroyBackgroundMedia();
         }
 
-        removeEventForwarding(this, mediaController);
         mediaController.background = true;
         this.backgroundMedia = mediaController;
         this.mediaController = null;
@@ -337,8 +336,6 @@ class ProgramController extends Eventable {
         mediaController.detach();
         mediaPool.recycle(mediaController.mediaElement);
         mediaController.destroy();
-
-        removeEventForwarding(this, mediaController);
 
         model.resetProvider();
         this.mediaController = null;
@@ -623,12 +620,8 @@ function assignMediaContainer(model, mediaController) {
     }
 }
 
-function removeEventForwarding(programController, mediaController) {
-    mediaController.off('all', programController.mediaControllerListener, programController);
-}
-
 function forwardEvents(programController, mediaController) {
-    removeEventForwarding(programController, mediaController);
+    mediaController.off('all', programController.mediaControllerListener, programController);
     mediaController.on('all', programController.mediaControllerListener, programController);
 }
 

--- a/src/js/program/program-listeners.js
+++ b/src/js/program/program-listeners.js
@@ -56,7 +56,7 @@ export function ProviderListener(mediaController) {
             }
             case MEDIA_BUFFER:
                 mediaModel.set('buffer', data.bufferPercent);
-            /* falls through to update duration while media is loaded */
+                /* falls through to update duration while media is loaded */
             case MEDIA_TIME: {
                 mediaModel.set('position', data.position);
                 const duration = data.duration;
@@ -67,10 +67,25 @@ export function ProviderListener(mediaController) {
             }
             case MEDIA_LEVELS:
                 mediaModel.set(MEDIA_LEVELS, data.levels);
+                /* falls through to update current level */
+            case MEDIA_LEVEL_CHANGED: {
+                const { currentQuality, levels } = data;
+                if (currentQuality > -1 && levels.length > 1) {
+                    mediaModel.set('currentLevel', parseInt(currentQuality));
+                }
                 break;
+            }
             case AUDIO_TRACKS:
                 mediaModel.set(AUDIO_TRACKS, data.tracks);
+                /* falls through to update current track */
+            case AUDIO_TRACK_CHANGED: {
+                const { currentTrack, tracks } = data;
+
+                if (currentTrack > -1 && tracks.length > 0 && currentTrack < tracks.length) {
+                    mediaModel.set('currentAudioTrack', parseInt(currentTrack));
+                }
                 break;
+            }
             case 'visualQuality':
                 mediaModel.set('visualQuality', Object.assign({}, data));
                 break;
@@ -118,18 +133,8 @@ export function MediaControllerListener(model, programController) {
                 Object.assign(model.get('itemMeta'), data.metadata);
                 break;
             }
-            case MEDIA_LEVELS:
-                model.setQualityLevel(data.currentQuality, data.levels);
-                break;
             case MEDIA_LEVEL_CHANGED:
-                model.setQualityLevel(data.currentQuality, data.levels);
                 model.persistQualityLevel(data.currentQuality, data.levels);
-                break;
-            case AUDIO_TRACKS:
-                model.setCurrentAudioTrack(data.currentTrack, data.tracks);
-                break;
-            case AUDIO_TRACK_CHANGED:
-                model.setCurrentAudioTrack(data.currentTrack, data.tracks);
                 break;
             case 'subtitlesTrackChanged':
                 model.persistVideoSubtitleTrack(data.currentTrack, data.tracks);


### PR DESCRIPTION
### This PR will...

- Remove model methods that only update mediaModel (these are handled in `ProviderListener` where other mediaModel properties are updated)
- Remove listeners from media-controller on destroy
- Set attached on the model before flushing queued events which may update other model properties
- Keep 'all' event listener on media-controller (queueing handles backgrounded behavior)
- Add tests for active item model changes
  - Provider events update the model when in the foreground
  - When backgrounded the model is ___not___ updated
  - When detached the model is ___not___ updated
  - When foregrounded queued events update the model 
  - When reattached queued events update the model 

### Why is this Pull Request needed?

This helps ensure that player API event behavior is consistent with previous versions. Background provider events should not trigger during ad breaks, but should immediately after the ad break ends and playback is resumed.