### PR TITLE
Call addCues with the correct arguments

### DIFF
--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -171,7 +171,7 @@ class TimeSlider extends Slider {
             return;
         }
         this.reset();
-        this.addCues(model.get('cues'));
+        this.addCues(model, model.get('cues'));
 
         var tracks = playlistItem.tracks;
         _.each(tracks, function (track) {


### PR DESCRIPTION
### Why is this Pull Request needed?
Because `cues` is falsy in the `setPlaylistItem` `addCues` call, cues are not added after a VAST preroll.

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-1105

