### PR TITLE
Move "dvrSeekLimit" to config and model

### DIFF
--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -46,6 +46,7 @@ const Model = function() {
         this.attributes.playlistItem = null;
         this.set('item', index);
         this.set('minDvrWindow', item.minDvrWindow);
+        this.set('dvrSeekLimit', item.dvrSeekLimit);
         this.set('playlistItem', item);
     };
 

--- a/src/js/playlist/item.js
+++ b/src/js/playlist/item.js
@@ -12,6 +12,7 @@ const isArray = Array.isArray;
  * @property {'none'|'metadata'|'auto'} preload - The selected preload setting.
  * @property {number} minDvrWindow - For live streams, the threshold at which the available media should be seekable,
  * and treated as a DVR stream.
+ * @property {number} - For live streams, the number of seconds away from the live edge the user is allowed to seek to
  */
 
 const Item = function(config) {
@@ -23,8 +24,13 @@ const Item = function(config) {
     var playlistItem = Object.assign({}, {
         sources: [],
         tracks: [],
-        minDvrWindow: 120
+        minDvrWindow: 120,
+        dvrSeekLimit: 25
     }, config);
+
+    if (playlistItem.dvrSeekLimit < 5) {
+        playlistItem.dvrSeekLimit = 25;
+    }
 
 
     if ((playlistItem.sources === Object(playlistItem.sources)) && !isArray(playlistItem.sources)) {

--- a/src/js/playlist/item.js
+++ b/src/js/playlist/item.js
@@ -29,7 +29,7 @@ const Item = function(config) {
     }, config);
 
     if (playlistItem.dvrSeekLimit < 5) {
-        playlistItem.dvrSeekLimit = 25;
+        playlistItem.dvrSeekLimit = 5;
     }
 
 

--- a/src/js/playlist/item.js
+++ b/src/js/playlist/item.js
@@ -5,14 +5,14 @@ const isArray = Array.isArray;
 /**
  * An item in the playlist
  * @typedef {object} PlaylistItem
- * @property {Array.<PlaylistItemSource>} sources - A list of alternative media sources for the player to choose from.
- * @property {Array.<PlaylistItemTrack>} tracks - A list of tracks associated with this item.
  * @property {string} file - The selected source URL to be played.
+ * @property {Array.<PlaylistItemSource>} sources - A list of alternative media sources for the player to choose from.
+ * @property {Array.<PlaylistItemTrack>} [tracks] - A list of tracks associated with this item.
  * @property {string} [image] - The poster image.
- * @property {'none'|'metadata'|'auto'} preload - The selected preload setting.
- * @property {number} minDvrWindow - For live streams, the threshold at which the available media should be seekable,
+ * @property {'none'|'metadata'|'auto'} [preload] - The selected preload setting.
+ * @property {number} [minDvrWindow] - For live streams, the threshold at which the available media should be seekable,
  * and treated as a DVR stream.
- * @property {number} - For live streams, the number of seconds away from the live edge the user is allowed to seek to
+ * @property {number} [dvrSeekLimit] - For live streams, the number of seconds away from the live edge the user is allowed to seek to
  */
 
 const Item = function(config) {

--- a/src/js/view/constants.js
+++ b/src/js/view/constants.js
@@ -1,2 +1,0 @@
-
-export const dvrSeekLimit = -25;

--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -1,4 +1,3 @@
-import { dvrSeekLimit } from 'view/constants';
 import _ from 'utils/underscore';
 import utils from 'utils/helpers';
 import UI, { getPointerType } from 'utils/ui';
@@ -142,8 +141,9 @@ class TimeSlider extends Slider {
         let pct = 0;
         if (duration) {
             if (this.streamType === 'DVR') {
-                const diff = duration - dvrSeekLimit;
-                pct = (diff - (position - dvrSeekLimit)) / diff * 100;
+                const dvrSeekLimit = this._model.get('dvrSeekLimit');
+                const diff = duration + dvrSeekLimit;
+                pct = (diff - (position + dvrSeekLimit)) / diff * 100;
             } else if (this.streamType === 'VOD' || !this.streamType) {
                 // Default to VOD behavior if streamType isn't set
                 pct = position / duration * 100;
@@ -177,7 +177,8 @@ class TimeSlider extends Slider {
             this._api.play(reasonInteraction());
         } else if (this.streamType === 'DVR') {
             const seekRange = this._model.get('seekRange');
-            position = seekRange.start + (-duration + dvrSeekLimit) * percent / 100;
+            const dvrSeekLimit = this._model.get('dvrSeekLimit');
+            position = seekRange.start + (-duration - dvrSeekLimit) * percent / 100;
             this._api.seek(position, reasonInteraction());
         } else {
             position = percent / 100 * duration;
@@ -200,7 +201,8 @@ class TimeSlider extends Slider {
 
         // For DVR we need to swap it around
         if (duration < 0) {
-            duration -= dvrSeekLimit;
+            const dvrSeekLimit = this._model.get('dvrSeekLimit');
+            duration += dvrSeekLimit;
             time = (duration * pct);
             time = duration - time;
         }

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -1,6 +1,5 @@
 import { cloneIcons } from 'view/controls/icons';
 import { Browser, OS } from 'environment/environment';
-import { dvrSeekLimit } from 'view/constants';
 import CustomButton from 'view/controls/components/custom-button';
 import utils from 'utils/helpers';
 import _ from 'utils/underscore';
@@ -314,7 +313,8 @@ export default class Controlbar {
             if (this._model.get('streamType') === 'DVR') {
                 // Seek to "Live" position within live buffer, but not before current position
                 const currentPosition = this._model.get('position');
-                this._api.seek(Math.max(dvrSeekLimit, currentPosition), reasonInteraction());
+                const dvrSeekLimit = this._model.get('dvrSeekLimit');
+                this._api.seek(Math.max(-dvrSeekLimit, currentPosition), reasonInteraction());
             }
         }, this);
 
@@ -365,9 +365,10 @@ export default class Controlbar {
         const duration = model.get('duration');
         if (model.get('streamType') === 'DVR') {
             const currentPosition = Math.ceil(position);
-            let time = currentPosition >= dvrSeekLimit ? '' : '-' + utils.timeFormat(-(position - dvrSeekLimit));
+            const dvrSeekLimit = this._model.get('dvrSeekLimit');
+            let time = currentPosition >= -dvrSeekLimit ? '' : '-' + utils.timeFormat(-(position + dvrSeekLimit));
             elapsedTime = countdownTime = time;
-            model.set('dvrLive', currentPosition >= dvrSeekLimit);
+            model.set('dvrLive', currentPosition >= -dvrSeekLimit);
         } else {
             elapsedTime = utils.timeFormat(position);
             countdownTime = utils.timeFormat(duration - position);
@@ -465,7 +466,9 @@ export default class Controlbar {
         if (this._model.get('streamType') === 'DVR') {
             // Seek to "Live" position within live buffer, but not before current position
             const currentPosition = this._model.get('position');
-            this._api.seek(Math.max(dvrSeekLimit, currentPosition), reasonInteraction());
+            const dvrSeekLimit = this._model.get('dvrSeekLimit');
+
+            this._api.seek(Math.max(-dvrSeekLimit, currentPosition), reasonInteraction());
         }
     }
 

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -1,5 +1,4 @@
 import { OS } from 'environment/environment';
-import { dvrSeekLimit } from 'view/constants';
 import { DISPLAY_CLICK, USER_ACTION, STATE_PAUSED, STATE_PLAYING, STATE_ERROR } from 'events/events';
 import Events from 'utils/backbone.events';
 import utils from 'utils/helpers';
@@ -200,8 +199,9 @@ export default class Controls {
             let max = model.get('duration');
             const position = model.get('position');
             if (model.get('streamType') === 'DVR') {
+                const dvrSeekLimit = model.get('dvrSeekLimit');
                 min = max;
-                max = Math.max(position, dvrSeekLimit);
+                max = Math.max(position, -dvrSeekLimit);
             }
             const newSeek = utils.between(position + amount, min, max);
             api.seek(newSeek, reasonInteraction());


### PR DESCRIPTION
### This PR will...

Set "dvrSeekLimit" on playlist items on the config and into the model so that it is configurable

### Why is this Pull Request needed?

To make it easier to reproduce the stream falling behind the live edge.

Example: Setting "dvrSeekLimit" makes it easier to reproduce this bug since not all streams update and play close to 25 seconds from the live edge.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-650

