### PR TITLE
Return the same autoplay Promise...

### DIFF
--- a/src/js/utils/can-autoplay.js
+++ b/src/js/utils/can-autoplay.js
@@ -54,10 +54,11 @@ export function canAutoplay (mediaPool, { cancelable, muted = false, allowMuted 
     const element = mediaPool.getTestElement();
     const key = muted ? 'muted' : `${allowMuted}`;
 
-    // Run tests only if test is not currently running, or browser setting is AUTOPLAY_ENABLED.
+    // Run test only if it is not currently running, or test previously evaluated to AUTOPLAY_ENABLED.
     if (!autoplayPagePromises[key]) {
         // Run the first test: autoplay with specified muted setting.
         autoplayPagePromises[key] = startPlayback(element, { muted }).catch((e) => {
+            // Second optional test: autoplay muted.
             if (!cancelable.cancelled() && muted === false && allowMuted) {
                 muted = true;
                 return startPlayback(element, { muted });
@@ -75,7 +76,6 @@ export function canAutoplay (mediaPool, { cancelable, muted = false, allowMuted 
         });
     }
 
-    // Run the first test: autoplay with specified muted setting.
     // If the cancelable was canceled, abort the test.
     const promise = autoplayPagePromises[key].then(result => {
         if (cancelable.cancelled()) {

--- a/src/js/utils/can-autoplay.js
+++ b/src/js/utils/can-autoplay.js
@@ -54,7 +54,7 @@ export function canAutoplay (mediaPool, { cancelable, muted = false, allowMuted 
     const element = mediaPool.getTestElement();
     const key = muted ? 'muted' : `${allowMuted}`;
 
-    // Run test only if it is not currently running, or test previously evaluated to AUTOPLAY_ENABLED.
+    // Skip test if it is currently running, or test previously evaluated to AUTOPLAY_ENABLED.
     if (!autoplayPagePromises[key]) {
         // Run the first test: autoplay with specified muted setting.
         autoplayPagePromises[key] = startPlayback(element, { muted }).catch((e) => {

--- a/src/js/utils/can-autoplay.js
+++ b/src/js/utils/can-autoplay.js
@@ -48,7 +48,7 @@ export const AUTOPLAY_ENABLED = 'autoplayEnabled';
 export const AUTOPLAY_MUTED = 'autoplayMuted';
 export const AUTOPLAY_DISABLED = 'autoplayDisabled';
 
-let autoplayPagePromises = {};
+const autoplayPagePromises = {};
 
 export function canAutoplay (mediaPool, { cancelable, muted = false, allowMuted = false, timeout = 250 }) {
     const element = mediaPool.getTestElement();

--- a/src/js/utils/can-autoplay.js
+++ b/src/js/utils/can-autoplay.js
@@ -84,9 +84,8 @@ export function canAutoplay (mediaPool, { cancelable, muted = false, allowMuted 
             if (muted) {
                 autoplayPagePromises[key] = null;
                 return AUTOPLAY_MUTED;
-            } else {
-                return AUTOPLAY_ENABLED;
             }
+            return AUTOPLAY_ENABLED;
         }
         autoplayPagePromises[key] = null;
         return AUTOPLAY_DISABLED;


### PR DESCRIPTION
### This PR will...

When multiple autostart players are embedded on the page only run one autoplay test for the mute options at once. Once autostart is allowed for that config, always return the same promise.

### Why is this Pull Request needed?

This prevents us from running the autoplay test unnecessarily. Multiple players all trying to start at the same time can use the same test. New players that want to autostart later can use the successful result of an earlier test.

#### Addresses Issue(s):

JW8-1158 ADS-936


