### PR TITLE
Add all captions tracks (608 + in-manifest) to the cc menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "karma-firefox-launcher": "1.0.1",
     "karma-junit-reporter": "1.2.0",
     "karma-mocha": "1.3.0",
+    "karma-mocha-reporter": "2.2.5",
     "karma-phantomjs-launcher": "1.0.4",
     "karma-requirejs": "1.1.0",
     "karma-safari-launcher": "1.0.0",
@@ -72,7 +73,8 @@
     "lint": "npm run lint:js && npm run lint:styles",
     "lint:js": "eslint './src/js'",
     "lint:styles": "stylelint './src/css/**/*.less'",
-    "lint:tests": "eslint './test/*.js'"
+    "lint:tests": "eslint './test/*.js'",
+    "karma:hook": "karma start --browsers=PhantomJS --reporters=mocha"
   },
   "engines": {
     "node": ">=4.3.1"

--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -49,8 +49,9 @@ define(['utils/underscore',
         } else {
             // Remove the 608 captions track that was mutated by the browser
             this._textTracks = _.reject(this._textTracks, function(track) {
-                if ((this.renderNatively && track._id === 'nativecaptions')) {
-                    delete this._tracksById[track._id];
+                var trackId = track._id;
+                if (this.renderNatively && trackId && trackId.indexOf('nativecaptions') === 0) {
+                    delete this._tracksById[trackId];
                     return true;
                 }
             }, this);
@@ -68,7 +69,7 @@ define(['utils/underscore',
                 var track = tracks[i];
                 if (!track._id) {
                     if (track.kind === 'captions' || track.kind === 'metadata') {
-                        track._id = 'native' + track.kind;
+                        track._id = 'native' + track.kind + i;
                         if (!track.label && track.kind === 'captions') {
                             // track label is read only in Safari
                             // 'captions' tracks without a label need a name in order for the cc menu to work
@@ -383,7 +384,8 @@ define(['utils/underscore',
             if (track) {
                 // FF does not remove the active cue from the dom when the track is hidden, so we must disable it
                 track.mode = 'disabled';
-                if (track.embedded || track._id === 'nativecaptions') {
+                var trackId = track._id;
+                if (trackId && trackId.indexOf('nativecaptions') === 0) {
                     track.mode = 'hidden';
                 }
             }


### PR DESCRIPTION
### This PR will...
Add all text tracks (608 captions + in-manifest subtitles) to the cc menu.
### Why is this Pull Request needed?
This was already fixed in https://github.com/jwplayer/jwplayer/pull/2395 for `v8.0.0`, but is also needed in JW7.
### Are there any points in the code the reviewer needs to double check?
No, but I added the mocha reporter so that the github pre-push hook works in JW7. 
### Are there any Pull Requests open in other repos which need to be merged with this?
No
#### Addresses Issue(s):
JW7-4273

