### PR TITLE
Replace jQuery hasClass implementation with classList.contains

### DIFF
--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -1,12 +1,8 @@
 import { trim } from 'utils/strings';
 import _ from 'utils/underscore';
 
-// hasClass uses code from jQuery
-// jQuery v1.11.2 | (c) 2005, 2014 jQuery Foundation, Inc. | Released under the MIT license | jquery.org/license
 export function hasClass(element, searchClass) {
-    const className = ' ' + searchClass + ' ';
-    return (element.nodeType === 1 && (' ' + element.className + ' ')
-        .replace(/[\t\r\n\f]/g, ' ').indexOf(className) >= 0);
+    return element.classList.contains(searchClass);
 }
 
 // Given a string, convert to element and return


### PR DESCRIPTION
Use the native `classList.contains` method supported in IE10 and up. 

### Why is this Pull Request needed?

Remove the need to attribute jQuery in our source.
