### PR TITLE
Copy 'androidhls', 'hlsjsdefault' and 'safarihlsjs' into playlist item sources when checking for provider support

### DIFF
--- a/src/js/api/core-loader.js
+++ b/src/js/api/core-loader.js
@@ -1,4 +1,5 @@
 import Item from 'playlist/item';
+import { fixSources } from 'playlist/playlist';
 import ProvidersSupported from 'providers/providers-supported';
 import registerProvider from 'providers/providers-register';
 import { module as ControlsModule } from 'controller/controls-loader';
@@ -50,7 +51,7 @@ export function requiresPolyfills() {
 export function requiresProvider(model, providerName) {
     const playlist = model.get('playlist');
     if (Array.isArray(playlist) && playlist.length) {
-        const sources = Item(playlist[0]).sources;
+        const sources = fixSources(Item(playlist[0]), model);
         for (let i = 0; i < sources.length; i++) {
             const source = sources[i];
             const providersManager = model.getProviders();
@@ -66,8 +67,7 @@ export function requiresProvider(model, providerName) {
 }
 
 function loadControlsPolyfillHtml5Bundle() {
-    bundleContainsProviders.html5 = true;
-    return require.ensure([
+    const loadPromise = require.ensure([
         'controller/controller',
         'view/controls/controls',
         'intersection-observer',
@@ -80,11 +80,12 @@ function loadControlsPolyfillHtml5Bundle() {
         registerProvider(require('providers/html5').default);
         return CoreMixin;
     }, chunkLoadErrorHandler, 'jwplayer.core.controls.polyfills.html5');
+    bundleContainsProviders.html5 = loadPromise;
+    return loadPromise;
 }
 
 function loadControlsHtml5Bundle() {
-    bundleContainsProviders.html5 = true;
-    return require.ensure([
+    const loadPromise = require.ensure([
         'controller/controller',
         'view/controls/controls',
         'providers/html5'
@@ -94,6 +95,8 @@ function loadControlsHtml5Bundle() {
         registerProvider(require('providers/html5').default);
         return CoreMixin;
     }, chunkLoadErrorHandler, 'jwplayer.core.controls.html5');
+    bundleContainsProviders.html5 = loadPromise;
+    return loadPromise;
 }
 
 function loadControlsPolyfillBundle() {

--- a/src/js/api/setup-steps.js
+++ b/src/js/api/setup-steps.js
@@ -48,10 +48,10 @@ function loadProvider(_model) {
         validatePlaylist(playlist);
 
         const providersManager = _model.getProviders();
-        const { name, provider } = providersManager.choose(playlist[0].sources[0]);
+        const { name } = providersManager.choose(playlist[0].sources[0]);
         // Skip provider loading if included in bundle
-        if (bundleContainsProviders.html5 && provider && name === 'html5') {
-            return;
+        if (bundleContainsProviders.html5 && name === 'html5') {
+            return bundleContainsProviders.html5;
         }
         return providersManager.load(name);
     });


### PR DESCRIPTION
### This PR will...

- Copy 'androidhls', 'hlsjsdefault' and 'safarihlsjs' into playlist item sources when checking for provider support
- Don't load html5 provider twice when bundled

### Why is this Pull Request needed?

These attributes need to be added to sources for provider selection to work properly. Provider selection is part of provider bundling and loaded. When the html5 provider is bundled with jwplayer.core.js, it should not be loaded again.

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-commercial/pull/5014

#### Addresses Issue(s):

JW8-1319

