### PR TITLE
Deprecate Discover Icon & Localization

### DIFF
--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -44,7 +44,7 @@ const Defaults = {
         rewind: 'Rewind 10 Seconds',
         nextUp: 'Next Up',
         nextUpClose: 'Next Up Close',
-        related: 'Discover',
+        related: 'More Videos',
         close: 'Close',
         settings: 'Settings',
         unmute: 'Unmute',


### PR DESCRIPTION
### This PR will...

Make the default `localization.related` value to be `More Videos`

### Why is this Pull Request needed?

Moving forward, we are not longer using the term 'Discover' to refer to recs

### Are there any points in the code the reviewer needs to double check?

Base branch needs to be in `v8.1.x` which hasn't been created yet

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-plugin-related/pull/223

#### Addresses Issue(s):

JW8-1100


