### PR TITLE
Fix handling of stalling buffering state and QoE in html5 provider

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -127,8 +127,6 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
             _seekOffset = null;
             _delayedSeek = 0;
             _this.seeking = true;
-            _videotag.removeEventListener('waiting', setLoadingState);
-            _videotag.addEventListener('waiting', setLoadingState);
             _this.trigger(MEDIA_SEEK, {
                 position,
                 offset
@@ -136,12 +134,13 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
         },
 
         seeked() {
-            _videotag.removeEventListener('waiting', setLoadingState);
             VideoEvents.seeked.call(_this);
         },
 
         waiting() {
-            if (!_this.seeking && _this.state === STATE_PLAYING) {
+            if (_this.seeking) {
+                _this.setState(STATE_LOADING);
+            } else if (_this.state === STATE_PLAYING) {
                 if (_this.atEdgeOfLiveStream()) {
                     _this.setPlaybackRate(1);
                 }
@@ -245,10 +244,6 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
             _this.trigger(MEDIA_VISUAL_QUALITY, visualQuality);
             visualQuality.reason = '';
         }
-    }
-
-    function setLoadingState() {
-        _this.setState(STATE_LOADING);
     }
 
     function _setPositionBeforeSeek(position) {

--- a/src/js/providers/video-actions-mixin.js
+++ b/src/js/providers/video-actions-mixin.js
@@ -1,14 +1,15 @@
 import { style } from 'utils/css';
+import endOfRange from 'utils/time-ranges';
 
 const VideoActionsMixin = {
     container: null,
 
-    volume: function(vol) {
+    volume(vol) {
         vol = Math.max(Math.min(vol / 100, 1), 0);
         this.video.volume = vol;
     },
 
-    mute: function(state) {
+    mute(state) {
         this.video.muted = !!state;
         if (!this.video.muted) {
             // Remove muted attribute once user unmutes so the video element doesn't get
@@ -17,7 +18,7 @@ const VideoActionsMixin = {
         }
     },
 
-    resize: function(width, height, stretching) {
+    resize(width, height, stretching) {
         if (!width || !height || !this.video.videoWidth || !this.video.videoHeight) {
             return false;
         }
@@ -38,24 +39,34 @@ const VideoActionsMixin = {
         return false;
     },
 
-    getContainer: function() {
+    getContainer() {
         return this.container;
     },
 
-    setContainer: function(element) {
+    setContainer(element) {
         this.container = element;
         if (this.video.parentNode !== element) {
             element.appendChild(this.video);
         }
     },
 
-    remove: function() {
+    remove() {
         this.stop();
         this.destroy();
         const container = this.container;
         if (container && container === this.video.parentNode) {
             container.removeChild(this.video);
         }
+    },
+
+    atEdgeOfLiveStream() {
+        if (!this.isLive()) {
+            return false;
+        }
+
+        // currentTime doesn't always get to the end of the buffered range
+        const timeFudge = 2;
+        return (endOfRange(this.video.buffered) - this.video.currentTime) <= timeFudge;
     }
 };
 

--- a/src/js/providers/video-attached-mixin.js
+++ b/src/js/providers/video-attached-mixin.js
@@ -1,75 +1,14 @@
-import { STATE_LOADING, STATE_STALLED, STATE_ERROR } from 'events/events';
-import endOfRange from 'utils/time-ranges';
-
-const STALL_DELAY = 256;
 
 const VideoAttachedMixin = {
-    stallCheckTimeout_: -1,
-    lastStalledTime_: NaN,
 
-    attachMedia: function() {
+    attachMedia() {
         this.eventsOn_();
     },
 
-    detachMedia: function() {
-        this.stopStallCheck();
+    detachMedia() {
         this.eventsOff_();
 
         return this.video;
-    },
-
-    stopStallCheck: function() {
-        clearTimeout(this.stallCheckTimeout_);
-    },
-
-    startStallCheck: function() {
-        this.stopStallCheck();
-        this.stallCheckTimeout_ = setTimeout(this.stalledHandler.bind(this, this.video.currentTime), STALL_DELAY);
-    },
-
-    stalledHandler: function(checkStartTime) {
-        if (checkStartTime !== this.video.currentTime) {
-            return;
-        }
-
-        if (this.video.paused || this.video.ended) {
-            return;
-        }
-
-        // A stall after loading/error, should just stay loading/error
-        if (this.state === STATE_LOADING || this.state === STATE_ERROR) {
-            return;
-        }
-
-        // During seek we stay in paused state
-        if (this.seeking) {
-            return;
-        }
-
-        if (this.atEdgeOfLiveStream()) {
-            this.setPlaybackRate(1);
-        }
-        this.setState(STATE_STALLED);
-    },
-
-    atEdgeOfLiveStream: function() {
-        if (!this.isLive()) {
-            return false;
-        }
-
-        // currentTime doesn't always get to the end of the buffered range
-        const timeFudge = 2;
-        return (endOfRange(this.video.buffered) - this.video.currentTime) <= timeFudge;
-    },
-
-    setAutoplayAttributes: function() {
-        this.video.setAttribute('autoplay', '');
-        this.video.setAttribute('muted', '');
-    },
-
-    removeAutoplayAttributes: function() {
-        this.video.removeAttribute('autoplay');
-        this.video.removeAttribute('muted');
     }
 };
 


### PR DESCRIPTION
### This PR will...

Replace the `stalledHandler` with a media element "waiting" event handler to change the player state to "buffering" (and QoE track "stalling") when the player under-buffers with the html5 provider. The "waiting" handler also replaces the "waiting" event listeners added and removed while seeking.

### Why is this Pull Request needed?

The `stalledHandler` stopped working when we began changing the state to "playing" on the media element "playing" event. The state is changed to playing before the first "timeupdate" event so `startStallCheck` is never called.

We still want to set the state to "playing" on the "playing" event when "waiting" hasn't fired. It ensures the buffer wheel goes away quickly on start and after seeking. We don't use that event if waiting fired (`this.stallTime` is set) because Safari and Firefox will fire it before playback has recovered from under-buffering. In that state we rely on "timeupdate" as we did before with an additional check that the media element's `currentTime` no longer equals `this.stallTime`.

### Are there any points in the code the reviewer needs to double check?

The `waiting` event lister is set to `noop` on Android native to keep with the previous practice of not running the stall check on Android native.

Unused methods in video-attached-mixin.js have been removed, and the `atEdgeOfLiveStream` method moved to video-actions-mixin.js.

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-commercial/pull/4575

#### Addresses Issue(s):

JW8-1125
