### PR TITLE
Prevent webpack from adding node polyfills

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -94,6 +94,7 @@ const multiConfig = [
     }
 ].map(configuration =>
     Object.assign({}, configuration, {
+        node: false,
         entry: {
             jwplayer: './src/js/jwplayer.js'
         },


### PR DESCRIPTION
### This PR will...

Prevent webpack from polyfilling `setImmediate` in promise-polyfill.

### Why is this Pull Request needed?

We've found sites that define `setImmediate` without defining `clearImmediate` before jwplayer.js is added to the page. This causes jwplayer.js to throw an exception on eval. We do not want `setImmediate` polyfilled for the promise-polyfill. `setImmediate` is only used by promise-polyfill if defined.

This also led me to forking setImmediate looking for a fix should we ever require this polyfill again https://github.com/YuzuJS/setImmediate/pull/71 

Removing this polyfill from the build also removes a little over 4kB from jwplayer.js minified.

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-commercial/pull/4998

#### Addresses Issue(s):

JW8-1361
