### PR TITLE
Add (is)Object checks to related "nextUp" event and providers.choose

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -199,9 +199,12 @@ Object.assign(Controller.prototype, {
             const related = _api.getPlugin('related');
             if (related) {
                 related.on('nextUp', (nextUp) => {
-                    // Format the item from the nextUp feed into a valid PlaylistItem
-                    const item = Item(nextUp);
-                    item.sources = fixSources(item, _model);
+                    let item = null;
+                    if (nextUp === Object(nextUp)) {
+                        // Format the item from the nextUp feed into a valid PlaylistItem
+                        item = Item(nextUp);
+                        item.sources = fixSources(item, _model);
+                    }
                     _model.set('nextUp', item);
                 });
             }

--- a/src/js/providers/providers.js
+++ b/src/js/providers/providers.js
@@ -45,26 +45,25 @@ Object.assign(Providers.prototype, {
 
     // Find the name of the first provider which can support the media source-type
     choose: function(source) {
-        // prevent throw on missing source
-        source = (source === Object(source)) ? source : {};
-        const count = ProvidersSupported.length;
-        for (let i = 0; i < count; i++) {
-            const provider = ProvidersSupported[i];
-            if (this.providerSupports(provider, source)) {
-                // prefer earlier providers
-                const priority = count - i - 1;
+        if (source === Object(source)) {
+            const count = ProvidersSupported.length;
+            for (let i = 0; i < count; i++) {
+                const provider = ProvidersSupported[i];
+                if (this.providerSupports(provider, source)) {
+                    // prefer earlier providers
+                    const priority = count - i - 1;
 
-                return {
-                    priority: priority,
-                    name: provider.name,
-                    type: source.type,
-                    providerToCheck: provider,
-                    // If provider isn't loaded, this will be undefined
-                    provider: ProvidersLoaded[provider.name]
-                };
+                    return {
+                        priority: priority,
+                        name: provider.name,
+                        type: source.type,
+                        providerToCheck: provider,
+                        // If provider isn't loaded, this will be undefined
+                        provider: ProvidersLoaded[provider.name]
+                    };
+                }
             }
         }
-
         return {};
     }
 });


### PR DESCRIPTION
Prevent the player from throwing `Cannot read property 'indexOf' of undefined` on the last related item.

When there are no more recs, related dispatches "nextUp" with an argument of `null`. This change prevents us from setting "nextUp" on the model to an empty playlist item when that happens. It also adds a guard around running `providerSupports` checks on `source` arguments that aren't Objects.

#### Addresses Issue(s):

JW8-1328

