### PR TITLE
Do not fire programController events during an ad

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -771,7 +771,12 @@ Object.assign(Controller.prototype, {
 
         function addProgramControllerListeners() {
             _programController
-                .on('all', _trigger, _this)
+                .on('all', (type, event) => {
+                    if (_this._instreamAdapter) {
+                        return;
+                    }
+                    _trigger(type, event);
+                }, _this)
                 .on('subtitlesTracks', (e) => {
                     _captions.setSubtitlesTracks(e.tracks);
                     const defaultCaptionsIndex = _captions.getCurrentIndex();


### PR DESCRIPTION
### This PR will...
stop sending player events from programController during an ad playback.

### Why is this Pull Request needed?
We do not want to fire player events (time event specifically) during DAI ad playback.
We cannot detach the provider during the ad playback when DAI stream is playing, because it will stop the content.
Do not forward the events from programController while ad playback to stop player events from triggering.

### Are there any points in the code the reviewer needs to double check?
No, but I want to check the tests on the build to see if any regressions are caused by this.

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):
ADS-971

