### PR TITLE
Prevent duplicate "captionsList" events

### DIFF
--- a/src/js/api/api-queue.js
+++ b/src/js/api/api-queue.js
@@ -42,7 +42,7 @@ export default function ApiQueueDecorator(instance, queuedCommands, predicate) {
     };
 
     this.off = function() {
-        commandQueue.forEach(({ command }) => {
+        queuedCommands.forEach((command) => {
             const method = undecoratedMethods[command];
             if (method) {
                 instance[command] = method;

--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -147,9 +147,9 @@ const Captions = function(_model) {
     }
 
     function _setCaptionsList() {
-        _selectDefaultIndex();
         const captionsList = _captionsMenu();
         if (listIdentity(captionsList) !== listIdentity(_model.get('captionsList'))) {
+            _selectDefaultIndex();
             _model.set('captionsList', captionsList);
         }
     }

--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -17,11 +17,10 @@ const Captions = function(_model) {
         _tracksById = {};
         _unknownCount = 0;
 
-        // Update model without dispatching events _updateMenu()
-        const captionsMenu = _captionsMenu();
+        // Update model without dispatching events
         const attributes = model.attributes;
         attributes.captionsIndex = 0;
-        attributes.captionsList = captionsMenu;
+        attributes.captionsList = _captionsMenu();
         model.set('captionsTrack', null);
     }, this);
 
@@ -48,9 +47,7 @@ const Captions = function(_model) {
                 }
             }
         }
-        const captionsMenu = _captionsMenu();
-        _selectDefaultIndex();
-        _setCaptionsList(captionsMenu);
+        _setCaptionsList();
     }, this);
 
     // Listen for captions menu index changes from the view
@@ -74,9 +71,7 @@ const Captions = function(_model) {
         // To avoid duplicate tracks in the menu when we reuse an _id, regenerate the tracks array
         _tracks = Object.keys(_tracksById).map(id => _tracksById[id]);
 
-        const captionsMenu = _captionsMenu();
-        _selectDefaultIndex();
-        _setCaptionsList(captionsMenu);
+        _setCaptionsList();
     }
 
     function _kindSupported(kind) {
@@ -143,7 +138,7 @@ const Captions = function(_model) {
         _setCurrentIndex(captionsMenuIndex);
     }
 
-    function _setCurrentIndex (index) {
+    function _setCurrentIndex(index) {
         if (_tracks.length) {
             _model.setVideoSubtitleTrack(index, _tracks);
         } else {
@@ -151,8 +146,16 @@ const Captions = function(_model) {
         }
     }
 
-    function _setCaptionsList (captionsMenu) {
-        _model.set('captionsList', captionsMenu);
+    function _setCaptionsList() {
+        _selectDefaultIndex();
+        const captionsList = _captionsMenu();
+        if (listIdentity(captionsList) !== listIdentity(_model.get('captionsList'))) {
+            _model.set('captionsList', captionsList);
+        }
+    }
+
+    function listIdentity(list) {
+        return list.map(item => `${item.id}-${item.label},`);
     }
 
     this.setSubtitlesTracks = _setSubtitlesTracks;

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -43,7 +43,7 @@ Object.assign(Controller.prototype, {
 
         let _view;
         let _captions;
-        let _preplay = false;
+        let _beforePlay = false;
         let _actionOnAttach;
         let _stopPlaylist = false;
         let _interruptPlay;
@@ -59,7 +59,7 @@ Object.assign(Controller.prototype, {
             return Events.trigger.call(this, type, data);
         };
 
-        const eventsReadyQueue = new ApiQueueDecorator(_this, [
+        let eventsReadyQueue = new ApiQueueDecorator(_this, [
             'trigger',
         ], () => true);
 
@@ -231,6 +231,7 @@ Object.assign(Controller.prototype, {
 
             eventsReadyQueue.flush();
             eventsReadyQueue.destroy();
+            eventsReadyQueue = null;
 
             _model.change('viewable', viewableChange);
             _model.change('viewable', _checkPlayOnViewable);
@@ -390,10 +391,10 @@ Object.assign(Controller.prototype, {
                 _setItem(0);
             }
 
-            if (!_preplay) {
-                _preplay = true;
+            if (!_beforePlay) {
+                _beforePlay = true;
                 _this.trigger(MEDIA_BEFOREPLAY, { playReason: playReason });
-                _preplay = false;
+                _beforePlay = false;
                 if (_interruptPlay) {
                     _interruptPlay = false;
                     _actionOnAttach = null;
@@ -446,7 +447,7 @@ Object.assign(Controller.prototype, {
                 _stopPlaylist = true;
             }
 
-            if (_preplay) {
+            if (_beforePlay) {
                 _interruptPlay = true;
             }
 
@@ -480,7 +481,7 @@ Object.assign(Controller.prototype, {
                     break;
                 }
                 default:
-                    if (_preplay) {
+                    if (_beforePlay) {
                         _interruptPlay = true;
                     }
             }
@@ -627,7 +628,7 @@ Object.assign(Controller.prototype, {
 
         /** Used for the InStream API **/
         function _detachMedia() {
-            if (_preplay) {
+            if (_beforePlay) {
                 _interruptPlay = true;
             }
 
@@ -822,7 +823,7 @@ Object.assign(Controller.prototype, {
         this.setCaptions = _view.setCaptions;
 
         this.checkBeforePlay = function() {
-            return _preplay;
+            return _beforePlay;
         };
 
         this.setControls = function (mode) {
@@ -899,7 +900,7 @@ Object.assign(Controller.prototype, {
             'setCurrentCaptions',
             'setCurrentQuality',
             'setFullscreen',
-        ], () => !this._model.get('itemReady'));
+        ], () => !this._model.get('itemReady') || eventsReadyQueue);
         // Add commands from CoreLoader to queue
         apiQueue.queue.push.apply(apiQueue.queue, commandQueue);
 

--- a/test/unit/api-queue-test.js
+++ b/test/unit/api-queue-test.js
@@ -1,0 +1,118 @@
+import ApiQueueDecorator from 'api/api-queue';
+import sinon from 'sinon';
+
+class TestObject {
+    constructor() {
+        this.data = [];
+    }
+    a() {
+        this.data.push('a');
+    }
+    b() {
+        this.data.push('b');
+    }
+    c() {
+        this.data.push('c');
+    }
+}
+
+describe('ApiQueueDecorator', function () {
+
+    let stub;
+    let a;
+    let b;
+    let c;
+
+    beforeEach(function () {
+        stub = sinon.createStubInstance(TestObject);
+        a = stub.a;
+        b = stub.b;
+        c = stub.c;
+    });
+
+    it('decorates methods on objects', function() {
+        const queue = new ApiQueueDecorator(stub, ['a', 'b'], () => true);
+
+        expect(queue).is.an('object');
+        expect(stub.a).to.not.equal(a);
+        expect(stub.b).to.not.equal(b);
+        expect(stub.c).to.equal(c);
+    });
+
+    it('off() removes decorators', function() {
+        const queue = new ApiQueueDecorator(stub, ['a', 'b'], () => true);
+
+        queue.off();
+
+        expect(stub.a).to.equal(a);
+        expect(stub.b).to.equal(b);
+    });
+
+    it('queues execution of decorated methods based on predicate', function() {
+        let ready = false;
+        const predecate = () => ready !== true;
+        const queue = new ApiQueueDecorator(stub, ['a', 'b'], predecate);
+
+        stub.a();
+        stub.b();
+        stub.c();
+
+        expect(a).to.have.callCount(0);
+        expect(b).to.have.callCount(0);
+        expect(c).to.have.callCount(1);
+
+        ready = true;
+        stub.b();
+
+        expect(a).to.have.callCount(1);
+        expect(b).to.have.callCount(2);
+
+        queue.destroy();
+    });
+
+    it('empty() clears the queue', function() {
+        let ready = false;
+        const predecate = () => ready !== true;
+        const queue = new ApiQueueDecorator(stub, ['a', 'b'], predecate);
+
+        stub.a();
+
+        expect(a).to.have.callCount(0);
+
+        queue.empty();
+        ready = true;
+        stub.b();
+
+        expect(a).to.have.callCount(0);
+        expect(b).to.have.callCount(1);
+    });
+
+    it('flush() executes calls in the queue', function() {
+        const queue = new ApiQueueDecorator(stub, ['a', 'b'], () => true);
+
+        stub.a();
+        stub.b();
+
+        expect(a).to.have.callCount(0);
+        expect(b).to.have.callCount(0);
+
+        queue.flush();
+
+        expect(a).to.have.callCount(1);
+        expect(b).to.have.callCount(1);
+    });
+
+    it('destory() removes decorators and empties the queue', function() {
+        const queue = new ApiQueueDecorator(stub, ['a', 'b'], () => true);
+
+        stub.a();
+        stub.b();
+        queue.destroy();
+        stub.a();
+
+        expect(stub.a).to.equal(a);
+        expect(stub.b).to.equal(b);
+        expect(a).to.have.callCount(1);
+        expect(b).to.have.callCount(0);
+    });
+});


### PR DESCRIPTION
### This PR will...

- Only dispatch "captionsList" events when the captions contents don't match the current contents.
- Fix an issue with the ApiQueueDecorator exposed by cucumber tests. (following up with unit tests).
- Keep API queue active until the player is ready so that "beforePlay" can't be fired before ready by calling play() in the "ready" event.

This is needed with native rendering where "subtitleTracks" change events are triggered for both sideloaded tracks and video element 'loaddata' events, which results in an update to "captionsList".

The ApiQueueDecorator fix is very important. The method for resetting decorated methods was flawed in that in only worked if there were commands in the queue. This doesn't matter for other places we use it, because we don't destroy the object while the player is running. Here, on ready it must be turned off and destroyed properly.

#### Addresses Issue(s):

JW8-1101
ADS-871