### PR TITLE
Add Padding to Display Icons While Casting

### DIFF
--- a/src/css/controls/imports/display.less
+++ b/src/css/controls/imports/display.less
@@ -49,6 +49,8 @@ display icons
 
 .jw-display-icon-container {
     display: inline-block;
+    padding: (@mobile-touch-target * 0.125);
+    margin: 0 (@mobile-touch-target * 0.5);
 
     .jw-icon {
         .square(75px);
@@ -90,11 +92,6 @@ display icons
 }
 
 .jw-breakpoint-1 {
-    .jw-display-icon-container {
-        padding: (@mobile-touch-target * 0.125);
-        margin: 0 (@mobile-touch-target * 0.5);
-    }
-
     .jw-display .jw-icon,
     .jw-display .jw-svg-icon {
         width: (@mobile-touch-target);


### PR DESCRIPTION
### This PR will...

Apply the margin and padding used for the display icon container towards all breakpoints instead of just breakpoint 1

### Why is this Pull Request needed?

We do not only show rewind and next display icons at breakpoint 1. While casting, they are always displayed at larger breakpoints. We need to apply the same margin and padding to the display icon containers so they are spaced out appropriately

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-1307

