### PR TITLE
Remove quality indication label if level clicked has the same quality as auto

### DIFF
--- a/src/css/controls/imports/settings-menu.less
+++ b/src/css/controls/imports/settings-menu.less
@@ -102,6 +102,8 @@
 
 .jw-auto-label {
     font-weight: initial;
+    font-size: 10px;
+    opacity: 0.5;
 }
 
 .jw-settings-content-item {

--- a/src/js/view/controls/settings-menu.js
+++ b/src/js/view/controls/settings-menu.js
@@ -182,7 +182,7 @@ export function setupSubmenuListeners(settingsMenu, controlbar, viewModel, api) 
     model.on('change:visualQuality', (changedModel, quality) => {
         const qualitySubMenu = settingsMenu.getSubmenu('quality');
         if (qualitySubMenu) {
-            changeAutoLabel(quality, qualitySubMenu, 0);
+            changeAutoLabel(quality, qualitySubMenu, model.get('currentLevel'));
         }
     });
 

--- a/src/js/view/controls/settings-menu.js
+++ b/src/js/view/controls/settings-menu.js
@@ -133,21 +133,22 @@ export function setupSubmenuListeners(settingsMenu, controlbar, viewModel, api) 
         );
     };
 
+    const changeAutoLabel = function (quality, qualitySubMenu, currentQuality) {
+        const items = qualitySubMenu.getItems();
+        const item = items[0].element().querySelector('.jw-auto-label');
+        const levels = model.get('levels');
+        const { level, mode } = quality;
+
+        item.textContent = currentQuality || mode === 'manual' ? '' : levels[level.index].label;
+    };
+
     // Quality Levels
     model.change('levels', onQualitiesChanged, settingsMenu);
     model.on('change:currentLevel', (changedModel, currentQuality) => {
         const qualitySubMenu = settingsMenu.getSubmenu('quality');
         const visualQuality = model.get('visualQuality');
-        if (qualitySubMenu && visualQuality) {
-            const items = qualitySubMenu.getItems();
-            const item = items[0].element().querySelector('.jw-auto-label');
-            const levels = model.get('levels');
-            const { mode, level } = visualQuality;
-
-            // Remove the quality from the "auto" label if we switch to the quality that auto was representing
-            if (mode === 'auto') {
-                item.textContent = item.textContent === levels[currentQuality].label ? '' : levels[level.index].label;
-            }
+        if (visualQuality && qualitySubMenu) {
+            changeAutoLabel(visualQuality, qualitySubMenu, currentQuality);
         }
         activateSubmenuItem('quality', currentQuality);
     }, settingsMenu);
@@ -181,12 +182,7 @@ export function setupSubmenuListeners(settingsMenu, controlbar, viewModel, api) 
     model.on('change:visualQuality', (changedModel, quality) => {
         const qualitySubMenu = settingsMenu.getSubmenu('quality');
         if (qualitySubMenu) {
-            const items = qualitySubMenu.getItems();
-            const item = items[0].element().querySelector('.jw-auto-label');
-            const levels = model.get('levels');
-            const { mode, level } = quality;
-
-            item.textContent = mode === 'auto' ? levels[level.index].label : ``;
+            changeAutoLabel(quality, qualitySubMenu, 0);
         }
     });
 

--- a/src/js/view/controls/settings-menu.js
+++ b/src/js/view/controls/settings-menu.js
@@ -136,6 +136,17 @@ export function setupSubmenuListeners(settingsMenu, controlbar, viewModel, api) 
     // Quality Levels
     model.change('levels', onQualitiesChanged, settingsMenu);
     model.on('change:currentLevel', (changedModel, currentQuality) => {
+        const qualitySubMenu = settingsMenu.getSubmenu('quality');
+        if (qualitySubMenu) {
+            const prevQuality = model.get('visualQuality').index;
+            // Remove the quality from the "auto" label if we switch to the quality that auto was representing
+            if (prevQuality === currentQuality) {
+                const items = qualitySubMenu.getItems();
+                const item = items[0].element().querySelector('.jw-auto-label');
+
+                item.textContent = '';
+            }
+        }
         activateSubmenuItem('quality', currentQuality);
     }, settingsMenu);
 
@@ -194,7 +205,7 @@ export function setupSubmenuListeners(settingsMenu, controlbar, viewModel, api) 
         }
     }, settingsMenu);
 
-    model.on('change:streamType', () => {  
+    model.on('change:streamType', () => {
         setupPlaybackRatesMenu(model, model.get('playbackRates'));
     }, settingsMenu);
 

--- a/src/js/view/controls/settings-menu.js
+++ b/src/js/view/controls/settings-menu.js
@@ -137,14 +137,16 @@ export function setupSubmenuListeners(settingsMenu, controlbar, viewModel, api) 
     model.change('levels', onQualitiesChanged, settingsMenu);
     model.on('change:currentLevel', (changedModel, currentQuality) => {
         const qualitySubMenu = settingsMenu.getSubmenu('quality');
-        if (qualitySubMenu) {
-            const prevQuality = model.get('visualQuality').index;
-            // Remove the quality from the "auto" label if we switch to the quality that auto was representing
-            if (prevQuality === currentQuality) {
-                const items = qualitySubMenu.getItems();
-                const item = items[0].element().querySelector('.jw-auto-label');
+        const visualQuality = model.get('visualQuality');
+        if (qualitySubMenu && visualQuality) {
+            const items = qualitySubMenu.getItems();
+            const item = items[0].element().querySelector('.jw-auto-label');
+            const levels = model.get('levels');
+            const { mode, level } = visualQuality;
 
-                item.textContent = '';
+            // Remove the quality from the "auto" label if we switch to the quality that auto was representing
+            if (mode === 'auto') {
+                item.textContent = item.textContent === levels[currentQuality].label ? '' : levels[level.index].label;
             }
         }
         activateSubmenuItem('quality', currentQuality);
@@ -184,7 +186,7 @@ export function setupSubmenuListeners(settingsMenu, controlbar, viewModel, api) 
             const levels = model.get('levels');
             const { mode, level } = quality;
 
-            item.textContent = mode === 'auto' ? `${levels[level.index].label}` : ``;
+            item.textContent = mode === 'auto' ? levels[level.index].label : ``;
         }
     });
 


### PR DESCRIPTION
### This PR will...

- Remove the quality from the "auto" label if we switch to the quality that auto was representing

- Make css changes to the label to make it more readable(discussed with @aliciahurst )

### Why is this Pull Request needed?

When making a manual change to a quality that was already represented by "auto", the label indicating the quality would stay there and vice versa. This is because there isnt a visualQuality event being triggered when we switch to a level that is already represented on auto

### Are there any points in the code the reviewer needs to double check?

There may be some redundant code now that the "currentLevel" and "visualQuality" events  handle when the label gets changed and the purpose for it in "currentLevel" is just to handle this one case where "visualQuality" wont fire because the qualities are the same


### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-233

