### PR TITLE
Fix setup tests and update playlist in setup after filtering

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -125,9 +125,10 @@ module.exports = function(config) {
         captureTimeout: 120 * 1000, // default 60000
 
         files: [
-            { pattern: 'test/index.js' },
-            { pattern: 'test/files/*', included: false },
-            { pattern: 'src/js/*', included: false }
+            { pattern: './node_modules/intersection-observer/intersection-observer.js' },
+            { pattern: './test/index.js' },
+            { pattern: './test/files/*', included: false },
+            { pattern: './src/js/*', included: false }
         ],
 
         // preprocess matching files before serving them to the browser

--- a/src/js/api/setup-steps.js
+++ b/src/js/api/setup-steps.js
@@ -43,6 +43,7 @@ function loadProvider(_model) {
         // Loads the first provider if not included in the core bundle
         // A provider loaded this way will not be set upon completion
         const playlist = filterPlaylist(_model.get('playlist'), _model);
+        _model.attributes.playlist = playlist;
 
         // Throw exception if playlist is empty
         validatePlaylist(playlist);

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,18 @@
+// Bundle files chunked by webpack
 import ProvidersLoaded from 'providers/providers-loaded';
+import * as vttparser from 'parsers/captions/vttparser';
 import * as html5 from 'providers/html5';
 import * as controls from 'view/controls/controls';
 import * as controller from 'controller/controller';
+
+// For unknown reasons importing xo causes webpack to split the chunks we need bundled
+// This polyfill will be embeded on the page by karma for IE
+// import xo from 'intersection-observer';
+
+// This should prevent us from attempting to load a chunk with 'intersection-observer'
+if (!('intersectionRatio' in window.IntersectionObserverEntry.prototype)) {
+    window.IntersectionObserverEntry.prototype.intersectionRatio = 1;
+}
 
 ProvidersLoaded.html5 = html5.default;
 
@@ -9,6 +20,7 @@ const testsContext = require.context('./unit', true);
 testsContext.keys().forEach(testsContext);
 
 export default [
+    vttparser,
     html5,
     controls,
     controller,

--- a/test/unit/setup-test.js
+++ b/test/unit/setup-test.js
@@ -69,8 +69,8 @@ describe('Setup', function() {
         return expectSetupError({
             // playlist is undefined
         }).then(({ event }) => {
-            expect(event.message).to.equal('No playable sources found');
             expect(event.code).to.equal(undefined);
+            expect(event.message).to.equal('No playable sources found');
         });
     });
 
@@ -78,8 +78,8 @@ describe('Setup', function() {
         return expectSetupError({
             playlist: ''
         }).then(({ event }) => {
-            expect(event.message).to.equal('No playable sources found');
             expect(event.code).to.equal(undefined);
+            expect(event.message).to.equal('No playable sources found');
         });
     });
 
@@ -87,8 +87,8 @@ describe('Setup', function() {
         return expectSetupError({
             playlist: 1
         }).then(({ event }) => {
-            expect(event.message).to.equal('No playable sources found');
             expect(event.code).to.equal(undefined);
+            expect(event.message).to.equal('No playable sources found');
         });
     });
 
@@ -96,8 +96,8 @@ describe('Setup', function() {
         return expectSetupError({
             playlist: true
         }).then(({ event }) => {
-            expect(event.message).to.equal('No playable sources found');
             expect(event.code).to.equal(undefined);
+            expect(event.message).to.equal('No playable sources found');
         });
     });
 
@@ -105,8 +105,8 @@ describe('Setup', function() {
         return expectSetupError({
             playlist: []
         }).then(({ event }) => {
-            expect(event.message).to.equal('No playable sources found');
             expect(event.code).to.equal(undefined);
+            expect(event.message).to.equal('No playable sources found');
         });
     });
 
@@ -118,8 +118,8 @@ describe('Setup', function() {
 
             expect(playlist).to.be.an('array').that.is.empty;
 
-            expect(event.message).to.equal('No playable sources found');
             expect(event.code).to.equal(undefined);
+            expect(event.message).to.equal('No playable sources found');
         });
     });
 

--- a/test/unit/setup-test.js
+++ b/test/unit/setup-test.js
@@ -1,147 +1,134 @@
+import instances from 'api/players';
 import Api from 'api/api';
 import ApiSettings from 'api/api-settings';
-import $ from 'jquery';
 
 describe('Setup', function() {
     this.timeout(3000);
 
-    beforeEach(function() {
+    beforeEach(() => {
         ApiSettings.debug = true;
-        // remove fixture
-        $('body').append('<div id="test-container"><div id="player"></div></div>');
+        // add fixture
+        const fixture = document.createElement('div');
+        const container = document.createElement('div');
+        fixture.id = 'test-fixture';
+        container.id = 'player';
+        fixture.appendChild(container);
+        document.body.appendChild(fixture);
     });
 
-    afterEach(function() {
+    afterEach(() => {
         ApiSettings.debug = false;
-        // remove fixture
-        $('#test-container').remove();
+        // remove fixture and player instances
+        const fixture = document.querySelector('#test-fixture');
+        if (fixture.parentNode) {
+            fixture.parentNode.removeChild(fixture);
+        }
+        for (let i = instances.length; i--;) {
+            instances[i].remove();
+        }
     });
 
-    it('fails when playlist is undefined', function (done) {
+    function expectReady(model) {
+        const container = document.querySelector('#player');
+        const api = new Api(container);
 
-        var readyHandler = function() {
-            expect(false, 'setup should not succeed').to.be.true;
-        };
-
-        var errorHandler = function (message) {
-            expect(message, 'setup failed with message: ' + message).to.be.true;
-        };
-
-        testSetup(done, {}, readyHandler, errorHandler);
-    });
-
-    it('fails when playlist is an empty string', function (done) {
-
-        var readyHandler = function() {
-            expect(false, 'setup should not succeed').to.be.true;
-        };
-
-        var errorHandler = function (message) {
-            expect(message, 'setup failed with message: ' + message).to.be.true;
-        };
-
-        testSetup(done, { playlist: '' }, readyHandler, errorHandler);
-    });
-
-    it('fails when playlist is a number', function (done) {
-
-        var readyHandler = function() {
-            expect(false, 'setup should not succeed').to.be.true;
-        };
-
-        var errorHandler = function (message) {
-            expect(message, 'setup failed with message: ' + message).to.be.true;
-        };
-
-        testSetup(done, { playlist: 1 }, readyHandler, errorHandler);
-    });
-
-    it('fails when playlist is a boolean', function (done) {
-
-        var readyHandler = function() {
-            expect(false, 'setup should not succeed').to.be.true;
-        };
-
-        var errorHandler = function (message) {
-            expect(message, 'setup failed with message: ' + message).to.be.true;
-        };
-
-        testSetup(done, { playlist: true }, readyHandler, errorHandler);
-    });
-
-    it('fails if playlist is empty', function (done) {
-        var model = {
-            playlist: []
-        };
-
-        testSetup(done, model, function() {
-            expect(false, 'setup should not succeed').to.be.true;
-            done();
-        }, function (message) {
-            expect(message, 'setup failed with message: ' + message).to.be.true;
-            done();
+        return new Promise((resolve, reject) => {
+            api.setup(model);
+            api.on('ready', function(event) {
+                resolve({
+                    api,
+                    event
+                });
+            });
+            api.on('setupError', function(event) {
+                reject(new Error('Expected "ready" after setup. Got "setupError" with:' +
+                    JSON.stringify(event)));
+            });
         });
-    });
-
-    it('fails when playlist items are filtered out', function (done) {
-        var model = {
-            playlist: [{ sources: [{ file: 'file.foo' }] }]
-        };
-
-        var playlist;
-        testSetup(done, model, function() {
-            // 'this' is the api instance
-            playlist = this.getPlaylist();
-            expect(playlist, 'playlist is an empty array').to.be.an('array').that.is.empty;
-            expect(false, 'setup should not succeed').to.be.true;
-            done();
-        }, function (message) {
-            playlist = this.getPlaylist();
-            expect(playlist, 'playlist is an empty array').to.be.an('array').that.is.empty;
-            expect(message, 'setup failed with message: ' + message).to.be.true;
-            done();
-        });
-        done();
-    });
-
-    it('succeeds when model.playlist.sources is valid', function (done) {
-        var model = {
-            playlist: [{ sources: [{ file: 'http://playertest.longtailvideo.com/mp4.mp4' }] }]
-        };
-
-        testSetup(done, model, function() {
-            expect(true, 'setup ok').to.be.true;
-            done();
-        }, function (message) {
-            expect(false, 'setup failed with message: ' + message).to.be.true;
-            done();
-        });
-    });
-
-    function testSetup(done, model, success, error) {
-        var container = $('#player')[0];
-        var api = new Api(container);
-        api.setup(model);
-
-        api.on('ready', function() {
-            success.call(api);
-            try {
-                api.remove();
-            } catch (e) {
-                expect(e.toString()).to.be.false;
-            }
-            done();
-        });
-        api.on('setupError', function (e) {
-            error.call(api, e.message);
-            try {
-                api.remove();
-            } catch (evt) {
-                expect(evt.toString()).to.be.false;
-            }
-            done();
-        });
-        done();
-        return api;
     }
+
+    function expectSetupError(model) {
+        const container = document.querySelector('#player');
+        const api = new Api(container);
+
+        return new Promise((resolve, reject) => {
+            api.setup(model);
+            api.on('ready', function() {
+                reject(new Error('Expected "setupError" after setup. Got "ready" instead.'));
+            });
+            api.on('setupError', function(event) {
+                resolve({
+                    api,
+                    event
+                });
+            });
+        });
+    }
+
+    it('fails when playlist is undefined', function() {
+        return expectSetupError({
+            // playlist is undefined
+        }).then(({ event }) => {
+            expect(event.message).to.equal('No playable sources found');
+            expect(event.code).to.equal(undefined);
+        });
+    });
+
+    it('fails when playlist is an empty string', function () {
+        return expectSetupError({
+            playlist: ''
+        }).then(({ event }) => {
+            expect(event.message).to.equal('No playable sources found');
+            expect(event.code).to.equal(undefined);
+        });
+    });
+
+    it('fails when playlist is a number', function () {
+        return expectSetupError({
+            playlist: 1
+        }).then(({ event }) => {
+            expect(event.message).to.equal('No playable sources found');
+            expect(event.code).to.equal(undefined);
+        });
+    });
+
+    it('fails when playlist is a boolean', function () {
+        return expectSetupError({
+            playlist: true
+        }).then(({ event }) => {
+            expect(event.message).to.equal('No playable sources found');
+            expect(event.code).to.equal(undefined);
+        });
+    });
+
+    it('fails if playlist is empty', function () {
+        return expectSetupError({
+            playlist: []
+        }).then(({ event }) => {
+            expect(event.message).to.equal('No playable sources found');
+            expect(event.code).to.equal(undefined);
+        });
+    });
+
+    it('fails when playlist items are filtered out', function () {
+        return expectSetupError({
+            playlist: [{ sources: [{ file: 'file.foo' }] }]
+        }).then(function ({ event, api }) {
+            const playlist = api.getPlaylist();
+
+            expect(playlist).to.be.an('array').that.is.empty;
+
+            expect(event.message).to.equal('No playable sources found');
+            expect(event.code).to.equal(undefined);
+        });
+    });
+
+    it('succeeds when model.playlist.sources is valid', function () {
+        return expectReady({
+            preload: 'none',
+            playlist: [{ sources: [{ file: 'http://playertest.longtailvideo.com/mp4.mp4' }] }]
+        }).then(({ event }) => {
+            expect(event.type).to.equal('ready');
+        });
+    });
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -91,9 +91,6 @@ const multiConfig = [
         optimization: {
             splitChunks: false
         },
-        stats: {
-            timings: true
-        },
         resolve: {
             modules: [
                 'src/js/',


### PR DESCRIPTION
### This PR will...
- Fix setup tests that exited via `done()` before running assertions
  - Now they use promises and have expect specific event output
- Update playlist in setup after filtering
  - An assertion that was being skipped missed a change were we did not update the playlist in the model before throwing a playlist error

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/5155

#### Addresses Issue(s):
JW8-1447

