### PR TITLE
Recs Accessibility

### DIFF
--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -213,12 +213,15 @@ export default class Controls {
         }
 
         function onEscape() {
-            const related = api.getPlugin('related');
             if (model.get('fullscreen')) {
                 api.setFullscreen(false);
                 this.playerContainer.blur();
                 this.userInactive();
-            } else if (related) {
+                return;
+            }
+
+            const related = api.getPlugin('related');
+            if (related) {
                 related.close({ type: 'escape' });
             }
         }

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -212,6 +212,17 @@ export default class Controls {
             api.setVolume(newVol);
         }
 
+        function onEscape() {
+            const related = api.getPlugin('related');
+            if (model.get('fullscreen')) {
+                api.setFullscreen(false);
+                this.playerContainer.blur();
+                this.userInactive();
+            } else if (related) {
+                related.close({ type: 'escape' });
+            }
+        }
+
         const handleKeydown = (evt) => {
             // If Meta keys return
             if (evt.ctrlKey || evt.metaKey) {
@@ -221,14 +232,7 @@ export default class Controls {
 
             switch (evt.keyCode) {
                 case 27: // Esc
-                    const related = api.getPlugin('related');
-                    if (model.get('fullscreen')) {
-                        api.setFullscreen(false);
-                        this.playerContainer.blur();
-                        this.userInactive();
-                    } else if (related) {
-                        related.close({ type: 'escape' });
-                    }
+                    onEscape();
                     break;
                 case 13: // enter
                 case 32: // space

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -221,9 +221,14 @@ export default class Controls {
 
             switch (evt.keyCode) {
                 case 27: // Esc
-                    api.setFullscreen(false);
-                    this.playerContainer.blur();
-                    this.userInactive();
+                    const related = api.getPlugin('related');
+                    if (model.get('fullscreen')) {
+                        api.setFullscreen(false);
+                        this.playerContainer.blur();
+                        this.userInactive();
+                    } else if (related) {
+                        related.close({ type: 'escape' });
+                    }
                     break;
                 case 13: // enter
                 case 32: // space


### PR DESCRIPTION
### This PR will...

If the recs shelf or overlay is open when you hit escape it will close the overlay.

If the player is in fullscreen and recs is open, when you hit escape it will exit fullscreen and keep recs open. 

### Why is this Pull Request needed?

To add accessibility support to the recs shelf, and allow the shelf to be closed via the ESC key when you are focused on any part of the player.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-plugin-related/pull/260

#### Addresses Issue(s):

JW8-1068

