### PR TITLE
Rework position saving for non-BGL ads so that autoplay exceptions donot reset saved seek time 

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -718,14 +718,12 @@ Object.assign(Controller.prototype, {
             }
         }
 
-        function _attachMedia(position) {
+        function _attachMedia() {
             // Called after instream ends
 
             if (Features.backgroundLoading) {
                 _programController.restoreBackgroundMedia();
             } else {
-                // Set the position before attaching so that we resume at the expected time
-                _programController.position = position || 0;
                 _programController.attached = true;
             }
 

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -24,7 +24,6 @@ var InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
     let _options = {};
     let _skipAd = _instreamItemNext;
     let _backgroundLoadTriggered = false;
-    let _oldpos;
     let _skipOffset;
     let _backgroundLoadStart;
     let _destroyed = false;
@@ -92,7 +91,6 @@ var InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
         // Keep track of the original player state
         _adProgram.setup();
 
-        _oldpos = _controller.get('position');
         _adProgram.on('all', _instreamForward, this);
         _adProgram.on(MEDIA_PLAY_ATTEMPT_FAILED, triggerPlayRejected, this);
         _adProgram.on(MEDIA_TIME, _instreamTime, this);
@@ -105,13 +103,6 @@ var InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
         const mediaElement = _adProgram.primedElement;
         const mediaContainer = _model.get('mediaContainer');
         mediaContainer.appendChild(mediaElement);
-
-        if (_controller.checkBeforePlay() || (_oldpos === 0 && !_controller.isBeforeComplete())) {
-            // make sure video restarts after preroll
-            _oldpos = 0;
-        } else if (_controller.isBeforeComplete() || _model.get('state') === STATE_COMPLETE) {
-            _oldpos = null;
-        }
 
         // This enters the player into instream mode
         _model.set('instream', _adProgram);
@@ -330,13 +321,13 @@ var InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
 
         // Re-attach the controller & resume playback
         // when instream was inited and the player was not destroyed\
-        _controller.attachMedia(_oldpos);
+        _controller.attachMedia();
 
         if (this.noResume) {
             return;
         }
 
-        if (_oldpos === null) {
+        if (_controller.isBeforeComplete() || _model.get('state') === STATE_COMPLETE) {
             _controller.stopVideo();
         } else {
             _controller.playVideo();

--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -101,11 +101,18 @@ export default class MediaController extends Eventable {
     }
 
     detach() {
-        const { model, provider } = this;
+        const { item, mediaModel, model, provider } = this;
         this.thenPlayPromise.cancel();
         provider.detachMedia();
         this.attached = false;
         model.set('attached', false);
+
+        // If detaching to play a midroll (pos > 0), ensure that the player resumes at the detached time by setting starttime
+        // We don't need to do this for prerolls because the player re-attaches at time 0 by default
+        const pos = mediaModel.get('position');
+        if (pos) {
+            item.starttime = pos;
+        }
     }
 
     // Executes the playPromise


### PR DESCRIPTION
### This PR will...
- Remove `oldPos` from the instream-adapter
- Set `item.starttime` as `position` when detaching

### Why is this Pull Request needed?
So that if a non-BGL provider encounters an autostart failed exception, the subsequent playback attempt will begin at the set seek time.

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-1357

