### PR TITLE
Don't hide right click menu on tap

### DIFF
--- a/src/js/view/controls/rightclick.js
+++ b/src/js/view/controls/rightclick.js
@@ -152,12 +152,10 @@ export default class RightClick {
     }
 
     onMouseOver() {
-        console.log('onMouseOver');
         this.mouseOverContext = true;
     }
 
     onMouseOut() {
-        console.log('onMouseOut');
         this.mouseOverContext = false;
     }
 

--- a/src/js/view/controls/rightclick.js
+++ b/src/js/view/controls/rightclick.js
@@ -75,6 +75,7 @@ export default class RightClick {
 
         this.el.style.left = off.x + 'px';
         this.el.style.top = off.y + 'px';
+        this.outCount = 0;
 
         addClass(this.playerElement, 'jw-flag-rightclick-open');
         addClass(this.el, 'jw-open');
@@ -84,15 +85,8 @@ export default class RightClick {
     }
 
     hideMenu(evt) {
-        if (!this.model.get('touchMode')) {
-            // If mouse is over the menu, hide the menu when mouse moves out
-            this.el.removeEventListener('mouseout', this.hideMenuHandler);
-            if (this.mouseOverContext) {
-                this.el.addEventListener('mouseout', this.hideMenuHandler);
-                return;
-            }
-        } else if (evt && this.el.contains(evt.target)) {
-            // If menu is tapped, do not hide menu
+        if (evt && this.el.contains(evt.target)) {
+            // Do not hide menu when clicking inside menu
             return;
         }
 
@@ -119,17 +113,22 @@ export default class RightClick {
 
         this.layer.appendChild(this.el);
 
-        this.hideMenuHandler = this.hideMenu.bind(this);
+        this.hideMenuHandler = e => this.hideMenu(e);
+        this.overHandler = () => {
+            this.mouseOverContext = true;
+        };
+        this.outHandler = (evt) => {
+            this.mouseOverContext = false;
+            if (evt.relatedTarget && !this.el.contains(evt.relatedTarget) && ++this.outCount > 1) {
+                this.hideMenu();
+            }
+        };
         this.addOffListener(this.playerElement);
         this.addOffListener(document);
 
         // Track if the mouse is above the menu or not
-        this.el.addEventListener('mouseover', () => {
-            this.mouseOverContext = true;
-        });
-        this.el.addEventListener('mouseout', () => {
-            this.mouseOverContext = false;
-        });
+        this.el.addEventListener('mouseover', this.overHandler);
+        this.el.addEventListener('mouseout', this.outHandler);
     }
 
     setup(_model, _playerElement, layer) {
@@ -185,14 +184,14 @@ export default class RightClick {
         clearTimeout(this._menuTimeout);
         if (this.el) {
             this.hideMenu();
-            this.removeOffListener(this.playerElement);
             this.removeOffListener(document);
-            this.el.removeEventListener('mouseout', this.hideMenuHandler);
-            this.hideMenuHandler = null;
+            this.el.removeEventListener('mouseover', this.overHandler);
+            this.el.removeEventListener('mouseout', this.outHandler);
             this.el = null;
         }
 
         if (this.playerElement) {
+            this.removeOffListener(this.playerElement);
             this.playerElement.removeEventListener('touchstart', this.startLongPressHandler);
             this.playerElement.removeEventListener('touchmove', this.cancelLongPressHandler);
             this.playerElement.removeEventListener('touchend', this.cancelLongPressHandler);

--- a/src/js/view/controls/rightclick.js
+++ b/src/js/view/controls/rightclick.js
@@ -92,7 +92,7 @@ export default class RightClick {
                 return;
             }
         } else if (evt && this.el.contains(evt.target)) {
-            // If menu is tapped, do not hide menu on elements
+            // If menu is tapped, do not hide menu
             return;
         }
 

--- a/src/js/view/controls/rightclick.js
+++ b/src/js/view/controls/rightclick.js
@@ -124,10 +124,12 @@ export default class RightClick {
         this.addOffListener(document);
 
         // Track if the mouse is above the menu or not
-        this.onMouseOverHandler = this.onMouseOver.bind(this);
-        this.onMouseOutHandler = this.onMouseOut.bind(this);
-        this.el.addEventListener('mouseover', this.onMouseOverHandler);
-        this.el.addEventListener('mouseout', this.onMouseOutHandler);
+        this.el.addEventListener('mouseover', () => {
+            this.mouseOverContext = true;
+        });
+        this.el.addEventListener('mouseout', () => {
+            this.mouseOverContext = false;
+        });
     }
 
     setup(_model, _playerElement, layer) {
@@ -149,14 +151,6 @@ export default class RightClick {
             _playerElement.addEventListener('touchend', this.cancelLongPressHandler);
             _playerElement.addEventListener('touchcancel', this.cancelLongPressHandler);
         }
-    }
-
-    onMouseOver() {
-        this.mouseOverContext = true;
-    }
-
-    onMouseOut() {
-        this.mouseOverContext = false;
     }
 
     startLongPress(evt) {
@@ -193,9 +187,7 @@ export default class RightClick {
             this.hideMenu();
             this.removeOffListener(this.playerElement);
             this.removeOffListener(document);
-            this.el.removeEventListener('mouseover', this.onMouseOverHandler);
-            this.el.removeEventListener('mouseout', this.onMouseOutHandler);
-            this.el.removeListener('mouseout', this.hideMenuHandler);
+            this.el.removeEventListener('mouseout', this.hideMenuHandler);
             this.hideMenuHandler = null;
             this.el = null;
         }


### PR DESCRIPTION
### This PR will...

- Prevent the right click menu to hide when a touch event occurs
- Remove usage of `ui.js` to avoid unnecessary events being added, which is causing links in the menu to not work

### Why is this Pull Request needed?

- The right click menu should stay open when a tap on it occurs. This mirrors the behaviour on desktop devices that keeps the menu open when hovering above it. 
- Ensures that links in the menu are working

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-1378

