### PR TITLE
Prime on beforePlay even if we will not be interrupting for an ad

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -424,12 +424,12 @@ Object.assign(Controller.prototype, {
                     startTime
                 });
                 _beforePlay = false;
+                if (_inInteraction(window.event)) {
+                    _programController.primeMediaElements();
+                }
                 if (_interruptPlay) {
                     _interruptPlay = false;
                     _actionOnAttach = null;
-                    if (_inInteraction(window.event)) {
-                        _programController.primeMediaElements();
-                    }
                     return resolved;
                 }
             }


### PR DESCRIPTION
### Why is this Pull Request needed?
So that if we background load the next item when a gesture is required, it will be allowed to play. This code currently does not prime media elements on the first play gesture, which is necessary to background load (and play) the next item. Non-BGL playlists are working without further gesture now because we are reusing the same tag for content (whose play method is called within the user gesture), and the modified code already works for ads.

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-1337

