### PR TITLE
Listen to mediaType change on view.init()

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -766,7 +766,7 @@ Object.assign(Controller.prototype, {
                 }, _this)
                 .on(MEDIA_ERROR, _this.triggerError, _this)
                 .on(MEDIA_TYPE, (event) => {
-                    // Re-trigger mediaType
+                    // Re-set mediaType so that it triggers change listeners even if queued
                     _model.set('mediaType', event.mediaType);
                 });
         }

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -22,7 +22,7 @@ import { INITIAL_MEDIA_STATE } from 'model/player-model';
 import { PLAYER_STATE, STATE_BUFFERING, STATE_IDLE, STATE_COMPLETE, STATE_PAUSED, STATE_PLAYING, STATE_ERROR, STATE_LOADING,
     STATE_STALLED, AUTOSTART_NOT_ALLOWED, MEDIA_BEFOREPLAY, PLAYLIST_LOADED, ERROR, PLAYLIST_COMPLETE, CAPTIONS_CHANGED, READY,
     MEDIA_ERROR, MEDIA_COMPLETE, CAST_SESSION, FULLSCREEN, PLAYLIST_ITEM, MEDIA_VOLUME, MEDIA_MUTE, PLAYBACK_RATE_CHANGED,
-    CAPTIONS_LIST, CONTROLS, RESIZE, MEDIA_VISUAL_QUALITY, MEDIA_TYPE } from 'events/events';
+    CAPTIONS_LIST, CONTROLS, RESIZE, MEDIA_VISUAL_QUALITY } from 'events/events';
 import ProgramController from 'program/program-controller';
 import initQoe from 'controller/qoe';
 import { BACKGROUND_LOAD_OFFSET } from '../program/program-constants';
@@ -764,11 +764,7 @@ Object.assign(Controller.prototype, {
                     // Insert a small delay here so that other complete handlers can execute
                     resolved.then(_completeHandler);
                 }, _this)
-                .on(MEDIA_ERROR, _this.triggerError, _this)
-                .on(MEDIA_TYPE, (event) => {
-                    // Re-set mediaType so that it triggers change listeners even if queued
-                    _model.set('mediaType', event.mediaType);
-                });
+                .on(MEDIA_ERROR, _this.triggerError, _this);
         }
 
         function updateProgramSoundSettings() {

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -22,7 +22,7 @@ import { INITIAL_MEDIA_STATE } from 'model/player-model';
 import { PLAYER_STATE, STATE_BUFFERING, STATE_IDLE, STATE_COMPLETE, STATE_PAUSED, STATE_PLAYING, STATE_ERROR, STATE_LOADING,
     STATE_STALLED, AUTOSTART_NOT_ALLOWED, MEDIA_BEFOREPLAY, PLAYLIST_LOADED, ERROR, PLAYLIST_COMPLETE, CAPTIONS_CHANGED, READY,
     MEDIA_ERROR, MEDIA_COMPLETE, CAST_SESSION, FULLSCREEN, PLAYLIST_ITEM, MEDIA_VOLUME, MEDIA_MUTE, PLAYBACK_RATE_CHANGED,
-    CAPTIONS_LIST, CONTROLS, RESIZE, MEDIA_VISUAL_QUALITY } from 'events/events';
+    CAPTIONS_LIST, CONTROLS, RESIZE, MEDIA_VISUAL_QUALITY, MEDIA_TYPE } from 'events/events';
 import ProgramController from 'program/program-controller';
 import initQoe from 'controller/qoe';
 import { BACKGROUND_LOAD_OFFSET } from '../program/program-constants';
@@ -764,7 +764,11 @@ Object.assign(Controller.prototype, {
                     // Insert a small delay here so that other complete handlers can execute
                     resolved.then(_completeHandler);
                 }, _this)
-                .on(MEDIA_ERROR, _this.triggerError, _this);
+                .on(MEDIA_ERROR, _this.triggerError, _this)
+                .on(MEDIA_TYPE, (event) => {
+                    // Re-trigger mediaType
+                    _model.set('mediaType', event.mediaType);
+                });
         }
 
         function updateProgramSoundSettings() {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -220,7 +220,6 @@ function View(_api, _model) {
         const playerViewModel = _model.player;
         playerViewModel.on('change:errorEvent', _errorHandler);
         
-        _model.on('change:mediaType', _onMediaTypeChange);
         _model.change('stretching', onStretchChange);
         _model.change('flashBlocked', onFlashBlockedChange);
 
@@ -297,6 +296,7 @@ function View(_api, _model) {
         _model.change('state', _stateHandler);
         playerViewModel.change('controls', changeControls);
         playerViewModel.change('streamType', _setLiveMode);
+        _model.change('mediaType', _onMediaTypeChange);
         // Set the title attribute of the video tag to display background media information on mobile devices
         if (_isMobile) {
             playerViewModel.change('playlistItem', setMediaTitleAttribute);


### PR DESCRIPTION
## Why is this Pull Request needed?
`view.setup` attaches the `change:mediaType` listener before the `mediaModel` is attached to the `viewModel`. This causes the listener to miss the `mediaType` event, and the event stays missed because we do not dispatch `mediaModel` diffs when setting the first `mediaModel`. This change moves the `mediaType` listener to `view.setup`, which attaches after the mediaModel is attached, causing the `change` handler to get (and set) the correct value.

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-1321 JW8-1322

