### PR TITLE
Restore stretching functionality in IE/Edge with HLS/DASH streams

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -15,6 +15,8 @@ import Events from 'utils/backbone.events';
 import Tracks from 'providers/tracks-mixin';
 import endOfRange from 'utils/time-ranges';
 import createPlayPromise from 'providers/utils/play-promise';
+import { fitToBounds, fitVideoUsingTransforms } from 'utils/video-fit';
+
 
 const clearTimeout = window.clearTimeout;
 const MIN_DVR_DURATION = 120;
@@ -590,26 +592,8 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
         // object-fit is not implemented in IE or Android Browser in 4.4 and lower
         // http://caniuse.com/#feat=object-fit
         // feature detection may work for IE but not for browsers where object-fit works for images only
-        const fitVideoUsingTransforms = Browser.ie || (OS.iOS && OS.version.major < 9) || Browser.androidNative;
         if (fitVideoUsingTransforms) {
-            // Use transforms to center and scale video in container
-            const x = -Math.floor(_videotag.videoWidth / 2 + 1);
-            const y = -Math.floor(_videotag.videoHeight / 2 + 1);
-            let scaleX = Math.ceil(width * 100 / _videotag.videoWidth) / 100;
-            let scaleY = Math.ceil(height * 100 / _videotag.videoHeight) / 100;
-            if (stretching === 'none') {
-                scaleX = scaleY = 1;
-            } else if (stretching === 'fill') {
-                scaleX = scaleY = Math.max(scaleX, scaleY);
-            } else if (stretching === 'uniform') {
-                scaleX = scaleY = Math.min(scaleX, scaleY);
-            }
-            styles.width = _videotag.videoWidth;
-            styles.height = _videotag.videoHeight;
-            styles.top = styles.left = '50%';
-            styles.margin = 0;
-            transform(_videotag,
-                'translate(' + x + 'px, ' + y + 'px) scale(' + scaleX.toFixed(2) + ', ' + scaleY.toFixed(2) + ')');
+            fitToBounds(_videotag, width, height, stretching, styles);
         }
         style(_videotag, styles);
     };

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -6,7 +6,7 @@ import { STATE_IDLE, MEDIA_META, MEDIA_ERROR, MEDIA_VISUAL_QUALITY, MEDIA_TYPE,
 import VideoEvents from 'providers/video-listener-mixin';
 import VideoAction from 'providers/video-actions-mixin';
 import VideoAttached from 'providers/video-attached-mixin';
-import { style, transform } from 'utils/css';
+import { style } from 'utils/css';
 import utils from 'utils/helpers';
 import { emptyElement } from 'utils/dom';
 import _ from 'utils/underscore';

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -15,8 +15,6 @@ import Events from 'utils/backbone.events';
 import Tracks from 'providers/tracks-mixin';
 import endOfRange from 'utils/time-ranges';
 import createPlayPromise from 'providers/utils/play-promise';
-import { fitToBounds, fitVideoUsingTransforms } from 'utils/video-fit';
-
 
 const clearTimeout = window.clearTimeout;
 const MIN_DVR_DURATION = 120;
@@ -568,34 +566,6 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
                 opacity: 0
             });
         }
