### PR TITLE
Fix play button position for live streams on smaller breakpoints

### DIFF
--- a/src/css/controls/flags/live.less
+++ b/src/css/controls/flags/live.less
@@ -2,7 +2,7 @@
 
 .jwplayer.jw-flag-live {
     .jw-display-icon-rewind {
-        display: none;
+        visibility: hidden;
     }
 
     .jw-controlbar {


### PR DESCRIPTION
### This PR will...

Change the styling on the `.jw-display-icon-rewind` when the `.jw-flag-live` class is present from using `display: none` to `visibility: hidden`

### Why is this Pull Request needed?

Without it, the play button will not be in the middle of the player on smaller breakpoints when the rewind button was not present (as it would not be in a non-DVR live stream).

### Are there any points in the code the reviewer needs to double check?

n/a

### Are there any Pull Requests open in other repos which need to be merged with this?

n/a

#### Addresses Issue(s):

JW8-1127

