### PR TITLE
Fix pause event after restoring background loaded media 

### DIFF
--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -259,6 +259,10 @@ class ProgramController extends Eventable {
             return;
         }
         if (backgroundMedia) {
+            // Set the state to buffering before attaching so that we don't resume in the "paused" state
+            // If the mediaController enters the foreground quickly enough (within one animation frame), no buffering
+            // wheel will be shown
+            backgroundMedia.mediaModel.attributes.mediaState = 'buffering';
             this._setActiveMedia(backgroundMedia);
             backgroundMedia.background = false;
             this.backgroundMedia = null;


### PR DESCRIPTION
### This PR will...
Set the background mediaModel's mediaState to buffering before restoring it to the foreground

### Why is this Pull Request needed?
To prevent a pause event from firing when foregrounding. Before the mediaController enters the background, we pause it (and this it's mediaState is `paused`). On restoration we sync the mediaModel's `mediaState` with the playerModel's; this results in a second `pause` event firing. By setting it to buffering we avoid this and also truthfully reflect the player's state (restoring to the foreground is considered buffering). If the restoration is quick enough no buffering wheel will show at all.

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-1237

