### PR TITLE
[JW8-1290] Display autostart unmute button only on touch.

### DIFF
--- a/src/css/controls/flags/ads.less
+++ b/src/css/controls/flags/ads.less
@@ -5,7 +5,6 @@
     .jw-logo,
     .jw-captions.jw-captions-enabled,
     .jw-nextup-container,
-    .jw-autostart-mute,
     .jw-text-duration,
     .jw-text-elapsed {
         display: none;

--- a/src/css/controls/flags/media-audio.less
+++ b/src/css/controls/flags/media-audio.less
@@ -1,10 +1,3 @@
-.jwplayer.jw-flag-media-audio {
-    // Hide autostart mute button
-    .jw-autostart-mute {
-        display: none;
-    }
-}
-
 .jw-flag-media-audio {
     .jw-preview {
         display: block;

--- a/src/css/controls/flags/user-inactive.less
+++ b/src/css/controls/flags/user-inactive.less
@@ -25,6 +25,12 @@
                 display: table;
             }
         }
+
+        &:not(.jw-flag-ads) {
+            .jw-autostart-mute {
+                display: flex;
+            }
+        }
     }
 
     &.jw-flag-casting {
@@ -36,12 +42,6 @@
             .jw-nextup-container {
                 display: none;
             }
-        }
-    }
-
-    &.jw-flag-touch:not(.jw-flag-ads) {
-        .jw-autostart-mute {
-            display: flex;
         }
     }
 }

--- a/src/css/controls/flags/user-inactive.less
+++ b/src/css/controls/flags/user-inactive.less
@@ -40,6 +40,6 @@
     }
 }
 
-.jw-state-playing.jw-flag-user-inactive .jw-autostart-mute {
+.jw-state-playing.jw-flag-touch.jw-flag-user-inactive .jw-autostart-mute {
     display: flex;
 }

--- a/src/css/controls/flags/user-inactive.less
+++ b/src/css/controls/flags/user-inactive.less
@@ -38,8 +38,10 @@
             }
         }
     }
-}
 
-.jw-state-playing.jw-flag-touch.jw-flag-user-inactive .jw-autostart-mute {
-    display: flex;
+    &.jw-flag-touch:not(.jw-flag-ads) {
+        .jw-autostart-mute {
+            display: flex;
+        }
+    }
 }

--- a/src/css/controls/states.less
+++ b/src/css/controls/states.less
@@ -79,13 +79,6 @@
 }
 
 // paused
-.jwplayer.jw-state-paused {
-    // Hide autostart mute button when paused by the browser
-    .jw-autostart-mute {
-        display: none;
-    }
-}
-
 .jwplayer.jw-state-paused,
 .jwplayer.jw-state-idle,
 .jwplayer.jw-state-error,

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -169,14 +169,19 @@ export default class Controls {
             this.div.insertBefore(settingsMenu.element(), controlbar.element());
         }
 
-        // Unmute Autoplay Button.
-        const setupUnmuteAutoplayButton = (_model) => {
+        // Unmute Autoplay behavior.
+        const setupUnmuteAutoplay = (_model) => {
             if (_model.get('autostartMuted')) {
                 const unmuteCallback = () => this.unmuteAutoplay(api, _model);
-                this.mute = button('jw-autostart-mute jw-off', unmuteCallback, _model.get('localization').unmute,
-                    [cloneIcon('volume-0')]);
-                this.mute.show();
-                this.div.appendChild(this.mute.element());
+
+                // Show unmute botton only on mobile.
+                if (OS.mobile) {
+                    this.mute = button('jw-autostart-mute jw-off', unmuteCallback, _model.get('localization').unmute,
+                        [cloneIcon('volume-0')]);
+                    this.mute.show();
+                    this.div.appendChild(this.mute.element());
+                }
+
                 // Set mute state in the controlbar
                 controlbar.renderVolume(true, _model.get('volume'));
                 // Hide the controlbar until the autostart flag is removed
@@ -186,8 +191,8 @@ export default class Controls {
                 this.unmuteCallback = unmuteCallback;
             }
         };
-        model.once('change:autostartMuted', setupUnmuteAutoplayButton);
-        setupUnmuteAutoplayButton(model);
+        model.once('change:autostartMuted', setupUnmuteAutoplay);
+        setupUnmuteAutoplay(model);
 
         // Keyboard Commands
         function adjustSeek(amount) {


### PR DESCRIPTION
### This PR will...
Hide the autostart unmute button on desktop and only show if the player has `jw-flag-touch`.

### Why is this Pull Request needed?
The autostart unmute button cannot be interacted with on desktop, as hovering it will display the full controlbar instead.

### Are there any points in the code the reviewer needs to double check?
Alternatively, we can move the `OS.mobile` check to inside `setupUnmuteAutoplayButton` in `controls.js` to not render the button in the first place. But, looking at how we general do things, we simply hide the button using CSS.

#### Addresses Issue(s):
JW8-1290