### PR TITLE
Stopped UCBrowser as being detected as Chrome

### DIFF
--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -32,7 +32,7 @@ export function isMSIE() {
 }
 
 export function isChrome() {
-    return userAgentMatch(/\s(?:Chrome|CriOS)\//i) && !isEdge();
+    return userAgentMatch(/\s(?:Chrome|CriOS)\//i) && !isEdge() && !userAgentMatch(/UCBrowser/i);
 }
 
 export function isIE() {


### PR DESCRIPTION
JW8-1256

### This PR will...

Exclude browsers with user-agent strings that include `UCBrowser` from being interpreted as Chrome in `getEnvironment()`.

### Why is this Pull Request needed?

This will allow publishers to work around features that are not supported in UC Browser but are in Chrome. It also should improve the chance that returning `true` for Chrome would be correct.

### Are there any points in the code the reviewer needs to double check?

n/a

### Are there any Pull Requests open in other repos which need to be merged with this?

n/a

#### Addresses Issue(s):

JW8-1256
GitHub - #2696 

