### PR TITLE
Add mousedown listener w/prevent default to volume icon

### DIFF
--- a/src/js/view/controls/components/volumetooltip.js
+++ b/src/js/view/controls/components/volumetooltip.js
@@ -23,6 +23,10 @@ export default class VolumeTooltip extends Tooltip {
             .on('over', this.openTooltip, this)
             .on('out', this.closeTooltip, this);
 
+        this.el.addEventListener('mousedown', (e) => {
+            e.preventDefault();
+        });
+
         this._model.on('change:volume', this.onVolume, this);
     }
 


### PR DESCRIPTION
### This PR will...
add a mousedown listener which will call preventDefault on the event
### Why is this Pull Request needed?
On ie11, The volume icon needed to be clicked 3 times before being toggled
### Are there any points in the code the reviewer needs to double check?
This fix copies the implementation of [`button.js`](https://github.com/jwplayer/jwplayer/blob/master/src/js/view/controls/components/button.js#L24). It is currently present in 3 places (including [related](https://github.com/jwplayer/jwplayer-plugin-related/pull/251/files#diff-fdc2dbda0ff4965c5fbbf0dc10c17cbaR79)). If we set `preventScrolling` to true when constructing the ui element with [`ui.js`](https://github.com/jwplayer/jwplayer/blob/master/src/js/utils/ui.js#L79), it will call `preventDefault` on the event; is there a reason this was excluded in `button.js`?

#### Addresses Issue(s):
JW8-1225

