### PR TITLE
Only display loading ad text at load (VAST)

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -115,8 +115,6 @@ var InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
             clickHandler.setAlternateClickHandlers(() => {}, null);
         }
 
-        this.setText(_model.get('localization').loadingAd);
-
         // We need to know if we're beforeComplete before we reattach, since re-attaching will toggle the beforeComplete flag back if set
         _beforeComplete = _controller.isBeforeComplete() || _model.get('state') === STATE_COMPLETE;
 
@@ -194,6 +192,9 @@ var InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
         if (_destroyed || !_inited) {
             return Promise.reject(new Error('Instream not setup'));
         }
+        
+        this.setText(_model.get('localization').loadingAd);
+
         // Copy the playlist item passed in and make sure it's formatted as a proper playlist item
         let playlist = item;
         if (_.isArray(item)) {


### PR DESCRIPTION
### This PR will...

IMDB noticed that there was not parity between Googima and VAST as it relates to when we display "Loading Ad"; this is due to a previous change I made ([here](https://github.com/jwplayer/jwplayer-ads-googima/pull/326)). 

This PR creates parity between the two clients, setting the localized "Loading Ad" text only when load item has been called.

### Why is this Pull Request needed?

Customer request and parity.

### Are there any points in the code the reviewer needs to double check?

N/A

### Are there any Pull Requests open in other repos which need to be merged with this?

No.

#### Addresses Issue(s):

ADS-1143

