### PR TITLE
Check if the mediaElement was already seeked before seeking on _completeLoad

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -370,7 +370,8 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
             _this.seek(startTime);
         }
 
-        if (startTime > 0) {
+        // Check if we have already seeked the mediaElement before _completeLoad has been called
+        if (startTime > 0 && _videotag.currentTime !== startTime) {
             _this.seek(startTime);
         }
 


### PR DESCRIPTION
### Why is this Pull Request needed?
So that we avoid duplicate seek calls from the html5 provider when calling seek on idle

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-1357

