### PR TITLE
Variant Idle Display Icons

### DIFF
--- a/src/css/controls.less
+++ b/src/css/controls.less
@@ -12,6 +12,7 @@
 @import "controls/imports/nextup";
 @import "controls/imports/autostartmute";
 @import "controls/imports/settings-menu";
+@import "controls/imports/idle-variants";
 
 // State specific
 @import "controls/states";

--- a/src/css/controls/imports/idle-variants.less
+++ b/src/css/controls/imports/idle-variants.less
@@ -1,0 +1,40 @@
+@import (reference) "../../shared-imports/vars";
+
+.jw-state-idle {
+    .jw-icon-display[class*="jw-ab-idle"] {
+        color: @white;
+        border-radius: 50%;
+        transition: background-color 150ms ease-in-out;
+        transition-property: background-color, filter;
+
+        .jw-svg-icon-play {
+            transform: scale(0.7, 0.7);
+        }
+
+        &.jw-ab-idle-stroke {
+            box-shadow: inset 0 0 0 3px currentColor;
+
+            &:hover {
+                background-color: fade(@white, 50%);
+            }
+
+            &,
+            & .jw-svg-icon-play {
+                filter: drop-shadow(1px 1px 2px rgba(0, 0, 0, 0.4));
+            }
+        }
+
+        &.jw-ab-idle-fill {
+            filter: drop-shadow(0 0 10px rgba(0, 0, 0, 0.4));
+            background-color: fade(@black, 30%);
+
+            .jw-svg-icon-play {
+                filter: drop-shadow(0 0 2px rgba(12, 26, 71, 0.2));
+            }
+
+            &:hover {
+                background-color: fade(@black, 70%);
+            }
+        }
+    }
+}

