### PR TITLE
Fix setup timeout

### DIFF
--- a/src/js/api/Setup.js
+++ b/src/js/api/Setup.js
@@ -1,4 +1,7 @@
+import loadCoreBundle from 'api/core-loader';
 import startSetup from 'api/setup-steps';
+import loadPlugins from 'plugins/plugins';
+import Promise from 'polyfills/promise';
 
 const SETUP_TIMEOUT_SECONDS = 30;
 
@@ -6,14 +9,25 @@ const Setup = function(_model) {
 
     let _setupFailureTimeout;
 
-    this.start = function () {
-        const setupPromise = startSetup(_model);
-        return new Promise((resolve, reject) => {
+    this.start = function (api) {
+
+        const setup = Promise.all([
+            loadCoreBundle(_model),
+            startSetup(_model),
+            loadPlugins(_model, api)
+        ]);
+
+        const timeout = new Promise((resolve, reject) => {
             _setupFailureTimeout = setTimeout(() => {
                 reject(new Error(`Setup Timeout Error: Setup took longer than ${SETUP_TIMEOUT_SECONDS} seconds to complete.`));
             }, SETUP_TIMEOUT_SECONDS * 1000);
-            return setupPromise.then(resolve).catch(reject);
+            setup.then(() => {
+                clearTimeout(_setupFailureTimeout);
+                resolve();
+            });
         });
+
+        return Promise.race([setup, timeout]);
     };
 
     this.destroy = function() {

--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -2,15 +2,13 @@ import ApiQueueDecorator from 'api/api-queue';
 import Config from 'api/config';
 import Setup from 'api/Setup';
 import Providers from 'providers/providers';
-import loadPlugins from 'plugins/plugins';
 import Timer from 'api/timer';
 import Storage from 'model/storage';
 import SimpleModel from 'model/simplemodel';
 import { INITIAL_PLAYER_STATE, INITIAL_MEDIA_STATE } from 'model/player-model';
 import { SETUP_ERROR, STATE_ERROR } from 'events/events';
 import Events from 'utils/backbone.events';
-import loadCoreBundle from 'api/core-loader';
-import Promise, { resolved } from 'polyfills/promise';
+import { resolved } from 'polyfills/promise';
 import ErrorContainer from 'view/error-container';
 import MediaElementPool from 'program/media-element-pool';
 import SharedMediaPool from 'program/shared-media-pool';
@@ -93,11 +91,7 @@ Object.assign(CoreShim.prototype, {
         }
         mediaPool.prime();
 
-        return Promise.all([
-            loadCoreBundle(model),
-            this.setup.start(),
-            loadPlugins(model, api)
-        ]).then(allPromises => {
+        return this.setup.start(api).then(allPromises => {
             const CoreMixin = allPromises[0];
             if (!this.setup) {
                 // Exit if `playerDestroy` was called on CoreLoader clearing the config

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -867,7 +867,6 @@ Object.assign(Controller.prototype, {
             }
             if (_captions) {
                 _captions.destroy();
-                _captions = null;
             }
             if (_programController) {
                 _programController.destroy();


### PR DESCRIPTION
### This PR will...

Put the three setup task groups `loadCoreBundle`, `loadPlugins`, and `startSetup` into a promise race against the 30 second setup timeout.

### Why is this Pull Request needed?

Before, the setup timeout was only running against `startSetup`. When that completed quickly, the setup timeout could no longer reject the setup promise stack. So "loadCoreBundle" and "loadPlugins" could still run, exempt from the setup timeout.

This and a [longer chunk loading timeout](https://github.com/jwplayer/jwplayer-commercial/pull/4542) will prevent "Network Error" setup errors due to poor network conditions delaying the loading of webpack modules. As long as webpack modules load within 30 seconds, the player can setup. This also leaves room for plugins to timeout (15 seconds) without breaking setup.

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-commercial/pull/4542

#### Addresses Issue(s):

JW8-1099

