### PR TITLE
[ADS-1050] Set state to paused after ad.

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -315,10 +315,9 @@ var InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
         _adProgram.off(null, null, _this);
         _adProgram.destroy();
 
-        // Sync player state with ad for model "change:state" events to trigger
+        // Force player state with ad to pause for model "change:state" events to trigger
         if (_inited && _adProgram.model) {
-            const adState = _adProgram.model.get('state');
-            _model.attributes.state = adState;
+            _model.attributes.state = STATE_PAUSED;
         }
 
         _model.set('instream', null);


### PR DESCRIPTION
### This PR will...
Force the model state to `STATE_PAUSED` after an ad completes - this will cause the player to reliably trigger the "play" event after midrolls (previously, it would only trigger this when BGL is enabled, or on VAST). IMA would not fire this event. 

#### Addresses Issue(s):
ADS-1050

