### PR TITLE
Add currentTime property to timeEventObject

### DIFF
--- a/src/js/providers/video-listener-mixin.js
+++ b/src/js/providers/video-listener-mixin.js
@@ -64,15 +64,16 @@ const VideoListenerMixin = {
         }
 
         var timeEventObject = {
-            position: position,
-            duration: duration
+            position,
+            duration,
+            metdata: {
+                currentTime: this.video.currentTime
+            }
         };
         if (this.getPtsOffset) {
             var ptsOffset = this.getPtsOffset();
             if (ptsOffset >= 0) {
-                timeEventObject.metadata = {
-                    mpegts: ptsOffset + position
-                };
+                timeEventObject.metadata.mpegts = ptsOffset + position;
             }
         }
 

--- a/src/js/providers/video-listener-mixin.js
+++ b/src/js/providers/video-listener-mixin.js
@@ -66,7 +66,7 @@ const VideoListenerMixin = {
         var timeEventObject = {
             position,
             duration,
-            metdata: {
+            metadata: {
                 currentTime: this.video.currentTime
             }
         };


### PR DESCRIPTION
### This PR will...

Instantiate metadata on the timeEventObject and set the currentTime property on metadata to the videos currentTime.

### Why is this Pull Request needed?

We need this to be visible when getAlignmentPosition is called so track.source can exist we can return the current time of the video when the stream type is DVR instead of position minus duration. This is so captions are properly displayed on Shaka DVR streams.

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-commercial/pull/4631

#### Addresses Issue(s):

JW8-868

