### PR TITLE
Fix style bleeding issues for elements without `.jw-reset`

### DIFF
--- a/src/css/jwplayer/imports/reset.less
+++ b/src/css/jwplayer/imports/reset.less
@@ -1,4 +1,5 @@
-.jw-reset {
+.jw-reset,
+.jwplayer *:not(.jw-reset) {
     color: inherit;
     background-color: transparent;
     padding: 0;


### PR DESCRIPTION
### This PR will...
Apply the reset styling to all elements inside the player that don't have the reset class

### Why is this Pull Request needed?
Style bleeding may be present on elements that don't have the reset class.

### Are there any points in the code the reviewer needs to double check?
All player element classes should be namespaced with `jw-`, so this PR may need to be modified to make it more specific if conflicts with other integrations are observed.

### Are there any Pull Requests open in other repos which need to be merged with this?
jwplayer/jwplayer-plugin-related#274

#### Addresses Issue(s):

JW8-1342

