### PR TITLE
Fix provider loading error handling

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -564,7 +564,9 @@ Object.assign(Controller.prototype, {
         function _item(index, meta) {
             _stop(true);
             _setItem(index);
-            _play(meta);
+            _play(meta).catch(() => {
+                // Suppress "Uncaught (in promise) Error"
+            });
         }
 
         function _setItem(index) {

--- a/src/js/providers/providers.js
+++ b/src/js/providers/providers.js
@@ -21,24 +21,20 @@ export const Loaders = {
 Object.assign(Providers.prototype, {
 
     load: function(providerName) {
-        return new Promise((resolve, reject) => {
-            const providerLoaderMethod = Loaders[providerName];
-            const rejectLoad = () => {
-                reject(new Error('Failed to load media'));
-            };
+        const providerLoaderMethod = Loaders[providerName];
+        const rejectLoad = () => {
+            return Promise.reject(new Error('Failed to load media'));
+        };
 
-            if (!providerLoaderMethod) {
-                rejectLoad();
-                return;
+        if (!providerLoaderMethod) {
+            return rejectLoad();
+        }
+        return providerLoaderMethod().then(() => {
+            const providerConstructor = ProvidersLoaded[providerName];
+            if (!providerConstructor) {
+                return rejectLoad();
             }
-            providerLoaderMethod().then(() => {
-                const providerConstructor = ProvidersLoaded[providerName];
-                if (!providerConstructor) {
-                    rejectLoad();
-                    return;
-                }
-                resolve(ProvidersLoaded[providerName]);
-            });
+            return providerConstructor;
         });
     },
 


### PR DESCRIPTION
### This PR will...

Fix error handling of providers, and suppress "Uncaught (in promise) Error" when there is a play promise error resulting from the `_play` call in the controller's `_item` method.

### Why is this Pull Request needed?

The player will get stuck in a buffering state otherwise.

#### Addresses Issue(s):

JW8-1326

