### PR TITLE
Add a flag to beforePlay media pool priming so that we do not destroy BGL buffer on subsequent plays

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -432,7 +432,7 @@ Object.assign(Controller.prototype, {
 
                 if (_inInteraction(window.event) && primeBeforePlay) {
                     _programController.primeMediaElements();
-                    primeBeforePlay = true;
+                    primeBeforePlay = false;
                 }
 
                 if (_interruptPlay) {

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -51,6 +51,7 @@ Object.assign(Controller.prototype, {
         let _interruptPlay;
         let checkAutoStartCancelable = cancelable(_checkAutoStart);
         let updatePlaylistCancelable = cancelable(function() {});
+        let hasPrimedBeforePlay = false;
 
         _this.originalContainer = _this.currentContainer = originalContainer;
         _this._events = eventListeners;
@@ -428,9 +429,12 @@ Object.assign(Controller.prototype, {
                     startTime
                 });
                 _beforePlay = false;
-                if (_inInteraction(window.event)) {
+
+                if (_inInteraction(window.event) && !hasPrimedBeforePlay) {
                     _programController.primeMediaElements();
+                    hasPrimedBeforePlay = true;
                 }
+
                 if (_interruptPlay) {
                     _interruptPlay = false;
                     _actionOnAttach = null;

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -302,13 +302,6 @@ class ProgramController extends Eventable {
      * @returns {void}
      */
     primeMediaElements() {
-        if (!Features.backgroundLoading) {
-            // If background loading is not supported, the model will always contain the shared media element
-            // Prime it so that playback after changing the active item does not require further gestures
-            const { model } = this;
-            const mediaElement = model.get('mediaElement');
-            mediaElement.load();
-        }
         this.mediaPool.prime();
     }
 

--- a/src/js/program/shared-media-pool.js
+++ b/src/js/program/shared-media-pool.js
@@ -1,7 +1,9 @@
 export default function SharedMediaPool(sharedElement, mediaPool) {
     return Object.assign({}, mediaPool, {
         prime() {
-            sharedElement.load();
+            if (!sharedElement.src) {
+                sharedElement.load();
+            }
         },
         getPrimedElement() {
             return sharedElement;


### PR DESCRIPTION
Fixes a regression introduced by  https://github.com/jwplayer/jwplayer/pull/2783

JW8-1340