### PR TITLE
Fix instream autoplay muted on iOS and Android

### DIFF
--- a/src/js/program/ad-program-controller.js
+++ b/src/js/program/ad-program-controller.js
@@ -83,18 +83,12 @@ export default class AdProgramController extends ProgramController {
         if (!provider) {
             return;
         }
-        const { playerModel } = this;
         this._setProvider(provider);
 
         // Match the main player's controls state
         provider.off(ERROR);
         provider.on(ERROR, function(data) {
             this.trigger(ERROR, data);
-        }, this);
-        playerModel.on('change:autostartMuted', function(data, value) {
-            if (!value) {
-                provider.mute(playerModel.get('mute'));
-            }
         }, this);
     }
 
@@ -128,13 +122,18 @@ export default class AdProgramController extends ProgramController {
         if (provider.setPlaybackRate) {
             provider.setPlaybackRate(1);
         }
-        playerModel.change('volume', function(data, value) {
+        playerModel.on('change:volume', function(data, value) {
             this.volume = value;
         }, this);
-        playerModel.change('mute', function(data, mute) {
+        playerModel.on('change:mute', function(data, mute) {
             this.mute = mute;
             if (!mute) {
                 this.volume = playerModel.get('volume');
+            }
+        }, this);
+        playerModel.on('change:autostartMuted', function(data, value) {
+            if (!value) {
+                model.set('autostartMuted', value);
             }
         }, this);
     }


### PR DESCRIPTION
### This PR will...

- Avoid changing mute state while instream playback is starting
- Keep instream `autostartMuted` state in sync with player

### Why is this Pull Request needed?

Instream's `mute`, `volume` and `autostartMuted` state is correct on setup and should not be reset by `change` handler on start. That was updating "muted" on all video tags and interrupting muted autoplay.

Keeping `autostartMuted` in sync with the player model insures that when the mute button is clicked autostart muted logic flows through the view and instream as expected, toggling mute correctly. Without this fix the mute button would need to be clicked twice for it to update.

#### Addresses Issue(s):

JW8-1228


