### PR TITLE
Do not show duration in the info overlay if duration is unknown

### DIFF
--- a/src/js/view/controls/info-overlay.js
+++ b/src/js/view/controls/info-overlay.js
@@ -51,7 +51,9 @@ export default function (container, model, api, onVisibility) {
                     durationText = 'DVR';
                     break;
                 default:
-                    durationText = timeFormat(duration);
+                    if (duration) {
+                        durationText = timeFormat(duration);
+                    }
             }
             durationContainer.textContent = durationText;
         }, instance);


### PR DESCRIPTION
### Why is this Pull Request needed?
So that the info overlay does not display the duration when the duration is not known.
### Are there any points in the code the reviewer needs to double check?
No
### Are there any Pull Requests open in other repos which need to be merged with this?
No
#### Addresses Issue(s):
JW8-1379
