### PR TITLE
Set item.starttime when seek is called before starting 

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -492,11 +492,10 @@ Object.assign(Controller.prototype, {
             if (_model.get('state') === STATE_ERROR) {
                 return;
             }
+            _programController.position = pos;
             if (!_model.get('scrubbing') && _model.get('state') !== STATE_PLAYING) {
                 _play(meta);
             }
-
-            _programController.position = pos;
         }
 
         function _item(index, meta) {
@@ -897,7 +896,6 @@ Object.assign(Controller.prototype, {
         const apiQueue = new ApiQueueDecorator(this, [
             'play',
             'pause',
-            'seek',
             'setCurrentAudioTrack',
             'setCurrentCaptions',
             'setCurrentQuality',

--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -214,7 +214,11 @@ export default class MediaController extends Eventable {
     }
 
     get setup() {
-        return this.mediaModel && this.mediaModel.get('setup');
+        return this.mediaModel.get('setup');
+    }
+
+    get started() {
+        return this.mediaModel.get('started');
     }
 
     set activeItem(item) {

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -546,7 +546,9 @@ class ProgramController extends Eventable {
             return;
         }
 
-        if (mediaController.attached) {
+        if (!mediaController.started) {
+            mediaController.item.starttime = pos;
+        } else if (mediaController.attached) {
             mediaController.position = pos;
         } else {
             mediaController.item.starttime = pos;

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -5,7 +5,7 @@ import cancelable from 'utils/cancelable';
 import { MediaControllerListener } from 'program/program-listeners';
 import Eventable from 'utils/eventable';
 
-import { ERROR, PLAYER_STATE, STATE_BUFFERING } from 'events/events';
+import { ERROR, PLAYER_STATE, STATE_BUFFERING, STATE_IDLE } from 'events/events';
 import { Features } from '../environment/environment';
 
 /** @private Do not include in JSDocs */
@@ -536,17 +536,18 @@ class ProgramController extends Eventable {
 
     /**
      * Seeks the media to the provided position.
-     * If the media is not attached, set the item's starttime, so that when reattaching, it resumes at that time.
+     * If the media is not attached, set the item's starttime so that when reattaching, it resumes at that time.
+     * If we seek before an item loads, set the item's starttime so that when playback begins, we buffer at that time.
      * @param {number} pos - The position to start at or seek to.
      * @returns {void}
      */
     set position(pos) {
-        const { mediaController } = this;
+        const { mediaController, model } = this;
         if (!mediaController) {
             return;
         }
 
-        if (!mediaController.started) {
+        if (!mediaController.started && !mediaController.preloaded && model.get(PLAYER_STATE) === STATE_IDLE) {
             mediaController.item.starttime = pos;
         } else if (mediaController.attached) {
             mediaController.position = pos;


### PR DESCRIPTION
### Why is this Pull Request needed?
So that we seek and start buffering at the set time if seek has been called before starting (right after `ready`, for example). Setting `starttime` leverages existing code to load at the set time.

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/4718
https://github.com/jwplayer/jwplayer-commercial/pull/4581

#### Addresses Issue(s):

JW8-1074

