### PR TITLE
Only set the player state to buffering after play attempt

### DIFF
--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -81,7 +81,6 @@ class ProgramController extends Eventable {
             this._destroyActiveMedia();
         }
 
-        model.set(PLAYER_STATE, STATE_BUFFERING);
         const mediaModelContext = model.mediaModel;
         this.loadPromise = this._setupMediaController(source)
             .then(nextMediaController => {
@@ -125,6 +124,8 @@ class ProgramController extends Eventable {
             playPromise = mediaController.play(playReason);
         } else {
             // Wait for the provider to load before starting initial playback
+            model.set(PLAYER_STATE, STATE_BUFFERING);
+
             // Make the subsequent promise cancelable so that we can avoid playback when no longer wanted
             const thenPlayPromise = cancelable((nextMediaController) => {
                 if (this.mediaController && this.mediaController.mediaModel === nextMediaController.mediaModel) {

--- a/test/unit/program-controller-test.js
+++ b/test/unit/program-controller-test.js
@@ -208,9 +208,8 @@ describe('ProgramController', function () {
         return programController.setActiveItem(0)
             .then(function () {
                 const provider = programController.mediaController.provider;
-                expect(model.trigger).to.have.callCount(backgroundLoading ? 7 : 6);
+                expect(model.trigger).to.have.callCount(backgroundLoading ? 6 : 5);
                 expect(model.trigger.firstCall).to.have.been.calledWith('change:playlistItem');
-                expect(model.trigger.getCall(call++)).to.have.been.calledWith('change:state', model, 'buffering', 'idle');
                 if (backgroundLoading) {
                     expect(model.trigger.getCall(call++)).to.have.been.calledWith('change:mediaElement');
                 }
@@ -226,7 +225,7 @@ describe('ProgramController', function () {
             .then(() => programController.setActiveItem(1))
             .then(function () {
                 const provider = programController.mediaController.provider;
-                expect(model.trigger).to.have.callCount(backgroundLoading ? 12 : 11);
+                expect(model.trigger).to.have.callCount(backgroundLoading ? 11 : 10);
                 expect(model.trigger.getCall(call++)).to.have.been.calledWith('change:item');
                 expect(model.trigger.getCall(call++)).to.have.been.calledWith('change:playlistItem');
                 expect(model.trigger.getCall(call++)).to.have.been.calledWith('change:mediaModel');


### PR DESCRIPTION
Prevent the player from emitting "buffer" events when the first playlist item is idle.

Also requires merging of test updates in commercial:

https://github.com/jwplayer/jwplayer-commercial/pull/4915

#### Addresses Issue(s):

JW8-1325

