### PR TITLE
Fix background load exceptions crashing playback, background loading of bad nextUp items

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -3,7 +3,7 @@ import { showView } from 'api/core-shim';
 import setConfig from 'api/set-config';
 import ApiQueueDecorator from 'api/api-queue';
 import PlaylistLoader from 'playlist/loader';
-import Playlist, { filterPlaylist, validatePlaylist } from 'playlist/playlist';
+import Playlist, { filterPlaylist, validatePlaylist, fixSources } from 'playlist/playlist';
 import InstreamAdapter from 'controller/instream-adapter';
 import Captions from 'controller/captions';
 import Model from 'controller/model';
@@ -26,6 +26,7 @@ import { PLAYER_STATE, STATE_BUFFERING, STATE_IDLE, STATE_COMPLETE, STATE_PAUSED
 import ProgramController from 'program/program-controller';
 import initQoe from 'controller/qoe';
 import { BACKGROUND_LOAD_OFFSET } from '../program/program-constants';
+import Item from 'playlist/item';
 
 // The model stores a different state than the provider
 function normalizeState(newstate) {
@@ -198,7 +199,10 @@ Object.assign(Controller.prototype, {
             const related = _api.getPlugin('related');
             if (related) {
                 related.on('nextUp', (nextUp) => {
-                    _model.set('nextUp', nextUp);
+                    // Format the item from the nextUp feed into a valid PlaylistItem
+                    const item = Item(nextUp);
+                    item.sources = fixSources(item, _model);
+                    _model.set('nextUp', item);
                 });
             }
 

--- a/src/js/playlist/playlist.js
+++ b/src/js/playlist/playlist.js
@@ -47,9 +47,10 @@ export function validatePlaylist(playlist) {
         throw new Error('No playable sources found');
     }
 }
+export const fixSources = (item, model) => filterSources(formatSources(item, model), model.getProviders());
 
 function formatSources(item, model) {
-    const sources = item.sources;
+    const sources = item.sources || [];
     const androidhls = model.get('androidhls');
     const safariHlsjs = model.get('safarihlsjs');
     const itemDrm = item.drm || model.get('drm');

--- a/src/js/playlist/playlist.js
+++ b/src/js/playlist/playlist.js
@@ -50,7 +50,7 @@ export function validatePlaylist(playlist) {
 export const fixSources = (item, model) => filterSources(formatSources(item, model), model.getProviders());
 
 function formatSources(item, model) {
-    const sources = item.sources || [];
+    const sources = item.sources;
     const androidhls = model.get('androidhls');
     const safariHlsjs = model.get('safarihlsjs');
     const itemDrm = item.drm || model.get('drm');

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -93,6 +93,10 @@ class ProgramController extends Eventable {
                     model.set('itemReady', true);
                     return nextMediaController;
                 }
+            })
+            .catch(err => {
+                this._destroyActiveMedia();
+                throw err;
             });
         return this.loadPromise;
     }
@@ -288,6 +292,9 @@ class ProgramController extends Eventable {
                 nextMediaController.preload();
                 return nextMediaController;
             })
+            .catch(() => {
+                background.clearNext();
+            })
         );
     }
 
@@ -403,11 +410,7 @@ class ProgramController extends Eventable {
         }
 
         return providers.load(name)
-            .then(ProviderConstructor => makeMediaController(ProviderConstructor))
-            .catch(e => {
-                this._destroyActiveMedia();
-                throw e;
-            });
+            .then(ProviderConstructor => makeMediaController(ProviderConstructor));
     }
 
     /**
@@ -425,6 +428,9 @@ class ProgramController extends Eventable {
         this._destroyMediaController(background.currentMedia);
         background.currentMedia = null;
         return nextLoadPromise.then(nextMediaController => {
+            if (!nextMediaController) {
+                return;
+            }
             model.attributes.itemReady = true;
             background.clearNext();
             if (this.adPlaying) {


### PR DESCRIPTION
### This PR will...
- Prevent BGL from destroying active playback on error
- Format `nextUp` so that it's a valid `PlaylistItem`

### Why is this Pull Request needed?
So that background loading does not affect active playback; and that when we're background loading recommendations, we're only working with valid items. The controller has currently been setting `nextUp` to whatever JSON came out of the feed, which is not always valid. This item was validated when loaded so it has caused no problems so far, but we need it to be valid to background load.

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-1342

