### PR TITLE
Delete mediaElement.src instead of setting it to an empty string

### DIFF
--- a/src/js/program/media-element-pool.js
+++ b/src/js/program/media-element-pool.js
@@ -78,7 +78,7 @@ function primeMediaElementForPlayback(mediaElement) {
         // Clear the src for MSE providers who have already preloaded so that we do a full reload
         // The HTML5 provider already reloads identical sources, so we don't always need to reset if for non-blobs
         if (mediaElement.src.indexOf('blob') > -1) {
-            mediaElement.src = '';
+            mediaElement.removeAttribute('src');
         }
 
         const played = mediaElement.played;


### PR DESCRIPTION
### Why is this Pull Request needed?
So that the src is actually reset. Setting it to a falsy value `null`, `''`, etc. will actually set it to the page's url (which breaks when you call `play`)

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

 JW8-1490

