### PR TITLE
Set item.starttime if seeking from complete 

### DIFF
--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -6,7 +6,7 @@ import { MediaControllerListener } from 'program/program-listeners';
 import Eventable from 'utils/eventable';
 import BackgroundMedia from 'program/background-media';
 
-import { ERROR, PLAYER_STATE, STATE_BUFFERING, STATE_IDLE } from 'events/events';
+import { ERROR, PLAYER_STATE, STATE_BUFFERING, STATE_IDLE, STATE_COMPLETE } from 'events/events';
 import { Features } from '../environment/environment';
 
 /** @private Do not include in JSDocs */
@@ -616,8 +616,10 @@ class ProgramController extends Eventable {
         if (!mediaController) {
             return;
         }
+        const state = model.get(PLAYER_STATE);
+        const beforeLoad = (!mediaController.started && !mediaController.preloaded && state === STATE_IDLE);
 
-        if (!mediaController.started && !mediaController.preloaded && model.get(PLAYER_STATE) === STATE_IDLE) {
+        if (beforeLoad || state === STATE_COMPLETE) {
             mediaController.item.starttime = pos;
         } else if (mediaController.attached) {
             mediaController.position = pos;


### PR DESCRIPTION
### Why is this Pull Request needed?
So that the player loads from the correct time following the re-setting and replaing of an item following complete:

https://github.com/jwplayer/jwplayer/blob/master/src/js/controller/controller.js#L412-L414
```
if (_model.get('state') === STATE_COMPLETE) {
    _stop(true);
    _setItem(0);
}
```

This causes the item to be reset and it's position reset to 0; if we seek via setting the media element's `currentTime`, it will be overwritten. Therefore, we must set the item's starttime so it will begin from the correct position when loaded.

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-1339

