### PR TITLE
Change mediaType when switching to/from instream mode

### DIFF
--- a/src/js/program/ad-program-controller.js
+++ b/src/js/program/ad-program-controller.js
@@ -12,6 +12,8 @@ export default class AdProgramController extends ProgramController {
         this.playerModel = model;
         this.provider = null;
 
+        adModel.mediaModel.attributes.mediaType = 'video';
+
         // Ad plugins must use only one element, and must use the same element during playback of an item
         // (i.e. prerolls, midrolls, and postrolls must use the same tag)
         let mediaElement;

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -757,6 +757,10 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
         if (_levels[0].type === 'hls') {
             var mediaType = 'video';
             if (_videotag.videoHeight === 0) {
+                // Safari will report videoHeight as 0 for HLS streams until readyState indicates that the browser has data
+                if ((OS.iOS || Browser.safari) && _videotag.readyState < 2) {
+                    return;
+                }
                 mediaType = 'audio';
             }
             _this.trigger(MEDIA_TYPE, { mediaType: mediaType });

--- a/src/js/view/view-model.js
+++ b/src/js/view/view-model.js
@@ -58,7 +58,7 @@ class PlayerViewModel extends SimpleModelExtendable {
         }, this);
 
         if (previousMediaModel) {
-            dispatchDiffChangeEvents(this, mediaModel.attributes, previousMediaModel);
+            dispatchDiffChangeEvents(this, mediaModel.attributes, previousMediaModel.attributes);
         }
     }
 

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -219,8 +219,8 @@ function View(_api, _model) {
 
         const playerViewModel = _model.player;
         playerViewModel.on('change:errorEvent', _errorHandler);
-        playerViewModel.on('change:mediaType', _onMediaTypeChange);
-
+        
+        _model.on('change:mediaType', _onMediaTypeChange);
         _model.change('stretching', onStretchChange);
         _model.change('flashBlocked', onFlashBlockedChange);
 


### PR DESCRIPTION
### This PR will...

- Prevent Safari from making html5 provider dispatch "audio" mediaType events while preloading HLS video streams
- Update mediaType on the view model when switching to and from instream mode

### Why is this Pull Request needed?

This ensures that the view toggles the '.jw-flag-media-audio' CSS class when entering and exiting ads mode. And, that this class does not get added to the player when preloading HLS video in Safari.

#### Addresses Issue(s):

JW8-1135


