### PR TITLE
Adjust autoplay behavior suggestions

### DIFF
--- a/src/js/utils/can-autoplay.js
+++ b/src/js/utils/can-autoplay.js
@@ -1,4 +1,4 @@
-// https://github.com/video-dev/can-autoplay/ (modified)
+// https://github.com/video-dev/can-autoplay/tree/v2.2.1 (modified)
 //
 // MIT License
 

--- a/src/js/utils/can-autoplay.js
+++ b/src/js/utils/can-autoplay.js
@@ -92,7 +92,7 @@ export function canAutoplay(mediaPool, { cancelable, muted = false, allowMuted =
     // Return playback promise, or timeout.
     let timeoutId;
     const timer = new Promise((resolve, reject) => {
-        timeout = setTimeout(() => {
+        timeoutId = setTimeout(() => {
             autoplayPagePromises[key] = null; // Clear cache.
             const error = new Error('Autoplay test timed out');
             error.reason = 'timeout';

--- a/src/js/utils/can-autoplay.js
+++ b/src/js/utils/can-autoplay.js
@@ -50,7 +50,7 @@ export const AUTOPLAY_DISABLED = 'autoplayDisabled';
 
 const autoplayPagePromises = {};
 
-export function canAutoplay (mediaPool, { cancelable, muted = false, allowMuted = false, timeout = 250 }) {
+export function canAutoplay(mediaPool, { cancelable, muted = false, allowMuted = false, timeout = 10000 }) {
     const element = mediaPool.getTestElement();
     const key = muted ? 'muted' : `${allowMuted}`;
 
@@ -70,23 +70,34 @@ export function canAutoplay (mediaPool, { cancelable, muted = false, allowMuted 
                 return AUTOPLAY_MUTED;
             }
             return AUTOPLAY_ENABLED;
-        }).catch(() => {
+        }).catch(error => {
+            clearTimeout(timeoutId);
             autoplayPagePromises[key] = null; // Clear cache.
-            return AUTOPLAY_DISABLED;
+            error.reason = AUTOPLAY_DISABLED;
+            throw error;
         });
     }
 
     // If the cancelable was canceled, abort the test.
     const promise = autoplayPagePromises[key].then(result => {
+        clearTimeout(timeoutId);
         if (cancelable.cancelled()) {
-            throw new Error('Autoplay test was cancelled');
+            const error = new Error('Autoplay test was cancelled');
+            error.reason = 'cancelled';
+            throw error;
         }
         return result;
     });
 
     // Return playback promise, or timeout.
+    let timeoutId;
     const timer = new Promise((resolve, reject) => {
-        setTimeout(reject, timeout, new Error('Autoplay test timed out'));
+        timeout = setTimeout(() => {
+            autoplayPagePromises[key] = null; // Clear cache.
+            const error = new Error('Autoplay test timed out');
+            error.reason = 'timeout';
+            reject(error);
+        }, timeout);
     });
     return Promise.race([ promise, timer ]);
 }


### PR DESCRIPTION
### This PR will...

Additional changes we should consider as part of the autoplay test and behavior changes.

- Change the test timeout to 10 seconds. Sites are slow. There is no rush.
- Revert "playOnViewable" behavior. Run the autostart test on viewable when attempting to autostart so that the test results represent page state at the time the player becomes viewable.
- Any failure in the autoplay test causes the test to catch
- Adds the actual play request to the test promise change, so if the actual play request fails we will still get an "autostartNotAllowed" event with `reason` "playAttemptFailed".
- Clear the timeout when the test ends first - this prevents the timeout callback from running when it isn't needed and stops the debugger from pausing on Promise rejection after the test is over

### Why is this Pull Request needed?

Builds on top of https://github.com/jwplayer/jwplayer/pull/2734 to provide error details when autostart is cancelled. This also makes the test more reliable by reducing the chance of a timeout and the chance of getting an fail result before a play-on-viewable player comes into view.

#### Addresses Issue(s):

JW8-1158
ADS-938