### PR TITLE
Close right click menu on tap (Android Chrome)

### DIFF
--- a/src/js/view/controls/rightclick.js
+++ b/src/js/view/controls/rightclick.js
@@ -169,10 +169,11 @@ export default class RightClick {
 
     addHideMenuHandlers() {
         this.removeHideMenuHandlers();
-        if (OS.iOS) {
-            this.playerElement.addEventListener('touchstart', this.hideMenuHandler);
-            document.addEventListener('touchstart', this.hideMenuHandler);
-        } else {
+
+        this.playerElement.addEventListener('touchstart', this.hideMenuHandler);
+        document.addEventListener('touchstart', this.hideMenuHandler);
+
+        if (!OS.iOS) {
             this.playerElement.addEventListener('click', this.hideMenuHandler);
             document.addEventListener('click', this.hideMenuHandler);
             // Track if the mouse is above the menu or not

--- a/src/js/view/controls/rightclick.js
+++ b/src/js/view/controls/rightclick.js
@@ -170,10 +170,10 @@ export default class RightClick {
     addHideMenuHandlers() {
         this.removeHideMenuHandlers();
 
-        this.playerElement.addEventListener('touchstart', this.hideMenuHandler);
-        document.addEventListener('touchstart', this.hideMenuHandler);
-
-        if (!OS.iOS) {
+        if (OS.mobile) {
+            this.playerElement.addEventListener('touchstart', this.hideMenuHandler);
+            document.addEventListener('touchstart', this.hideMenuHandler);
+        } else {
             this.playerElement.addEventListener('click', this.hideMenuHandler);
             document.addEventListener('click', this.hideMenuHandler);
             // Track if the mouse is above the menu or not

--- a/src/js/view/controls/rightclick.js
+++ b/src/js/view/controls/rightclick.js
@@ -170,10 +170,10 @@ export default class RightClick {
     addHideMenuHandlers() {
         this.removeHideMenuHandlers();
 
-        if (OS.mobile) {
-            this.playerElement.addEventListener('touchstart', this.hideMenuHandler);
-            document.addEventListener('touchstart', this.hideMenuHandler);
-        } else {
+        this.playerElement.addEventListener('touchstart', this.hideMenuHandler);
+        document.addEventListener('touchstart', this.hideMenuHandler);
+
+        if (!OS.mobile) {
             this.playerElement.addEventListener('click', this.hideMenuHandler);
             document.addEventListener('click', this.hideMenuHandler);
             // Track if the mouse is above the menu or not


### PR DESCRIPTION
### This PR will...

always add a `touchstart` listener to hide the menu, not just for iOS. Otherwise, the right click menu will not hide on a tap on the player or page when its open.

### Why is this Pull Request needed?

After the right-click menu was opened on Android Chrome, when tapping anywhere outside of the menu should close it. This was only happening on iOS.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-1464

