### PR TITLE
Fire "itemReady" for background loaded items

### DIFF
--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -72,7 +72,6 @@ class ProgramController extends Eventable {
                 // Reinitialize the mediaController with the new item, allowing a new playback session
                 mediaController.activeItem = item;
                 this._setActiveMedia(mediaController);
-                model.set('itemReady', true);
                 return this.loadPromise;
             }
 
@@ -89,7 +88,6 @@ class ProgramController extends Eventable {
                 if (mediaModelContext === model.mediaModel) {
                     nextMediaController.activeItem = item;
                     this._setActiveMedia(nextMediaController);
-                    model.set('itemReady', true);
                     return nextMediaController;
                 }
             })
@@ -209,7 +207,6 @@ class ProgramController extends Eventable {
         const castMediaController = new MediaController(castProvider, model);
         castMediaController.activeItem = playlistItem;
         this._setActiveMedia(castMediaController);
-        model.set('itemReady', true);
     }
 
     /**
@@ -344,6 +341,7 @@ class ProgramController extends Eventable {
         model.setProvider(provider);
 
         forwardEvents(this, mediaController);
+        model.set('itemReady', true);
     }
 
     /**
@@ -424,7 +422,7 @@ class ProgramController extends Eventable {
      * @memberOf ProgramController
      */
     _activateBackgroundMedia() {
-        const { background, background: { nextLoadPromise }, model } = this;
+        const { background, background: { nextLoadPromise } } = this;
         // Activating this item means that any media already loaded in the background will no longer be needed
         this._destroyMediaController(background.currentMedia);
         background.currentMedia = null;
@@ -432,7 +430,6 @@ class ProgramController extends Eventable {
             if (!nextMediaController) {
                 return;
             }
-            model.attributes.itemReady = true;
             background.clearNext();
             if (this.adPlaying) {
                 background.currentMedia = nextMediaController;

--- a/test/unit/program-controller-test.js
+++ b/test/unit/program-controller-test.js
@@ -323,7 +323,7 @@ describe('ProgramController', function () {
                 expect(model.persistQualityLevel).to.have.callCount(0);
                 expect(model.persistVideoSubtitleTrack).to.have.callCount(0);
                 programController.restoreBackgroundMedia();
-                expect(model.set).to.have.callCount(12);
+                expect(model.set).to.have.callCount(13);
                 expect(model.set.firstCall).to.have.been.calledWith('mediaElement');
                 expect(model.set.getCall(1)).to.have.been.calledWith('mediaModel');
                 expect(model.set.getCall(2)).to.have.been.calledWith('provider');
@@ -379,13 +379,28 @@ describe('ProgramController', function () {
                 expect(model.persistQualityLevel).to.have.callCount(0);
                 expect(model.persistVideoSubtitleTrack).to.have.callCount(0);
                 programController.restoreBackgroundMedia();
-                expect(model.set).to.have.callCount(13);
+                expect(model.set).to.have.callCount(14);
                 expect(model.set.firstCall).to.have.been.calledWith('mediaElement');
                 expect(model.set.getCall(1)).to.have.been.calledWith('mediaModel');
                 expect(model.set.getCall(2)).to.have.been.calledWith('provider');
                 expect(model.trigger).to.have.callCount(7);
                 expect(model.persistQualityLevel).to.have.callCount(1);
                 expect(model.persistVideoSubtitleTrack).to.have.callCount(1);
+            });
+    });
+
+    it('fires itemReady for background loaded items', function() {
+        sinon.spy(model, 'trigger');
+        return programController.setActiveItem(0)
+            .then(function () {
+                expect(model.trigger).to.have.callCount(6);
+                expect(model.trigger.lastCall).to.have.been.calledWith('change:itemReady', model, true);
+                programController.backgroundLoad(mp4Item);
+            })
+            .then(() => programController.setActiveItem(1))
+            .then(function () {
+                expect(model.trigger).to.have.callCount(14);
+                expect(model.trigger.lastCall).to.have.been.calledWith('change:itemReady', model, true);
             });
     });
 });


### PR DESCRIPTION
### This PR will...
Set "itemReady" in `_setActiveMedia` so that "change:itemReady" is always fired when the player changes items and that item is ready to be played.

#### Addresses Issue(s):
JW8-1332

