### PR TITLE
Close volume tooltip after tab

### DIFF
--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -151,6 +151,10 @@ const UI = function (elem, options) {
         }
     }
 
+    function blurHandler(evt) {
+        triggerEvent(OUT, evt);
+    }
+
     function keyHandler(evt) {
         if (isEnterKey(evt)) {
             triggerEvent(ENTER, evt);
@@ -317,7 +321,7 @@ const UI = function (elem, options) {
 
         if (options.useFocus) {
             elem.removeEventListener('focus', overHandler);
-            elem.removeEventListener('blur', outHandler);
+            elem.removeEventListener('blur', blurHandler);
         }
     };
 

--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -142,11 +142,8 @@ const UI = function (elem, options) {
 
     function outHandler(evt) {
         // elementFromPoint to handle an issue where setPointerCapture is causing a pointerout event
-        if (_useMouseEvents ||
-            (_supportsPointerEvents && evt.pointerType !== 'touch' && (
-                (evt.x === undefined && evt.y === undefined) ||
-                !elem.contains(document.elementFromPoint(evt.x, evt.y)))
-            )) {
+        if (_useMouseEvents || (_supportsPointerEvents && evt.pointerType !== 'touch' &&
+                !elem.contains(document.elementFromPoint(evt.x, evt.y)))) {
             triggerEvent(OUT, evt);
         }
     }

--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -100,7 +100,7 @@ const UI = function (elem, options) {
         elem.addEventListener('pointerdown', interactStartHandler, listenerOptions);
         if (options.useHover) {
             elem.addEventListener('pointerover', overHandler);
-            elem.addEventListener('pointerout', outHandler);
+            elem.addEventListener('pointerout', pointerOutHandler);
         }
         if (options.useMove) {
             elem.addEventListener('pointermove', moveHandler);
@@ -140,15 +140,18 @@ const UI = function (elem, options) {
         }
     }
 
-    function outHandler(evt) {
-        // elementFromPoint to handle an issue where setPointerCapture is causing a pointerout event
-        if (_useMouseEvents || (_supportsPointerEvents && evt.pointerType !== 'touch' &&
-                !elem.contains(document.elementFromPoint(evt.x, evt.y)))) {
-            triggerEvent(OUT, evt);
+    function pointerOutHandler(evt) {
+        if (evt.pointerType !== 'touch') {
+            // elementFromPoint to handle an issue where setPointerCapture is causing a pointerout event
+            const { x, y } = evt;
+            const overElement = document.elementFromPoint(x, y);
+            if (!elem.contains(overElement)) {
+                triggerEvent(OUT, evt);
+            }
         }
     }
 
-    function blurHandler(evt) {
+    function outHandler(evt) {
         triggerEvent(OUT, evt);
     }
 
@@ -305,7 +308,7 @@ const UI = function (elem, options) {
             elem.removeEventListener('pointermove', interactDragHandler);
             elem.removeEventListener('pointermove', moveHandler);
             elem.removeEventListener('pointercancel', interactEndHandler);
-            elem.removeEventListener('pointerout', outHandler);
+            elem.removeEventListener('pointerout', pointerOutHandler);
             elem.removeEventListener('pointerup', interactEndHandler);
         }
 
@@ -318,7 +321,7 @@ const UI = function (elem, options) {
 
         if (options.useFocus) {
             elem.removeEventListener('focus', overHandler);
-            elem.removeEventListener('blur', blurHandler);
+            elem.removeEventListener('blur', outHandler);
         }
     };
 

--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -142,8 +142,11 @@ const UI = function (elem, options) {
 
     function outHandler(evt) {
         // elementFromPoint to handle an issue where setPointerCapture is causing a pointerout event
-        if (_useMouseEvents || (_supportsPointerEvents && evt.pointerType !== 'touch' &&
-            !elem.contains(document.elementFromPoint(evt.x, evt.y)))) {
+        if (_useMouseEvents ||
+            (_supportsPointerEvents && evt.pointerType !== 'touch' && (
+                (evt.x === undefined && evt.y === undefined) ||
+                !elem.contains(document.elementFromPoint(evt.x, evt.y)))
+            )) {
             triggerEvent(OUT, evt);
         }
     }


### PR DESCRIPTION
### This PR will...

check that an event has pointer coords before `document.elementFromPoint`

### Why is this Pull Request needed?

When focus on the volume button, the volume tooltip should appear. When tabbing out of it, the logic to check that it should appear on hover out should not be called. Otherwise, `document.elementFromPoint` fails:

`Uncaught TypeError: Failed to execute 'elementFromPoint' on 'Document': The provided double value is non-finite.`

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-1253
