### PR TITLE
[Do not merge] Load media when media element is null

### DIFF
--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -36,7 +36,7 @@ export default class MediaController extends Eventable {
 
         model.set('playRejected', false);
         let playPromise = resolved;
-        if (mediaModel.get('setup')) {
+        if (mediaModel.get('setup') && this.mediaElement) {
             playPromise = provider.play() || resolved;
         } else {
             mediaModel.set('setup', true);


### PR DESCRIPTION
### This PR will...
Load the current item if the mediaElement is null. 
### Why is this Pull Request needed?
Currently SDKs using JW8 are unable to resume playback when a midRoll ends because load is not called at the end of the midroll. 
Load is not called because `mediaModel.get('setup')` is always true, the cause being that in `ad-program-controller.js`, `srcReset` is never called since in SDKs `mediaElement.src !== model.get('mediaSrc')` will never be true (playback is rendered natively)
### Are there any points in the code the reviewer needs to double check?
An alternative solution is to call `srcReset` in the `ad-program-controller` when model.get('mediarc') is null. 
in `ad-program-controller.js`:
```
if (mediaElement.src !== model.get('mediaSrc') || !model.get('mediaSrc')) {
       this.srcReset();
}
```
### Are there any Pull Requests open in other repos which need to be merged with this?
n/a
#### Addresses Issue(s):
SDK JW8 upgrade

