### PR TITLE
Don't background load for live and DVR streams

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -175,7 +175,9 @@ Object.assign(Controller.prototype, {
             if ((item || recsAuto) && Features.backgroundLoading) {
                 const onPosition = (changedMediaModel, position) => {
                     // Do not background load DAI items because that item will be dynamically replaced before play
-                    if ((item && !item.daiSetting) && position >= mediaModel.get('duration') - BACKGROUND_LOAD_OFFSET) {
+                    const allowPreload = (item && !item.daiSetting);
+                    const duration = mediaModel.get('duration');
+                    if (allowPreload && position && duration > 0 && position >= duration - BACKGROUND_LOAD_OFFSET) {
                         mediaModel.off('change:position', onPosition, this);
                         _programController.backgroundLoad(item);
                     } else if (recsAuto) {


### PR DESCRIPTION
### This PR will...

Prevent the next item from being preloaded in the background during a live or DVR stream.

### Why is this Pull Request needed?

Since we can't use the position and duration to know when a live or DVR stream will end, we shouldn't use them to trigger background loading. Duration either `Infinity` (live) or position is a negative number. There is no reliable signal to trigger preloading of the next item, other than a stream error which is out of scope for background loading.

### Are there other PRs related to this one?

https://github.com/jwplayer/jwplayer/pull/2822 targets the same changes against v8.2.x. Since it hasn't been merged and we focusing on 8.3.0 now, I made this PR so that we can get this merged and tested against development.

#### Addresses Issue(s):

JW8-1374

