### PR TITLE
Delete API plugin instances between player setup

### DIFF
--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -42,6 +42,10 @@ function coreFactory(api, element) {
  * @returns {void}
  */
 function resetPlayer(api, core) {
+    const plugins = api.plugins;
+    Object.keys(plugins).forEach(key => {
+        delete plugins[key];
+    });
     api.off();
     core.playerDestroy();
     core.getContainer().removeAttribute('data-jwplayer-id');

--- a/test/unit/api-test.js
+++ b/test/unit/api-test.js
@@ -139,6 +139,17 @@ describe('Api', function() {
         }).remove();
     });
 
+    it('resets plugins on setup', function() {
+        const api = createApi('player');
+        const plugin = { addToPlayer: () => {} };
+
+        api.addPlugin('testPlugin', plugin);
+        expect(api.getPlugin('testPlugin')).to.equal(plugin);
+
+        api.setup({});
+        expect(api.getPlugin('testPlugin')).to.equal(undefined);
+    });
+
     it('event dispatching', function() {
         const api = createApi('player');
         const originalEvent = {


### PR DESCRIPTION
### This PR will...

Clear plugins when a player is reset

### Why is this Pull Request needed?

So that plugins are reinstantiated when the player is setup again. If this is not done, then the plugin instance may continue to reference objects or DOM elements relative to the previous player embed, and run for a setup that did not contain any configuration for that plugin.

#### Addresses Issue(s):

JW8-1271

