### PR TITLE
Add canAutoplay test

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -12,6 +12,7 @@ import ViewModel from 'view/view-model';
 import changeStateEvent from 'events/change-state-event';
 import eventsMiddleware from 'controller/events-middleware';
 import Events from 'utils/backbone.events';
+import { canAutoplay } from 'utils/can-autoplay';
 import { OS, Features } from 'environment/environment';
 import { streamType } from 'providers/utils/stream-type';
 import Promise, { resolved } from 'polyfills/promise';
@@ -254,6 +255,17 @@ Object.assign(Controller.prototype, {
                 // this player has been destroyed
                 return;
             }
+
+            // Detect and store browser autoplay setting in the model.
+            const adConfig = _this._model.get('advertising');
+            canAutoplay(mediaPool, {
+                cancelable: checkAutoStartCancelable,
+                muted: _this.getMute(),
+                allowMuted: adConfig ? adConfig.autoplayadsmuted : false
+            })
+                .then(result => _model.set('canAutoplay', result))
+                .catch(function() {});
+
             if (!OS.mobile && _model.get('autostart') === true) {
                 // Autostart immediately if we're not mobile and not waiting for the player to become viewable first
                 _autoStart();
@@ -742,7 +754,7 @@ Object.assign(Controller.prototype, {
         this.getState = _getState;
         this.next = _nextUp;
         this.setConfig = (newConfig) => {
-            setConfig(_this, newConfig); 
+            setConfig(_this, newConfig);
         };
         this.setItemIndex = _setItem;
 
@@ -771,7 +783,7 @@ Object.assign(Controller.prototype, {
             updateProgramSoundSettings();
         };
         this.setPlaybackRate = (playbackRate) => {
-            _model.setPlaybackRate(playbackRate); 
+            _model.setPlaybackRate(playbackRate);
         };
         this.getProvider = () => _model.get('provider');
         this.getWidth = () => _model.get('containerWidth');

--- a/src/js/program/media-element-pool.js
+++ b/src/js/program/media-element-pool.js
@@ -34,9 +34,19 @@ export default function MediaElementPool() {
         getTestElement() {
             return testElement;
         },
-        clean,
-        cleanTestElement() {
-            clean(testElement);
+        clean(mediaElement) {
+            // Try to clean the media element so that we don't see frames of the previous video when reusing a tag
+            // We don't want to call load again if the media element is already clean
+            if (!mediaElement.src) {
+                return;
+            }
+
+            mediaElement.removeAttribute('src');
+            try {
+                mediaElement.load();
+            } catch (e) {
+                // Calling load may throw an exception, but does not result in an error state
+            }
         },
         recycle(mediaElement) {
             if (mediaElement && !pool.some(element => element === mediaElement)) {
@@ -55,21 +65,6 @@ export default function MediaElementPool() {
             });
         }
     };
-}
-
-function clean(mediaElement) {
-    // Try to clean the media element so that we don't see frames of the previous video when reusing a tag
-    // We don't want to call load again if the media element is already clean
-    if (!mediaElement.src) {
-        return;
-    }
-
-    mediaElement.removeAttribute('src');
-    try {
-        mediaElement.load();
-    } catch (e) {
-        // Calling load may throw an exception, but does not result in an error state
-    }
 }
 
 function primeMediaElementForPlayback(mediaElement) {

--- a/src/js/program/media-element-pool.js
+++ b/src/js/program/media-element-pool.js
@@ -14,6 +14,9 @@ export default function MediaElementPool() {
     // Reserve an element exclusively for ads
     const adElement = pool.shift();
 
+    // Reserve an element exclusively for feature testing.
+    const testElement = pool.shift();
+
     return {
         prime() {
             elements.forEach(primeMediaElementForPlayback);
@@ -28,19 +31,12 @@ export default function MediaElementPool() {
         getAdElement() {
             return adElement;
         },
-        clean(mediaElement) {
-            // Try to clean the media element so that we don't see frames of the previous video when reusing a tag
-            // We don't want to call load again if the media element is already clean
-            if (!mediaElement.src) {
-                return;
-            }
-
-            mediaElement.removeAttribute('src');
-            try {
-                mediaElement.load();
-            } catch (e) {
-                // Calling load may throw an exception, but does not result in an error state
-            }
+        getTestElement() {
+            return testElement;
+        },
+        clean,
+        cleanTestElement() {
+            clean(testElement);
         },
         recycle(mediaElement) {
             if (mediaElement && !pool.some(element => element === mediaElement)) {
@@ -59,6 +55,21 @@ export default function MediaElementPool() {
             });
         }
     };
+}
+
+function clean(mediaElement) {
+    // Try to clean the media element so that we don't see frames of the previous video when reusing a tag
+    // We don't want to call load again if the media element is already clean
+    if (!mediaElement.src) {
+        return;
+    }
+
+    mediaElement.removeAttribute('src');
+    try {
+        mediaElement.load();
+    } catch (e) {
+        // Calling load may throw an exception, but does not result in an error state
+    }
 }
 
 function primeMediaElementForPlayback(mediaElement) {

--- a/src/js/program/program-constants.js
+++ b/src/js/program/program-constants.js
@@ -1,5 +1,5 @@
 // The number of tags allocated in the media pool
-export const MEDIA_POOL_SIZE = 3;
+export const MEDIA_POOL_SIZE = 4;
 // The number of seconds before a BGL trigger at which we should start background loading. This ensures that we have
 // kicked off background loading before being able to transition to that item
 export const BACKGROUND_LOAD_OFFSET = 2;

--- a/src/js/utils/can-autoplay.js
+++ b/src/js/utils/can-autoplay.js
@@ -23,6 +23,7 @@
 // SOFTWARE.
 
 import createPlayPromise from '../providers/utils/play-promise';
+import Promise from '../polyfills/promise';
 
 /**
  * Small video file with audio.
@@ -34,27 +35,32 @@ import createPlayPromise from '../providers/utils/play-promise';
  */
 const VIDEO = 'data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAC721kYXQhEAUgpBv/wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA3pwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcCEQBSCkG//AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADengAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAsJtb292AAAAbG12aGQAAAAAAAAAAAAAAAAAAAPoAAAALwABAAABAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAB7HRyYWsAAABcdGtoZAAAAAMAAAAAAAAAAAAAAAIAAAAAAAAALwAAAAAAAAAAAAAAAQEAAAAAAQAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAACRlZHRzAAAAHGVsc3QAAAAAAAAAAQAAAC8AAAAAAAEAAAAAAWRtZGlhAAAAIG1kaGQAAAAAAAAAAAAAAAAAAKxEAAAIAFXEAAAAAAAtaGRscgAAAAAAAAAAc291bgAAAAAAAAAAAAAAAFNvdW5kSGFuZGxlcgAAAAEPbWluZgAAABBzbWhkAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAADTc3RibAAAAGdzdHNkAAAAAAAAAAEAAABXbXA0YQAAAAAAAAABAAAAAAAAAAAAAgAQAAAAAKxEAAAAAAAzZXNkcwAAAAADgICAIgACAASAgIAUQBUAAAAAAfQAAAHz+QWAgIACEhAGgICAAQIAAAAYc3R0cwAAAAAAAAABAAAAAgAABAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAIAAAABAAAAHHN0c3oAAAAAAAAAAAAAAAIAAAFzAAABdAAAABRzdGNvAAAAAAAAAAEAAAAsAAAAYnVkdGEAAABabWV0YQAAAAAAAAAhaGRscgAAAAAAAAAAbWRpcmFwcGwAAAAAAAAAAAAAAAAtaWxzdAAAACWpdG9vAAAAHWRhdGEAAAABAAAAAExhdmY1Ni40MC4xMDE=';
 
-function startPlayback (element, { muted }) {
+function startPlayback (element, { muted, timeout }) {
     // Configure element.
     element.muted = muted;
     element.src = VIDEO;
 
-    // Start playback and return promise.
-    const promise = element.play() || createPlayPromise(element);
-    return promise
+    // Start playback.
+    const promise = (element.play() || createPlayPromise(element))
         .then(() => true)
         .catch(() => false);
+
+    // Return playback promise, or timeout.
+    const timer = new Promise((resolve, reject) => {
+        setTimeout(reject, timeout, new Error('Autoplay test timed out'));
+    });
+    return Promise.race([ promise, timer ]);
 }
 
 export const AUTOPLAY_ENABLED = 'autoplayEnabled';
 export const AUTOPLAY_MUTED = 'autoplayMuted';
 export const AUTOPLAY_DISABLED = 'autoplayDisabled';
 
-export function canAutoplay (mediaPool, { cancelable, muted = false, allowMuted = false }) {
+export function canAutoplay (mediaPool, { cancelable, muted = false, allowMuted = false, timeout = 250 }) {
     const element = mediaPool.getTestElement();
 
     // Run the first test: autoplay with specified muted setting.
-    return startPlayback(element, { muted }).then(result => {
+    return startPlayback(element, { muted, timeout }).then(result => {
         if (cancelable.cancelled()) {
             throw new Error('Autoplay test was cancelled');
         }
@@ -62,7 +68,7 @@ export function canAutoplay (mediaPool, { cancelable, muted = false, allowMuted 
         // Second optional test: autoplay muted.
         if (result === false && muted === false && allowMuted) {
             muted = true;
-            return startPlayback(element, { muted });
+            return startPlayback(element, { muted, timeout });
         }
         return result;
     }).then(result => {

--- a/src/js/utils/can-autoplay.js
+++ b/src/js/utils/can-autoplay.js
@@ -1,0 +1,94 @@
+// https://github.com/video-dev/can-autoplay/ (modified)
+//
+// MIT License
+
+// Copyright (c) 2017 video-dev
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import createPlayPromise from '../providers/utils/play-promise';
+
+/**
+ * Small video file with audio.
+ * Source: https://github.com/mathiasbynens/small
+ *
+ * @constant
+ * @default
+ * @type {String}
+ */
+const VIDEO = 'data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAC721kYXQhEAUgpBv/wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA3pwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcCEQBSCkG//AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADengAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAsJtb292AAAAbG12aGQAAAAAAAAAAAAAAAAAAAPoAAAALwABAAABAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAB7HRyYWsAAABcdGtoZAAAAAMAAAAAAAAAAAAAAAIAAAAAAAAALwAAAAAAAAAAAAAAAQEAAAAAAQAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAACRlZHRzAAAAHGVsc3QAAAAAAAAAAQAAAC8AAAAAAAEAAAAAAWRtZGlhAAAAIG1kaGQAAAAAAAAAAAAAAAAAAKxEAAAIAFXEAAAAAAAtaGRscgAAAAAAAAAAc291bgAAAAAAAAAAAAAAAFNvdW5kSGFuZGxlcgAAAAEPbWluZgAAABBzbWhkAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAADTc3RibAAAAGdzdHNkAAAAAAAAAAEAAABXbXA0YQAAAAAAAAABAAAAAAAAAAAAAgAQAAAAAKxEAAAAAAAzZXNkcwAAAAADgICAIgACAASAgIAUQBUAAAAAAfQAAAHz+QWAgIACEhAGgICAAQIAAAAYc3R0cwAAAAAAAAABAAAAAgAABAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAIAAAABAAAAHHN0c3oAAAAAAAAAAAAAAAIAAAFzAAABdAAAABRzdGNvAAAAAAAAAAEAAAAsAAAAYnVkdGEAAABabWV0YQAAAAAAAAAhaGRscgAAAAAAAAAAbWRpcmFwcGwAAAAAAAAAAAAAAAAtaWxzdAAAACWpdG9vAAAAHWRhdGEAAAABAAAAAExhdmY1Ni40MC4xMDE=';
+
+function startPlayback (element, { timeout }) {
+    element.src = VIDEO;
+
+    return new Promise((resolve, reject) => {
+        const playResult = element.play() || createPlayPromise(element);
+        const timeoutId = setTimeout(() => {
+            reject(new Error(`Timeout ${timeout} ms has been reached`));
+        }, timeout);
+        const sendOutput = (result) => {
+            clearTimeout(timeoutId);
+            resolve(result);
+        };
+
+        playResult
+            .then(() => sendOutput(true))
+            .catch(() => sendOutput(false));
+    });
+}
+
+export const AUTOPLAY_ENABLED = 'autoplayEnabled';
+export const AUTOPLAY_MUTED = 'autoplayMuted';
+export const AUTOPLAY_DISABLED = 'autoplayDisabled';
+
+export function canAutoplay (controller, { muted = false, allowMuted = false, timeout = 250 }) {
+    // Set-up.
+    const mediaPool = controller.mediaPool;
+    const element = mediaPool.getPrimedElement();
+    const initialMute = element.muted;
+    const reset = () => {
+        mediaPool.syncMute(initialMute);
+        mediaPool.recycle(element);
+        controller.attached = true; // Re-attach.
+    };
+    controller.attached = false; // Detach.
+
+    // Run the first test: autoplay with specified muted setting.
+    mediaPool.syncMute(muted);
+    return startPlayback(element, { timeout }).then(result => {
+        // Second optional test: autoplay muted.
+        if (result === false && muted === false && allowMuted) {
+            muted = true;
+            mediaPool.syncMute(muted);
+            return startPlayback(element, { timeout });
+        }
+        return result;
+    }).then(result => {
+        reset();
+
+        // Return autoplay flag.
+        if (result === true) {
+            return muted ? AUTOPLAY_MUTED : AUTOPLAY_ENABLED;
+        }
+        return AUTOPLAY_DISABLED;
+    }).catch(err => {
+        reset();
+        throw err;
+    });
+}

--- a/src/js/utils/can-autoplay.js
+++ b/src/js/utils/can-autoplay.js
@@ -72,15 +72,10 @@ export function canAutoplay (mediaPool, { cancelable, muted = false, allowMuted 
         }
         return result;
     }).then(result => {
-        mediaPool.cleanTestElement();
-
         // Return autoplay flag.
         if (result === true) {
             return muted ? AUTOPLAY_MUTED : AUTOPLAY_ENABLED;
         }
         return AUTOPLAY_DISABLED;
-    }).catch(err => {
-        mediaPool.cleanTestElement();
-        throw err;
     });
 }

--- a/test/unit/media-pool-tests.js
+++ b/test/unit/media-pool-tests.js
@@ -3,7 +3,7 @@ import { MEDIA_POOL_SIZE } from 'program/program-constants';
 import sinon from 'sinon';
 
 describe('Media Element Pool', function () {
-    const numTags = MEDIA_POOL_SIZE - 1;
+    const numTags = MEDIA_POOL_SIZE - 2; // Subtract preallocated ad & test elements.
     let mediaPool = null;
     beforeEach(function () {
         mediaPool = new MediaPool();


### PR DESCRIPTION
### This PR will...
Expose a `canAutoplay(mediaPool, options)` function which returns a promise, with options:
- `cancelable`: if this cancelable promise is cancelled, the test will be interrupted and cancelled.
- `muted`: test against a muted `<video>` if `true`.
- `allowMuted`: applicable only if `muted` is false (i.e. the test was performed on an unmuted `<video>` element) - performs a second test to see if we can autoplay a muted `<video>` element.
- `timeout`:  rejects the promise if an individual test takes more than the specified amount (ms).

Promise is rejected with error (no autoplay errors here! - e.g. timeout error), or resolve with one of:
- `AUTOPLAY_ENABLED`: The browser allows (unmuted) autoplay.
- `AUTOPLAY_MUTED`: The browser allows muted autoplay. Note if the `muted` option was `true`, this is the worst-case scenario (i.e. no test for unmuted autoplay was performed, so the browser setting might actually be `AUTOPLAY_ENABLED`). 
- `AUTOPLAY_DISABLED`: The browser does not allow autoplay. Note if the `allowMuted` option was `false`, the browser setting might actually be `AUTOPLAY_MUTED`.

### Why is this Pull Request needed?
Deal with autoplay issues in Safari / Chrome 65+. Follow-up work to be done (other tickets).

### Are there any points in the code the reviewer needs to double check?
The `muted` and `allowMuted` options allow you to control if one or two tests will be performed. For example, if, as a publisher, you always want to autoplay muted, there is no point in testing if the browser supports unmuted autoplay. The options allow you to control what test(s) is/are actually performed.

#### Addresses Issue(s):
JW8-1157
ADS-937