### PR TITLE
Store the beforeComplete flag before re-attaching after an ad 

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -28,6 +28,7 @@ var InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
     let _backgroundLoadStart;
     let _destroyed = false;
     let _inited = false;
+    let _beforeComplete = false;
 
     const _clickHandler = (evt) => {
         if (_destroyed) {
@@ -115,6 +116,10 @@ var InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
         }
 
         this.setText(_model.get('localization').loadingAd);
+
+        // We need to know if we're beforeComplete before we reattach, since re-attaching will toggle the beforeComplete flag back if set
+        _beforeComplete = _controller.isBeforeComplete() || _model.get('state') === STATE_COMPLETE;
+
         return this;
     };
 
@@ -328,7 +333,7 @@ var InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
             return;
         }
 
-        if (_controller.isBeforeComplete() || _model.get('state') === STATE_COMPLETE) {
+        if (_beforeComplete) {
             _controller.stopVideo();
         } else {
             _controller.playVideo();


### PR DESCRIPTION
### Why is this Pull Request needed?
So that we will stop the video when coming back from the end of a preroll insteading of calling play, which would replay the video. VAST reset `beforeComplete` on postroll end by prematurely re-attaching instead of leaving it to the instream-adapter.

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-1391

