### PR TITLE
Add guard check for visualQuality Event

### DIFF
--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -138,6 +138,9 @@ export default class MediaController extends Eventable {
                 // Start firing visualQuality once playback has started
                 mediaModel.off(MEDIA_VISUAL_QUALITY, null, this);
                 mediaModel.change(MEDIA_VISUAL_QUALITY, (changedMediaModel, eventData) => {
+                    if (!eventData) {
+                        return;
+                    }
                     this.trigger(MEDIA_VISUAL_QUALITY, eventData);
                 }, this);
                 syncPlayerWithMediaModel(mediaModel);

--- a/src/js/program/program-listeners.js
+++ b/src/js/program/program-listeners.js
@@ -92,9 +92,6 @@ export function ProviderListener(mediaController) {
                 }
                 break;
             }
-            case 'visualQuality':
-                mediaModel.set('visualQuality', Object.assign({}, data));
-                break;
             default:
                 break;
         }


### PR DESCRIPTION
### This PR will...

Only trigger visualQuality event in media-controller if the eventData argument isn't a falsy value.

### Why is this Pull Request needed?

An empty visualQuality event is triggered in the media-controller when preload is set to "none" on play attempt for HLS. The eventData argument that would be passed in when it's triggered returns null. We dont know the actual visualQuality until the adaptation event fires

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-1404

