### PR TITLE
Only pause a tag when actually detached 

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -287,12 +287,6 @@ var InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
             _view.clickHandler().revertAlternateClickHandlers();
         }
 
-        const mediaElement = _adProgram.primedElement;
-        const mediaContainer = _model.get('mediaContainer');
-        if (mediaElement.parentNode === mediaContainer) {
-            mediaContainer.removeChild(mediaElement);
-        }
-
         _model.off(null, null, _adProgram);
         _adProgram.off(null, null, _this);
         _adProgram.destroy();

--- a/src/js/program/ad-program-controller.js
+++ b/src/js/program/ad-program-controller.js
@@ -142,7 +142,7 @@ export default class AdProgramController extends ProgramController {
         const { model, mediaPool } = this;
         model.off();
 
-        // We only use one media element from ads; getPrimedElement will return it;
+        // We only use one media element from ads; getPrimedElement will return it
         const mediaElement = mediaPool.getPrimedElement();
         if (!Features.backgroundLoading) {
             if (mediaElement) {

--- a/src/js/program/ad-program-controller.js
+++ b/src/js/program/ad-program-controller.js
@@ -37,7 +37,7 @@ export default class AdProgramController extends ProgramController {
     }
 
     setup() {
-        const { model, playerModel } = this;
+        const { model, playerModel, primedElement } = this;
         const playerAttributes = playerModel.attributes;
         const mediaModelContext = playerModel.mediaModel;
         model.setup({
@@ -60,6 +60,10 @@ export default class AdProgramController extends ProgramController {
         model.on(ERROR, function(data) {
             this.trigger(ERROR, data);
         }, this);
+
+        if (!primedElement.paused) {
+            primedElement.pause();
+        }
     }
 
     setActiveItem(index) {
@@ -135,9 +139,11 @@ export default class AdProgramController extends ProgramController {
 
 
     destroy() {
-        const { model, mediaElement, mediaPool } = this;
+        const { model, mediaPool } = this;
         model.off();
 
+        // We only use one media element from ads; getPrimedElement will return it;
+        const mediaElement = mediaPool.getPrimedElement();
         if (!Features.backgroundLoading) {
             if (mediaElement) {
                 mediaElement.removeEventListener('emptied', this.srcResetListener);
@@ -148,6 +154,10 @@ export default class AdProgramController extends ProgramController {
             }
         } else {
             mediaPool.clean();
+            const mediaContainer = model.get('mediaContainer');
+            if (mediaElement.parentNode === mediaContainer) {
+                mediaContainer.removeChild(mediaElement);
+            }
         }
     }
 

--- a/src/js/program/ad-program-controller.js
+++ b/src/js/program/ad-program-controller.js
@@ -22,10 +22,6 @@ export default class AdProgramController extends ProgramController {
             // Take the tag that we're using to play the current item. The tag has been freed before reaching this point
             mediaElement = model.get('mediaElement');
 
-            if (!mediaElement.paused) {
-                mediaElement.pause();
-            }
-
             adModel.attributes.mediaElement = mediaElement;
             adModel.attributes.mediaSrc = mediaElement.src;
 

--- a/src/js/providers/video-attached-mixin.js
+++ b/src/js/providers/video-attached-mixin.js
@@ -15,10 +15,6 @@ const VideoAttachedMixin = {
         this.stopStallCheck();
         this.eventsOff_();
 
-        if (this.video && !this.video.paused && this.video.pause) {
-            this.video.pause();
-        }
-
         return this.video;
     },
 

--- a/src/js/providers/video-attached-mixin.js
+++ b/src/js/providers/video-attached-mixin.js
@@ -15,7 +15,7 @@ const VideoAttachedMixin = {
         this.stopStallCheck();
         this.eventsOff_();
 
-        if (this.video && !this.video.paused) {
+        if (this.video && !this.video.paused && this.video.pause) {
             this.video.pause();
         }
 

--- a/src/js/providers/video-attached-mixin.js
+++ b/src/js/providers/video-attached-mixin.js
@@ -15,6 +15,10 @@ const VideoAttachedMixin = {
         this.stopStallCheck();
         this.eventsOff_();
 
+        if (this.video && !this.video.paused) {
+            this.video.pause();
+        }
+
         return this.video;
     },
 


### PR DESCRIPTION
### What does this Pull Request do?
- Only pauses a tag when initializing an ad (as opposed to just creating instream)
- Only remove a tag from the container when backround loading

### Why is this Pull Request needed?
- DAI and nonlinear ads create an instream adapter, but do not init - and therefore should not pause the video (as this was previous behavior.
- Removing the tag on destroy when not background loading causes ads to pause

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-1112

