### PR TITLE
Show controls on iFrame mouseover. Do not show on mouseout.

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -407,6 +407,7 @@ function View(_api, _model) {
         });
 
         _playerElement.addEventListener('mousemove', moveHandler);
+        _playerElement.addEventListener('mouseover', overHandler);
         _playerElement.addEventListener('mouseout', outHandler);
 
         return clickHandler;
@@ -418,8 +419,14 @@ function View(_api, _model) {
         }
     }
 
+    function overHandler(event) {
+        if (_controls && !_controls.showing && event.target.nodeName === 'IFRAME') {
+            _controls.userActive();
+        }
+    }
+
     function outHandler(event) {
-        if (_controls && event.relatedTarget && !_playerElement.contains(event.relatedTarget)) {
+        if (_controls && _controls.showing && event.relatedTarget && !_playerElement.contains(event.relatedTarget)) {
             _controls.userActive();
         }
     }
@@ -805,6 +812,7 @@ function View(_api, _model) {
             displayClickHandler.destroy();
             _playerElement.removeEventListener('mousemove', moveHandler);
             _playerElement.removeEventListener('mouseout', outHandler);
+            _playerElement.removeEventListener('mouseover', overHandler);
             displayClickHandler = null;
         }
         _captionsRenderer.destroy();

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -375,6 +375,8 @@ function View(_api, _model) {
             },
             tap: () => {
                 _playerElement.removeEventListener('mousemove', moveHandler);
+                _playerElement.removeEventListener('mouseout', outHandler);
+                _playerElement.removeEventListener('mouseover', overHandler);
                 _this.trigger(DISPLAY_CLICK);
                 if (settingsMenuVisible()) {
                     _controls.settingsMenu.close();


### PR DESCRIPTION
### This PR will...

Show controls on iFrame mouseover. Do not show on mouseout.

### Why is this Pull Request needed?

iFrames swallow all mouse events except for "mouseover". We use to show controls when hovering over a VPAID ad so this `overHandler` change restores that behavior.

The "mouseout" handler ensures that controls fade out after 2 seconds when mousing out of the controlbar. If controls are already hidden, then the "mouseout" handler `outHandler` should not show controls.

Remove all mouse event listeners on first tap. This prevents the mouse events from interfering with touch controls and improves performance on mobile devices.

#### Addresses Issue(s):

JW8-1308

