### PR TITLE
Trust 'playbackRate' value from providers

### DIFF
--- a/src/js/program/program-listeners.js
+++ b/src/js/program/program-listeners.js
@@ -121,14 +121,9 @@ export function MediaControllerListener(model, programController) {
                     model.set(type, data[type]);
                 }
                 return;
-            case MEDIA_RATE_CHANGE: {
-                const rate = data.playbackRate;
-                // Check if its a generally usable rate.  Shaka changes rate to 0 when pause or buffering.
-                if (rate > 0) {
-                    model.set('playbackRate', rate);
-                }
+            case MEDIA_RATE_CHANGE:
+                model.set('playbackRate', data.playbackRate);
                 return;
-            }
             case MEDIA_META: {
                 Object.assign(model.get('itemMeta'), data.metadata);
                 break;


### PR DESCRIPTION
### This PR will...

Allow 'playbackRate' value of `0` from providers. 

### Why is this Pull Request needed?

We now handle Shaka's setting of playbackRate to `0` as stalling. The `MEDIA_RATE_CHANGE` will not be fired in this case.

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-commercial/pull/4597

#### Addresses Issue(s):

 JW8-1144

