### PR TITLE
Bugfix/beforeplay prime flag

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -432,7 +432,7 @@ Object.assign(Controller.prototype, {
 
                 if (_inInteraction(window.event) && primeBeforePlay) {
                     _programController.primeMediaElements();
-                    primeBeforePlay = true;
+                    primeBeforePlay = false;
                 }
 
                 if (_interruptPlay) {

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -436,6 +436,11 @@ Object.assign(Controller.prototype, {
                 }
 
                 if (_interruptPlay) {
+                    // Force tags to prime if we're about to play an ad
+                    // Resetting the source in order to prime is OK since we'll be switching it anyway
+                    if (_inInteraction(window.event) && !Features.backgroundLoading) {
+                        _model.get('mediaElement').load();
+                    }
                     _interruptPlay = false;
                     _actionOnAttach = null;
                     return resolved;

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -51,6 +51,7 @@ Object.assign(Controller.prototype, {
         let _interruptPlay;
         let checkAutoStartCancelable = cancelable(_checkAutoStart);
         let updatePlaylistCancelable = cancelable(function() {});
+        let hasPrimedBeforePlay = false;
 
         _this.originalContainer = _this.currentContainer = originalContainer;
         _this._events = eventListeners;
@@ -428,9 +429,12 @@ Object.assign(Controller.prototype, {
                     startTime
                 });
                 _beforePlay = false;
-                if (_inInteraction(window.event)) {
+
+                if (_inInteraction(window.event) && !hasPrimedBeforePlay) {
                     _programController.primeMediaElements();
+                    hasPrimedBeforePlay = true;
                 }
+
                 if (_interruptPlay) {
                     _interruptPlay = false;
                     _actionOnAttach = null;

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -302,13 +302,6 @@ class ProgramController extends Eventable {
      * @returns {void}
      */
     primeMediaElements() {
-        if (!Features.backgroundLoading) {
-            // If background loading is not supported, the model will always contain the shared media element
-            // Prime it so that playback after changing the active item does not require further gestures
-            const { model } = this;
-            const mediaElement = model.get('mediaElement');
-            mediaElement.load();
-        }
         this.mediaPool.prime();
     }
 

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -299,6 +299,7 @@ class ProgramController extends Eventable {
     /**
      * Primes media elements so that they can autoplay without further user gesture.
      * A primed element is required for media to load in the background.
+     * This method does not prime elements who already have a source set ("safe prime").
      * @returns {void}
      */
     primeMediaElements() {

--- a/src/js/program/shared-media-pool.js
+++ b/src/js/program/shared-media-pool.js
@@ -1,7 +1,9 @@
 export default function SharedMediaPool(sharedElement, mediaPool) {
     return Object.assign({}, mediaPool, {
         prime() {
-            sharedElement.load();
+            if (!sharedElement.src) {
+                sharedElement.load();
+            }
         },
         getPrimedElement() {
             return sharedElement;


### PR DESCRIPTION
### This PR will...
Force media elements to prime before an ad if background loading is not supported 

### Why is this Pull Request needed?
If we go to play a preroll (without BGL support), the media element may not be primed. We must force it to prime before handing off the instream (as indicated by `_interruptPlay`). This is a safe operation because `src` will be replaced by the ad plugin anyway.

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-1340

