### PR TITLE
Disable BGL for Safari 

### DIFF
--- a/src/js/environment/environment.js
+++ b/src/js/environment/environment.js
@@ -178,7 +178,7 @@ Object.defineProperties(Features, {
         enumerable: true
     },
     backgroundLoading: {
-        get: memoize(() => !OS.iOS),
+        get: memoize(() => !(OS.iOS || Browser.safari)),
         enumerable: true
     }
 });


### PR DESCRIPTION
### Why is this Pull Request needed?
If we switch tabs with a video loaded into a background, Safari will disable the video rendering pipeline for that tag. As a result we only get audio with a blank screen. We will file a bug ticket against Webkit and pursue a fix.

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-1154

