### PR TITLE
Only filter playlist once at the end of setup

### DIFF
--- a/src/js/api/setup-steps.js
+++ b/src/js/api/setup-steps.js
@@ -1,4 +1,4 @@
-import setPlaylist from 'api/set-playlist';
+import filterPlaylist from 'playlist/playlist';
 import { PLAYLIST_LOADED, ERROR } from 'events/events';
 import Promise, { resolved } from 'polyfills/promise';
 import PlaylistLoader from 'playlist/loader';
@@ -32,17 +32,15 @@ export function loadPlaylist(_model) {
     return resolved;
 }
 
-function filterPlaylist(_model) {
+function loadProvider(_model) {
     return loadPlaylist(_model).then(() => {
         if (destroyed(_model)) {
             return;
         }
-        // Filter the playlist and update the model's 'playlist'
-        setPlaylist(_model, _model.get('playlist'), _model.get('feedData'));
 
         // Loads the first provider if not included in the core bundle
         // A provider loaded this way will not be set upon completion
-        const playlist = _model.get('playlist');
+        const playlist = filterPlaylist(_model.get('playlist'), _model);
         const providersManager = _model.getProviders();
         const firstProviderNeeded = providersManager.required([playlist[0]]);
         // Skip provider loading if included in bundle
@@ -84,7 +82,7 @@ const startSetup = function(_model) {
         return Promise.reject();
     }
     return Promise.all([
-        filterPlaylist(_model),
+        loadProvider(_model),
         loadSkin(_model)
     ]);
 };


### PR DESCRIPTION
### Why is this Pull Request needed?

Since we're now using controller `updatePlaylist` at the end of setup to keep `setup` and `load` functionality in sync https://github.com/jwplayer/jwplayer/commit/82a994d909c51b809715f9a37ca490c1755d9cb3, we don't need to update the playlist during setup. Running the filter twice was resetting `allSources` in the playlist items.

#### Addresses Issue(s):

JW8-1115


