### PR TITLE
[JW8-1158 ADS-938] Use autoplay test to determine autostart.

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -272,7 +272,10 @@ Object.assign(Controller.prototype, {
                     if (!_model.get('playOnViewable')) {
                         _autoStart();
                     }
-                }).catch(function() { });
+                }).catch(function() {
+                    // If the test failed, we will never autostart.
+                    _model.set('autostart', false);
+                });
             }
             apiQueue.flush();
         }
@@ -436,6 +439,7 @@ Object.assign(Controller.prototype, {
                 const mode = _model.get('canAutoplay');
 
                 if (mode === AUTOPLAY_DISABLED) {
+                    _model.set('autostart', false);
                     return _this.trigger(AUTOSTART_NOT_ALLOWED);
                 }
 

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -273,8 +273,11 @@ Object.assign(Controller.prototype, {
                         _autoStart();
                     }
                 }).catch(function() {
-                    // If the test failed, we will never autostart.
+                    // Never autostart if the test fails. Emit event unless test was explicitly canceled.
                     _model.set('autostart', false);
+                    if (!checkAutoStartCancelable.cancelled()) {
+                        _this.trigger(AUTOSTART_NOT_ALLOWED, { reason: 'autoplayTestFailed' });
+                    }
                 });
             }
             apiQueue.flush();
