### PR TITLE
[JW8-1158 ADS-936] Sync sound settings.

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -434,6 +434,7 @@ Object.assign(Controller.prototype, {
                 // Only apply autostartMuted on un-muted autostart attempt.
                 if (_model.get('canAutoplay') === AUTOPLAY_MUTED && !_this.getMute()) {
                     _model.set('autostartMuted', true);
+                    updateProgramSoundSettings();
                 }
 
                 return _play({ reason: 'autostart' }).catch(() => {


### PR DESCRIPTION
### This PR will...
Fix a bug where the muted state didn't propagate properly. This caused issues (playback would not start, while it should've started muted) and test failures in Safari (desktop & iPad), Chrome (Android) and maybe others.

### Why is this Pull Request needed?
We need to call `updateProgramSoundSettings` to sync the mute state - through the programController's `mute` setter it will sync the muted state in the different media elements.

#### Addresses Issue(s):
JW8-1158
ADS-936