### PR TITLE
Fix quality label being displayed in html5 provider

### DIFF
--- a/src/js/view/controls/settings-menu.js
+++ b/src/js/view/controls/settings-menu.js
@@ -135,8 +135,7 @@ export function setupSubmenuListeners(settingsMenu, controlbar, viewModel, api) 
 
     const changeAutoLabel = function (quality, qualitySubMenu, currentQuality) {
         const levels = model.get('levels');
-        // return early if the label isnt "Auto";
-        // (ex: html5 where we have multiple sources for the video)
+        // Return early if the label isn't "Auto" (html5 provider with multiple mp4 sources)
         if (levels[0].label !== 'Auto') {
             return;
         }

--- a/src/js/view/controls/settings-menu.js
+++ b/src/js/view/controls/settings-menu.js
@@ -134,9 +134,14 @@ export function setupSubmenuListeners(settingsMenu, controlbar, viewModel, api) 
     };
 
     const changeAutoLabel = function (quality, qualitySubMenu, currentQuality) {
+        const levels = model.get('levels');
+        // return early if the label isnt "Auto";
+        // (ex: html5 where we have multiple sources for the video)
+        if (levels[0].label !== 'Auto') {
+            return;
+        }
         const items = qualitySubMenu.getItems();
         const item = items[0].element().querySelector('.jw-auto-label');
-        const levels = model.get('levels');
 
         item.textContent = currentQuality ? '' : levels[quality.level.index].label;
     };

--- a/src/js/view/utils/submenu-factory.js
+++ b/src/js/view/utils/submenu-factory.js
@@ -73,7 +73,7 @@ export function removeAudioTracksSubmenu(settingsMenu) {
 export function addQualitiesSubmenu(settingsMenu, qualitiesList, action, initialSelectionIndex, tooltipText) {
     const qualitiesItems = qualitiesList.map((track, index) => {
         let content = track.label;
-        if (index === 0) {
+        if (content === 'Auto' && index === 0) {
             content += '&nbsp;<span class="jw-reset jw-auto-label"></span>';
         }
 


### PR DESCRIPTION
### This PR will...

Prevent quality label from being created and displayed in html5 provider where we have a player that has multiple sources for a video instead of an adaptive stream.

### Why is this Pull Request needed?

We currently create the auto label when we iterate over "qualitiesList" in "addQualitiesSubmenu" and hit the first item because "Auto" will always be the first one. That isn't the case where we have multiple sources for a video instead of it being an adaptive stream. The first quality in that case would be whatever source is first in the config

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-1439