@@ -440,7 +443,7 @@ Object.assign(Controller.prototype, {
 
                 if (mode === AUTOPLAY_DISABLED) {
                     _model.set('autostart', false);
-                    return _this.trigger(AUTOSTART_NOT_ALLOWED);
+                    return _this.trigger(AUTOSTART_NOT_ALLOWED, { reason: mode });
                 }
 
                 // Only apply autostartMuted on un-muted autostart attempt.

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -423,7 +423,7 @@ Object.assign(Controller.prototype, {
             }
 
             // Detect and store browser autoplay setting in the model.
-            const adConfig = _this._model.get('advertising');
+            const adConfig = _model.get('advertising');
             canAutoplay(mediaPool, {
                 cancelable: checkAutoStartCancelable,
                 muted: _this.getMute(),
@@ -442,7 +442,6 @@ Object.assign(Controller.prototype, {
                     }
                     _actionOnAttach = null;
                 });
-
             }).catch(error => {
                 _model.set('canAutoplay', AUTOPLAY_DISABLED);
                 _model.set('autostart', false);

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -12,7 +12,7 @@ import ViewModel from 'view/view-model';
 import changeStateEvent from 'events/change-state-event';
 import eventsMiddleware from 'controller/events-middleware';
 import Events from 'utils/backbone.events';
-import { canAutoplay } from 'utils/can-autoplay';
+import { AUTOPLAY_DISABLED, AUTOPLAY_MUTED, canAutoplay } from 'utils/can-autoplay';
 import { OS, Features } from 'environment/environment';
 import { streamType } from 'providers/utils/stream-type';
 import Promise, { resolved } from 'polyfills/promise';
@@ -20,7 +20,7 @@ import cancelable from 'utils/cancelable';
 import _ from 'utils/underscore';
 import { INITIAL_MEDIA_STATE } from 'model/player-model';
 import { PLAYER_STATE, STATE_BUFFERING, STATE_IDLE, STATE_COMPLETE, STATE_PAUSED, STATE_PLAYING, STATE_ERROR, STATE_LOADING,
-    STATE_STALLED, MEDIA_BEFOREPLAY, PLAYLIST_LOADED, ERROR, PLAYLIST_COMPLETE, CAPTIONS_CHANGED, READY,
+    STATE_STALLED, AUTOSTART_NOT_ALLOWED, MEDIA_BEFOREPLAY, PLAYLIST_LOADED, ERROR, PLAYLIST_COMPLETE, CAPTIONS_CHANGED, READY,
     MEDIA_ERROR, MEDIA_COMPLETE, CAST_SESSION, FULLSCREEN, PLAYLIST_ITEM, MEDIA_VOLUME, MEDIA_MUTE, PLAYBACK_RATE_CHANGED,
     CAPTIONS_LIST, CONTROLS, RESIZE, MEDIA_VISUAL_QUALITY } from 'events/events';
 import ProgramController from 'program/program-controller';
@@ -75,7 +75,7 @@ Object.assign(Controller.prototype, {
         _view.on('all', _trigger, _this);
 
         const _programController = new ProgramController(_model, mediaPool);
-        syncInitialModelState();
+        updateProgramSoundSettings();
         addProgramControllerListeners();
         initQoe(_model, _programController);
 
@@ -234,9 +234,11 @@ Object.assign(Controller.prototype, {
             eventsReadyQueue = null;
 
             _model.change('viewable', viewableChange);
-            _model.change('viewable', _checkPlayOnViewable);
-            _model.once('change:autostartFailed change:autostartMuted change:mute', function(model) {
-                model.off('change:viewable', _checkPlayOnViewable);
+            _model.once('change:canAutoplay', function(model) {
+                model.once('change:autostartFailed change:autostartMuted change:mute', function() {
+                    model.off('change:viewable', _checkPlayOnViewable);
+                });
+                model.change('viewable', _checkPlayOnViewable);
             });
 
             // Run _checkAutoStart() last
@@ -256,19 +258,21 @@ Object.assign(Controller.prototype, {
                 return;
             }
 
-            // Detect and store browser autoplay setting in the model.
-            const adConfig = _this._model.get('advertising');
-            canAutoplay(mediaPool, {
-                cancelable: checkAutoStartCancelable,
-                muted: _this.getMute(),
-                allowMuted: adConfig ? adConfig.autoplayadsmuted : false
-            })
-                .then(result => _model.set('canAutoplay', result))
-                .catch(function() {});
+            if (_model.get('autostart')) {
+                // Detect and store browser autoplay setting in the model.
+                const adConfig = _this._model.get('advertising');
+                canAutoplay(mediaPool, {
+                    cancelable: checkAutoStartCancelable,
+                    muted: _this.getMute(),
+                    allowMuted: adConfig ? adConfig.autoplayadsmuted : true
+                }).then(result => {
+                    _model.set('canAutoplay', result);
 
-            if (!OS.mobile && _model.get('autostart') === true) {
-                // Autostart immediately if we're not mobile and not waiting for the player to become viewable first
-                _autoStart();
+                    // Autostart immediately if we're not waiting for the player to become viewable first.
+                    if (!_model.get('playOnViewable')) {
+                        _autoStart();
+                    }
+                }).catch(function() { });
             }
             apiQueue.flush();
         }
@@ -428,7 +432,19 @@ Object.assign(Controller.prototype, {
 
         function _autoStart() {
             const state = _model.get('state');
-            if (state === STATE_IDLE || state === STATE_PAUSED) {
+            if (!checkAutoStartCancelable.cancelled() && (state === STATE_IDLE || state === STATE_PAUSED)) {
+                const mode = _model.get('canAutoplay');
+
+                if (mode === AUTOPLAY_DISABLED) {
+                    return _this.trigger(AUTOSTART_NOT_ALLOWED);
+                }
+
+                // Only apply autostartMuted on un-muted autostart attempt.
+                if (mode === AUTOPLAY_MUTED && !_this.getMute()) {
+                    _model.set('autostartMuted', true);
+                    updateProgramSoundSettings();
+                }
+
                 _play({ reason: 'autostart' }).catch(() => {
                     if (!_this._instreamAdapter) {
                         _model.set('autostartFailed', true);
@@ -714,12 +730,6 @@ Object.assign(Controller.prototype, {
                     resolved.then(_completeHandler);
                 }, _this)
                 .on(MEDIA_ERROR, _this.triggerError, _this);
-        }
-
-        function syncInitialModelState() {
-            // Mute the video if autostarting on mobile, except for Android SDK. Otherwise, honor the model's mute value
-            _programController.mute = (_model.autoStartOnMobile() && !_model.get('sdkplatform')) || _model.get('mute');
-            _programController.volume = _model.get('volume');
         }
 
         function updateProgramSoundSettings() {

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -257,7 +257,7 @@ Object.assign(Controller.prototype, {
             }
 
             // Autostart immediately if we're not waiting for the player to become viewable first.
-            if (!_model.get('playOnViewable')) {
+            if (_model.get('autostart') === true && !_model.get('playOnViewable')) {
                 _autoStart();
             }
             apiQueue.flush();

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -234,11 +234,9 @@ Object.assign(Controller.prototype, {
             eventsReadyQueue = null;
 
             _model.change('viewable', viewableChange);
-            _model.once('change:canAutoplay', function(model) {
-                model.once('change:autostartFailed change:autostartMuted change:mute', function() {
-                    model.off('change:viewable', _checkPlayOnViewable);
-                });
-                model.change('viewable', _checkPlayOnViewable);
+            _model.change('viewable', _checkPlayOnViewable);
+            _model.once('change:autostartFailed change:autostartMuted change:mute', function(model) {
+                model.off('change:viewable', _checkPlayOnViewable);
             });
 
             // Run _checkAutoStart() last
@@ -258,27 +256,9 @@ Object.assign(Controller.prototype, {
                 return;
             }
 
-            if (_model.get('autostart')) {
-                // Detect and store browser autoplay setting in the model.
-                const adConfig = _this._model.get('advertising');
-                canAutoplay(mediaPool, {
-                    cancelable: checkAutoStartCancelable,
-                    muted: _this.getMute(),
-                    allowMuted: adConfig ? adConfig.autoplayadsmuted : true
-                }).then(result => {
-                    _model.set('canAutoplay', result);
-
-                    // Autostart immediately if we're not waiting for the player to become viewable first.
-                    if (!_model.get('playOnViewable')) {
-                        _autoStart();
-                    }
-                }).catch(function() {
-                    // Never autostart if the test fails. Emit event unless test was explicitly canceled.
-                    _model.set('autostart', false);
-                    if (!checkAutoStartCancelable.cancelled()) {
-                        _this.trigger(AUTOSTART_NOT_ALLOWED, { reason: 'autoplayTestFailed' });
-                    }
-                });
+            // Autostart immediately if we're not waiting for the player to become viewable first.
+            if (!_model.get('playOnViewable')) {
+                _autoStart();
             }
             apiQueue.flush();
         }
@@ -438,27 +418,44 @@ Object.assign(Controller.prototype, {
 
         function _autoStart() {
             const state = _model.get('state');
-            if (!checkAutoStartCancelable.cancelled() && (state === STATE_IDLE || state === STATE_PAUSED)) {
-                const mode = _model.get('canAutoplay');
+            if (state !== STATE_IDLE && state !== STATE_PAUSED) {
+                return;
+            }
 
-                if (mode === AUTOPLAY_DISABLED) {
-                    _model.set('autostart', false);
-                    return _this.trigger(AUTOSTART_NOT_ALLOWED, { reason: mode });
-                }
+            // Detect and store browser autoplay setting in the model.
+            const adConfig = _this._model.get('advertising');
+            canAutoplay(mediaPool, {
+                cancelable: checkAutoStartCancelable,
+                muted: _this.getMute(),
+                allowMuted: adConfig ? adConfig.autoplayadsmuted : true
+            }).then(result => {
+                _model.set('canAutoplay', result);
 
                 // Only apply autostartMuted on un-muted autostart attempt.
-                if (mode === AUTOPLAY_MUTED && !_this.getMute()) {
+                if (_model.get('canAutoplay') === AUTOPLAY_MUTED && !_this.getMute()) {
                     _model.set('autostartMuted', true);
-                    updateProgramSoundSettings();
                 }
 
-                _play({ reason: 'autostart' }).catch(() => {
+                return _play({ reason: 'autostart' }).catch(() => {
                     if (!_this._instreamAdapter) {
                         _model.set('autostartFailed', true);
                     }
                     _actionOnAttach = null;
                 });
-            }
+
+            }).catch(error => {
+                _model.set('canAutoplay', AUTOPLAY_DISABLED);
+                _model.set('autostart', false);
+
+                // Emit event unless test was explicitly canceled.
+                if (!checkAutoStartCancelable.cancelled()) {
+                    const { reason } = error;
+                    _this.trigger(AUTOSTART_NOT_ALLOWED, {
+                        reason,
+                        error
+                    });
+                }
+            });
         }
 
         function _stop(internal) {

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -1,4 +1,4 @@
-import { Browser, OS } from 'environment/environment';
+import { OS } from 'environment/environment';
 import SimpleModel from 'model/simplemodel';
 import { INITIAL_PLAYER_STATE, INITIAL_MEDIA_STATE } from 'model/player-model';
 import { STATE_IDLE } from 'events/events';
@@ -173,27 +173,6 @@ const Model = function() {
         this.persistCaptionsTrack();
     };
 
-    function _autoStartSupportedIOS() {
-        if (!OS.iOS) {
-            return false;
-        }
-        // Autostart only supported in iOS 10 or higher - check if the version is 9 or less
-        return OS.version.major >= 10;
-    }
-
-    function platformCanAutostart() {
-        var autostartAdsIsEnabled = (!_this.get('advertising') || _this.get('advertising').autoplayadsmuted);
-        var iosBrowserIsSupported = _autoStartSupportedIOS() && (Browser.safari || Browser.chrome || Browser.facebook);
-        var androidBrowserIsSupported = OS.android && Browser.chrome;
-        var mobileBrowserIsSupported = (iosBrowserIsSupported || androidBrowserIsSupported);
-        var isAndroidSdk = _this.get('sdkplatform') === 1;
-        return (!_this.get('sdkplatform') && autostartAdsIsEnabled && mobileBrowserIsSupported) || isAndroidSdk;
-    }
-
-    this.autoStartOnMobile = function() {
-        return this.get('autostart') && platformCanAutostart();
-    };
-
     // Mobile players always wait to become viewable.
     // Desktop players must have autostart set to viewable
     this.setAutoStart = function(autoStart) {
@@ -201,11 +180,7 @@ const Model = function() {
             this.set('autostart', autoStart);
         }
 
-        const autoStartOnMobile = this.autoStartOnMobile();
-        const isAndroidSdk = _this.get('sdkplatform') === 1;
-        if (autoStartOnMobile && !isAndroidSdk) {
-            this.set('autostartMuted', true);
-        }
+        const autoStartOnMobile = OS.mobile && this.get('autostart');
         this.set('playOnViewable', autoStartOnMobile || this.get('autostart') === 'viewable');
     };
 

--- a/src/js/events/events.js
+++ b/src/js/events/events.js
@@ -162,6 +162,11 @@ export const AD_TIME = 'adTime';
 // Events
 
 /**
+ * Triggered when the browsers' autoplay setting prohibits autostarting playback.
+ */
+export const AUTOSTART_NOT_ALLOWED = 'autostartNotAllowed';
+
+/**
  * Event triggered when media playback ends because the last segment has been played.
 */
 export const MEDIA_COMPLETE = STATE_COMPLETE;

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -161,21 +161,23 @@ export default class Controls {
             this.div.insertBefore(settingsMenu.element(), controlbar.element());
         }
 
-        // Unmute Autoplay Button. Ignore iOS9. Muted autoplay is supported in iOS 10+
-        if (model.get('autostartMuted')) {
-            const unmuteCallback = () => this.unmuteAutoplay(api, model);
-            this.mute = button('jw-autostart-mute jw-off', unmuteCallback, model.get('localization').unmute,
-                [cloneIcon('volume-0')]);
-            this.mute.show();
-            this.div.appendChild(this.mute.element());
-            // Set mute state in the controlbar
-            controlbar.renderVolume(true, model.get('volume'));
-            // Hide the controlbar until the autostart flag is removed
-            utils.addClass(this.playerContainer, 'jw-flag-autostart');
+        // Unmute Autoplay Button.
+        model.once('change:autostartMuted', (_model, muted) => {
+            if (muted) {
+                const unmuteCallback = () => this.unmuteAutoplay(api, _model);
+                this.mute = button('jw-autostart-mute jw-off', unmuteCallback, _model.get('localization').unmute,
+                    [cloneIcon('volume-0')]);
+                this.mute.show();
+                this.div.appendChild(this.mute.element());
+                // Set mute state in the controlbar
+                controlbar.renderVolume(true, _model.get('volume'));
+                // Hide the controlbar until the autostart flag is removed
+                utils.addClass(this.playerContainer, 'jw-flag-autostart');
 
-            model.on('change:autostartFailed change:autostartMuted change:mute', unmuteCallback, this);
-            this.unmuteCallback = unmuteCallback;
-        }
+                _model.on('change:autostartFailed change:autostartMuted change:mute', unmuteCallback, this);
+                this.unmuteCallback = unmuteCallback;
+            }
+        });
 
         // Keyboard Commands
         function adjustSeek(amount) {

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -162,8 +162,8 @@ export default class Controls {
         }
 
         // Unmute Autoplay Button.
-        model.once('change:autostartMuted', (_model, muted) => {
-            if (muted) {
+        const setupUnmuteAutoplayButton = (_model) => {
+            if (_model.get('autostartMuted')) {
                 const unmuteCallback = () => this.unmuteAutoplay(api, _model);
                 this.mute = button('jw-autostart-mute jw-off', unmuteCallback, _model.get('localization').unmute,
                     [cloneIcon('volume-0')]);
@@ -177,7 +177,9 @@ export default class Controls {
                 _model.on('change:autostartFailed change:autostartMuted change:mute', unmuteCallback, this);
                 this.unmuteCallback = unmuteCallback;
             }
-        });
+        };
+        model.once('change:autostartMuted', setupUnmuteAutoplayButton);
+        setupUnmuteAutoplayButton(model);
 
         // Keyboard Commands
         function adjustSeek(amount) {


### PR DESCRIPTION
### This PR will...

- Adjust autostart behavior to only autostart if we are allowed to do so by the browser setting. If configured to do so, the behavior will fall back to autostart muted. 
- Simplify the explicit OS / browser checking in the model, as we rely on the `canAutoplay` test instead. 
- Emit an `autostartNotAllowed` event if:
-- The browser forbids autoplay,
-- The browser allows autoplay muted, but we want to autoplay unmuted.

### Why is this Pull Request needed?
Deal with browser autoplay policy changes.

### Are there any points in the code the reviewer needs to double check?
- I'm not too happy with the changes in `controls.js`. Since the `autostartMuted` flag is available only after the autoplay test, we can't configure the unmuted controls upon view setup. Instead, the updated code waits for the flag to be set, before updating the controls.
- Also, if the test errors (e.g. timeout), we currently fall back to play-to-click, but do not emit the `autostartNotAllowed` event. Do we want to emit this if a test error occurs?
- The `autostartNotAllowed` event currently does not have any properties - do we want to add any information to this event?

### Are there any Pull Requests open in other repos which need to be merged with this?
jwplayer/jwplayer-commercial#4730
jwplayer/jwplayer-ads-freewheel#104

#### Addresses Issue(s):
JW8-1158
ADS-938