--- a/src/css/controls/imports/idle-variants.less
+++ b/src/css/controls/imports/idle-variants.less
@@ -1,14 +1,16 @@
 @import "../../shared-imports/vars";
 
 .jw-state-idle {
-    .jw-icon-display[class*="jw-ab-idle"] {
-        color: @white;
-        border-radius: 50%;
-        transition: background-color 150ms ease-in-out;
-        transition-property: background-color, filter;
+    .jw-icon-display {
+        &[class*="jw-ab-idle"] {
+            border-radius: 50%;
+            color: @white;
+            transition: background-color @default-transition;
+            transition-property: background-color, filter;
 
-        .jw-svg-icon-play {
-            transform: scale(0.7, 0.7);
+            .jw-svg-icon-play {
+                transform: scale(0.7, 0.7);
+            }
         }
 
         &.jw-ab-idle-stroke {
@@ -20,12 +22,12 @@
 
             &,
             & .jw-svg-icon-play {
-                filter: drop-shadow(1px 1px 2px rgba(0, 0, 0, 0.4));
+                filter: drop-shadow(1px 1px 2px fade(@black, 40%));
             }
         }
 
         &.jw-ab-idle-fill {
-            filter: drop-shadow(0 0 10px rgba(0, 0, 0, 0.4));
+            filter: drop-shadow(0 0 10px fade(@black, 40%));
             background-color: fade(@black, 30%);
 
             .jw-svg-icon-play {
@@ -38,3 +40,4 @@
         }
     }
 }
+

--- a/src/css/controls/imports/idle-variants.less
+++ b/src/css/controls/imports/idle-variants.less
@@ -1,4 +1,4 @@
-@import (reference) "../../shared-imports/vars";
+@import "../../shared-imports/vars";
 
 .jw-state-idle {
     .jw-icon-display[class*="jw-ab-idle"] {

--- a/src/js/view/controls/play-display-icon.js
+++ b/src/js/view/controls/play-display-icon.js
@@ -1,5 +1,6 @@
 import Events from 'utils/backbone.events';
 import UI from 'utils/ui';
+import { addClass, removeClass } from 'utils/dom';
 
 export default class PlayDisplayIcon {
     constructor(_model, api, element) {
@@ -7,6 +8,7 @@ export default class PlayDisplayIcon {
 
         const localization = _model.get('localization');
         const iconDisplay = element.getElementsByClassName('jw-icon-display')[0];
+        const idleClass = _model.get('idleClass');
         element.style.cursor = 'pointer';
         this.icon = iconDisplay;
         this.el = element;
@@ -15,34 +17,53 @@ export default class PlayDisplayIcon {
             this.trigger(evt.type);
         });
 
-        _model.on('change:state', (model, newstate) => {
-            let newstateLabel;
-            switch (newstate) {
+        _model.on('change:state', (model, newState, oldState) => {
+            let newStateLabel;
+            switch (newState) {
                 case 'buffering':
-                    newstateLabel = localization.buffer;
+                    newStateLabel = localization.buffer;
                     break;
                 case 'playing':
-                    newstateLabel = localization.pause;
+                    newStateLabel = localization.pause;
                     break;
                 case 'paused':
-                    newstateLabel = localization.playback;
+                    newStateLabel = localization.playback;
                     break;
                 case 'complete':
-                    newstateLabel = localization.replay;
+                    newStateLabel = localization.replay;
+                    break;
+                case 'idle':
+                    newStateLabel = localization.playback;
                     break;
                 default:
-                    newstateLabel = '';
+                    newStateLabel = '';
                     break;
             }
-            if (newstateLabel === '') {
+            if (newStateLabel === '') {
                 iconDisplay.removeAttribute('aria-label');
             } else {
-                iconDisplay.setAttribute('aria-label', newstateLabel);
+                iconDisplay.setAttribute('aria-label', newStateLabel);
             }
+
+            this.toggleIdleClass(oldState, newState, idleClass);
         });
+
+        this.toggleIdleClass('', 'idle', idleClass);
     }
 
     element() {
         return this.el;
     }
+
+    toggleIdleClass(oldState, newState, idleClass) {
+        if (idleClass !== 'stroke' && idleClass !== 'fill') {
+            return;
+        }
+
+        if (oldState === 'idle') {
+            removeClass(this.icon, 'jw-ab-idle-' + idleClass);
+        } else if (newState === 'idle') {
+            addClass(this.icon, 'jw-ab-idle-' + idleClass);
+        }
+    };
 }

--- a/src/js/view/controls/play-display-icon.js
+++ b/src/js/view/controls/play-display-icon.js
@@ -26,23 +26,21 @@ export default class PlayDisplayIcon {
                 case 'playing':
                     newStateLabel = localization.pause;
                     break;
+                case 'idle':
                 case 'paused':
                     newStateLabel = localization.playback;
                     break;
                 case 'complete':
                     newStateLabel = localization.replay;
                     break;
-                case 'idle':
-                    newStateLabel = localization.playback;
-                    break;
                 default:
                     newStateLabel = '';
                     break;
             }
-            if (newStateLabel === '') {
-                iconDisplay.removeAttribute('aria-label');
-            } else {
+            if (newStateLabel !== '') {
                 iconDisplay.setAttribute('aria-label', newStateLabel);
+            } else {
+                iconDisplay.removeAttribute('aria-label');
             }
 
             this.toggleIdleClass(oldState, newState, idleButton);
@@ -56,7 +54,7 @@ export default class PlayDisplayIcon {
     }
 
     toggleIdleClass(oldState, newState, idleButton) {
-        if (idleButton !== 'stroke' && idleButton !== 'fill') {
+        if (!(idleButton === 'stroke' || idleButton === 'fill')) {
             return;
         }
 

--- a/src/js/view/controls/play-display-icon.js
+++ b/src/js/view/controls/play-display-icon.js
@@ -65,5 +65,5 @@ export default class PlayDisplayIcon {
         } else if (newState === 'idle') {
             addClass(this.icon, 'jw-ab-idle-' + idleClass);
         }
-    };
+    }
 }

--- a/src/js/view/controls/play-display-icon.js
+++ b/src/js/view/controls/play-display-icon.js
@@ -8,7 +8,7 @@ export default class PlayDisplayIcon {
 
         const localization = _model.get('localization');
         const iconDisplay = element.getElementsByClassName('jw-icon-display')[0];
-        const idleClass = _model.get('idleClass');
+        const idleButton = _model.get('idleButton');
         element.style.cursor = 'pointer';
         this.icon = iconDisplay;
         this.el = element;
@@ -45,25 +45,25 @@ export default class PlayDisplayIcon {
                 iconDisplay.setAttribute('aria-label', newStateLabel);
             }
 
-            this.toggleIdleClass(oldState, newState, idleClass);
+            this.toggleIdleClass(oldState, newState, idleButton);
         });
 
-        this.toggleIdleClass('', 'idle', idleClass);
+        this.toggleIdleClass('', 'idle', idleButton);
     }
 
     element() {
         return this.el;
     }
 
-    toggleIdleClass(oldState, newState, idleClass) {
-        if (idleClass !== 'stroke' && idleClass !== 'fill') {
+    toggleIdleClass(oldState, newState, idleButton) {
+        if (idleButton !== 'stroke' && idleButton !== 'fill') {
             return;
         }
 
         if (oldState === 'idle') {
-            removeClass(this.icon, 'jw-ab-idle-' + idleClass);
+            removeClass(this.icon, 'jw-ab-idle-' + idleButton);
         } else if (newState === 'idle') {
-            addClass(this.icon, 'jw-ab-idle-' + idleClass);
+            addClass(this.icon, 'jw-ab-idle-' + idleButton);
         }
     }
 }

--- a/test/unit/play-display-icon-test.js
+++ b/test/unit/play-display-icon-test.js
@@ -1,0 +1,123 @@
+import PlayDisplayIcon from 'view/controls/play-display-icon';
+import SimpleModel from 'model/simplemodel';
+
+describe('PlayDisplayIcon', function() {
+    let model;
+    let displayIcon;
+    let element;
+    let icon;
+    const localization = {
+        playback: 'Start Playback',
+        replay: 'Replay',
+        pause: 'Pause',
+        buffer: 'Buffering'
+    };
+
+    beforeEach(function() {
+        model = Object.assign({}, SimpleModel);
+        model.set('localization', localization);
+        icon = document.createElement('div');
+        icon.className = 'jw-icon-display';
+        element = document.createElement('div');
+        element.appendChild(icon);
+    });
+
+    describe('on init', function() {
+
+        it('should not add class if config is not set', function() {
+            displayIcon = new PlayDisplayIcon(model, {}, element);
+
+            expect(icon.className).to.not.include('jw-ab-idle-');
+        });
+
+        it('should not add class if config is default', function() {
+            model.set('idleClass', 'default');
+
+            displayIcon = new PlayDisplayIcon(model, {}, element);
+
+            expect(icon.className).to.not.include('jw-ab-idle-');
+        });
+
+        it('should not add class if config is invalid', function() {
+            model.set('idleClass', 'invalid');
+
+            displayIcon = new PlayDisplayIcon(model, {}, element);
+
+            expect(icon.className).to.not.include('jw-ab-idle-');
+        });
+
+        it('should add class if config is stroke', function() {
+            model.set('idleClass', 'stroke');
+
+            displayIcon = new PlayDisplayIcon(model, {}, element);
+
+            expect(icon.className).to.include('jw-ab-idle-stroke');
+        });
+
+        it('should add class if config is fill', function() {
+            model.set('idleClass', 'fill');
+
+            displayIcon = new PlayDisplayIcon(model, {}, element);
+
+            expect(icon.className).to.include('jw-ab-idle-fill');
+        });
+    });
+
+    describe('on state change', function() {
+
+        it('should add class if new state is idle (stop playback)', function() {
+            model.set('state', 'playing');
+            model.set('idleClass', 'stroke');
+
+            displayIcon = new PlayDisplayIcon(model, {}, element);
+
+            model.set('state', 'idle');
+
+            expect(icon.className).to.include('jw-ab-idle-stroke');
+        });
+
+        it('should remove class if old state is idle (start playback)', function() {
+            model.set('state', 'idle');
+            model.set('idleClass', 'stroke');
+
+            displayIcon = new PlayDisplayIcon(model, {}, element);
+
+            model.set('state', 'playing');
+
+            expect(icon.className).to.not.include('jw-ab-idle-stroke');
+        });
+
+        it('should add playback aria label if new state is idle (stop playback)', function() {
+            displayIcon = new PlayDisplayIcon(model, {}, element);
+
+            model.set('state', 'idle');
+
+            expect(icon.getAttribute('aria-label')).to.equal(localization.playback);
+        });
+
+        it('should add pause aria label if old state is idle (start playback)', function() {
+            displayIcon = new PlayDisplayIcon(model, {}, element);
+
+            model.set('state', 'playing');
+
+            expect(icon.getAttribute('aria-label')).to.equal(localization.pause);
+        });
+
+        it('should remove aria label if new state label is empty', function() {
+            localization.replay = '';
+            displayIcon = new PlayDisplayIcon(model, {}, element);
+
+            model.set('state', 'complete');
+
+            expect(icon.getAttribute('aria-label')).to.equal(null);
+        });
+
+        it('should remove aria label if new state is invalid', function() {
+            displayIcon = new PlayDisplayIcon(model, {}, element);
+
+            model.set('state', 'invalid');
+
+            expect(icon.getAttribute('aria-label')).to.equal(null);
+        });
+    });
+});

--- a/test/unit/play-display-icon-test.js
+++ b/test/unit/play-display-icon-test.js
@@ -31,7 +31,7 @@ describe('PlayDisplayIcon', function() {
         });
 
         it('should not add class if config is default', function() {
-            model.set('idleClass', 'default');
+            model.set('idleButton', 'default');
 
             displayIcon = new PlayDisplayIcon(model, {}, element);
 
@@ -39,7 +39,7 @@ describe('PlayDisplayIcon', function() {
         });
 
         it('should not add class if config is invalid', function() {
-            model.set('idleClass', 'invalid');
+            model.set('idleButton', 'invalid');
 
             displayIcon = new PlayDisplayIcon(model, {}, element);
 
@@ -47,7 +47,7 @@ describe('PlayDisplayIcon', function() {
         });
 
         it('should add class if config is stroke', function() {
-            model.set('idleClass', 'stroke');
+            model.set('idleButton', 'stroke');
 
             displayIcon = new PlayDisplayIcon(model, {}, element);
 
@@ -55,7 +55,7 @@ describe('PlayDisplayIcon', function() {
         });
 
         it('should add class if config is fill', function() {
-            model.set('idleClass', 'fill');
+            model.set('idleButton', 'fill');
 
             displayIcon = new PlayDisplayIcon(model, {}, element);
 
@@ -67,7 +67,7 @@ describe('PlayDisplayIcon', function() {
 
         it('should add class if new state is idle (stop playback)', function() {
             model.set('state', 'playing');
-            model.set('idleClass', 'stroke');
+            model.set('idleButton', 'stroke');
 
             displayIcon = new PlayDisplayIcon(model, {}, element);
 
@@ -78,7 +78,7 @@ describe('PlayDisplayIcon', function() {
 
         it('should remove class if old state is idle (start playback)', function() {
             model.set('state', 'idle');
-            model.set('idleClass', 'stroke');
+            model.set('idleButton', 'stroke');
 
             displayIcon = new PlayDisplayIcon(model, {}, element);
 


### PR DESCRIPTION
### This PR will...

Introduce two variants of the idle display icon:
- Play button with a stroke around it
- Play button with a semi-transparent dark grey background

### Why is this Pull Request needed?

To test if different display icons will bring more attention to the play button in the idle state

### Are there any points in the code the reviewer needs to double check?

https://github.com/jwplayer/borg/pull/146/files

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-1268

