### PR TITLE
When play is triggered by seek, add startTime to meta event to notify plugins

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -560,6 +560,8 @@ Object.assign(Controller.prototype, {
             }
             _programController.position = pos;
             if (!_model.get('scrubbing') && _model.get('state') !== STATE_PLAYING) {
+                meta = meta || {};
+                meta.playTrigger = 'seek';
                 this.play(meta);
             }
         }

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -398,6 +398,7 @@ Object.assign(Controller.prototype, {
             }
 
             const playReason = _getReason(meta);
+            const playTrigger = meta ? meta.playTrigger : null;
             _model.set('playReason', playReason);
             // Stop autoplay behavior if the video is started by the user or an api call
             if (playReason === 'interaction' || playReason === 'external') {
@@ -418,7 +419,10 @@ Object.assign(Controller.prototype, {
 
             if (!_beforePlay) {
                 _beforePlay = true;
-                _this.trigger(MEDIA_BEFOREPLAY, { playReason: playReason });
+                _this.trigger(MEDIA_BEFOREPLAY, {
+                    playReason: playReason,
+                    playTrigger
+                });
                 _beforePlay = false;
                 if (_interruptPlay) {
                     _interruptPlay = false;

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -398,7 +398,7 @@ Object.assign(Controller.prototype, {
             }
 
             const playReason = _getReason(meta);
-            const playTrigger = meta ? meta.playTrigger : null;
+            const startTime = meta ? meta.startTime : null;
             _model.set('playReason', playReason);
             // Stop autoplay behavior if the video is started by the user or an api call
             if (playReason === 'interaction' || playReason === 'external') {
@@ -420,8 +420,8 @@ Object.assign(Controller.prototype, {
             if (!_beforePlay) {
                 _beforePlay = true;
                 _this.trigger(MEDIA_BEFOREPLAY, {
-                    playReason: playReason,
-                    playTrigger
+                    playReason,
+                    startTime
                 });
                 _beforePlay = false;
                 if (_interruptPlay) {
@@ -565,7 +565,7 @@ Object.assign(Controller.prototype, {
             _programController.position = pos;
             if (!_model.get('scrubbing') && _model.get('state') !== STATE_PLAYING) {
                 meta = meta || {};
-                meta.playTrigger = 'seek';
+                meta.startTime = pos;
                 this.play(meta);
             }
         }


### PR DESCRIPTION
### This PR will...
Add startTime to meta event when play is triggered by seek API.

### Why is this Pull Request needed?
A new ad rule needs to be added to follow up with the seek API before the start of the content, so that the viewer is not overloaded with too many ads.
This PR will notify the ad plugins on beforePlay event that the play is due to seek API, so that the ad plugins can correctly avoid playing the preroll.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-ads-vast/pull/346

#### Addresses Issue(s):

JW8-1327

