### PR TITLE
[JW8-1288] Reset autostart cancelable on pause.

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -486,6 +486,7 @@ Object.assign(Controller.prototype, {
         function _pause(meta) {
             _actionOnAttach = null;
             checkAutoStartCancelable.cancel();
+            checkAutoStartCancelable = cancelable(_checkAutoStart);
 
             const pauseReason = _getReason(meta);
             _model.set('pauseReason', pauseReason);


### PR DESCRIPTION
### This PR will...
Reset the autostart cancelable on pause.

### Why is this Pull Request needed?
~~On mobile, if the element is not viewable (i.e. added to the DOM only after ready), we currently autopause the video, which cancels the autostart check. Once the element becomes viewable (i.e. is added to the DOM), however, we now want to perform the canAutoplay test - but because the autostart was cancelled earlier, this will fail. By resetting the autostart cancelable, the test always uses the latest cancelable, which will work as expected.~~

Resets cancelable before every test instead instead of on pause. In addition, moved the `autostartMuted` change listener to after we set it for the first time. Finally, once a user clicks-to-play, we never autostart/pause on viewable change (similar to click-to-pause behavior).

### Are there any points in the code the reviewer needs to double check?
~~Alternatively, I looked into only calling _pause is the element is not currently idle - however this is a bit more complicated as there are other non-playing states (e.g. buffering / error). This seems to be the cleaner solution.~~

#### Addresses Issue(s):
JW8-1288
