### PR TITLE
Improve mouse handling that shows and hides controls

### DIFF
--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -141,7 +141,7 @@ const UI = function (elem, options) {
     }
 
     function pointerOutHandler(evt) {
-        if (evt.pointerType !== 'touch') {
+        if (evt.pointerType !== 'touch' && 'x' in evt) {
             // elementFromPoint to handle an issue where setPointerCapture is causing a pointerout event
             const { x, y } = evt;
             const overElement = document.elementFromPoint(x, y);

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -4,6 +4,7 @@ import { dvrSeekLimit } from 'view/constants';
 import CustomButton from 'view/controls/components/custom-button';
 import utils from 'utils/helpers';
 import _ from 'utils/underscore';
+import { USER_ACTION } from 'events/events';
 import Events from 'utils/backbone.events';
 import UI from 'utils/ui';
 import ariaLabel from 'utils/aria';
@@ -319,7 +320,7 @@ export default class Controlbar {
 
         // When the control bar is interacted with, trigger a user action event
         new UI(this.el).on('click tap drag', function () {
-            this.trigger('userAction');
+            this.trigger(USER_ACTION);
         }, this);
         _.each(menus, function (ele) {
             ele.on('open-tooltip', this.closeMenus, this);

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -3,7 +3,7 @@ import { dvrSeekLimit } from 'view/constants';
 import { DISPLAY_CLICK, USER_ACTION, STATE_PAUSED, STATE_PLAYING, STATE_ERROR } from 'events/events';
 import Events from 'utils/backbone.events';
 import utils from 'utils/helpers';
-import { now } from 'utils/clock';
+import { now } from 'utils/date';
 import button from 'view/controls/components/button';
 import Controlbar from 'view/controls/controlbar';
 import DisplayContainer from 'view/controls/display-container';
@@ -413,7 +413,7 @@ export default class Controls {
     userInactive() {
         clearTimeout(this.activeTimeout);
         this.activeTimeout = -1;
-        const remainingTime = now() - this.inactiveTime;
+        const remainingTime = this.inactiveTime - now();
         if (this.inactiveTime && remainingTime > 16) {
             this.activeTimeout = setTimeout(() => this.userInactive(), remainingTime);
             return;

--- a/src/js/view/utils/clickhandler.js
+++ b/src/js/view/utils/clickhandler.js
@@ -18,9 +18,6 @@ export default class ClickHandler {
                     return;
                 }
                 this.trigger('doubleClick');
-            },
-            move: function() {
-                this.trigger('move');
             }
         }, this);
     }

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -402,11 +402,23 @@ function View(_api, _model) {
                     }
                 }
             },
-            doubleClick: () => _controls && api.setFullscreen(),
-            move: () => _controls && _controls.userActive()
+            doubleClick: () => _controls && api.setFullscreen()
         });
 
+        _playerElement.addEventListener('mousemove', moveHandler);
+        _playerElement.addEventListener('mouseout', outHandler);
+
         return clickHandler;
+    }
+
+    function moveHandler(event) {
+        _controls && _controls.mouseMove(event);
+    }
+
+    function outHandler(event) {
+        if (event.relatedTarget && !_playerElement.contains(event.relatedTarget)) {
+            _controls && _controls.userActive();
+        }
     }
 
     function onStretchChange(model, newVal) {
@@ -443,12 +455,6 @@ function View(_api, _model) {
         removeClass(_playerElement, 'jw-flag-controls-hidden');
 
         controls.enable(_api, _model);
-        controls.addActiveListeners(_logo.element());
-
-        const logoContainer = controls.logoContainer();
-        if (logoContainer) {
-            _logo.setContainer(logoContainer);
-        }
 
         // refresh breakpoint and timeslider classes
         if (_lastHeight) {
@@ -469,23 +475,12 @@ function View(_api, _model) {
         if (_model.get('instream')) {
             _controls.setupInstream();
         }
-
-        const overlaysElement = _playerElement.querySelector('.jw-overlays');
-        overlaysElement.addEventListener('mousemove', _userActivityCallback);
     };
 
     this.removeControls = function () {
-        _logo.setContainer(_playerElement);
-
         if (_controls) {
-            _controls.removeActiveListeners(_logo.element());
             _controls.disable(_model);
             _controls = null;
-        }
-
-        const overlay = document.querySelector('.jw-overlays');
-        if (overlay) {
-            overlay.removeEventListener('mousemove', _userActivityCallback);
         }
 
         addClass(_playerElement, 'jw-flag-controls-hidden');
@@ -619,10 +614,6 @@ function View(_api, _model) {
     function _setLiveMode(model, streamType) {
         const live = (streamType === 'LIVE');
         toggleClass(_playerElement, 'jw-flag-live', live);
-    }
-
-    function _userActivityCallback(/* event */) {
-        _controls.userActive();
     }
 
     function _onMediaTypeChange(model, val) {
@@ -809,6 +800,8 @@ function View(_api, _model) {
         }
         if (displayClickHandler) {
             displayClickHandler.destroy();
+            _playerElement.removeEventListener('mousemove', moveHandler);
+            _playerElement.removeEventListener('mouseout', outHandler);
             displayClickHandler = null;
         }
         _captionsRenderer.destroy();

--- a/test/unit/controls-test.js
+++ b/test/unit/controls-test.js
@@ -1,0 +1,37 @@
+import Controls from 'view/controls/controls';
+import sinon from 'sinon';
+
+describe('Controls', function() {
+
+    it('is a class', function() {
+        expect(Controls).to.be.a('function');
+        expect(Controls.constructor).to.be.a('function');
+    });
+
+    const controls = new Controls(document, document.createElement('div'));
+    controls.settingsMenu = {};
+
+    describe('userActive', function() {
+
+        afterEach(function() {
+            controls.off();
+        });
+
+        it('triggers a "userActive" event', function() {
+            const spy = sinon.spy();
+            controls.on('userActive', spy);
+            controls.showing = false;
+            controls.userActive(0);
+            expect(spy).to.have.callCount(1);
+        });
+
+        it('triggers a "userInactive" event', function() {
+            const spy = sinon.spy();
+            controls.on('userInactive', spy);
+            controls.userInactive();
+            expect(spy).to.have.callCount(1);
+        });
+    });
+
+
+});


### PR DESCRIPTION
### This PR will...

- Fix mouse out handling not hiding controls when mousing out from the bottom of the player (controlbar)
- Remove dead code for adding logo to controls (`controls.right` is always `null`)
- Use only two event listeners "mousemove" and "mouseout" on the player container
  - Removes "ActiveListeners" code that added event listeners to controlbar, logo and nextup
  - The out handler is only used when the mouse leaves the player container
  - The move handler doesn't create a timeout when the mouse is over controlbar, logo or nextup
  - Don't use `ClickHandler` or `UI` for these listeners - It adds overhead making it difficult to work directly with input events
- Simplify `controls.userActive` interface
  - Just pass in a timeout of `0` to prevent a user active timeout from being created 
- Prevent new timeouts from being started for every call to `controls.userActive` - since this is called on "mousemove", there are a lot of timeouts cleared and set that we can avoid.
- Add initial unit-tests for Controls

### Why is this Pull Request needed?

Fixes a regression in mouse out handling caused by removing the use of "mouseout". Without the `_playerElement.contains(event.relatedTarget)` filter on that event it fires even when mousing out of child player elements.

Reducing the number of input event handlers (ActiveListeners) helps improve UI responsiveness.

### Are there any points in the code the reviewer needs to double check?

- Cross-browser testing: mobile
- Could we use a `_.debounce` pattern the `controls.userActive` timeout?

#### Addresses Issue(s):

JW8-1182

