### PR TITLE
Support requestFilter and xhr options in ajax utils

### DIFF
--- a/test/unit/ajax-test.js
+++ b/test/unit/ajax-test.js
@@ -140,6 +140,46 @@ describe('utils.ajax', function() {
         });
     });
 
+    it('supports a custom xhr argument', function (done) {
+        const customXhr = new window.XMLHttpRequest();
+        const xmlHttpRequest = ajax({
+            xhr: customXhr,
+            url: '/base/test/files/playlist.json',
+            oncomplete: function (xhrResult) {
+                expect(xhrResult).to.equal(customXhr);
+                expect(xhrResult.status).to.equal(200);
+                done();
+            },
+            onerror: function(message, requestUrl, xhrResult) {
+                assert.fail(xhrResult.status, 200, message, requestUrl);
+                done();
+            }
+        });
+        expect(xmlHttpRequest).to.equal(customXhr);
+    });
+
+    it('supports a requestFilter xhr argument', function (done) {
+        const customXhr = new window.XMLHttpRequest();
+        const xmlHttpRequest = ajax({
+            requestFilter: function(request) {
+                expect(request).to.have.property('url').which.equals('/base/test/files/playlist.json');
+                expect(request).to.have.property('xhr');
+                return customXhr;
+            },
+            url: '/base/test/files/playlist.json',
+            oncomplete: function (xhrResult) {
+                expect(xhrResult).to.equal(customXhr);
+                expect(xhrResult.status).to.equal(200);
+                done();
+            },
+            onerror: function(message, requestUrl, xhrResult) {
+                assert.fail(xhrResult.status, 200, message, requestUrl);
+                done();
+            }
+        });
+        expect(xmlHttpRequest).to.equal(customXhr);
+    });
+
     it('error "Error loading file" (bad request)', function (done) {
         ajax({
             oncomplete: function () {


### PR DESCRIPTION
Allow an `XmlHttpRequest` object to be passed to `ajax` via options, or returned via `options.requestFilter`. This will allow request filters to be implemented in player components that use the ajax util.

A request filter would run before all xhr listeners are set and before `open` is called. Ajax callback and timeout cannot be changed and will still be controlled by the player to prevent bad filters from breaking player functionality.