### PR TITLE
Add default feedData to model in setup

### DIFF
--- a/src/js/api/setup-steps.js
+++ b/src/js/api/setup-steps.js
@@ -11,22 +11,26 @@ export function loadPlaylist(_model) {
         return new Promise((resolve, reject) => {
             const playlistLoader = new PlaylistLoader();
             playlistLoader.on(PLAYLIST_LOADED, function(data) {
-                const loadedPlaylist = Playlist(data.playlist);
+                const loadedPlaylist = data.playlist;
                 delete data.playlist;
-                _model.attributes.playlist = loadedPlaylist;
-                _model.attributes.feedData = data;
+                setPlaylistAttributes(_model, loadedPlaylist, data);
                 resolve();
             });
             playlistLoader.on(ERROR, err => {
-                _model.attributes.playlist = [];
-                _model.attributes.feedData = {};
+                setPlaylistAttributes(_model, [], {});
                 reject(new Error(`Error loading playlist: ${err.message}`));
             });
             playlistLoader.load(playlist);
         });
     }
-    _model.attributes.playlist = Playlist(playlist);
+    setPlaylistAttributes(_model, playlist, {});
     return resolved;
+}
+
+function setPlaylistAttributes(model, playlist, feedData) {
+    const attributes = model.attributes;
+    attributes.playlist = Playlist(playlist);
+    attributes.feedData = feedData;
 }
 
 function loadProvider(_model) {

--- a/test/data/model-properties.js
+++ b/test/data/model-properties.js
@@ -1,7 +1,6 @@
 export const optionalProperties = {
     aspectratio: 1.0,
     fullscreen: false,
-    feedData: {},
     errorEvent: null,
     _destroyed: null,
     playOnViewable: false,
@@ -90,6 +89,7 @@ export default {
     audioMode: false,
     state: '',
     playlist: [{}],
+    feedData: {},
     item: 0,
     duration: 0,
     position: 0,


### PR DESCRIPTION
### This PR will...
Add default feedData to model in setup so that each playlist item gets a default feedData property.

### Why is this Pull Request needed?
Changes in setup caused this property to not get set on the model for inline playlists and thus not added to playlist items. Existing player integrations and cucumber tests expect `jwplayer().getPlaylistItem().feedData` and `jwplayer().getConfig().feedData` to always be an object.

#### Addresses Issue(s):

JW8-1137

