### PR TITLE
fixed isAndroid: true being returned for Windows Phone

### DIFF
--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -62,7 +62,7 @@ export function isAndroidNative() {
 }
 
 export function isAndroid() {
-    return userAgentMatch(/Android/i);
+    return userAgentMatch(/Android/i) && !userAgentMatch(/Windows Phone/i);
 }
 
 /** Matches iOS, Android and Windows Phone devices **/


### PR DESCRIPTION
### This PR will...

Only return `isAndroid(): true` if the UA string does not also contain `Windows Phone`.

### Why is this Pull Request needed?

The UA string for Windows Phones contained the word 'Android' so `isAndroid` was returning `true`. Found after #2638 was closed.

### Are there any points in the code the reviewer needs to double check?

n/a

### Are there any Pull Requests open in other repos which need to be merged with this?

n/a

#### Addresses Issue(s):

JW8-932
