### PR TITLE
Only load provider when it is not loaded

### DIFF
--- a/src/js/api/setup-steps.js
+++ b/src/js/api/setup-steps.js
@@ -48,8 +48,13 @@ function loadProvider(_model) {
         validatePlaylist(playlist);
 
         const providersManager = _model.getProviders();
-        const { name } = providersManager.choose(playlist[0].sources[0]);
-        // Skip provider loading if included in bundle
+        const { provider, name } = providersManager.choose(playlist[0].sources[0]);
+
+        // If provider already loaded or a locally registered one, return it
+        if (typeof provider === 'function') {
+            return provider;
+        }
+
         if (bundleContainsProviders.html5 && name === 'html5') {
             return bundleContainsProviders.html5;
         }


### PR DESCRIPTION
### This PR will...

Fix https://github.com/jwplayer/jwplayer/issues/2828

### Why is this Pull Request needed?

Restore support for locally registered custom playback providers.

### Are there any points in the code the reviewer needs to double check?

I attempted to write a unit test for this but this involves `global-api.registerProvider` which is not available in the `setup-steps` unit test.

### Are there any Pull Requests open in other repos which need to be merged with this?

None.

#### Addresses Issue(s):

JW8-2828

