### PR TITLE
Avoid background loading DAI items

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -165,10 +165,12 @@ Object.assign(Controller.prototype, {
                 model.setStreamType(type);
             });
 
-            const recsAuto = (model.get('related') || {}).oncomplete === 'autoplay';
             const index = model.get('item') + 1;
+            const recsAuto = (model.get('related') || {}).oncomplete === 'autoplay';
             let item = model.get('playlist')[index];
-            if ((item || recsAuto) && Features.backgroundLoading) {
+            // Do not background load DAI items because that item will be dynamically replaced
+            const isValidItem = (item && !item.daiSetting) || recsAuto;
+            if (isValidItem && Features.backgroundLoading) {
                 const onPosition = (changedMediaModel, position) => {
                     if (item && position >= mediaModel.get('duration') - BACKGROUND_LOAD_OFFSET) {
                         mediaModel.off('change:position', onPosition, this);

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -168,11 +168,10 @@ Object.assign(Controller.prototype, {
             const index = model.get('item') + 1;
             const recsAuto = (model.get('related') || {}).oncomplete === 'autoplay';
             let item = model.get('playlist')[index];
-            // Do not background load DAI items because that item will be dynamically replaced
-            const isValidItem = (item && !item.daiSetting) || recsAuto;
-            if (isValidItem && Features.backgroundLoading) {
+            if ((item || recsAuto) && Features.backgroundLoading) {
                 const onPosition = (changedMediaModel, position) => {
-                    if (item && position >= mediaModel.get('duration') - BACKGROUND_LOAD_OFFSET) {
+                    // Do not background load DAI items because that item will be dynamically replaced before play
+                    if ((item && !item.daiSetting) && position >= mediaModel.get('duration') - BACKGROUND_LOAD_OFFSET) {
                         mediaModel.off('change:position', onPosition, this);
                         _programController.backgroundLoad(item);
                     } else if (recsAuto) {


### PR DESCRIPTION
### Why is this Pull Request needed?
DAI items are dynamically replaced before being loaded, so it does not make sense to background load these items. It also fixes a bug where DAI was not finding the video tag it needed, resulting in the ad not playing.

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

 JW8-1333

