### PR TITLE
Create setSkipOffset instream API 

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -355,6 +355,11 @@ var InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
         }
         return _adProgram.primedElement;
     };
+
+    this.setSkipOffset = function(skipOffset) {
+        // IMA will pass -1 if it doesn't know the skipoffset, or if the ad is unskippable
+        _skipOffset = skipOffset > 0 ? skipOffset : null;
+    };
 };
 
 Object.assign(InstreamAdapter.prototype, Events);

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -356,9 +356,17 @@ var InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
         return _adProgram.primedElement;
     };
 
+    /**
+     * Sets the internal skip offset. Does not set the skip button.
+     * @param {Number} skipOffset - The number of seconds from the start where the ad becomes skippable.
+     * @returns void
+     */
     this.setSkipOffset = function(skipOffset) {
         // IMA will pass -1 if it doesn't know the skipoffset, or if the ad is unskippable
         _skipOffset = skipOffset > 0 ? skipOffset : null;
+        if (_adProgram) {
+            _adProgram.model.set('skipOffset', _skipOffset);
+        }
     };
 };
 


### PR DESCRIPTION
### Why is this Pull Request needed?
Googima manages it's own skip offset and needs a way to communicate this to the player. IMA will call `setSkipOffset` before the first `instreamTime` event.

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-ads-googima/pull/305

#### Addresses Issue(s):

JW8-1060

