### PR TITLE
Avoid resetting position & duration in srcReset

### DIFF
--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -256,11 +256,13 @@ const MediaModel = Model.MediaModel = function() {
 
 Object.assign(MediaModel.prototype, SimpleModel, {
     srcReset() {
-        Object.assign(this.attributes, INITIAL_MEDIA_STATE, {
+        Object.assign(this.attributes, {
             setup: false,
             started: false,
             preloaded: false,
             visualQuality: null,
+            buffer: 0,
+            currentTime: 0
         });
     }
 });

--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -228,7 +228,6 @@ export default class MediaController extends Eventable {
         const mediaModelState = mediaModel.attributes;
         mediaModel.srcReset();
         mediaModelState.position = position;
-        mediaModelState.currentTime = 0;
         mediaModelState.duration = duration;
 
         this.item = item;

--- a/test/unit/mediaModel-test.js
+++ b/test/unit/mediaModel-test.js
@@ -1,0 +1,28 @@
+import { MediaModel } from 'controller/model';
+
+describe('mediaModel', function() {
+    let mediaModel;
+    beforeEach(function () {
+        mediaModel = new MediaModel();
+    });
+
+    describe('srcReset', function () {
+       it('resets certain mediaModel properties to their defaults', function () {
+            mediaModel.srcReset();
+            expect(mediaModel.attributes.setup).to.equal(false);
+            expect(mediaModel.attributes.started).to.equal(false);
+            expect(mediaModel.attributes.preloaded).to.equal(false);
+            expect(mediaModel.attributes.visualQuality).to.equal(null);
+            expect(mediaModel.attributes.buffer).to.equal(0);
+            expect(mediaModel.attributes.currentTime).to.equal(0);
+       });
+
+       it('does not reset position or duration', function () {
+           mediaModel.attributes.position = 10;
+           mediaModel.attributes.duration = 30;
+           mediaModel.srcReset();
+           expect(mediaModel.attributes.position).to.equal(10);
+           expect(mediaModel.attributes.duration).to.equal(30);
+       });
+    });
+});


### PR DESCRIPTION
### Why is this Pull Request needed?
During ad playback when not background loading, we expect `getPosition` and `getDuration` to return the position & duration of the content, as captured before the ad. `srcReset` has been resetting these properties to 0, causing these API methods to also return 0.

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-1251

