### PR TITLE
Disable Related Open & Close API during ads

### DIFF
--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -29,6 +29,7 @@ const Model = function() {
         Object.keys(INITIAL_MEDIA_STATE).forEach(key => {
             config[key] = mediaModelAttributes[key];
         });
+        config.instreamMode = !!config.instream;
         delete config.instream;
         delete config.mediaModel;
         return config;


### PR DESCRIPTION
### This PR will...
set an instreamMode bool to the config before deleting the instream object
### Why is this Pull Request needed?
To allow the related plugin and other clients to check if the player is in ads mode.
### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?
[related](https://github.com/jwplayer/jwplayer-plugin-related/pull/275)
#### Addresses Issue(s):
JW8-1362

