### PR TITLE
Add adsMode api to instream adapter

### DIFF
--- a/src/js/providers/instream-provider.js
+++ b/src/js/providers/instream-provider.js
@@ -1,0 +1,14 @@
+export default class InstreamProvider {
+
+    constructor(utils, Events) {
+        utils.extend(this, Events);
+    }
+
+    attachMedia() {}
+
+    detachMedia() {}
+
+    volume() {}
+
+    mute() {}
+}


### PR DESCRIPTION
### This PR will...
Create a new api on instream called ```enableAdsMode``` that switches the control bar from playback mode to ads mode, where the viewer cannot seek.

### Why is this Pull Request needed?
Exposing the api is essential to solve the problem for all publishers who have different variations of SSAI.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):
ADS-272

