### PR TITLE
Bugfix: Mobile controls toggle regression

### DIFF
--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -60,6 +60,15 @@ export default class Controls {
         this.logo = null;
         this.div = null;
         this.dimensions = {};
+        this.userInactiveTimeout = () => {
+            // Rerun at the scheduled time if remaining time is greater than the display refresh rate
+            const remainingTime = this.inactiveTime - now();
+            if (this.inactiveTime && remainingTime > 16) {
+                this.activeTimeout = setTimeout(this.userInactiveTimeout, remainingTime);
+                return;
+            }
+            this.userInactive();
+        };
     }
 
     enable(api, model) {
@@ -396,7 +405,7 @@ export default class Controls {
         if (timeout > 0) {
             this.inactiveTime = now() + timeout;
             if (this.activeTimeout === -1) {
-                this.activeTimeout = setTimeout(() => this.userInactive(), timeout);
+                this.activeTimeout = setTimeout(this.userInactiveTimeout, timeout);
             }
         } else {
             clearTimeout(this.activeTimeout);
@@ -413,11 +422,6 @@ export default class Controls {
     userInactive() {
         clearTimeout(this.activeTimeout);
         this.activeTimeout = -1;
-        const remainingTime = this.inactiveTime - now();
-        if (this.inactiveTime && remainingTime > 16) {
-            this.activeTimeout = setTimeout(() => this.userInactive(), remainingTime);
-            return;
-        }
         if (this.settingsMenu.visible) {
             return;
         }

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -374,6 +374,7 @@ function View(_api, _model) {
                 }
             },
             tap: () => {
+                _playerElement.removeEventListener('mousemove', moveHandler);
                 _this.trigger(DISPLAY_CLICK);
                 if (settingsMenuVisible()) {
                     _controls.settingsMenu.close();

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -412,12 +412,14 @@ function View(_api, _model) {
     }
 
     function moveHandler(event) {
-        _controls && _controls.mouseMove(event);
+        if (_controls) {
+            _controls.mouseMove(event);
+        }
     }
 
     function outHandler(event) {
-        if (event.relatedTarget && !_playerElement.contains(event.relatedTarget)) {
-            _controls && _controls.userActive();
+        if (_controls && event.relatedTarget && !_playerElement.contains(event.relatedTarget)) {
+            _controls.userActive();
         }
     }
 


### PR DESCRIPTION
### This PR will...

Fix a regressions with toggling controls on tap caused by https://github.com/jwplayer/jwplayer/pull/2748

- Create a single delegate for `userInactiveTimeout` for each Controls instance
- Remove "mousemove" listener when "tap" events are received

### Why is this Pull Request needed?

Having a single delegate for `userInactiveTimeout` allows `userInactive` to always hide controls immediately when called, like it did before, without interference from debounced timeout logic.

"mousemove" events trigger user activity, which we do not want on devices with tap input. Removing the "mousemove" listener on "tap" allows us to support both modes of controls toggling without performing a user-agent check or using UI.js to forward "move" events.

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer/pull/2752/files

#### Addresses Issue(s):

JW8-1182

