### PR TITLE
Background load nextUp item in recs-auto mode

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -164,13 +164,16 @@ Object.assign(Controller.prototype, {
                 model.setStreamType(type);
             });
 
+            const recsAuto = (model.get('related') || {}).oncomplete === 'autoplay';
             const index = model.get('item') + 1;
-            const item = model.get('playlist')[index];
-            if (Features.backgroundLoading && item) {
+            let item = model.get('playlist')[index];
+            if ((item || recsAuto) && Features.backgroundLoading) {
                 const onPosition = (changedMediaModel, position) => {
-                    if (position >= mediaModel.get('duration') - BACKGROUND_LOAD_OFFSET) {
+                    if (item && position >= mediaModel.get('duration') - BACKGROUND_LOAD_OFFSET) {
                         mediaModel.off('change:position', onPosition, this);
                         _programController.backgroundLoad(item);
+                    } else if (recsAuto) {
+                        item = _model.get('nextUp');
                     }
                 };
                 mediaModel.on('change:position', onPosition, this);

--- a/src/js/program/background-media.js
+++ b/src/js/program/background-media.js
@@ -20,15 +20,13 @@ export default function BackgroundMedia() {
         setNext(item, loadPromise) {
             nextMedia = { item, loadPromise };
         },
+        isNext(item) {
+            return !!(nextMedia && JSON.stringify(nextMedia.item.sources[0]) === JSON.stringify(item.sources[0]));
+        },
         clearNext() {
             nextMedia = null;
         }
     }, {
-        nextItem: {
-            get() {
-                return nextMedia ? nextMedia.item : null;
-            }
-        },
         nextLoadPromise: {
             get() {
                 return nextMedia ? nextMedia.loadPromise : null;

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -54,7 +54,7 @@ class ProgramController extends Eventable {
         }
 
         // Activate the background media if it's loading the item we want to play
-        if (background.nextItem === item) {
+        if (background.isNext(item)) {
             // First destroy the active item so that the BGL provider can enter the foreground
             this._destroyActiveMedia();
             // Attach the BGL provider into the load/play chain


### PR DESCRIPTION
### This PR will...

Background load the next up item from related when the player and plugin are in "Recs Auto" mode.

### Why is this Pull Request needed?

So that autoplayed recommendations are preloaded and start playing fast.

### Things to consider

This change does a deep equals using `JSON.stringify` to compare item sources. The nextUp item will never `===` the playlist item after related replaces the playlist with `jwplayer().load()`. The load methods's input is always processed item by item with new objects created using the `Item` and `Source` modules.

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-commercial/pull/4890

#### Addresses Issue(s):

JW8-32

