### PR TITLE
Return currentTime in getAlignmentPosition

### DIFF
--- a/src/js/view/captionsrenderer.js
+++ b/src/js/view/captionsrenderer.js
@@ -114,20 +114,16 @@ const CaptionsRenderer = function (viewModel) {
     this.getAlignmentPosition = function (track, timeEvent) {
         const source = track.source;
         const metadata = timeEvent.metadata;
+        let time = timeEvent.currentTime;
 
         // subtitles with "source" time must be synced with "metadata[source]"
         if (source) {
             if (metadata && _.isNumber(metadata[source])) {
-                return metadata[source];
+                time = metadata[source];
             }
-            return;
-        } else if (timeEvent.duration < 0) {
-            // When the duration is negative (DVR mode), need to make alignmentPosition positive for captions to work
-            return timeEvent.position - timeEvent.duration;
-        }
+        } 
 
-        // Default to syncing with current position
-        return timeEvent.position;
+        return time;
     };
 
     this.clear = function () {


### PR DESCRIPTION
### This PR will...

Return currentTime from the time event in getAlignmentPosition if metadata source is undefined.

### Why is this Pull Request needed?

We no longer update position on timeupdate if the stream is DVR, which causes captions to be out of sync. We can return currentTime instead to cover all cases.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-1111

