### PR TITLE
Prevent state changes for backgrounded mediaControllers 

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -156,7 +156,7 @@ Object.assign(Controller.prototype, {
         _model.on('change:mediaModel', function(model, mediaModel) {
             model.set('errorEvent', undefined);
             mediaModel.change('mediaState', function (changedMediaModel, state) {
-                if (!model.get('errorEvent')) {
+                if (!model.get('errorEvent') && !model.get('instream')) {
                     model.set(PLAYER_STATE, normalizeState(state));
                 }
             }, this);

--- a/src/js/program/program-listeners.js
+++ b/src/js/program/program-listeners.js
@@ -30,7 +30,9 @@ export function ProviderListener(mediaController) {
                 // Always fire change:mediaState to keep player model in sync
                 const previousState = mediaModel.attributes.mediaState;
                 mediaModel.attributes.mediaState = data.newstate;
-                mediaModel.trigger('change:mediaState', mediaModel, data.newstate, previousState);
+                if (mediaController.attached && !mediaController.background) {
+                    mediaModel.trigger('change:mediaState', mediaModel, data.newstate, previousState);
+                }
                 // This "return" is important because
                 //  we are choosing to not propagate model event.
                 //  Instead letting the master controller do so

--- a/src/js/program/program-listeners.js
+++ b/src/js/program/program-listeners.js
@@ -27,13 +27,10 @@ export function ProviderListener(mediaController) {
                     mediaController.thenPlayPromise.cancel();
                     mediaModel.srcReset();
                 }
-
-                if (mediaController.attached && !mediaController.background) {
-                    //fire change:mediaState to keep player model in sync
-                    const previousState = mediaModel.attributes.mediaState;
-                    mediaModel.attributes.mediaState = data.newstate;
-                    mediaModel.trigger('change:mediaState', mediaModel, data.newstate, previousState);
-                }
+                // Always fire change:mediaState to keep player model in sync
+                const previousState = mediaModel.attributes.mediaState;
+                mediaModel.attributes.mediaState = data.newstate;
+                mediaModel.trigger('change:mediaState', mediaModel, data.newstate, previousState);
                 // This "return" is important because
                 //  we are choosing to not propagate model event.
                 //  Instead letting the master controller do so

--- a/src/js/program/program-listeners.js
+++ b/src/js/program/program-listeners.js
@@ -27,10 +27,11 @@ export function ProviderListener(mediaController) {
                     mediaController.thenPlayPromise.cancel();
                     mediaModel.srcReset();
                 }
-                // Always fire change:mediaState to keep player model in sync
-                const previousState = mediaModel.attributes.mediaState;
-                mediaModel.attributes.mediaState = data.newstate;
+
                 if (mediaController.attached && !mediaController.background) {
+                    //fire change:mediaState to keep player model in sync
+                    const previousState = mediaModel.attributes.mediaState;
+                    mediaModel.attributes.mediaState = data.newstate;
                     mediaModel.trigger('change:mediaState', mediaModel, data.newstate, previousState);
                 }
                 // This "return" is important because


### PR DESCRIPTION
### This PR will...
check if the mediaController is attached and not in background before triggering a change in mediaState
### Why is this Pull Request needed?
When a midRoll begins or playAd is called, a pause event is triggered causing the related shelf to open. Before BGL was introduced, a pause event was not fired before an ad.
### Are there any points in the code the reviewer needs to double check?
should the media model still be updated ?
### Are there any Pull Requests open in other repos which need to be merged with this?
A prevention is added in [Related](https://github.com/jwplayer/jwplayer-plugin-related/pull/275) to prevent API calls during ad playback from opening related views
#### Addresses Issue(s):
JW8-1362

