### PR TITLE
Bugfix/stretching object fit transform

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -6,7 +6,7 @@ import { STATE_IDLE, STATE_PLAYING, STATE_STALLED, MEDIA_META, MEDIA_ERROR, MEDI
 import VideoEvents from 'providers/video-listener-mixin';
 import VideoAction from 'providers/video-actions-mixin';
 import VideoAttached from 'providers/video-attached-mixin';
-import { style, transform } from 'utils/css';
+import { style } from 'utils/css';
 import utils from 'utils/helpers';
 import { emptyElement } from 'utils/dom';
 import _ from 'utils/underscore';
@@ -584,52 +584,6 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
                 opacity: 0
             });
         }
-    };
-
-    this.resize = function(width, height, stretching) {
-        if (!width || !height || !_videotag.videoWidth || !_videotag.videoHeight) {
-            return;
-        }
-        const styles = {
-            objectFit: '',
-            width: '',
-            height: ''
-        };
-        if (stretching === 'uniform') {
-            // snap video to edges when the difference in aspect ratio is less than 9%
-            const playerAspectRatio = width / height;
-            const videoAspectRatio = _videotag.videoWidth / _videotag.videoHeight;
-            if (Math.abs(playerAspectRatio - videoAspectRatio) < 0.09) {
-                styles.objectFit = 'fill';
-                stretching = 'exactfit';
-            }
-        }
-        // Prior to iOS 9, object-fit worked poorly
-        // object-fit is not implemented in IE or Android Browser in 4.4 and lower
-        // http://caniuse.com/#feat=object-fit
-        // feature detection may work for IE but not for browsers where object-fit works for images only
-        const fitVideoUsingTransforms = Browser.ie || (OS.iOS && OS.version.major < 9) || Browser.androidNative;
-        if (fitVideoUsingTransforms) {
-            // Use transforms to center and scale video in container
-            const x = -Math.floor(_videotag.videoWidth / 2 + 1);
-            const y = -Math.floor(_videotag.videoHeight / 2 + 1);
-            let scaleX = Math.ceil(width * 100 / _videotag.videoWidth) / 100;
-            let scaleY = Math.ceil(height * 100 / _videotag.videoHeight) / 100;
-            if (stretching === 'none') {
-                scaleX = scaleY = 1;
-            } else if (stretching === 'fill') {
-                scaleX = scaleY = Math.max(scaleX, scaleY);
-            } else if (stretching === 'uniform') {
-                scaleX = scaleY = Math.min(scaleX, scaleY);
-            }
-            styles.width = _videotag.videoWidth;
-            styles.height = _videotag.videoHeight;
-            styles.top = styles.left = '50%';
-            styles.margin = 0;
-            transform(_videotag,
-                'translate(' + x + 'px, ' + y + 'px) scale(' + scaleX.toFixed(2) + ', ' + scaleY.toFixed(2) + ')');
-        }
-        style(_videotag, styles);
     };
 
     this.setFullscreen = function(state) {

--- a/src/js/providers/video-actions-mixin.js
+++ b/src/js/providers/video-actions-mixin.js
@@ -1,4 +1,5 @@
-import { style } from 'utils/css';
+import { Browser, OS } from 'environment/environment';
+import { style, transform } from 'utils/css';
 import endOfRange from 'utils/time-ranges';
 
 const VideoActionsMixin = {
@@ -19,24 +20,57 @@ const VideoActionsMixin = {
     },
 
     resize(width, height, stretching) {
-        if (!width || !height || !this.video.videoWidth || !this.video.videoHeight) {
-            return false;
+        const { video } = this;
+        const { videoWidth, videoHeight } = video;
+        if (!width || !height || !videoWidth || !videoHeight) {
+            return;
         }
+        const styles = {
+            objectFit: '',
+            width: '',
+            height: ''
+        };
         if (stretching === 'uniform') {
-            // snap video to edges when the difference in aspect ratio is less than 9%
-            var playerAspectRatio = width / height;
-            var videoAspectRatio = this.video.videoWidth / this.video.videoHeight;
-            var objectFit = null;
-            if (Math.abs(playerAspectRatio - videoAspectRatio) < 0.09) {
-                objectFit = 'fill';
+            // Snap video to edges when the difference in aspect ratio is less than 9% and perceivable
+            const playerAspectRatio = width / height;
+            const videoAspectRatio = videoWidth / videoHeight;
+            const edgeMatch = Math.abs(playerAspectRatio - videoAspectRatio);
+            if (edgeMatch < 0.09 && edgeMatch > 0.0025) {
+                styles.objectFit = 'fill';
+                stretching = 'exactfit';
             }
-            style(this.video, {
-                objectFit,
-                width: null,
-                height: null
-            });
         }
-        return false;
+        // Prior to iOS 9, object-fit worked poorly
+        // object-fit is not implemented in IE or Android Browser in 4.4 and lower
+        // http://caniuse.com/#feat=object-fit
+        // feature detection may work for IE but not for browsers where object-fit works for images only
+        const fitVideoUsingTransforms = Browser.ie || (OS.iOS && OS.version.major < 9) || Browser.androidNative;
+        if (fitVideoUsingTransforms) {
+            if (stretching !== 'uniform') {
+                // Use transforms to center and scale video in container
+                const x = -Math.floor(videoWidth / 2 + 0.9);
+                const y = -Math.floor(videoHeight / 2 + 0.9);
+                let scaleX = Math.ceil(width * 100 / videoWidth) / 100;
+                let scaleY = Math.ceil(height * 100 / videoHeight) / 100;
+                if (stretching === 'none') {
+                    scaleX = scaleY = 1;
+                } else if (stretching === 'fill') {
+                    scaleX = scaleY = Math.max(scaleX, scaleY);
+                } else if (stretching === 'uniform') {
+                    scaleX = scaleY = Math.min(scaleX, scaleY);
+                }
+                styles.width = videoWidth;
+                styles.height = videoHeight;
+                styles.top = styles.left = '50%';
+                styles.margin = 0;
+                transform(video,
+                    'translate(' + x + 'px, ' + y + 'px) scale(' + scaleX.toFixed(2) + ', ' + scaleY.toFixed(2) + ')');
+            } else {
+                styles.top = styles.left = styles.margin = '';
+                transform(video, '');
+            }
+        }
+        style(video, styles);
     },
 
     getContainer() {

--- a/src/js/providers/video-listener-mixin.js
+++ b/src/js/providers/video-listener-mixin.js
@@ -38,19 +38,6 @@ const VideoListenerMixin = {
     },
 
     timeupdate() {
-        var height = this.video.videoHeight;
-        if (height !== this._helperLastVideoHeight) {
-            if (this.adaptation) {
-                this.adaptation({
-                    size: {
-                        width: this.video.videoWidth,
-                        height: height
-                    }
-                });
-            }
-        }
-        this._helperLastVideoHeight = height;
-
         const position = this.getCurrentTime();
         const duration = this.getDuration();
         if (isNaN(duration)) {
@@ -162,7 +149,8 @@ const VideoListenerMixin = {
     },
 
     ended() {
-        this._helperLastVideoHeight = 0;
+        this.videoHeight = 0;
+        this.streamBitrate = 0;
         if (this.state !== STATE_IDLE && this.state !== STATE_COMPLETE) {
             this.trigger(MEDIA_COMPLETE);
         }


### PR DESCRIPTION
### This PR will...

- Move video stretching object-fit transform workaround to mixins
- Avoid using object-fit workaround for imperceivable changes in aspect ratio
`edgeMatch < 0.09 && edgeMatch > 0.0025`
- Fix object-fit workaround centering for even dimensions
`-Math.floor(videoWidth / 2 + 0.9)`
- Update provider adaptation variables for changes in https://github.com/jwplayer/jwplayer-commercial/pull/5020

### Why is this Pull Request needed?

IE and Edge browsers do no support CSS "object-fit" on video elements which we rely on to fit video in the player for "stretching" settings other than "uniform". For years we've worked around this in our html5 provider on IE, iOS and legacy Android browsers. These changes will also apply the workaround when playback in handled by commercial providers such as hlsjs and shaka.

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-commercial/pull/5020

#### Addresses Issue(s):

JW8-772

