### PR TITLE
Reset beforeComplete on stop

### DIFF
--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -50,6 +50,7 @@ export default class MediaController extends Eventable {
 
     stop() {
         const { provider } = this;
+        this.beforeComplete = false;
         provider.stop();
     }
 

--- a/test/unit/background-loading-test.js
+++ b/test/unit/background-loading-test.js
@@ -78,6 +78,16 @@ describe('Background Loading', function () {
         });
     });
 
+    describe('mediaController.stop', function () {
+        it('resets beforeComplete', function () {
+            mediaController.container = container;
+            mediaController.beforeComplete = true;
+            expect(mediaController.beforeComplete).to.equal(true);
+            mediaController.stop();
+            expect(mediaController.beforeComplete).to.equal(false);
+        });
+    });
+
     describe('prograController._setActiveMedia()', function () {
         it('activates the given mediaController', function () {
             programController._setActiveMedia(mediaController);


### PR DESCRIPTION
### This PR will...

Set `mediaController.beforeComplete` to `false` on stop.

### Why is this Pull Request needed?

When an item is stopped while handling the "beforeComplete" event, it is no longer in a before complete state. 

This fix is necessary for scenarios where a new item or playlist is loaded on "beforeComplete" (test/squash/iframes/vast-load-onBeforeComplete.html). Without it, the player thinks it should enter the complete state when ending an ad break for the new item.

```js
jwplayer("container").setup({
    file: '//content.com/video-1.mp4',
    advertising: {
        client: 'vast',
        tag: '//ads.com/pre.xml',
        skipoffset: '2'
    }
}).on('beforeComplete', function() {
    // At this point playback is stopped for the current item, and a new item is loaded.
    // The "beforeComplete" must be reset, or any ad breaks for the new item will end
    // with the player returning to the complete state.
    this.load([{
        file: '//content.com/video-2.mp4'
    }]).play();
});
```

#### Addresses Issue(s):

JW8-1425

