### PR TITLE
Prevent instream "playAttempt" when calling load()

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -292,6 +292,10 @@ Object.assign(Controller.prototype, {
 
         function _load(item, feedData) {
 
+            const instream = _this._instreamAdapter;
+            if (instream) {
+                instream.noResume = true;
+            }
             _this.trigger('destroyPlugin', {});
             _stop(true);
 
@@ -847,8 +851,6 @@ Object.assign(Controller.prototype, {
             try {
                 setPlaylist(_model, playlist, feedData);
             } catch (error) {
-                _model.set('item', 0);
-                _model.set('playlistItem', null);
                 return Promise.reject(error);
             }
             return _setItem(_model.get('item'));

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -315,6 +315,10 @@ var InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
         // when instream was inited and the player was not destroyed\
         _controller.attachMedia(_oldpos);
 
+        if (this.noResume) {
+            return;
+        }
+
         if (_oldpos === null) {
             _controller.stopVideo();
         } else {


### PR DESCRIPTION
### This PR will...

Prevent instream from attempting to resume playback when `load()` is changing the play context.

### Why is this Pull Request needed?

Calling `load()` cancels ad playback, and either replaces the playlist, or picks a new item by setting a new playlist index. Because of this, instream should not attempt to resume playback as it's torn down.

### Other

Also cleaned up an oopsie around playlist error handling. Instead of getting "no playable sources" errors, an event was fired that broke clients of the "playlistItem" event and `getPlaylistItem`.

#### Addresses Issue(s):

Fixes #2678 JW8-1107

