### PR TITLE
Set "mediaType" to audio when mimeType is "audio/mp4"

### DIFF
--- a/src/js/providers/default.js
+++ b/src/js/providers/default.js
@@ -94,9 +94,9 @@ const DefaultProvider = {
     },
 
     sendMediaType: function(levels) {
-        var level = levels[0];
-        var type = level.type;
-        var isAudioFile = (type === 'oga' || type === 'aac' || type === 'mp3' ||
+        const level = levels[0];
+        const type = level.type;
+        const isAudioFile = (type === 'oga' || type === 'aac' || type === 'mp3' ||
             type === 'mpeg' || type === 'vorbis' || level.mimeType === 'audio/mp4');
 
         this.trigger(MEDIA_TYPE, {

--- a/src/js/providers/default.js
+++ b/src/js/providers/default.js
@@ -94,9 +94,10 @@ const DefaultProvider = {
     },
 
     sendMediaType: function(levels) {
-        var type = levels[0].type;
+        var level = levels[0];
+        var type = level.type;
         var isAudioFile = (type === 'oga' || type === 'aac' || type === 'mp3' ||
-            type === 'mpeg' || type === 'vorbis');
+            type === 'mpeg' || type === 'vorbis' || level.mimeType === 'audio/mp4');
 
         this.trigger(MEDIA_TYPE, {
             mediaType: isAudioFile ? 'audio' : 'video'

--- a/src/js/providers/default.js
+++ b/src/js/providers/default.js
@@ -94,8 +94,7 @@ const DefaultProvider = {
     },
 
     sendMediaType: function(levels) {
-        const level = levels[0];
-        const { type, mimeType } = level;
+        const { type, mimeType } = levels[0];
         const isAudioFile = (type === 'oga' || type === 'aac' || type === 'mp3' ||
             type === 'mpeg' || type === 'vorbis' || (mimeType && mimeType.indexOf('audio/') === 0));
 

--- a/src/js/providers/default.js
+++ b/src/js/providers/default.js
@@ -95,9 +95,9 @@ const DefaultProvider = {
 
     sendMediaType: function(levels) {
         const level = levels[0];
-        const type = level.type;
+        const { type, mimeType } = level;
         const isAudioFile = (type === 'oga' || type === 'aac' || type === 'mp3' ||
-            type === 'mpeg' || type === 'vorbis' || level.mimeType === 'audio/mp4');
+            type === 'mpeg' || type === 'vorbis' || (mimeType && mimeType.indexOf('audio/') === 0));
 
         this.trigger(MEDIA_TYPE, {
             mediaType: isAudioFile ? 'audio' : 'video'


### PR DESCRIPTION
### This PR will...

Set "mediaType" to audio when mimeType is "audio/mp4"

### Why is this Pull Request needed?

Setting the type to "audio/mp4" in the config causes the type to become "mp4" when we trigger a media_type event and because of that, we trigger mediaType as video instead of audio. This is because when we do the check in default.js, the type of the level becomes "mp4" instead of "aac" and the poster image will disappear on playback

### Are there any points in the code the reviewer needs to double check?

Should this be accounted for in source.js instead?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-1407

