### PR TITLE
Call controller.play in _seek so that it is queued until playback begins

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -553,7 +553,7 @@ Object.assign(Controller.prototype, {
             }
             _programController.position = pos;
             if (!_model.get('scrubbing') && _model.get('state') !== STATE_PLAYING) {
-                _play(meta);
+                this.play(meta);
             }
         }
 


### PR DESCRIPTION
### Why is this Pull Request needed?
So that if we call play during the seek call, that play call is queued in the `ApiQueue`. The reason it was not queued before is that only the prototype `this.play` method is captured by the queueing function.

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-1302 JW8-1303

