### PR TITLE
Read mediaContainer off the playerModel when destroying ad-program 

### DIFF
--- a/src/js/program/ad-program-controller.js
+++ b/src/js/program/ad-program-controller.js
@@ -139,7 +139,7 @@ export default class AdProgramController extends ProgramController {
 
 
     destroy() {
-        const { model, mediaPool } = this;
+        const { model, mediaPool, playerModel } = this;
         model.off();
 
         // We only use one media element from ads; getPrimedElement will return it
@@ -154,7 +154,7 @@ export default class AdProgramController extends ProgramController {
             }
         } else {
             mediaPool.clean();
-            const mediaContainer = model.get('mediaContainer');
+            const mediaContainer = playerModel.get('mediaContainer');
             if (mediaElement.parentNode === mediaContainer) {
                 mediaContainer.removeChild(mediaElement);
             }


### PR DESCRIPTION
### Why is this Pull Request needed?
The player was failing to rove the BGL tag from the DOM. The ad model does not contain `mediaContainer`

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-1126

