### PR TITLE
Implement standardized errors for webpack module loading

### DIFF
--- a/src/js/api/core-loader.js
+++ b/src/js/api/core-loader.js
@@ -4,6 +4,7 @@ import ProvidersSupported from 'providers/providers-supported';
 import registerProvider from 'providers/providers-register';
 import { ControlsLoader } from 'controller/controls-loader';
 import { resolved } from 'polyfills/promise';
+import { PlayerError, SETUP_ERROR_LOADING_CORE_JS } from 'api/errors';
 
 let bundlePromise = null;
 
@@ -16,12 +17,10 @@ export default function loadCoreBundle(model) {
     return bundlePromise;
 }
 
-export function chunkLoadErrorHandler(code) {
+export function chunkLoadErrorHandler(code, error) {
     // Webpack require.ensure error: "Loading chunk 3 failed"
     return () => {
-        const error = new Error('Network error');
-        error.code = code;
-        throw error;
+        throw new PlayerError('Network Error', SETUP_ERROR_LOADING_CORE_JS + code, error);
     };
 }
 

--- a/src/js/api/core-loader.js
+++ b/src/js/api/core-loader.js
@@ -16,9 +16,13 @@ export default function loadCoreBundle(model) {
     return bundlePromise;
 }
 
-export function chunkLoadErrorHandler(/* error */) {
+export function chunkLoadErrorHandler(code) {
     // Webpack require.ensure error: "Loading chunk 3 failed"
-    throw new Error('Network error');
+    return () => {
+        const error = new Error('Network error');
+        error.code = code;
+        throw error;
+    };
 }
 
 export function selectBundle(model) {
@@ -79,7 +83,7 @@ function loadControlsPolyfillHtml5Bundle() {
         ControlsLoader.controls = require('view/controls/controls').default;
         registerProvider(require('providers/html5').default);
         return CoreMixin;
-    }, chunkLoadErrorHandler, 'jwplayer.core.controls.polyfills.html5');
+    }, chunkLoadErrorHandler(105), 'jwplayer.core.controls.polyfills.html5');
     bundleContainsProviders.html5 = loadPromise;
     return loadPromise;
 }
@@ -94,7 +98,7 @@ function loadControlsHtml5Bundle() {
         ControlsLoader.controls = require('view/controls/controls').default;
         registerProvider(require('providers/html5').default);
         return CoreMixin;
-    }, chunkLoadErrorHandler, 'jwplayer.core.controls.html5');
+    }, chunkLoadErrorHandler(104), 'jwplayer.core.controls.html5');
     bundleContainsProviders.html5 = loadPromise;
     return loadPromise;
 }
@@ -109,7 +113,7 @@ function loadControlsPolyfillBundle() {
         const CoreMixin = require('controller/controller').default;
         ControlsLoader.controls = require('view/controls/controls').default;
         return CoreMixin;
-    }, chunkLoadErrorHandler, 'jwplayer.core.controls.polyfills');
+    }, chunkLoadErrorHandler(103), 'jwplayer.core.controls.polyfills');
 }
 
 function loadControlsBundle() {
@@ -120,7 +124,7 @@ function loadControlsBundle() {
         const CoreMixin = require('controller/controller').default;
         ControlsLoader.controls = require('view/controls/controls').default;
         return CoreMixin;
-    }, chunkLoadErrorHandler, 'jwplayer.core.controls');
+    }, chunkLoadErrorHandler(102), 'jwplayer.core.controls');
 }
 
 function loadCore() {
@@ -129,7 +133,7 @@ function loadCore() {
             'controller/controller'
         ], function (require) {
             return require('controller/controller').default;
-        }, chunkLoadErrorHandler, 'jwplayer.core');
+        }, chunkLoadErrorHandler(101), 'jwplayer.core');
     });
 }
 
@@ -139,7 +143,7 @@ function loadIntersectionObserverIfNeeded() {
             'intersection-observer'
         ], function (require) {
             return require('intersection-observer');
-        }, chunkLoadErrorHandler, 'polyfills.intersection-observer');
+        }, chunkLoadErrorHandler(120), 'polyfills.intersection-observer');
     }
     return resolved;
 }

--- a/src/js/api/errors.js
+++ b/src/js/api/errors.js
@@ -25,6 +25,11 @@ export const SETUP_ERROR_LICENSE_INVALID = 100012;
 export const SETUP_ERROR_LICENSE_EXPIRED = 100013;
 
 /**
+ * @enum {ErrorCode} Setup failed because a core module failed to load.
+ */
+export const SETUP_ERROR_LOADING_CORE_JS = 101000;
+
+/**
  * Class representing the jwplayer() API.
  * Creates an instance of the player.
  * @class PlayerError

--- a/src/js/controller/controls-loader.js
+++ b/src/js/controller/controls-loader.js
@@ -12,7 +12,7 @@ export function loadControls() {
             return ControlsModule;
         }, function() {
             controlsPromise = null;
-            chunkLoadErrorHandler();
+            chunkLoadErrorHandler(130)();
         }, 'jwplayer.controls');
     }
     return controlsPromise;

--- a/src/js/controller/tracks-loader.js
+++ b/src/js/controller/tracks-loader.js
@@ -96,5 +96,5 @@ function xhrSuccess(xhr, track, successHandler, errorHandler) {
 function loadVttParser() {
     return require.ensure(['parsers/captions/vttparser'], function (require) {
         return require('parsers/captions/vttparser').default;
-    }, chunkLoadErrorHandler, 'vttparser');
+    }, chunkLoadErrorHandler(131), 'vttparser');
 }

--- a/src/js/providers/providers.js
+++ b/src/js/providers/providers.js
@@ -14,7 +14,7 @@ export const Loaders = {
             const provider = require('providers/html5').default;
             registerProvider(provider);
             return provider;
-        }, chunkLoadErrorHandler, 'provider.html5');
+        }, chunkLoadErrorHandler(152), 'provider.html5');
     }
 };
 

--- a/src/js/view/captionsrenderer.js
+++ b/src/js/view/captionsrenderer.js
@@ -328,7 +328,7 @@ const CaptionsRenderer = function (viewModel) {
     function loadWebVttPolyfill() {
         return require.ensure(['polyfills/webvtt'], function (require) {
             _WebVTT = require('polyfills/webvtt').default;
-        }, chunkLoadErrorHandler, 'polyfills.webvtt');
+        }, chunkLoadErrorHandler(121), 'polyfills.webvtt');
     }
 
     _model.on('change:playlistItem', function () {

--- a/test/unit/errors/core-loader-error-tests.js
+++ b/test/unit/errors/core-loader-error-tests.js
@@ -1,0 +1,12 @@
+import sinon from 'sinon';
+import { chunkLoadErrorHandler } from 'api/core-loader';
+
+describe('core-loader errors', function () {
+    it('exports a chunkLoadErrorHandler function which throws a JWError', function () {
+        const handler = chunkLoadErrorHandler(105);
+        expect(handler).to.be.a('function');
+        // The handler itself is a function, which returns a function which throws
+        expect(chunkLoadErrorHandler).to.not.throw();
+        expect(handler).to.throw();
+    });
+});


### PR DESCRIPTION
### Why is this Pull Request needed?
So that webpack module load errors are trackable, programmable, all those good things etc. 

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/5154

#### Addresses Issue(s):

JW8-1444

