### PR TITLE
Use the view-model's "streamType"

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -295,7 +295,7 @@ function View(_api, _model) {
 
         _model.change('state', _stateHandler);
         playerViewModel.change('controls', changeControls);
-        playerViewModel.change('streamType', _setLiveMode);
+        _model.change('streamType', _setLiveMode);
         _model.change('mediaType', _onMediaTypeChange);
         playerViewModel.change('playlistItem', onPlaylistItem);
         // Triggering 'resize' resulting in player 'ready'


### PR DESCRIPTION
Use the view-model's "streamType" so that ads don't show live controls when played over live content.

The instream model always starts with a "streamType" of "VOD". Changing the "streamType" listener to the view-model triggers change updates to "streamType" when the player model and instream model have different values. This removes the `.jw-flag-live` from the player container when ads are played. 

#### Addresses Issue(s):
JW8-1373

