### PR TITLE
Set posterImage on playlistItem change

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -297,7 +297,6 @@ function View(_api, _model) {
         playerViewModel.change('controls', changeControls);
         playerViewModel.change('streamType', _setLiveMode);
         _model.change('mediaType', _onMediaTypeChange);
-        // Set the title attribute of the video tag to display background media information on mobile devices
         playerViewModel.change('playlistItem', onPlaylistItem);
         // Triggering 'resize' resulting in player 'ready'
         _lastWidth = _lastHeight = null;
@@ -703,6 +702,7 @@ function View(_api, _model) {
 
     function onPlaylistItem(model, item) {
         setPosterImage(item);
+        // Set the title attribute of the video tag to display background media information on mobile devices
         if (_isMobile) {
             setMediaTitleAttribute(model, item);
         }

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -616,11 +616,6 @@ function View(_api, _model) {
         const isAudioFile = (val === 'audio');
         const provider = model.get('provider');
 
-        // Set the poster image for each audio file encountered in a playlist
-        if (isAudioFile) {
-            setPosterImage(model.get('playlistItem'));
-        }
-
         toggleClass(_playerElement, 'jw-flag-media-audio', isAudioFile);
 
         const isFlash = (provider && provider.name.indexOf('flash') === 0);


### PR DESCRIPTION
### Why is this Pull Request needed?
So that the posterImage is set for an item loaded via the `load` API. Since we were always loading the posterImage before (even when `autostart: true`), this change does not negatively impact performance.

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):
JW8-1322
