### PR TITLE
Idle button variant with "Play" label

### DIFF
--- a/src/css/controls/imports/idle-variants.less
+++ b/src/css/controls/imports/idle-variants.less
@@ -38,6 +38,37 @@
                 background-color: fade(@black, 70%);
             }
         }
+
+        &.jw-ab-idle-label {
+            filter: drop-shadow(1px 1px 5px rgba(12, 26, 71, 0.25));
+            font: normal 26px/1 Arial, Helvetica, sans-serif;
+            position: relative;
+            -webkit-font-smoothing: antialiased;
+
+            &::after {
+                content: "Play";
+                display: block;
+                line-height: 1;
+                position: absolute;
+                text-align: center;
+                text-indent: 0.25em;
+                top: 100%;
+                width: 100%;
+            }
+
+            .jw-flag-small-player& {
+                font-size: 16px;
+            }
+
+            .jw-breakpoint-0& {
+                font-size: 12px;
+            }
+
+            .jw-breakpoint-2&,
+            .jw-breakpoint-3& {
+                font-size: 22px;
+            }
+        }
     }
 }
 

--- a/src/css/controls/imports/idle-variants.less
+++ b/src/css/controls/imports/idle-variants.less
@@ -41,7 +41,7 @@
 
         &.jw-ab-idle-label {
             filter: drop-shadow(1px 1px 5px rgba(12, 26, 71, 0.25));
-            font: normal 22px/1 Arial, Helvetica, sans-serif;
+            font: normal 16px/1 Arial, Helvetica, sans-serif;
             position: relative;
             -webkit-font-smoothing: antialiased;
 
@@ -56,18 +56,8 @@
                 width: 100%;
             }
 
-            .jw-flag-small-player& {
-                font-size: 16px;
-            }
-
             .jw-breakpoint-0& {
                 font-size: 12px;
-            }
-
-            .jw-breakpoint-2&,
-            .jw-breakpoint-3&,
-            .jw-breakpoint-4& {
-                font-size: 18px;
             }
         }
     }

--- a/src/css/controls/imports/idle-variants.less
+++ b/src/css/controls/imports/idle-variants.less
@@ -41,7 +41,7 @@
 
         &.jw-ab-idle-label {
             filter: drop-shadow(1px 1px 5px rgba(12, 26, 71, 0.25));
-            font: normal 26px/1 Arial, Helvetica, sans-serif;
+            font: normal 22px/1 Arial, Helvetica, sans-serif;
             position: relative;
             -webkit-font-smoothing: antialiased;
 
@@ -51,7 +51,7 @@
                 line-height: 1;
                 position: absolute;
                 text-align: center;
-                text-indent: 0.25em;
+                text-indent: 0.35em;
                 top: 100%;
                 width: 100%;
             }
@@ -65,8 +65,9 @@
             }
 
             .jw-breakpoint-2&,
-            .jw-breakpoint-3& {
-                font-size: 22px;
+            .jw-breakpoint-3&,
+            .jw-breakpoint-4& {
+                font-size: 18px;
             }
         }
     }

--- a/src/js/view/controls/play-display-icon.js
+++ b/src/js/view/controls/play-display-icon.js
@@ -54,7 +54,7 @@ export default class PlayDisplayIcon {
     }
 
     toggleIdleClass(oldState, newState, idleButton) {
-        if (!(idleButton === 'stroke' || idleButton === 'fill')) {
+        if (!(idleButton === 'stroke' || idleButton === 'fill' || idleButton === 'label')) {
             return;
         }
 

--- a/test/unit/play-display-icon-test.js
+++ b/test/unit/play-display-icon-test.js
@@ -61,6 +61,14 @@ describe('PlayDisplayIcon', function() {
 
             expect(icon.className).to.include('jw-ab-idle-fill');
         });
+
+        it('should add class if config is label', function() {
+            model.set('idleButton', 'label');
+
+            displayIcon = new PlayDisplayIcon(model, {}, element);
+
+            expect(icon.className).to.include('jw-ab-idle-label');
+        });
     });
 
     describe('on state change', function() {


### PR DESCRIPTION
### This PR will...

Add a new variant to the idle button a/b test: The play button with "Play" beneath it. It is enabled by settings the "idleButton" config to "label"

### Why is this Pull Request needed?

To test whether having the "Play" text will attract users to play more videos

### Are there any points in the code the reviewer needs to double check?

For the a/b test, we are NOT localizing the word "Play"

@radium-v Changes the CSS so that the font size matches the title description, except for breakpoint 0. I also upped the indentation a smidge to make it more centered with the play icon.

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/borg/pull/310

#### Addresses Issue(s):

JW8-1424

