### PR TITLE
Align with the left property instead of paddingLeft

### DIFF
--- a/src/js/polyfills/webvtt.js
+++ b/src/js/polyfills/webvtt.js
@@ -415,6 +415,7 @@ function CueStyleBox(window, cue) {
         position: 'relative',
         paddingLeft: 0,
         paddingRight: 0,
+        left: 0,
         top: 0,
         bottom: 0,
         display: 'inline',
@@ -478,7 +479,7 @@ function CueStyleBox(window, cue) {
     // the right from there.
     if (!cue.vertical) {
         this.applyStyles({
-            paddingLeft: this.formatStyle(textPos, '%'),
+            left: this.formatStyle(textPos, '%'),
             width: this.formatStyle(cue.size, '%')
         });
         // Vertical box orientation; textPos is the distance from the top edge of the
@@ -495,7 +496,7 @@ function CueStyleBox(window, cue) {
         this.applyStyles({
             top: this.formatStyle(box.top, 'px'),
             bottom: this.formatStyle(box.bottom, 'px'),
-            paddingLeft: this.formatStyle(box.left, 'px'),
+            left: this.formatStyle(box.left, 'px'),
             paddingRight: this.formatStyle(box.right, 'px'),
             height: 'auto',
             width: this.formatStyle(box.width, 'px')
@@ -632,7 +633,7 @@ BoxPosition.prototype.toCSSCompatValues = function (reference) {
     return {
         top: this.top - reference.top,
         bottom: reference.bottom - this.bottom,
-        paddingLeft: this.left - reference.left,
+        left: this.left - reference.left,
         paddingRight: reference.right - this.right,
         height: this.height,
         width: this.width
@@ -787,7 +788,7 @@ function moveBoxToLinePosition(window, styleBox, containerBox, boxPositions, num
                 break;
             case 'rl':
                 styleBox.applyStyles({
-                    paddingLeft: styleBox.formatStyle(linePos, '%')
+                    left: styleBox.formatStyle(linePos, '%')
                 });
                 break;
             case 'lr':


### PR DESCRIPTION
### Why is this Pull Request needed?
`paddingLeft` will squish the captions against the edge of the captions container, causing them to display vertically at one line per word. Using `left` allows the captions to break as intended in the VTT file. I believe this is because the container's  (`jw-captions` div) `content-box` box model, which considered `padding` as part of the overall size.

### Are there any points in the code the reviewer needs to double check?
Do we still need paddingLeft in some cases? Maybe not all properties should be changed from `paddingLeft` to `left`

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

 JW8-1109

