### PR TITLE
[WIP] Add PlayerError class and miscellaneous setup error codes

### DIFF
--- a/src/js/api/Setup.js
+++ b/src/js/api/Setup.js
@@ -1,6 +1,7 @@
 import loadCoreBundle from 'api/core-loader';
 import startSetup from 'api/setup-steps';
 import loadPlugins from 'plugins/plugins';
+import { PlayerError, SETUP_ERROR_TIMEOUT } from 'api/errors';
 import Promise from 'polyfills/promise';
 
 const SETUP_TIMEOUT_SECONDS = 30;
@@ -19,7 +20,10 @@ const Setup = function(_model) {
 
         const timeout = new Promise((resolve, reject) => {
             _setupFailureTimeout = setTimeout(() => {
-                reject(new Error(`Setup Timeout Error: Setup took longer than ${SETUP_TIMEOUT_SECONDS} seconds to complete.`));
+                const error = new PlayerError(
+                    `Setup Timeout Error: Setup took longer than ${SETUP_TIMEOUT_SECONDS} seconds to complete.`,
+                    SETUP_ERROR_TIMEOUT);
+                reject(error);
             }, SETUP_TIMEOUT_SECONDS * 1000);
             const timeoutCancelled = () => {
                 clearTimeout(_setupFailureTimeout);

--- a/src/js/api/errors.js
+++ b/src/js/api/errors.js
@@ -1,0 +1,41 @@
+import { _isValidNumber } from 'utils/underscore';
+/**
+ * @typedef {number} ErrorCode
+ * @module errors
+ **/
+
+/**
+ * @type {ErrorCode} Setup failed because it took longer than 30 seconds.
+ */
+export const SETUP_ERROR_TIMEOUT = 100001;
+
+/**
+ * @enum {ErrorCode} Setup failed because no license key was found.
+ */
+export const SETUP_ERROR_LICENSE_MISSING = 100011;
+
+/**
+ * @enum {ErrorCode} Setup failed because the license key was invalid.
+ */
+export const SETUP_ERROR_LICENSE_INVALID = 100012;
+
+/**
+ * @enum {ErrorCode} Setup failed because the license key expired.
+ */
+export const SETUP_ERROR_LICENSE_EXPIRED = 100013;
+
+/**
+ * Class representing the jwplayer() API.
+ * Creates an instance of the player.
+ * @class PlayerError
+ * @param {message} string - The error message.
+ * @param {code} [ErrorCode] - The error code.
+ * @param {sourceError} [Error] - The lower level error, caught by the player, which resulted in this error.
+ */
+export class PlayerError extends Error {
+    constructor(message, code, sourceError) {
+        super(message);
+        this.code = _isValidNumber(code) ? code : null;
+        this.sourceError = sourceError || null;
+    }
+}


### PR DESCRIPTION
### This PR will...

- Add PlayerError class 
- Define miscellaneous setup error codes
- Update setup timeout error to include a code using new interface 

### Why is this Pull Request needed?

Improve "setupError" events and tracking. Error codes will allow us to replace error messages, and give developers a straightforward way to look up documentation for errors output by the player.

### Are there any points in the code the reviewer needs to double check?

TODO: Update/Implement setup unit tests

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-commercial/pull/5147

#### Addresses Issue(s):

JW8-1284 JW8-1447

