### PR TITLE
Check if "levels" exist in "changeAutoLabel"

### DIFF
--- a/src/js/view/controls/settings-menu.js
+++ b/src/js/view/controls/settings-menu.js
@@ -136,7 +136,7 @@ export function setupSubmenuListeners(settingsMenu, controlbar, viewModel, api) 
     const changeAutoLabel = function (quality, qualitySubMenu, currentQuality) {
         const levels = model.get('levels');
         // Return early if the label isn't "Auto" (html5 provider with multiple mp4 sources)
-        if (levels[0].label !== 'Auto') {
+        if (!levels || levels[0].label !== 'Auto') {
             return;
         }
         const items = qualitySubMenu.getItems();


### PR DESCRIPTION
### This PR will...

Return early rom the "changeAutoLabel" function if "levels" aren't defined on the model.

### Why is this Pull Request needed?

Player goes into error state when switching to the next playlist item because "levels" is not defined by the time "changeAutoLabel" fires from the"visualQuality" event.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-1439

