### PR TITLE
Clear blob sources when priming for android

### DIFF
--- a/src/js/program/media-element-pool.js
+++ b/src/js/program/media-element-pool.js
@@ -75,7 +75,12 @@ function primeMediaElementForPlayback(mediaElement) {
         // If the player sets up without a gesture and preloads, the background tag may not be primed for playback.
         // We need to load again on Android in order to play without another gesture. But make sure we're only reloading
         // a tag which hasn't begun playback yet
-        const played = mediaElement.played;
+        const { played, src } = mediaElement;
+        // Clear the src for MSE providers who have already preloaded so that we do a full reload
+        // The HTML5 provider already reloads identical sources, so we don't always need to reset if for non-blobs
+        if (src.indexOf('blob') > -1) {
+            mediaElement.src = '';
+        }
         if (!played || (played && !played.length)) {
             mediaElement.load();
         }

--- a/src/js/program/media-element-pool.js
+++ b/src/js/program/media-element-pool.js
@@ -75,12 +75,13 @@ function primeMediaElementForPlayback(mediaElement) {
         // If the player sets up without a gesture and preloads, the background tag may not be primed for playback.
         // We need to load again on Android in order to play without another gesture. But make sure we're only reloading
         // a tag which hasn't begun playback yet
-        const { played, src } = mediaElement;
         // Clear the src for MSE providers who have already preloaded so that we do a full reload
         // The HTML5 provider already reloads identical sources, so we don't always need to reset if for non-blobs
-        if (src.indexOf('blob') > -1) {
+        if (mediaElement.src.indexOf('blob') > -1) {
             mediaElement.src = '';
         }
+
+        const played = mediaElement.played;
         if (!played || (played && !played.length)) {
             mediaElement.load();
         }


### PR DESCRIPTION
### Why is this Pull Request needed?
So that if we preload a non-primed media element in Android Chrome, it is reset and reloaded when a gesture is received

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/5152

#### Addresses Issue(s):
 JW8-1477
