### PR TITLE
Add liveTimeout, a configurable duration to kill a stale live stream

### DIFF
--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -152,11 +152,11 @@ const Config = function(options, persisted) {
     if (config.liveTimeout !== null) {
         if (_isNaN(liveTimeout) || !_isNumber(liveTimeout)) {
             liveTimeout = null;
-        } else if (config.liveTimeout !== 0) {
+        } else if (liveTimeout !== 0) {
             liveTimeout = Math.max(30, liveTimeout);
         }
+        config.liveTimeout = liveTimeout;
     }
-    config.liveTimeout = liveTimeout;
 
     return config;
 };

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -1,6 +1,7 @@
 import _ from 'utils/underscore';
 import { loadFrom, getScriptPath } from 'utils/playerutils';
 import { serialize } from 'utils/parser';
+import { _isNumber, _isNaN } from 'utils/underscore';
 
 /* global __webpack_public_path__:true */
 /* eslint camelcase: 0 */
@@ -147,11 +148,15 @@ const Config = function(options, persisted) {
     config.qualityLabels = config.qualityLabels || config.hlslabels;
     delete config.duration;
 
+    let liveTimeout = config.liveTimeout;
     if (config.liveTimeout !== null) {
-        if (config.liveTimeout !== 0) {
-            config.liveTimeout = Math.max(30, config.liveTimeout);
+        if (_isNaN(liveTimeout) || !_isNumber(liveTimeout)) {
+            liveTimeout = null;
+        } else if (config.liveTimeout !== 0) {
+            liveTimeout = Math.max(30, liveTimeout);
         }
     }
+    config.liveTimeout = liveTimeout;
 
     return config;
 };

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -5,21 +5,16 @@ import { serialize } from 'utils/parser';
 /* global __webpack_public_path__:true */
 /* eslint camelcase: 0 */
 // Defaults
+// Alphabetical order
 const Defaults = {
     autostart: false,
-    controls: true,
-    displaytitle: true,
-    displaydescription: true,
-    defaultPlaybackRate: 1,
-    playbackRateControls: false,
-    playbackRates: [0.5, 1, 1.25, 1.5, 2],
-    repeat: false,
     castAvailable: false,
-    stretching: 'uniform',
-    mute: false,
-    volume: 90,
-    width: 640,
+    controls: true,
+    defaultPlaybackRate: 1,
+    displaydescription: true,
+    displaytitle: true,
     height: 360,
+    liveTimeout: null,
     localization: {
         player: 'Video Player',
         play: 'Play',
@@ -50,8 +45,15 @@ const Defaults = {
         unmute: 'Unmute',
         copied: 'Copied'
     },
+    mute: false,
+    nextUpDisplay: true,
+    playbackRateControls: false,
+    playbackRates: [0.5, 1, 1.25, 1.5, 2],
     renderCaptionsNatively: false,
-    nextUpDisplay: true
+    repeat: false,
+    stretching: 'uniform',
+    volume: 90,
+    width: 640
 };
 
 function _deserialize(options) {
@@ -144,6 +146,12 @@ const Config = function(options, persisted) {
 
     config.qualityLabels = config.qualityLabels || config.hlslabels;
     delete config.duration;
+
+    if (config.liveTimeout !== null) {
+        if (config.liveTimeout !== 0) {
+            config.liveTimeout = Math.max(30, config.liveTimeout);
+        }
+    }
 
     return config;
 };

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -149,7 +149,7 @@ const Config = function(options, persisted) {
     delete config.duration;
 
     let liveTimeout = config.liveTimeout;
-    if (config.liveTimeout !== null) {
+    if (liveTimeout !== null) {
         if (_isNaN(liveTimeout) || !_isNumber(liveTimeout)) {
             liveTimeout = null;
         } else if (liveTimeout !== 0) {

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -206,7 +206,11 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
 
     const _videotag = mediaElement;
     const visualQuality = { level: {} };
-    const _staleStreamDuration = 3 * 10 * 1000;
+    // Prefer the config timeout, which is allowed to be 0 and null by default
+    const _staleStreamDuration =
+        _playerConfig.liveTimeout !== null
+            ? this.jwConfig.liveTimeout
+            : 3 * 10 * 1000;
 
     let _canSeek = false; // true on valid time event
     let _delayedSeek = 0;
@@ -768,6 +772,10 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
 
     // If we're live and the buffer end has remained the same for some time, mark the stream as stale and check if the stream is over
     function checkStaleStream() {
+        // Never kill a stale live stream if the timeout was configured to 0
+        if (_staleStreamDuration === 0) {
+            return;
+        }
         var endOfBuffer = endOfRange(_videotag.buffered);
         var live = _this.isLive();
 

--- a/test/data/model-properties.js
+++ b/test/data/model-properties.js
@@ -99,4 +99,5 @@ export default {
     castAvailable: false,
     qualityLabels: undefined,
     itemReady: false,
+    liveTimeout: null
 };

--- a/test/unit/api-config-test.js
+++ b/test/unit/api-config-test.js
@@ -30,6 +30,22 @@ describe('API Config', function() {
             expect(new Config({ id: 'abc' })).to.have.property('id').which.is.a('string').which.equals('abc');
             expect(new Config({ id: '123' })).to.have.property('id').which.is.a('string').which.equals('123');
         });
+
+        describe('liveTimeout', function () {
+            it('should default liveTimeout to 30 if between 1 and 30', function () {
+                expect(new Config({ liveTimeout: 1 })).to.have.property('liveTimeout').which.equals(30);
+                expect(new Config({ liveTimeout: 29 })).to.have.property('liveTimeout').which.equals(30);
+                expect(new Config({ liveTimeout: -1 })).to.have.property('liveTimeout').which.equals(30);
+            });
+
+            it('should not change a config value of 0', function () {
+                expect(new Config({ liveTimeout: 0 })).to.have.property('liveTimeout').which.equals(0);
+            });
+
+            it('should not change a config value of null', function () {
+                expect(new Config({ liveTimeout: null })).to.have.property('liveTimeout').which.equals(null);
+            });
+        });
     });
 
     describe('aspect ratio/width', function() {

--- a/test/unit/api-config-test.js
+++ b/test/unit/api-config-test.js
@@ -45,6 +45,19 @@ describe('API Config', function() {
             it('should not change a config value of null', function () {
                 expect(new Config({ liveTimeout: null })).to.have.property('liveTimeout').which.equals(null);
             });
+
+            it('should change NaN to null', function () {
+                expect(new Config({ liveTimeout: NaN })).to.have.property('liveTimeout').which.equals(null);
+            });
+
+            it('should change undefined to null', function () {
+                expect(new Config({ liveTimeout: undefined })).to.have.property('liveTimeout').which.equals(null);
+            });
+
+            it('should change a non-number to to null', function () {
+                expect(new Config({ liveTimeout: 'z' })).to.have.property('liveTimeout').which.equals(null);
+                expect(new Config({ liveTimeout: {} })).to.have.property('liveTimeout').which.equals(null);
+            });
         });
     });
 


### PR DESCRIPTION
### This PR will...
- Add `liveTimeout` config option with default value `null`
- Constraint `liveTimeout` values between 1 and 30 to 30; allow a value of 0 to indicate that a stream should never be killed
- Leave stream timeout up to provider when `liveTimeout === null`
- Alphabetize config options

### Why is this Pull Request needed?
Customers do not always want to have a stale stream killed. Instead of a boolean option, we decided on a configurable value with sensible defaults.

### Are there any points in the code the reviewer needs to double check?
Is a minimum value of 30 fair?

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/4696

#### Addresses Issue(s):

JW8-1171

