### PR TITLE
Use attach detach with providers that do not use a video tag

### DIFF
--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -189,6 +189,10 @@ export default class MediaController extends Eventable {
         if (!this.attached) {
             return false;
         }
+        // A provider without a video tag cannot be backgrounded
+        if (!provider.video) {
+            return false;
+        }
         // A backgrounded provider does not have a parent container, or has one, but without the media tag as a child
         return !container || (container && !container.contains(provider.video));
     }
@@ -231,7 +235,16 @@ export default class MediaController extends Eventable {
 
     set background(shouldBackground) {
         const { container, provider } = this;
-        if (!container || !provider.video) {
+        // A provider without a video tag must use attach and detach
+        if (!provider.video) {
+            if (shouldBackground) {
+                this.detach();
+            } else {
+                this.attach();
+            }
+            return;
+        }
+        if (!container) {
             return;
         }
 

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -202,7 +202,7 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
         }
     });
 
-    const _videotag = _this.video = mediaElement;
+    const _videotag = mediaElement;
     const visualQuality = { level: {} };
     const _staleStreamDuration = 3 * 10 * 1000;
 

--- a/test/mock/mock-provider.js
+++ b/test/mock/mock-provider.js
@@ -34,3 +34,14 @@ export default class MockProvider extends MockDefault {
         }
     }
 }
+
+export class MockVideolessProvider extends MockProvider {
+    constructor() {
+        super();
+        this.video = undefined;
+    }
+
+    remove() {
+        this.destroy();
+    }
+}

--- a/test/unit/background-loading-test.js
+++ b/test/unit/background-loading-test.js
@@ -58,7 +58,7 @@ describe('Background Loading', function () {
             expect(mockProvider.getContainer()).to.equal(container);
 
             mediaController.background = true;
-            expect(container.querySelector('video')).to.equal(null)
+            expect(container.querySelector('video')).to.equal(null);
             expect(mediaController.container).to.equal(null);
             expect(mediaController.pause.calledOnce).to.equal(true);
         });
@@ -116,7 +116,7 @@ describe('Background Loading', function () {
             programController.backgroundActiveMedia();
 
             programController.on('time', () => {
-                throw 'Should not have forwarded a background event';
+                throw new Error('Should not have forwarded a background event');
             });
             mediaController.trigger('time');
         });
@@ -132,7 +132,6 @@ describe('Background Loading', function () {
             mediaController.destroy = sinon.spy();
             mediaPool.recycle = sinon.spy();
 
-            const newMockProvider = new MockProvider();
             mockProvider.video = document.createElement('video');
             const newMediaController = new MediaController(mockProvider, model);
             programController._setActiveMedia(newMediaController);


### PR DESCRIPTION
### This PR will...

Use media-controller's attach/detach methods when background is set on providers that do use a video tag (`provider.video`).

### Why is this Pull Request needed?

The program-controller either uses backgrounding logic or attach/detach based on a global Feature setting. However, backgrounding only works with providers that have a video property. The Flash provider does not have a video property, use a video tag, or have the ability to be removed from the DOM without completely resetting it's state (plugins only run while in the DOM).

Because of this limitation, the flash provider was exempt from backgrounding, but always reported as backgrounded. None of it's events were ever forwarded through the program-controller.

To get around this, attach/detach is used, which has the same affect.

### Are there any points in the code the reviewer needs to double check?

Events appear to come through, and I was able to run through a simple VAST config with an flv playlist item. There's also a new test with mock "videoless" provider to assert this fix.

I have not run through cucumber tests for Flash, but would like to know how reliable the coverage we have there is and how often we run it and report bugs against it. We can discuss IE 11 Win 7 only testing vs another platform using flv sources - maybe one for quick reliable results, and IE11 for full coverage.

#### Addresses Issue(s):

JW8-1089

