### PR TITLE
Keep instream model volume and mute in sync with the player

### DIFF
--- a/src/js/program/ad-program-controller.js
+++ b/src/js/program/ad-program-controller.js
@@ -91,15 +91,6 @@ export default class AdProgramController extends ProgramController {
         provider.on(ERROR, function(data) {
             this.trigger(ERROR, data);
         }, this);
-        playerModel.on('change:volume', function(data, value) {
-            this.volume = value;
-        }, this);
-        playerModel.on('change:mute', function(data, mute) {
-            this.mute = mute;
-            if (!mute) {
-                this.volume = playerModel.get('volume');
-            }
-        }, this);
         playerModel.on('change:autostartMuted', function(data, value) {
             if (!value) {
                 provider.mute(playerModel.get('mute'));
@@ -137,8 +128,16 @@ export default class AdProgramController extends ProgramController {
         if (provider.setPlaybackRate) {
             provider.setPlaybackRate(1);
         }
+        playerModel.change('volume', function(data, value) {
+            this.volume = value;
+        }, this);
+        playerModel.change('mute', function(data, mute) {
+            this.mute = mute;
+            if (!mute) {
+                this.volume = playerModel.get('volume');
+            }
+        }, this);
     }
-
 
     destroy() {
         const { model, mediaPool, playerModel } = this;


### PR DESCRIPTION
### This PR will...

Always update instream model volume and mute when these attributes change on the player model.

### Why is this Pull Request needed?

Because instream model attributes shadow player attributes preventing change events from being emitted on the view-model. For the volume button and slider to visually change during an ad break, the instream attributes must be updated.

### Are there any points in the code the reviewer needs to double check?

The volume and mute setters in ad-program-controller.js set volume and mute on the provider if there is no mediaController. I assume this is to prevent a feedback loop where it goes provider->mc->model->instream->provider. And, only psuedo providers are updated in this case which do not loop back to either model.

#### Addresses Issue(s):

JW8-1221


