### PR TITLE
Stop Controls from Hiding when Hovering NextUp Display

### DIFF
--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -117,6 +117,8 @@ export default class Controls {
             nextUpToolTip.setup(this.context);
             controlbar.nextUpToolTip = nextUpToolTip;
 
+            this.addActiveListeners(nextUpToolTip.element());
+
             // NextUp needs to be behind the controlbar to not block other tooltips
             this.div.appendChild(nextUpToolTip.element());
         }
@@ -141,7 +143,7 @@ export default class Controls {
                     api.play(settingsInteraction);
                 }
             }
-            
+
             // Trigger userActive so that a dismissive click outside the player can hide the controlbar
             this.userActive(null, visible || isKeyEvent);
             lastState = state;

--- a/src/js/view/utils/clickhandler.js
+++ b/src/js/view/utils/clickhandler.js
@@ -3,15 +3,14 @@ import UI from 'utils/ui';
 import Events from 'utils/backbone.events';
 
 export default class ClickHandler {
-    constructor(model, element, options) {
+    constructor(model, element) {
         Object.assign(this, Events);
 
         this.revertAlternateClickHandlers();
         this.domElement = element;
         this.model = model;
 
-        const defaultOptions = { enableDoubleTap: true, useMove: true };
-        this.ui = new UI(element, Object.assign(defaultOptions, options)).on({
+        this.ui = new UI(element, { enableDoubleTap: true, useMove: true }).on({
             'click tap': this.clickHandler,
             'doubleClick doubleTap': function() {
                 if (this.alternateDoubleClickHandler) {
@@ -22,12 +21,6 @@ export default class ClickHandler {
             },
             move: function() {
                 this.trigger('move');
-            },
-            over: function() {
-                this.trigger('over');
-            },
-            out: function() {
-                this.trigger('out');
             }
         }, this);
     }

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -359,7 +359,7 @@ function View(_api, _model) {
     }
 
     function clickHandlerHelper(api, model, videoLayer) {
-        const clickHandler = new ClickHandler(model, videoLayer, { useHover: true });
+        const clickHandler = new ClickHandler(model, videoLayer);
         const controls = model.get('controls');
         clickHandler.on({
             click: () => {
@@ -403,8 +403,7 @@ function View(_api, _model) {
                 }
             },
             doubleClick: () => _controls && api.setFullscreen(),
-            move: () => _controls && _controls.userActive(),
-            over: () => _controls && _controls.userActive()
+            move: () => _controls && _controls.userActive()
         });
 
         return clickHandler;


### PR DESCRIPTION
### This PR will...

* Stop the controls from hiding when mouse is hovering over the nextUp overlay.
* Remove the 'over' handler as 'move' makes it redundant.

### Why is this Pull Request needed?

* When the nextUp display was hovered and the controls would hide, the nextUp would flicker as an 'over' event was being called on the .jw-media element.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-1004

