### PR TITLE
Don't assign setup core js error code to non-essential webpack modules

### DIFF
--- a/src/js/api/core-loader.js
+++ b/src/js/api/core-loader.js
@@ -20,7 +20,7 @@ export default function loadCoreBundle(model) {
 export function chunkLoadErrorHandler(code, error) {
     // Webpack require.ensure error: "Loading chunk 3 failed"
     return () => {
-        throw new PlayerError('Network error', SETUP_ERROR_LOADING_CORE_JS + code, error);
+        throw new PlayerError('Network error', code, error);
     };
 }
 
@@ -82,7 +82,7 @@ function loadControlsPolyfillHtml5Bundle() {
         ControlsLoader.controls = require('view/controls/controls').default;
         registerProvider(require('providers/html5').default);
         return CoreMixin;
-    }, chunkLoadErrorHandler(105), 'jwplayer.core.controls.polyfills.html5');
+    }, chunkLoadErrorHandler(SETUP_ERROR_LOADING_CORE_JS + 105), 'jwplayer.core.controls.polyfills.html5');
     bundleContainsProviders.html5 = loadPromise;
     return loadPromise;
 }
@@ -97,7 +97,7 @@ function loadControlsHtml5Bundle() {
         ControlsLoader.controls = require('view/controls/controls').default;
         registerProvider(require('providers/html5').default);
         return CoreMixin;
-    }, chunkLoadErrorHandler(104), 'jwplayer.core.controls.html5');
+    }, chunkLoadErrorHandler(SETUP_ERROR_LOADING_CORE_JS + 104), 'jwplayer.core.controls.html5');
     bundleContainsProviders.html5 = loadPromise;
     return loadPromise;
 }
@@ -112,7 +112,7 @@ function loadControlsPolyfillBundle() {
         const CoreMixin = require('controller/controller').default;
         ControlsLoader.controls = require('view/controls/controls').default;
         return CoreMixin;
-    }, chunkLoadErrorHandler(103), 'jwplayer.core.controls.polyfills');
+    }, chunkLoadErrorHandler(SETUP_ERROR_LOADING_CORE_JS + 103), 'jwplayer.core.controls.polyfills');
 }
 
 function loadControlsBundle() {
@@ -123,7 +123,7 @@ function loadControlsBundle() {
         const CoreMixin = require('controller/controller').default;
         ControlsLoader.controls = require('view/controls/controls').default;
         return CoreMixin;
-    }, chunkLoadErrorHandler(102), 'jwplayer.core.controls');
+    }, chunkLoadErrorHandler(SETUP_ERROR_LOADING_CORE_JS + 102), 'jwplayer.core.controls');
 }
 
 function loadCore() {
@@ -132,7 +132,7 @@ function loadCore() {
             'controller/controller'
         ], function (require) {
             return require('controller/controller').default;
-        }, chunkLoadErrorHandler(101), 'jwplayer.core');
+        }, chunkLoadErrorHandler(SETUP_ERROR_LOADING_CORE_JS + 101), 'jwplayer.core');
     });
 }
 
@@ -142,7 +142,7 @@ function loadIntersectionObserverIfNeeded() {
             'intersection-observer'
         ], function (require) {
             return require('intersection-observer');
-        }, chunkLoadErrorHandler(120), 'polyfills.intersection-observer');
+        }, chunkLoadErrorHandler(SETUP_ERROR_LOADING_CORE_JS + 120), 'polyfills.intersection-observer');
     }
     return resolved;
 }


### PR DESCRIPTION
### This PR will...

Only assign setup error codes to core webpack components. Non-essential webpack modules result in "error" events that do not break playback, and we will be renaming those to "warning" events in JW8-1504.

### Why is this Pull Request needed?

`chunkLoadErrorHandler` is used in several places. This PR ensures that we only assign `SETUP_ERROR_LOADING_CORE_JS` to core components essential to setup in core-loader.js

Here's the breakdown:

1. core-loader.js - A `chunkLoadErrorHandler` exception results in a "setupError"
2. providers.js `Loaders` - Can be a setup error or a player error depending on when provider is loaded. This work should be handled separately (JIRA pendning)
3. controls-loader `.loadControls()` - "warning" JW8-1504
4. tracks-loader - "warning" JW8-1504
5. captionsrenderer - "warning" JW8-1504
6. casting and airplay - "warning" JW8-1504

"warning" events do not have a dialog shown to the user, are not tracked, and thus don't require error codes at this time.

#### Addresses Issue(s):

JW8-1444

