### PR TITLE
Add background tag priming for Android 

### DIFF
--- a/src/js/program/media-element-pool.js
+++ b/src/js/program/media-element-pool.js
@@ -65,11 +65,14 @@ function primeMediaElementForPlayback(mediaElement) {
     // If we're in a user-gesture event call load() on video to allow async playback
     if (!mediaElement.src) {
         mediaElement.load();
-    } else if (OS.android && !mediaElement.parentNode && !mediaElement.currentTime) {
+    } else if (OS.android && !mediaElement.parentNode) {
         // If the player sets up without a gesture and preloads, the background tag may not be primed for playback.
         // We need to load again on Android in order to play without another gesture. But make sure we're only reloading
-        // a tag which hasn't begun playback yet.
-        mediaElement.load();
+        // a tag which hasn't begun playback yet
+        const played = mediaElement.played;
+        if (!played || (played && !played.length)) {
+            mediaElement.load();
+        }
     }
 }
 

--- a/src/js/program/media-element-pool.js
+++ b/src/js/program/media-element-pool.js
@@ -1,4 +1,5 @@
 import { MEDIA_POOL_SIZE } from 'program/program-constants';
+import { OS } from 'environment/environment';
 
 export default function MediaElementPool() {
     const maxPrimedTags = MEDIA_POOL_SIZE;
@@ -64,6 +65,12 @@ function primeMediaElementForPlayback(mediaElement) {
     // If we're in a user-gesture event call load() on video to allow async playback
     if (!mediaElement.src) {
         mediaElement.load();
+    } else if (OS.android && !mediaElement.parentNode) {
+        // If the player sets up without a gesture and preloads, the background tag may not be primed for playback.
+        // We need to load again on Android in order to play without another gesture
+        if (!mediaElement.played.length) {
+            mediaElement.load();
+        }
     }
 }
 

--- a/src/js/program/media-element-pool.js
+++ b/src/js/program/media-element-pool.js
@@ -65,9 +65,10 @@ function primeMediaElementForPlayback(mediaElement) {
     // If we're in a user-gesture event call load() on video to allow async playback
     if (!mediaElement.src) {
         mediaElement.load();
-    } else if (OS.android && !mediaElement.parentNode && !mediaElement.played.length) {
+    } else if (OS.android && !mediaElement.parentNode && !mediaElement.currentTime) {
         // If the player sets up without a gesture and preloads, the background tag may not be primed for playback.
-        // We need to load again on Android in order to play without another gesture
+        // We need to load again on Android in order to play without another gesture. But make sure we're only reloading
+        // a tag which hasn't begun playback yet.
         mediaElement.load();
     }
 }

--- a/src/js/program/media-element-pool.js
+++ b/src/js/program/media-element-pool.js
@@ -65,12 +65,10 @@ function primeMediaElementForPlayback(mediaElement) {
     // If we're in a user-gesture event call load() on video to allow async playback
     if (!mediaElement.src) {
         mediaElement.load();
-    } else if (OS.android && !mediaElement.parentNode) {
+    } else if (OS.android && !mediaElement.parentNode && !mediaElement.played.length) {
         // If the player sets up without a gesture and preloads, the background tag may not be primed for playback.
         // We need to load again on Android in order to play without another gesture
-        if (!mediaElement.played.length) {
-            mediaElement.load();
-        }
+        mediaElement.load();
     }
 }
 


### PR DESCRIPTION
### Why is this Pull Request needed?
A player which did not set up within a gesture will not start with primed tags. If we preload and then play a preroll, we have background loaded content which cannot be played without further gesture on Android. This PR will call load again on Android if the media has set a src, but has not yet begun playback (and is thus safe to reload).

### Are there any points in the code the reviewer needs to double check?
Sure

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-1076

