### PR TITLE
Reset item.starttime to 0 when loading an ad so that replayed ads beg…

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -213,9 +213,10 @@ var InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
 
         const adModel = _adProgram.model;
         adModel.set('playlist', playlist);
-
         _model.set('hideAdsControls', false);
 
+        // Reset starttime so that if the same ad is replayed by a plugin, it reloads from the start
+        item.starttime = 0;
         // Dispatch playlist item event for ad pods
         _this.trigger(PLAYLIST_ITEM, {
             index: _arrayIndex,


### PR DESCRIPTION
### Why is this Pull Request needed?
So that replayed ads begin from the start. Ad pods with sequentially duplicate items technically replay the same ad.

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-1351

