### PR TITLE
[ADS-1074] Trigger mute on autostartMuted change.

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -484,6 +484,7 @@ Object.assign(Controller.prototype, {
 
                     _model.once('change:autostartMuted', function(model) {
                         model.off('change:viewable', _checkPlayOnViewable);
+                        _this.trigger(MEDIA_MUTE, { mute: _model.getMute() });
                     });
                 }
 


### PR DESCRIPTION
### This PR will...
Trigger a `mute` event when unmuting from autostart muted scenario. Current behavior is not to emit any events.

### Why is this Pull Request needed?
The mute state in the player changes from mute to unmute, so we should fire the corresponding event.

### Are there any points in the code the reviewer needs to double check?
N/A

### Are there any Pull Requests open in other repos which need to be merged with this?
N/A

#### Addresses Issue(s):
ADS-1074