### PR TITLE
Mute button is only set on mobile.

### DIFF
--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -408,7 +408,7 @@ export default class Controls {
         api.setMute(mute);
         // the model's mute value may not have changed. ensure the controlbar's mute button is in the right state
         this.controlbar.renderVolume(mute, model.get('volume'));
-        if (OS.mobile) {
+        if (this.mute) {
             this.mute.hide();
         }
 

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -408,7 +408,10 @@ export default class Controls {
         api.setMute(mute);
         // the model's mute value may not have changed. ensure the controlbar's mute button is in the right state
         this.controlbar.renderVolume(mute, model.get('volume'));
-        this.mute.hide();
+        if (OS.mobile) {
+            this.mute.hide();
+        }
+
         utils.removeClass(this.playerContainer, 'jw-flag-autostart');
         this.userActive();
     }


### PR DESCRIPTION
### This PR will...
Fix a `TypeError: null is not an object (evaluating 'this.mute.hide')` on desktop when attempting to unmute from `autostartMuted`.

### Why is this Pull Request needed?
The mute button is only set on mobile ([here](https://github.com/jwplayer/jwplayer/blob/master/src/js/view/controls/controls.js#L178)), but we try to hide it on all devices. This PR restricts it to mobile.

### Are there any points in the code the reviewer needs to double check?
N/A

### Are there any Pull Requests open in other repos which need to be merged with this?
N/A

#### Addresses Issue(s):
N/A (found as part of ADS-1074)