### PR TITLE
Return false for isSafari when on phantom

### DIFF
--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -44,7 +44,7 @@ export function isIE() {
 }
 
 export function isSafari() {
-    return userAgentMatch(/safari/i) && !userAgentMatch(/(?:Chrome|CriOS|chromium|android)/i);
+    return userAgentMatch(/safari/i) && !userAgentMatch(/(?:Chrome|CriOS|chromium|android|phantom)/i);
 }
 
 /** Matches iOS devices **/


### PR DESCRIPTION
### Why is this Pull Request needed?
PhantomJS isn't Safari, but our UA detection is triggering a false positive. This is causing failing unit tests.

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No 
