### PR TITLE
Clear Cues When Changing Playlist Items

### DIFF
--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -275,8 +275,6 @@ class TimeSlider extends Slider {
                 this.addCue(ele);
             });
             this.drawCues();
-        } else {
-            this.resetChapters();
         }
     }
 

--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -281,6 +281,7 @@ class TimeSlider extends Slider {
 
     reset() {
         this.resetThumbnails();
+        this.resetChapters();
         this.timeTip.resetWidth();
         this.textLength = 0;
     }

--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -269,6 +269,7 @@ class TimeSlider extends Slider {
     }
 
     addCues(model, cues) {
+        this.resetChapters();
         if (cues && cues.length) {
             cues.forEach((ele) => {
                 this.addCue(ele);
@@ -281,7 +282,6 @@ class TimeSlider extends Slider {
 
     reset() {
         this.resetThumbnails();
-        this.resetChapters();
         this.timeTip.resetWidth();
         this.textLength = 0;
     }


### PR DESCRIPTION
JW8-1352

### This PR will...

Add `this.resetChapters()` to the `reset()` method in timeslider.js in order to make sure the cue points are cleared when switching playlist items.

### Why is this Pull Request needed?

If the previous playlist item had mid-rolls, the cues would not clear on the timeline in another playlist item. For example, the first playlist item had an ad break cue at 5 second and the second item had an ad break cue at 15 seconds, the first playlist item would properly have a cue at 0:05 but the second item would have one at 0:05 and one at 0:15.

### Are there any points in the code the reviewer needs to double check?

n/a

### Are there any Pull Requests open in other repos which need to be merged with this?

n/a

#### Addresses Issue(s):

JW8-1352
GitHub #2793 

