### PR TITLE
Fix captions list comparison

### DIFF
--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -155,7 +155,7 @@ const Captions = function(_model) {
     }
 
     function listIdentity(list) {
-        return list.map(item => `${item.id}-${item.label},`);
+        return list.map(item => `${item.id}-${item.label}`).join(',');
     }
 
     this.setSubtitlesTracks = _setSubtitlesTracks;


### PR DESCRIPTION
### This PR will...

Fix the captions list comparison `identity` function.

### Why is this Pull Request needed?

This method is expected to return a string representation of the captions list array, but it was still returning an array, preventing comparison from working.
 
#### Addresses Issue(s):

JW8-1101

