### PR TITLE
[DO NOT MERGE] Set fullscreen when screen.orientation changes on Android Chrome

### DIFF
--- a/src/js/view/utils/views-manager.js
+++ b/src/js/view/utils/views-manager.js
@@ -42,6 +42,9 @@ function scheduleResponsiveRedraw() {
         views.forEach(view => {
             view.checkResized();
         });
+        views.forEach(view => {
+            view.checkOrientation();
+        });
     });
 }
 

--- a/src/js/view/utils/views-manager.js
+++ b/src/js/view/utils/views-manager.js
@@ -42,9 +42,12 @@ function scheduleResponsiveRedraw() {
         views.forEach(view => {
             view.checkResized();
         });
-        views.forEach(view => {
-            view.checkOrientation();
-        });
+    });
+}
+
+function checkOrientation(event) {
+    views.forEach(view => {
+        view.checkOrientation(event.target.type);
     });
 }
 
@@ -58,12 +61,14 @@ document.addEventListener('visibilitychange', onVisibilityChange);
 document.addEventListener('webkitvisibilitychange', onVisibilityChange);
 window.addEventListener('resize', scheduleResponsiveRedraw);
 window.addEventListener('orientationchange', scheduleResponsiveRedraw);
+screen.orientation.addEventListener('change', checkOrientation);
 
 window.addEventListener('beforeunload', () => {
     document.removeEventListener('visibilitychange', onVisibilityChange);
     document.removeEventListener('webkitvisibilitychange', onVisibilityChange);
     window.removeEventListener('resize', scheduleResponsiveRedraw);
     window.removeEventListener('orientationchange', scheduleResponsiveRedraw);
+    screen.orientation.removeEventListener('change', checkOrientation);
 });
 
 export default {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -150,6 +150,13 @@ function View(_api, _model) {
         }
     };
 
+    this.checkOrientation = function() {
+        if (OS.android && Browser.chrome) {
+            const orientationType = window.screen.orientation.type;
+            this.model.set('fullscreen', orientationType === 'landscape-primary' || orientationType === 'landscape-secondary');
+        }
+    };
+
     function _responsiveListener() {
         cancelAnimationFrame(_resizeContainerRequestId);
         _resizeContainerRequestId = requestAnimationFrame(_responsiveUpdate);

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -152,7 +152,18 @@ function View(_api, _model) {
 
     this.checkOrientation = function(type) {
         if (OS.android && Browser.chrome && _this.model.get('visibility') >= 0.75) {
-            _this.model.set('fullscreen', type === 'landscape-primary' || type === 'landscape-secondary');
+            const state = _this.model.get('state');
+            const isLandscape = type === 'landscape-primary' || type === 'landscape-secondary';
+
+            if (!isLandscape && state === 'paused') {
+                // Set fullscreen to false when going back to portrait while paused and return early
+                _this.model.set('fullscreen', false);
+                return;
+            }
+
+            if (state === 'playing') {
+                _this.model.set('fullscreen', isLandscape);
+            }
         }
     };
 

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -150,10 +150,9 @@ function View(_api, _model) {
         }
     };
 
-    this.checkOrientation = function() {
+    this.checkOrientation = function(type) {
         if (OS.android && Browser.chrome) {
-            const orientationType = window.screen.orientation.type;
-            this.model.set('fullscreen', orientationType === 'landscape-primary' || orientationType === 'landscape-secondary');
+            _this.model.set('fullscreen', type === 'landscape-primary' || type === 'landscape-secondary');
         }
     };
 

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -151,7 +151,7 @@ function View(_api, _model) {
     };
 
     this.checkOrientation = function(type) {
-        if (OS.android && Browser.chrome) {
+        if (OS.android && Browser.chrome && _this.model.get('visibility') >= 0.75) {
             _this.model.set('fullscreen', type === 'landscape-primary' || type === 'landscape-secondary');
         }
     };


### PR DESCRIPTION
### This PR will...

Set "fullscreen" to true when the viewer switches from portrait to landscape (works turning your phone clockwise and counter clockwise). Sets it to false when going from landscape to portrait 

- Player must be at least 75% visible
- Player exits from fullscreen if video is paused 

### Why is this Pull Request needed?

New feature to improve user experience

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-1380