### PR TITLE
Set bitrateSelection & bandwidthEstimate on model & preserve to localstorage

### DIFF
--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -152,7 +152,7 @@ const Config = function(options, persisted) {
 
     let liveTimeout = config.liveTimeout;
     if (liveTimeout !== null) {
-        if (_isNaN(liveTimeout) || !_isNumber(liveTimeout)) {
+        if (!isValidNumber(liveTimeout)) {
             liveTimeout = null;
         } else if (liveTimeout !== 0) {
             liveTimeout = Math.max(30, liveTimeout);
@@ -162,11 +162,15 @@ const Config = function(options, persisted) {
 
     const parsedBwEstimate = parseFloat(config.bandwidthEstimate);
     const parsedBitrateSelection = parseFloat(config.bitrateSelection);
-    config.bandwidthEstimate = _isNumber(parsedBwEstimate) ? parsedBwEstimate : Defaults.bandwidthEstimate;
-    config.bitrateSelection = _isNumber(parsedBitrateSelection) ? parsedBitrateSelection : Defaults.bitrateSelection;
+    config.bandwidthEstimate = isValidNumber(parsedBwEstimate) ? parsedBwEstimate : Defaults.bandwidthEstimate;
+    config.bitrateSelection = isValidNumber(parsedBitrateSelection) ? parsedBitrateSelection : Defaults.bitrateSelection;
 
     return config;
 };
+
+function isValidNumber(num) {
+    return _isNumber(num) && !_isNaN(num);
+}
 
 function _evaluateAspectRatio(ar, width) {
     if (width.toString().indexOf('%') === -1) {

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -9,6 +9,8 @@ import { _isNumber, _isNaN } from 'utils/underscore';
 // Alphabetical order
 const Defaults = {
     autostart: false,
+    bandwidthEstimate: null,
+    bitrateSelection: null,
     castAvailable: false,
     controls: true,
     defaultPlaybackRate: 1,
@@ -157,6 +159,11 @@ const Config = function(options, persisted) {
         }
         config.liveTimeout = liveTimeout;
     }
+
+    const parsedBwEstimate = parseFloat(config.bandwidthEstimate);
+    const parsedBitrateSelection = parseFloat(config.bitrateSelection);
+    config.bandwidthEstimate = _isNumber(parsedBwEstimate) ? parsedBwEstimate : Defaults.bandwidthEstimate;
+    config.bitrateSelection = _isNumber(parsedBitrateSelection) ? parsedBitrateSelection : Defaults.bitrateSelection;
 
     return config;
 };

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -1,7 +1,7 @@
 import _ from 'utils/underscore';
 import { loadFrom, getScriptPath } from 'utils/playerutils';
 import { serialize } from 'utils/parser';
-import { _isNumber, _isNaN } from 'utils/underscore';
+import { _isValidNumber } from 'utils/underscore';
 
 /* global __webpack_public_path__:true */
 /* eslint camelcase: 0 */
@@ -152,7 +152,7 @@ const Config = function(options, persisted) {
 
     let liveTimeout = config.liveTimeout;
     if (liveTimeout !== null) {
-        if (!isValidNumber(liveTimeout)) {
+        if (!_isValidNumber(liveTimeout)) {
             liveTimeout = null;
         } else if (liveTimeout !== 0) {
             liveTimeout = Math.max(30, liveTimeout);
@@ -162,15 +162,11 @@ const Config = function(options, persisted) {
 
     const parsedBwEstimate = parseFloat(config.bandwidthEstimate);
     const parsedBitrateSelection = parseFloat(config.bitrateSelection);
-    config.bandwidthEstimate = isValidNumber(parsedBwEstimate) ? parsedBwEstimate : Defaults.bandwidthEstimate;
-    config.bitrateSelection = isValidNumber(parsedBitrateSelection) ? parsedBitrateSelection : Defaults.bitrateSelection;
+    config.bandwidthEstimate = _isValidNumber(parsedBwEstimate) ? parsedBwEstimate : Defaults.bandwidthEstimate;
+    config.bitrateSelection = _isValidNumber(parsedBitrateSelection) ? parsedBitrateSelection : Defaults.bitrateSelection;
 
     return config;
 };
-
-function isValidNumber(num) {
-    return _isNumber(num) && !_isNaN(num);
-}
 
 function _evaluateAspectRatio(ar, width) {
     if (width.toString().indexOf('%') === -1) {

--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -69,7 +69,8 @@ Object.assign(CoreShim.prototype, {
             'volume',
             'mute',
             'captionLabel',
-            'qualityLabel'
+            'bandwidthEstimate',
+            'bitrateSelection'
         ]);
         const persisted = storage && storage.getAllItems();
         model.attributes = model.attributes || {};

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -36,9 +36,11 @@ const Model = function() {
 
     this.persistQualityLevel = function(quality, levels) {
         const currentLevel = levels[quality] || {};
-        if (currentLevel.bitrate) {
-            this.set('bitrateSelection', currentLevel.bitrate);
+        const bitrate = currentLevel.bitrate;
+        if (!_.isNumber(bitrate) || _.isNaN(bitrate)) {
+            return;
         }
+        this.set('bitrateSelection', bitrate);
     };
 
     this.setActiveItem = function (index) {
@@ -197,9 +199,10 @@ const Model = function() {
     };
 
     this.persistBandwidthEstimate = function (bwEstimate) {
-        if (bwEstimate && this.attributes.bandwidthEstimate !== bwEstimate) {
-            this.set('bandwidthEstimate', bwEstimate);
+        if (!_.isNumber(bwEstimate) || _.isNaN(bwEstimate)) {
+            return;
         }
+        this.set('bandwidthEstimate', bwEstimate);
     };
 };
 

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -37,7 +37,7 @@ const Model = function() {
     this.persistQualityLevel = function(quality, levels) {
         var currentLevel = levels[quality] || {};
         var label = currentLevel.label;
-        this.set('qualityLabel', label);
+        this.set('bitrateSelection', currentLevel.bitrate);
     };
 
     this.setActiveItem = function (index) {
@@ -193,6 +193,12 @@ const Model = function() {
         mediaModel.set('position', position);
         mediaModel.set('currentTime', 0);
         mediaModel.set('duration', duration);
+    };
+
+    this.persistBandwidthEstimate = function (bwEstimate) {
+        if (_.isNumber(bwEstimate) && this.attributes.bandwidthEstimate !== bwEstimate) {
+            this.set('bandwidthEstimate', bwEstimate);
+        }
     };
 };
 

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -2,7 +2,7 @@ import { OS } from 'environment/environment';
 import SimpleModel from 'model/simplemodel';
 import { INITIAL_PLAYER_STATE, INITIAL_MEDIA_STATE } from 'model/player-model';
 import { STATE_IDLE } from 'events/events';
-import _ from 'utils/underscore';
+import _, { _isValidNumber } from 'utils/underscore';
 import { seconds } from 'utils/strings';
 import Providers from 'providers/providers';
 
@@ -37,7 +37,7 @@ const Model = function() {
     this.persistQualityLevel = function(quality, levels) {
         const currentLevel = levels[quality] || {};
         const bitrate = currentLevel.bitrate;
-        if (!_.isNumber(bitrate) || _.isNaN(bitrate)) {
+        if (!_isValidNumber(bitrate)) {
             return;
         }
         this.set('bitrateSelection', bitrate);
@@ -199,7 +199,7 @@ const Model = function() {
     };
 
     this.persistBandwidthEstimate = function (bwEstimate) {
-        if (!_.isNumber(bwEstimate) || _.isNaN(bwEstimate)) {
+        if (!_isValidNumber(bwEstimate)) {
             return;
         }
         this.set('bandwidthEstimate', bwEstimate);

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -35,9 +35,10 @@ const Model = function() {
     };
 
     this.persistQualityLevel = function(quality, levels) {
-        var currentLevel = levels[quality] || {};
-        var label = currentLevel.label;
-        this.set('bitrateSelection', currentLevel.bitrate);
+        const currentLevel = levels[quality] || {};
+        if (currentLevel.bitrate) {
+            this.set('bitrateSelection', currentLevel.bitrate);
+        }
     };
 
     this.setActiveItem = function (index) {
@@ -196,7 +197,7 @@ const Model = function() {
     };
 
     this.persistBandwidthEstimate = function (bwEstimate) {
-        if (_.isNumber(bwEstimate) && this.attributes.bandwidthEstimate !== bwEstimate) {
+        if (bwEstimate && this.attributes.bandwidthEstimate !== bwEstimate) {
             this.set('bandwidthEstimate', bwEstimate);
         }
     };

--- a/src/js/events/events.js
+++ b/src/js/events/events.js
@@ -415,6 +415,6 @@ export const BREAKPOINT = 'breakpoint';
 export const NATIVE_FULLSCREEN = 'fullscreenchange';
 
 /**
- * Triggered when a bandwidth estimate is calculated
+ * Triggered when a new bandwidth estimate is available
  */
 export const BANDWIDTH_ESTIMATE = 'bandwidthEstimate';

--- a/src/js/events/events.js
+++ b/src/js/events/events.js
@@ -413,3 +413,8 @@ export const BREAKPOINT = 'breakpoint';
  * Triggered when receiving a native 'fullscreenchange' event from a video tag
 */
 export const NATIVE_FULLSCREEN = 'fullscreenchange';
+
+/**
+ * Triggered when a bandwidth estimate is calculated
+ */
+export const BANDWIDTH_ESTIMATE = 'bandwidthEstimate';

--- a/src/js/program/program-listeners.js
+++ b/src/js/program/program-listeners.js
@@ -90,11 +90,6 @@ export function ProviderListener(mediaController) {
             case 'visualQuality':
                 mediaModel.set('visualQuality', Object.assign({}, data));
                 break;
-            case BANDWIDTH_ESTIMATE:
-                if (data) {
-                    mediaModel.set('bandwidthEstimate', Object.assign({}, data));
-                }
-                break;
             default:
                 break;
         }

--- a/src/js/program/program-listeners.js
+++ b/src/js/program/program-listeners.js
@@ -3,7 +3,7 @@ import { PLAYER_STATE, STATE_IDLE, MEDIA_VOLUME, MEDIA_MUTE,
     MEDIA_TYPE, AUDIO_TRACKS, AUDIO_TRACK_CHANGED,
     MEDIA_RATE_CHANGE, MEDIA_BUFFER, MEDIA_TIME, MEDIA_LEVELS, MEDIA_LEVEL_CHANGED, MEDIA_ERROR,
     MEDIA_BEFORECOMPLETE, MEDIA_COMPLETE, MEDIA_META, MEDIA_SEEK, MEDIA_SEEKED,
-    NATIVE_FULLSCREEN, MEDIA_VISUAL_QUALITY } from 'events/events';
+    NATIVE_FULLSCREEN, MEDIA_VISUAL_QUALITY, BANDWIDTH_ESTIMATE } from 'events/events';
 
 export function ProviderListener(mediaController) {
     return function (type, data) {
@@ -90,6 +90,11 @@ export function ProviderListener(mediaController) {
             case 'visualQuality':
                 mediaModel.set('visualQuality', Object.assign({}, data));
                 break;
+            case BANDWIDTH_ESTIMATE:
+                if (data) {
+                    mediaModel.set('bandwidthEstimate', Object.assign({}, data));
+                }
+                break;
             default:
                 break;
         }
@@ -143,6 +148,10 @@ export function MediaControllerListener(model, programController) {
             case 'subtitlesTracksData':
                 model.trigger(type, data);
                 break;
+            case BANDWIDTH_ESTIMATE: {
+                model.persistBandwidthEstimate(data.bandwidthEstimate);
+                return;
+            }
             default:
         }
 

--- a/src/js/providers/bandwidth-monitor.js
+++ b/src/js/providers/bandwidth-monitor.js
@@ -7,11 +7,7 @@ export default function BandwidthMonitor(provider, initialEstimate) {
         start() {
             this.stop();
             setInterval(() => {
-                const bwEstimate = provider.getBandwidthEstimate();
-                if (!bwEstimate) {
-                    return;
-                }
-                bandwidthEstimate = bwEstimate;
+                bandwidthEstimate = provider.getBandwidthEstimate();
                 provider.trigger(BANDWIDTH_ESTIMATE, {
                     bandwidthEstimate
                 });

--- a/src/js/providers/bandwidth-monitor.js
+++ b/src/js/providers/bandwidth-monitor.js
@@ -1,13 +1,15 @@
 import { BANDWIDTH_ESTIMATE } from 'events/events';
 import { _isNumber } from 'utils/underscore';
 
-export default function BandwidthMonitor(provider) {
+export default function BandwidthMonitor(provider, initialEstimate) {
     let bandwidthMonitorInterval = null;
+    let bandwidthEstimate = initialEstimate;
     return {
         start() {
             setInterval(() => {
-                const bandwidthEstimate = provider.getBandwidthEstimate();
-                if (_isNumber(bandwidthEstimate)) {
+                const bwEstimate = provider.getBandwidthEstimate();
+                if (_isNumber(bwEstimate)) {
+                    bandwidthEstimate = bwEstimate;
                     provider.trigger(BANDWIDTH_ESTIMATE, {
                         bandwidthEstimate
                     });
@@ -16,6 +18,9 @@ export default function BandwidthMonitor(provider) {
         },
         stop() {
             clearInterval(bandwidthMonitorInterval);
+        },
+        getEstimate() {
+            return bandwidthEstimate;
         }
     };
 }

--- a/src/js/providers/bandwidth-monitor.js
+++ b/src/js/providers/bandwidth-monitor.js
@@ -8,12 +8,13 @@ export default function BandwidthMonitor(provider, initialEstimate) {
         start() {
             setInterval(() => {
                 const bwEstimate = provider.getBandwidthEstimate();
-                if (_isNumber(bwEstimate)) {
-                    bandwidthEstimate = bwEstimate;
-                    provider.trigger(BANDWIDTH_ESTIMATE, {
-                        bandwidthEstimate
-                    });
+                if (!bwEstimate) {
+                    return;
                 }
+                bandwidthEstimate = bwEstimate;
+                provider.trigger(BANDWIDTH_ESTIMATE, {
+                    bandwidthEstimate
+                });
             }, 1000);
         },
         stop() {

--- a/src/js/providers/bandwidth-monitor.js
+++ b/src/js/providers/bandwidth-monitor.js
@@ -1,5 +1,4 @@
 import { BANDWIDTH_ESTIMATE } from 'events/events';
-import { _isNumber } from 'utils/underscore';
 
 export default function BandwidthMonitor(provider, initialEstimate) {
     let bandwidthMonitorInterval = null;

--- a/src/js/providers/bandwidth-monitor.js
+++ b/src/js/providers/bandwidth-monitor.js
@@ -1,0 +1,21 @@
+import { BANDWIDTH_ESTIMATE } from 'events/events';
+import { _isNumber } from 'utils/underscore';
+
+export default function BandwidthMonitor(provider) {
+    let bandwidthMonitorInterval = null;
+    return {
+        start() {
+            setInterval(() => {
+                const bandwidthEstimate = provider.getBandwidthEstimate();
+                if (_isNumber(bandwidthEstimate)) {
+                    provider.trigger(BANDWIDTH_ESTIMATE, {
+                        bandwidthEstimate
+                    });
+                }
+            }, 1000);
+        },
+        stop() {
+            clearInterval(bandwidthMonitorInterval);
+        }
+    };
+}

--- a/src/js/providers/bandwidth-monitor.js
+++ b/src/js/providers/bandwidth-monitor.js
@@ -5,6 +5,7 @@ export default function BandwidthMonitor(provider, initialEstimate) {
     let bandwidthEstimate = initialEstimate;
     return {
         start() {
+            this.stop();
             setInterval(() => {
                 const bwEstimate = provider.getBandwidthEstimate();
                 if (!bwEstimate) {

--- a/src/js/providers/bandwidth-monitor.js
+++ b/src/js/providers/bandwidth-monitor.js
@@ -1,4 +1,5 @@
 import { BANDWIDTH_ESTIMATE } from 'events/events';
+import { _isValidNumber } from 'utils/underscore';
 
 export default function BandwidthMonitor(provider, initialEstimate) {
     let bandwidthMonitorInterval = null;
@@ -7,7 +8,11 @@ export default function BandwidthMonitor(provider, initialEstimate) {
         start() {
             this.stop();
             setInterval(() => {
-                bandwidthEstimate = provider.getBandwidthEstimate();
+                const bwEstimate = provider.getBandwidthEstimate();
+                if (!_isValidNumber(bwEstimate)) {
+                    return;
+                }
+                bandwidthEstimate = bwEstimate;
                 provider.trigger(BANDWIDTH_ESTIMATE, {
                     bandwidthEstimate
                 });

--- a/src/js/providers/default.js
+++ b/src/js/providers/default.js
@@ -67,6 +67,9 @@ const DefaultProvider = {
     getPlaybackRate: function() {
         return 1;
     },
+    getBandwidthEstimate() {
+        return null;
+    },
 
     // TODO :: The following are targets for removal after refactoring
     checkComplete: noop,

--- a/src/js/utils/underscore.js
+++ b/src/js/utils/underscore.js
@@ -736,6 +736,7 @@ _.result = function (object, property) {
 };
 
 const _isNumber = _.isNumber;
+const _isValidNumber = (val) => _isNumber(val) && !_isNaN(val);
 
-export { _isNaN, _isNumber };
+export { _isNaN, _isNumber, _isValidNumber };
 export default _;

--- a/test/data/model-properties.js
+++ b/test/data/model-properties.js
@@ -45,7 +45,7 @@ export const optionalProperties = {
     viewable: true,
     castClicked: false,
     castState: '',
-    castActive: '',
+    castActive: ''
 };
 
 export const adModelProperties = {
@@ -102,4 +102,6 @@ export default {
     itemReady: false,
     liveTimeout: null,
     setupConfig: {},
+    bandwidthEstimate: null,
+    bitrateSelection: null
 };

--- a/test/unit/program-controller-test.js
+++ b/test/unit/program-controller-test.js
@@ -54,7 +54,7 @@ const providerPlayerModelEvents = [
     {
         type: 'levelsChanged',
         currentQuality: 1,
-        levels: [ { label: 'level1' }, { label: 'level2' } ]
+        levels: [ { label: 'level1', bitrate: 100 }, { label: 'level2', bitrate: 200 } ]
     },
     {
         type: 'subtitlesTrackChanged',
@@ -251,12 +251,12 @@ describe('ProgramController', function () {
                 });
                 expect(model.set).to.have.callCount(4);
                 expect(model.set.firstCall).to.have.been.calledWith('volume', 10);
-                expect(model.set.getCall(1)).to.have.been.calledWith('qualityLabel', 'level2');
+                expect(model.set.getCall(1)).to.have.been.calledWith('bitrateSelection', 200);
                 expect(model.set.getCall(2)).to.have.been.calledWith('captionsIndex', 0);
                 expect(model.set.getCall(3)).to.have.been.calledWith('captionLabel', 'Off');
                 expect(model.trigger).to.have.callCount(5);
                 expect(model.trigger.firstCall).to.have.been.calledWith('change:volume');
-                expect(model.trigger.getCall(1)).to.have.been.calledWith('change:qualityLabel');
+                expect(model.trigger.getCall(1)).to.have.been.calledWith('change:bitrateSelection');
                 expect(model.trigger.getCall(2)).to.have.been.calledWith('change:captionsIndex');
                 expect(model.trigger.getCall(3)).to.have.been.calledWith('change:captionLabel');
                 expect(model.trigger.getCall(4)).to.have.been.calledWith('subtitlesTracks');


### PR DESCRIPTION
### What does this Pull Request do?
- Saves the bandwidth estimate during playback to localStorage
- Deprecates qualityLabel as a method of preserving quality between sessions
- If manually selected, preserve the bitrate of the currently playing item in localStorage

### Why is this Pull Request needed?
So that when the player starts a new session, playback quality is propagated from previous session

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/5006

#### Addresses Issue(s):

JW8-1204

