### PR TITLE
Delete item.starttime on playback complete

### DIFF
--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -10,6 +10,7 @@ import {
     PLAYER_STATE, STATE_PAUSED, STATE_BUFFERING, STATE_COMPLETE,
     MEDIA_VISUAL_QUALITY
 } from 'events/events';
+import {_isNumber} from "../utils/underscore";
 
 export default class MediaController extends Eventable {
     constructor(provider, model) {
@@ -161,7 +162,8 @@ export default class MediaController extends Eventable {
     }
 
     _playbackComplete() {
-        const { provider } = this;
+        const { item, provider } = this;
+        delete item.starttime;
         this.beforeComplete = false;
         provider.setState(STATE_COMPLETE);
         this.trigger(MEDIA_COMPLETE, {});

--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -162,7 +162,9 @@ export default class MediaController extends Eventable {
 
     _playbackComplete() {
         const { item, provider } = this;
-        delete item.starttime;
+        if (item) {
+            delete item.starttime;
+        }
         this.beforeComplete = false;
         provider.setState(STATE_COMPLETE);
         this.trigger(MEDIA_COMPLETE, {});

--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -10,7 +10,6 @@ import {
     PLAYER_STATE, STATE_PAUSED, STATE_BUFFERING, STATE_COMPLETE,
     MEDIA_VISUAL_QUALITY
 } from 'events/events';
-import {_isNumber} from "../utils/underscore";
 
 export default class MediaController extends Eventable {
     constructor(provider, model) {

--- a/test/unit/background-loading-test.js
+++ b/test/unit/background-loading-test.js
@@ -67,6 +67,9 @@ describe('Background Loading', function () {
         it('triggers beforeComplete when false and the media has already ended', function () {
             const onComplete = sinon.spy();
             mediaController.container = container;
+            mediaController.item = {
+                starttime: 42
+            }
             mediaController.beforeComplete = true;
             mediaController.background = true;
             mediaController.on('complete', onComplete);
@@ -75,6 +78,7 @@ describe('Background Loading', function () {
             mediaController.background = false;
             expect(onComplete.calledOnce).to.equal(true);
             expect(mediaController.beforeComplete).to.equal(false);
+            expect(mediaController.item.starttime).to.not.exist;
         });
     });
 


### PR DESCRIPTION
### Why is this Pull Request needed?
So that if we replay an item in a playlist whose schedule contains a postroll, the first item will begin playback at time 0

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):
JW8-1423

JW8-###

