### PR TITLE
Disable Airplay for Playlists with Dash

### DIFF
--- a/src/js/providers/providers-supported.js
+++ b/src/js/providers/providers-supported.js
@@ -25,35 +25,39 @@ const MimeTypes = {
 const SupportsMatrix = [
     {
         name: 'html5',
-        supports: function (source) {
-            if (isAndroidHls(source) === false) {
-                return false;
-            }
-
-            if (!video.canPlayType) {
-                return false;
-            }
-
-            const file = source.file;
-            const type = source.type;
-
-            // Ensure RTMP files are not seen as videos
-            if (isRtmp(file, type)) {
-                return false;
-            }
-
-            const mimeType = source.mimeType || MimeTypes[type];
-
-            // Not OK to use HTML5 with no extension
-            if (!mimeType) {
-                return false;
-            }
-
-            // Last, but not least, we ask the browser
-            // (But only if it's a video with an extension known to work in HTML5)
-            return !!video.canPlayType(mimeType);
-        }
+        supports: supportsType
     }
 ];
+
+export function supportsType(source) {
+    {
+        if (isAndroidHls(source) === false) {
+            return false;
+        }
+
+        if (!video.canPlayType) {
+            return false;
+        }
+
+        const file = source.file;
+        const type = source.type;
+
+        // Ensure RTMP files are not seen as videos
+        if (isRtmp(file, type)) {
+            return false;
+        }
+
+        const mimeType = source.mimeType || MimeTypes[type];
+
+        // Not OK to use HTML5 with no extension
+        if (!mimeType) {
+            return false;
+        }
+
+        // Last, but not least, we ask the browser
+        // (But only if it's a video with an extension known to work in HTML5)
+        return !!video.canPlayType(mimeType);
+    }
+}
 
 export default SupportsMatrix;


### PR DESCRIPTION
### This PR will...

Expose the html5 supports methods so it can be accessible by the commercial controller

### Why is this Pull Request needed?

Since airplay is not supported by shaka, attempts to play a dash stream when airplay is enabled will cause the player to fail and produce video error code 4 `'File could not be played'`. 

`supportsType` is used to check if the playlist has any unsupported items, which will trigger airplay to be disabled.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-commercial/pull/4835

#### Addresses Issue(s):

JW8-1282

