### PR TITLE
Add new method for DAI to enable time slider

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -64,6 +64,25 @@ var InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
 
     this.type = 'instream';
 
+    this.addAdProgramTimeListener = function() {
+        if (_inited || _destroyed) {
+            return;
+        }
+
+        _adProgram.on(MEDIA_TIME, _instreamTime, this);
+
+        // This enters the player into instream mode
+        _model.set('instream', _adProgram);
+
+        // don't trigger api play/pause on display click
+        const clickHandler = _view.clickHandler();
+        if (clickHandler) {
+            clickHandler.setAlternateClickHandlers(() => {}, null);
+        }
+
+        return this;
+    };
+
     this.init = function() {
         if (_inited || _destroyed) {
             return;
@@ -98,8 +117,9 @@ var InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
         _adProgram.model.set('state', STATE_BUFFERING);
 
         // don't trigger api play/pause on display click
-        if (_view.clickHandler()) {
-            _view.clickHandler().setAlternateClickHandlers(() => {}, null);
+        const clickHandler = _view.clickHandler();
+        if (clickHandler) {
+            clickHandler.setAlternateClickHandlers(() => {}, null);
         }
 
         this.setText(_model.get('localization').loadingAd);


### PR DESCRIPTION
### This PR will...
Create new function in InstreamAdapter that does NOT detach the media, but still listen to the time event and remove view click handler.

### Why is this Pull Request needed?
We want to be able to update the duration and time when DAI ad is playing. Since DAI is a stream with ad already in the stream, we do not want to detach the media.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-ads-dai/pull/28

#### Addresses Issue(s):
ADS-656
