### PR TITLE
Removed mouseout event listener from controls.js

### DIFF
--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -58,8 +58,7 @@ export default class Controls {
         this.div = null;
         this.right = null;
         this.activeListeners = {
-            mousemove: () => clearTimeout(this.activeTimeout),
-            mouseout: () => this.userActive()
+            mousemove: () => clearTimeout(this.activeTimeout)
         };
         this.dimensions = {};
     }
@@ -388,14 +387,12 @@ export default class Controls {
     addActiveListeners(element) {
         if (element && !OS.mobile) {
             element.addEventListener('mousemove', this.activeListeners.mousemove);
-            element.addEventListener('mouseout', this.activeListeners.mouseout);
         }
     }
 
     removeActiveListeners(element) {
         if (element) {
             element.removeEventListener('mousemove', this.activeListeners.mousemove);
-            element.removeEventListener('mouseout', this.activeListeners.mouseout);
         }
     }
 


### PR DESCRIPTION
### This PR will...

Remove the mouseout event listener from controls.js

### Why is this Pull Request needed?

This is a continuation of #2677 which was rejected by QA because the behavior came back on subsequent playlist items. Instead of the 'mouseover' event being triggered, the 'mouseout' event was being called.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-1004

