### PR TITLE
Add "defaultBandwidthEstimate" property to config

### DIFF
--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -77,6 +77,15 @@ function _normalizeSize(val) {
     return val;
 }
 
+
+function _adjustDefaultBwEstimate(estimate) {
+    if (_isValidNumber(estimate)) {
+        return estimate > 1 ? estimate : 1;
+    }
+
+    return Defaults.defaultBandwidthEstimate;
+}
+
 const Config = function(options, persisted) {
     let allOptions = Object.assign({}, (window.jwplayer || {}).defaults, persisted, options);
 
@@ -167,7 +176,7 @@ const Config = function(options, persisted) {
     const parsedDefaultBwEstimate = parseFloat(config.defaultBandwidthEstimate);
     config.bandwidthEstimate = _isValidNumber(parsedBwEstimate) ? parsedBwEstimate : Defaults.bandwidthEstimate;
     config.bitrateSelection = _isValidNumber(parsedBitrateSelection) ? parsedBitrateSelection : Defaults.bitrateSelection;
-    config.defaultBandwidthEstimate = _isValidNumber(parsedDefaultBwEstimate) && parsedDefaultBwEstimate < 1 ? 1 : parsedDefaultBwEstimate;
+    config.defaultBandwidthEstimate = _adjustDefaultBwEstimate(parsedDefaultBwEstimate);
     return config;
 };
 

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -167,7 +167,7 @@ const Config = function(options, persisted) {
     const parsedDefaultBwEstimate = parseFloat(config.defaultBandwidthEstimate);
     config.bandwidthEstimate = _isValidNumber(parsedBwEstimate) ? parsedBwEstimate : Defaults.bandwidthEstimate;
     config.bitrateSelection = _isValidNumber(parsedBitrateSelection) ? parsedBitrateSelection : Defaults.bitrateSelection;
-    config.defaultBandwidthEstimate = _isValidNumber(parsedDefaultBwEstimate) && parsedDefaultBwEstimate > 0 ? parsedDefaultBwEstimate : Defaults.defaultBandwidthEstimate;
+    config.defaultBandwidthEstimate = _isValidNumber(parsedDefaultBwEstimate) && parsedDefaultBwEstimate < 0 ? 1 : parsedDefaultBwEstimate;
     return config;
 };
 

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -78,8 +78,9 @@ function _normalizeSize(val) {
 
 
 function _adjustDefaultBwEstimate(estimate) {
-    if (_isValidNumber(parseFloat(estimate))) {
-        return Math.max(estimate, 1);
+    const parsedEstimate = parseFloat(estimate);
+    if (_isValidNumber(parsedEstimate)) {
+        return Math.max(parsedEstimate, 1);
     }
 
     return Defaults.bandwidthEstimate;

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -78,8 +78,8 @@ function _normalizeSize(val) {
 
 
 function _adjustDefaultBwEstimate(estimate) {
-    if (_isValidNumber(estimate)) {
-        return estimate > 1 ? estimate : 1;
+    if (_isValidNumber(parseFloat(estimate))) {
+        return Math.max(estimate, 1);
     }
 
     return Defaults.bandwidthEstimate;
@@ -172,7 +172,7 @@ const Config = function(options, persisted) {
 
     const parsedBwEstimate = parseFloat(config.bandwidthEstimate);
     const parsedBitrateSelection = parseFloat(config.bitrateSelection);
-    config.bandwidthEstimate = _isValidNumber(parsedBwEstimate) ? parsedBwEstimate : _adjustDefaultBwEstimate(parseFloat(config.defaultBandwidthEstimate));
+    config.bandwidthEstimate = _isValidNumber(parsedBwEstimate) ? parsedBwEstimate : _adjustDefaultBwEstimate(config.defaultBandwidthEstimate);
     config.bitrateSelection = _isValidNumber(parsedBitrateSelection) ? parsedBitrateSelection : Defaults.bitrateSelection;
     return config;
 };

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -13,7 +13,6 @@ const Defaults = {
     bitrateSelection: null,
     castAvailable: false,
     controls: true,
-    defaultBandwidthEstimate: null,
     defaultPlaybackRate: 1,
     displaydescription: true,
     displaytitle: true,
@@ -83,7 +82,7 @@ function _adjustDefaultBwEstimate(estimate) {
         return estimate > 1 ? estimate : 1;
     }
 
-    return Defaults.defaultBandwidthEstimate;
+    return Defaults.bandwidthEstimate;
 }
 
 const Config = function(options, persisted) {
@@ -173,10 +172,8 @@ const Config = function(options, persisted) {
 
     const parsedBwEstimate = parseFloat(config.bandwidthEstimate);
     const parsedBitrateSelection = parseFloat(config.bitrateSelection);
-    const parsedDefaultBwEstimate = parseFloat(config.defaultBandwidthEstimate);
-    config.bandwidthEstimate = _isValidNumber(parsedBwEstimate) ? parsedBwEstimate : Defaults.bandwidthEstimate;
+    config.bandwidthEstimate = _isValidNumber(parsedBwEstimate) ? parsedBwEstimate : _adjustDefaultBwEstimate(parseFloat(config.defaultBandwidthEstimate));
     config.bitrateSelection = _isValidNumber(parsedBitrateSelection) ? parsedBitrateSelection : Defaults.bitrateSelection;
-    config.defaultBandwidthEstimate = _adjustDefaultBwEstimate(parsedDefaultBwEstimate);
     return config;
 };
 

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -162,11 +162,12 @@ const Config = function(options, persisted) {
         config.liveTimeout = liveTimeout;
     }
 
-    const parsedBwEstimate = parseFloat(!config.bandwidthEstimate && config.defaultBandwidthEstimate > -1 ? config.defaultBandwidthEstimate : config.bandwidthEstimate);
+    const parsedBwEstimate = parseFloat(config.bandwidthEstimate);
     const parsedBitrateSelection = parseFloat(config.bitrateSelection);
+    const parsedDefaultBwEstimate = parseFloat(config.defaultBandwidthEstimate);
     config.bandwidthEstimate = _isValidNumber(parsedBwEstimate) ? parsedBwEstimate : Defaults.bandwidthEstimate;
     config.bitrateSelection = _isValidNumber(parsedBitrateSelection) ? parsedBitrateSelection : Defaults.bitrateSelection;
-
+    config.defaultBandwidthEstimate = _isValidNumber(parsedDefaultBwEstimate) && parsedDefaultBwEstimate > 0 ? parsedDefaultBwEstimate : Defaults.defaultBandwidthEstimate;
     return config;
 };
 

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -13,6 +13,7 @@ const Defaults = {
     bitrateSelection: null,
     castAvailable: false,
     controls: true,
+    defaultBandwidthEstimate: null,
     defaultPlaybackRate: 1,
     displaydescription: true,
     displaytitle: true,
@@ -161,7 +162,7 @@ const Config = function(options, persisted) {
         config.liveTimeout = liveTimeout;
     }
 
-    const parsedBwEstimate = parseFloat(config.bandwidthEstimate);
+    const parsedBwEstimate = parseFloat(!config.bandwidthEstimate && config.defaultBandwidthEstimate > -1 ? config.defaultBandwidthEstimate : config.bandwidthEstimate);
     const parsedBitrateSelection = parseFloat(config.bitrateSelection);
     config.bandwidthEstimate = _isValidNumber(parsedBwEstimate) ? parsedBwEstimate : Defaults.bandwidthEstimate;
     config.bitrateSelection = _isValidNumber(parsedBitrateSelection) ? parsedBitrateSelection : Defaults.bitrateSelection;

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -167,7 +167,7 @@ const Config = function(options, persisted) {
     const parsedDefaultBwEstimate = parseFloat(config.defaultBandwidthEstimate);
     config.bandwidthEstimate = _isValidNumber(parsedBwEstimate) ? parsedBwEstimate : Defaults.bandwidthEstimate;
     config.bitrateSelection = _isValidNumber(parsedBitrateSelection) ? parsedBitrateSelection : Defaults.bitrateSelection;
-    config.defaultBandwidthEstimate = _isValidNumber(parsedDefaultBwEstimate) && parsedDefaultBwEstimate < 0 ? 1 : parsedDefaultBwEstimate;
+    config.defaultBandwidthEstimate = _isValidNumber(parsedDefaultBwEstimate) && parsedDefaultBwEstimate < 1 ? 1 : parsedDefaultBwEstimate;
     return config;
 };
 

--- a/test/data/model-properties.js
+++ b/test/data/model-properties.js
@@ -71,6 +71,7 @@ export default {
     base: '',
     controls: true,
     stretching: 'uniform',
+    defaultBandwidthEstimate: null,
     defaultPlaybackRate: 1.0,
     displaytitle: true,
     displaydescription: true,

--- a/test/data/model-properties.js
+++ b/test/data/model-properties.js
@@ -71,7 +71,6 @@ export default {
     base: '',
     controls: true,
     stretching: 'uniform',
-    defaultBandwidthEstimate: null,
     defaultPlaybackRate: 1.0,
     displaytitle: true,
     displaydescription: true,


### PR DESCRIPTION
### This PR will...

Add "defaultBandwidthEstimate" property to config 

### Why is this Pull Request needed?

To allow publishers to define a startup bandwidth so their viewers can start playback with a higher quality

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-1204