-    };
-
-    this.resize = function(width, height, stretching) {
-        if (!width || !height || !_videotag.videoWidth || !_videotag.videoHeight) {
-            return;
-        }
-        const styles = {
-            objectFit: '',
-            width: '',
-            height: ''
-        };
-        if (stretching === 'uniform') {
-            // snap video to edges when the difference in aspect ratio is less than 9%
-            const playerAspectRatio = width / height;
-            const videoAspectRatio = _videotag.videoWidth / _videotag.videoHeight;
-            if (Math.abs(playerAspectRatio - videoAspectRatio) < 0.09) {
-                styles.objectFit = 'fill';
-                stretching = 'exactfit';
-            }
-        }
-        // Prior to iOS 9, object-fit worked poorly
-        // object-fit is not implemented in IE or Android Browser in 4.4 and lower
-        // http://caniuse.com/#feat=object-fit
-        // feature detection may work for IE but not for browsers where object-fit works for images only
-        if (fitVideoUsingTransforms) {
-            fitToBounds(_videotag, width, height, stretching, styles);
-        }
-        style(_videotag, styles);
     };
 
     this.setFullscreen = function(state) {

--- a/src/js/providers/video-actions-mixin.js
+++ b/src/js/providers/video-actions-mixin.js
@@ -23,21 +23,21 @@ const VideoActionsMixin = {
             return false;
         }
         const _videotag = this.video;
-        const styles = {
-            objectFit: '',
-            width: '',
-            height: '',
+        let styles = {
+            objectFit: null,
+            width: null,
+            height: null,
         };
         if (stretching === 'uniform') {
             // snap video to edges when the difference in aspect ratio is less than 9%
-            var playerAspectRatio = width / height;
-            var videoAspectRatio = _videotag.videoWidth / _videotag.videoHeight;
+            let playerAspectRatio = width / height;
+            let videoAspectRatio = _videotag.videoWidth / _videotag.videoHeight;
             if (Math.abs(playerAspectRatio - videoAspectRatio) < 0.09) {
                 styles.objectFit = 'fill';
             }
         }
         if (fitVideoUsingTransforms) {
-            fitToBounds(_videotag, width, height, stretching, styles);  
+            styles = fitToBounds(_videotag, width, height, stretching, styles);  
         } 
         style(_videotag, styles);
         return false;

--- a/src/js/providers/video-actions-mixin.js
+++ b/src/js/providers/video-actions-mixin.js
@@ -1,4 +1,5 @@
 import { style } from 'utils/css';
+import { fitToBounds, fitVideoUsingTransforms } from 'utils/video-fit';
 
 const VideoActionsMixin = {
     container: null,
@@ -21,20 +22,24 @@ const VideoActionsMixin = {
         if (!width || !height || !this.video.videoWidth || !this.video.videoHeight) {
             return false;
         }
+        const _videotag = this.video;
+        const styles = {
+            objectFit: '',
+            width: '',
+            height: '',
+        };
         if (stretching === 'uniform') {
             // snap video to edges when the difference in aspect ratio is less than 9%
             var playerAspectRatio = width / height;
-            var videoAspectRatio = this.video.videoWidth / this.video.videoHeight;
-            var objectFit = null;
+            var videoAspectRatio = _videotag.videoWidth / _videotag.videoHeight;
             if (Math.abs(playerAspectRatio - videoAspectRatio) < 0.09) {
-                objectFit = 'fill';
+                styles.objectFit = 'fill';
             }
-            style(this.video, {
-                objectFit,
-                width: null,
-                height: null
-            });
         }
+        if (fitVideoUsingTransforms) {
+            fitToBounds(_videotag, width, height, stretching, styles);  
+        } 
+        style(_videotag, styles);
         return false;
     },
 

--- a/src/js/utils/video-fit.js
+++ b/src/js/utils/video-fit.js
@@ -1,0 +1,26 @@
+import { transform } from 'utils/css';
+import { Browser, OS } from 'environment/environment'; 
+
+export const fitVideoUsingTransforms = Browser.ie || (OS.iOS && OS.version.major < 9) || Browser.androidNative;
+
+export function fitToBounds(_videotag, width, height, stretching, styles) {
+    // Use transforms to center and scale video in container
+    const x = -Math.floor(_videotag.videoWidth / 2 + 1);
+    const y = -Math.floor(_videotag.videoHeight / 2 + 1);
+    let scaleX = Math.ceil(width * 100 / _videotag.videoWidth) / 100;
+    let scaleY = Math.ceil(height * 100 / _videotag.videoHeight) / 100;
+    if (stretching === 'none') {
+        scaleX = scaleY = 1;
+    } else if (stretching === 'fill') {
+        scaleX = scaleY = Math.max(scaleX, scaleY);
+    } else if (stretching === 'uniform') {
+        scaleX = scaleY = Math.min(scaleX, scaleY);
+    }
+    styles.width = _videotag.videoWidth;
+    styles.height = _videotag.videoHeight;
+    styles.top = styles.left = '50%';
+    styles.margin = 0;
+    transform(_videotag,
+        'translate(' + x + 'px, ' + y + 'px) scale(' + scaleX.toFixed(2) + ', ' + scaleY.toFixed(2) + ')');
+    return styles;
+}


### PR DESCRIPTION
### This PR will...

Enables stretching settings to be respected in IE/Edge. Because IE/Edge do not support object-fit, moved existing logic from HTML5 provider into the VideoActionsMixin. Refactored further to have HTML5 provider rely on this mix-in, as opposed to its own method. 

### Why is this Pull Request needed?

Stretching settings had not been functioning on IE/Edge with HLS/DASH streams. 

### Are there any points in the code the reviewer needs to double check?

N/A

### Are there any Pull Requests open in other repos which need to be merged with this?

No

#### Addresses Issue(s):

JW8-772

