### PR TITLE
Added configuration used in setup() call to model attributes

### DIFF
--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -196,9 +196,6 @@ export default function Api(element) {
 
             resetPlayer(this, core);
             core = coreFactory(this, element);
-
-            options.id = playerId;
-
             core.init(options, this);
 
             // bind event listeners passed in to the config

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -81,7 +81,6 @@ const Config = function(options, persisted) {
     allOptions.localization = Object.assign({}, Defaults.localization, allOptions.localization);
 
     let config = Object.assign({}, Defaults, allOptions);
-    config.setupConfig = Object.assign({}, options);
     if (config.base === '.') {
         config.base = getScriptPath('jwplayer.js');
     }

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -81,6 +81,7 @@ const Config = function(options, persisted) {
     allOptions.localization = Object.assign({}, Defaults.localization, allOptions.localization);
 
     let config = Object.assign({}, Defaults, allOptions);
+    config.setupConfig = Object.assign({}, options);
     if (config.base === '.') {
         config.base = getScriptPath('jwplayer.js');
     }

--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -77,7 +77,10 @@ Object.assign(CoreShim.prototype, {
         Object.assign(this.mediaShim, INITIAL_MEDIA_STATE);
 
         // Assigning config properties to the model needs to be synchronous for chained get API methods
-        const configuration = Config(options, persisted);
+        const setupConfig = options;
+        const configuration = Config(Object.assign({}, options), persisted);
+        configuration.id = api.id;
+        configuration.setupConfig = setupConfig;
         Object.assign(model.attributes, configuration, INITIAL_PLAYER_STATE);
         model.getProviders = function() {
             return new Providers(configuration);

--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -78,8 +78,7 @@ Object.assign(CoreShim.prototype, {
 
         // Assigning config properties to the model needs to be synchronous for chained get API methods
         const configuration = Config(options, persisted);
-        const setupConfig = { setupConfig: Object.assign({}, options) };
-        Object.assign(model.attributes, configuration, INITIAL_PLAYER_STATE, setupConfig);
+        Object.assign(model.attributes, configuration, INITIAL_PLAYER_STATE);
         model.getProviders = function() {
             return new Providers(configuration);
         };

--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -78,7 +78,8 @@ Object.assign(CoreShim.prototype, {
 
         // Assigning config properties to the model needs to be synchronous for chained get API methods
         const configuration = Config(options, persisted);
-        Object.assign(model.attributes, configuration, INITIAL_PLAYER_STATE);
+        const setupConfig = { setupConfig: Object.assign({}, options) };
+        Object.assign(model.attributes, configuration, INITIAL_PLAYER_STATE, setupConfig);
         model.getProviders = function() {
             return new Providers(configuration);
         };

--- a/test/data/model-properties.js
+++ b/test/data/model-properties.js
@@ -100,5 +100,6 @@ export default {
     castAvailable: false,
     qualityLabels: undefined,
     itemReady: false,
-    liveTimeout: null
+    liveTimeout: null,
+    setupConfig: {},
 };


### PR DESCRIPTION
### This PR will...

Adds a property, "setupConfig", to the model, and exposes it in the jwplayer().getConfig() method. "setupConfig" holds an unmodified copy of the configuration provided in the setup() call.

### Why is this Pull Request needed?

The addition of the unmodified configuration object assists in debugging and troubleshooting for the TS teams.

### Are there any points in the code the reviewer needs to double check?

At the point in which I make a clone of the configuration, the "id" and "analytics" properties have been appended to the configuration object, regardless of whether these were explicitly defined in the setup() block.

Given that the intended use for this value is to receive the unmodified object, it is somewhat counter-intuitive, but I figured it would be less cumbersome to avoid any logic for removing these additional properties (especially given that analytics could be a user defined key/value pair). 

### Are there any Pull Requests open in other repos which need to be merged with this?

No.

#### Addresses Issue(s):

JW8-1223

