### PR TITLE
Changed Default Localization for Live to 'Live'

### DIFF
--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -39,7 +39,7 @@ const Defaults = {
         replay: 'Replay',
         buffer: 'Loading',
         more: 'More',
-        liveBroadcast: 'Live broadcast',
+        liveBroadcast: 'Live',
         loadingAd: 'Loading ad',
         rewind: 'Rewind 10 Seconds',
         nextUp: 'Next Up',


### PR DESCRIPTION
JW8-1194

### This PR will...

Change the default localization value for liveBroadcast from 'Live Broadcast' to 'Live'

### Why is this Pull Request needed?

In JW 8, only the text "Live" is displayed when a live stream is embedded.

### Are there any points in the code the reviewer needs to double check?

Nah.

### Are there any Pull Requests open in other repos which need to be merged with this?

Nah.

#### Addresses Issue(s):

JW8-1194

