### PR TITLE
Implement a small time padding around BGL triggers

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -140,8 +140,7 @@ var InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
         // If no skipoffset is set, default to background loading 5 seconds before the end
         if (!_backgroundLoadStart) {
             // Ensure background loading doesn't degrade ad performance by starting too early
-            const backgroundLoadOffset = duration - BACKGROUND_LOAD_OFFSET;
-            _backgroundLoadStart = offsetToSeconds(_skipOffset, backgroundLoadOffset) || backgroundLoadOffset;
+            _backgroundLoadStart = offsetToSeconds(_skipOffset, duration) - BACKGROUND_LOAD_OFFSET || duration - BACKGROUND_LOAD_OFFSET;
         }
         if (!_backgroundLoadTriggered && position >= Math.max(_backgroundLoadStart, BACKGROUND_LOAD_MIN_OFFSET)) {
             _controller.preloadNextItem();

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -2,7 +2,7 @@ import { STATE_BUFFERING, STATE_COMPLETE, STATE_PAUSED,
     MEDIA_META, MEDIA_TIME, MEDIA_COMPLETE,
     PLAYLIST_ITEM, PLAYLIST_COMPLETE,
     INSTREAM_CLICK, AD_SKIPPED } from 'events/events';
-import { BACKGROUND_LOAD_OFFSET } from '../program/program-constants';
+import { BACKGROUND_LOAD_OFFSET, BACKGROUND_LOAD_MIN_OFFSET } from '../program/program-constants';
 import Promise from 'polyfills/promise';
 import Events from 'utils/backbone.events';
 import _ from 'utils/underscore';
@@ -204,12 +204,12 @@ var InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
             _this.setupSkipButton(skipoffset, _options);
             _backgroundLoadPosition = skipoffset - BACKGROUND_LOAD_OFFSET;
         } else {
-            // If no skipoffset is set, reckon the BGL start from the end of the current video
+            // If no skipoffset is set, calculate BGL start from the end of the current video
             _backgroundLoadPosition = item.duration - BACKGROUND_LOAD_OFFSET;
         }
 
         // Ensure background loading doesn't degrade ad performance by starting too early
-        _backgroundLoadPosition = Math.max(_backgroundLoadPosition, BACKGROUND_LOAD_OFFSET);
+        _backgroundLoadPosition = Math.max(_backgroundLoadPosition, BACKGROUND_LOAD_MIN_OFFSET);
 
         return playPromise;
     };

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -140,7 +140,7 @@ var InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
         // If no skipoffset is set, default to background loading 5 seconds before the end
         if (!_backgroundLoadStart) {
             // Ensure background loading doesn't degrade ad performance by starting too early
-            _backgroundLoadStart = offsetToSeconds(_skipOffset, duration) - BACKGROUND_LOAD_OFFSET || duration - BACKGROUND_LOAD_OFFSET;
+            _backgroundLoadStart = (offsetToSeconds(_skipOffset, duration) || duration) - BACKGROUND_LOAD_OFFSET;
         }
         if (!_backgroundLoadTriggered && position >= Math.max(_backgroundLoadStart, BACKGROUND_LOAD_MIN_OFFSET)) {
             _controller.preloadNextItem();

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -2,7 +2,7 @@ import { STATE_BUFFERING, STATE_COMPLETE, STATE_PAUSED,
     MEDIA_META, MEDIA_TIME, MEDIA_COMPLETE,
     PLAYLIST_ITEM, PLAYLIST_COMPLETE,
     INSTREAM_CLICK, AD_SKIPPED } from 'events/events';
-import { BACKGROUND_LOAD_OFFSET, BACKGROUND_LOAD_MIN_OFFSET } from '../program/program-constants';
+import { BACKGROUND_LOAD_OFFSET } from '../program/program-constants';
 import Promise from 'polyfills/promise';
 import Events from 'utils/backbone.events';
 import _ from 'utils/underscore';
@@ -200,16 +200,16 @@ var InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
         _backgroundLoadTriggered = false;
         const skipoffset = item.skipoffset || _options.skipoffset;
         if (skipoffset) {
-            // Start background loading once the skip button is clickable
+            // Start background loading shortly before the skip button is clickable
             _this.setupSkipButton(skipoffset, _options);
-            _backgroundLoadPosition = skipoffset;
+            _backgroundLoadPosition = skipoffset - BACKGROUND_LOAD_OFFSET;
         } else {
-            // If no skipoffset is set, default to background loading 5 seconds before the end
+            // If no skipoffset is set, reckon the BGL start from the end of the current video
             _backgroundLoadPosition = item.duration - BACKGROUND_LOAD_OFFSET;
         }
 
         // Ensure background loading doesn't degrade ad performance by starting too early
-        _backgroundLoadPosition = Math.max(_backgroundLoadPosition, BACKGROUND_LOAD_MIN_OFFSET);
+        _backgroundLoadPosition = Math.max(_backgroundLoadPosition, BACKGROUND_LOAD_OFFSET);
 
         return playPromise;
     };

--- a/src/js/program/program-constants.js
+++ b/src/js/program/program-constants.js
@@ -1,6 +1,5 @@
 // The number of tags allocated in the media pool
 export const MEDIA_POOL_SIZE = 3;
-// The default number of seconds from the end of a video from which we should start background loading
-export const BACKGROUND_LOAD_OFFSET = 5;
-// The earliest time (in seconds) from the start of an ad background loading can begin
-export const BACKGROUND_LOAD_MIN_OFFSET = 1;
+// The number of seconds before a BGL trigger at which we should start background loading. This ensures that we have
+// kicked off background loading before being able to transition to that item
+export const BACKGROUND_LOAD_OFFSET = 2;

--- a/src/js/program/program-constants.js
+++ b/src/js/program/program-constants.js
@@ -3,3 +3,5 @@ export const MEDIA_POOL_SIZE = 3;
 // The number of seconds before a BGL trigger at which we should start background loading. This ensures that we have
 // kicked off background loading before being able to transition to that item
 export const BACKGROUND_LOAD_OFFSET = 2;
+// The minimum time from the start of a video in which we can background load
+export const BACKGROUND_LOAD_MIN_OFFSET = 1;


### PR DESCRIPTION
### Why is this Pull Request needed?
To ensure we start background loading before being able to transition to that item. This ensures that we always (attempt to) load something. With the current implementation tying BGL to when the skip button becomes clickable, automated tests work too quickly to allow BGL to begin.

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No