### PR TITLE
[JW8-1290] Display autostart unmute button only on touch.

### DIFF
--- a/src/css/controls/flags/user-inactive.less
+++ b/src/css/controls/flags/user-inactive.less
@@ -40,6 +40,6 @@
     }
 }
 
-.jw-state-playing.jw-flag-user-inactive .jw-autostart-mute {
+.jw-state-playing.jw-flag-touch.jw-flag-user-inactive .jw-autostart-mute {
     display: flex;
 }


### PR DESCRIPTION
### This PR will...
Hide the autostart unmute button on desktop and only show if the player has `jw-flag-touch`.

### Why is this Pull Request needed?
The autostart unmute button cannot be interacted with on desktop, as hovering it will display the full controlbar instead.

### Are there any points in the code the reviewer needs to double check?
Alternatively, we can move the `OS.mobile` check to inside `setupUnmuteAutoplayButton` in `controls.js` to not render the button in the first place. But, looking at how we general do things, we simply hide the button using CSS.

#### Addresses Issue(s):
JW8-1290