### PR TITLE
Ajax Error Codes

### DIFF
--- a/src/js/utils/helpers.js
+++ b/src/js/utils/helpers.js
@@ -36,13 +36,26 @@ import {
     transform,
     getRgba
 } from 'utils/css';
-import { ajax, crossdomain } from 'utils/ajax';
+import { ajax } from 'utils/ajax';
 
 export const log = (typeof console.log === 'function') ? console.log.bind(console) : function() {};
 
 const between = function (num, min, max) {
     return Math.max(Math.min(num, max), min);
 };
+
+// TODO: deprecate (jwplayer-ads-vast uses utils.crossdomain(url))
+function crossdomain(uri) {
+    const a = document.createElement('a');
+    const b = document.createElement('a');
+    a.href = location.href;
+    try {
+        b.href = uri;
+        b.href = b.href; /* IE fix for relative urls */
+        return a.protocol + '//' + a.host !== b.protocol + '//' + b.host;
+    } catch (e) {/* swallow */}
+    return true;
+}
 
 // The predicate received the arguments (key, value) instead of (value, key)
 const foreach = function (aData, fnEach) {

--- a/src/js/utils/parser.js
+++ b/src/js/utils/parser.js
@@ -53,19 +53,11 @@ function containsParserErrors(childNodes) {
 export function parseXML(input) {
     let parsedXML = null;
     try {
-        // Parse XML in FF/Chrome/Safari/Opera
-        if ('DOMParser' in window) {
-            parsedXML = (new window.DOMParser()).parseFromString(input, 'text/xml');
-            // In Firefox the XML doc may contain the parsererror, other browsers it's further down
-            if (containsParserErrors(parsedXML.childNodes) ||
-                (parsedXML.childNodes && containsParserErrors(parsedXML.childNodes[0].childNodes))) {
-                parsedXML = null;
-            }
-        } else {
-            // Internet Explorer
-            parsedXML = new window.ActiveXObject('Microsoft.XMLDOM');
-            parsedXML.async = 'false';
-            parsedXML.loadXML(input);
+        parsedXML = (new window.DOMParser()).parseFromString(input, 'text/xml');
+        // In Firefox the XML doc may contain the parsererror, other browsers it's further down
+        if (containsParserErrors(parsedXML.childNodes) ||
+            (parsedXML.childNodes && containsParserErrors(parsedXML.childNodes[0].childNodes))) {
+            parsedXML = null;
         }
     } catch (e) {/* Expected when content is not XML */}
 

--- a/test/unit/ajax-test.js
+++ b/test/unit/ajax-test.js
@@ -4,240 +4,216 @@ describe('utils.ajax', function() {
     this.timeout(5000);
 
     function validateXHR(xhr) {
-        if ('XDomainRequest' in window) {
-            expect(xhr).to.be.instanceOf(window.XDomainRequest);
-        } else {
-            expect(xhr).to.be.instanceOf(window.XMLHttpRequest);
-        }
+        expect(xhr).to.be.instanceOf(window.XMLHttpRequest);
     }
 
-    it('uses default mimetype "text/xml" with legacy boolean argument', function (done) {
-        const xhr = ajax('/base/test/files/playlist.xml',
-            function success(xhrResult) {
-                expect(xhrResult)
-                    .to.equal(xhr);
-                expect(xhrResult.responseText)
-                    .to.be.a('string')
-                    .and.have.lengthOf(2401);
-                expect(xhrResult)
-                    .to.have.property('responseXML')
-                    .that.does.not.equal(undefined);
-                expect(xhrResult.status)
-                    .to.equal(200);
-                done();
-            },
-            function error(message, requestUrl, xhrResult) {
-                assert.fail(xhrResult.status, 200, message, requestUrl);
-                done();
-            },
-            true
-        );
-        validateXHR(xhr);
+    function expectSuccess(options) {
+        return new Promise((resolve, reject) => {
+            options.oncomplete = (result) => {
+                resolve({
+                    result,
+                    xhr
+                });
+            };
+            options.onerror = (message, url, result) => {
+                reject(new Error(`Expected request to return OK status 200. ` +
+                    `Got ${result.status} "${message}" ${url}`));
+            };
+            const xhr = ajax(options);
+        });
+    }
+
+    function expectError(options, successHandler) {
+        return new Promise((resolve, reject) => {
+            options.oncomplete = (result) => {
+                reject(successHandler(result));
+            };
+            options.onerror = (message, url, result) => {
+                resolve({
+                    message,
+                    url,
+                    result
+                });
+            };
+            ajax(options);
+        });
+    }
+
+    it('uses default mimetype "text/xml" with legacy boolean argument', function () {
+        return new Promise((resolve, reject) => {
+            const xhr = ajax('/base/test/files/playlist.xml',
+                function success(result) {
+                    resolve({
+                        result,
+                        xhr
+                    });
+                },
+                function error(message, requestUrl, xhrResult) {
+                    reject(new Error(`Expected request to return OK status 200. ` +
+                        `Got ${xhrResult.status} "${message}" ${requestUrl}`));
+                },
+                true
+            );
+            validateXHR(xhr);
+        }).then(({ result, xhr }) => {
+            expect(result).to.equal(xhr);
+            expect(result).to.have.property('responseText').which.is.a('string').and.has.lengthOf(2401);
+            expect(result).to.have.property('responseXML').which.does.not.equal(undefined);
+            expect(result).to.have.property('status').which.equals(200);
+        });
     });
 
-    it('supports responseType "text" argument', function (done) {
-        const xhr = ajax({
+    it('supports responseType "text" argument', function () {
+        return expectSuccess({
             url: '/base/test/files/playlist.json',
-            oncomplete: function (xhrResult) {
-                expect(xhrResult.responseText)
-                    .to.be.a('string')
-                    .and.have.lengthOf(161);
-                expect(xhrResult.status)
-                    .to.equal(200);
-                done();
-            },
-            onerror: function (message, requestUrl, xhrResult) {
-                assert.fail(xhrResult.status, 200, message, requestUrl);
-                done();
-            },
             responseType: 'text'
+        }).then(({ result, xhr }) => {
+            validateXHR(xhr);
+            expect(result).to.have.property('responseText').which.is.a('string').and.has.lengthOf(161);
+            expect(result).to.have.property('status').which.equals(200);
         });
-        validateXHR(xhr);
     });
 
-    it('supports responseType "json" argument', function (done) {
-        const xhr = ajax({
+    it('supports responseType "json" argument', function () {
+        return expectSuccess({
             url: '/base/test/files/playlist.json',
-            oncomplete: function (xhrResult) {
-                expect(xhrResult.response).to.be.an('array');
-                expect(xhrResult.response[0].file).to.equal('http://content.bitsontherun.com/videos/3XnJSIm4-52qL9xLP.mp4');
-                done();
-            },
-            onerror: function (message, requestUrl, xhrResult) {
-                assert.fail(xhrResult.status, 200, message, requestUrl);
-                done();
-            },
             responseType: 'json'
+        }).then(({ result, xhr }) => {
+            validateXHR(xhr);
+            expect(result).to.have.property('response').which.is.an('array').and.has.lengthOf(2);
+            expect(result.response[0]).to.have.property('file')
+                .which.equals('http://content.bitsontherun.com/videos/3XnJSIm4-52qL9xLP.mp4');
         });
-        validateXHR(xhr);
     });
 
-    it('supports timeout argument', function (done) {
+    it('supports timeout argument', function () {
         const nonce = Math.random().toFixed(20).substr(2);
 
-        ajax({
+        return expectError({
             url: '//playertest.longtailvideo.com/vast/preroll.xml?n=' + nonce,
-            oncomplete: function () {
-                assert.fail('XHR request completed', 'XHR request should have timed out');
-                done();
-            },
-            onerror: function (message, requestUrl, xhrResult) {
-                expect(xhrResult.status).to.equal(0);
-                expect(message).to.equal('Timeout');
-                done();
-            },
             timeout: 0.0001,
             responseType: 'text'
+        }, success => {
+            return new Error(`Expected XHR request to timeout. It succeeded with status ${success.status}.`);
+        }).then(({ message, url, result }) => {
+            expect(message).to.equal('Timeout');
+            expect(url).to.be.a('string');
+            expect(result).to.have.property('status').which.equals(0);
         });
     });
 
-    it('supports withCredentials argument', function (done) {
-        ajax({
+    it('supports withCredentials argument', function () {
+        return expectSuccess({
             url: '/base/test/files/playlist.json',
-            oncomplete: function (xhrResult) {
-                if ('withCredentials' in xhrResult) {
-                    expect(xhrResult).to.have.property('withCredentials').that.equals(true);
-                } else {
-                    assert.isOk(true, 'withCredentials is not available in this browser');
-                }
-                done();
-            },
-            onerror: function(message, requestUrl, xhrResult) {
-                assert.fail(xhrResult.status, 200, message, requestUrl);
-                done();
-            },
             withCredentials: true,
             responseType: 'text'
+        }).then(({ result }) => {
+            if ('withCredentials' in result) {
+                expect(result).to.have.property('withCredentials').which.equals(true);
+            } else {
+                assert.isOk(true, 'withCredentials is not available in this browser');
+            }
         });
     });
 
-    it('supports retryWithoutCredentials argument', function (done) {
-        const xhr = ajax({
+    it('supports retryWithoutCredentials argument', function () {
+        return expectSuccess({
             url: 'https://cdn.jwplayer.com/v2/playlists/r1AALLcN?format=mrss',
-            oncomplete: function (xhrResult) {
-                expect(xhrResult, 'A second XHR instance is created to re-request without credentials')
-                    .to.not.equal(xhr);
-                expect(xhrResult)
-                    .to.have.property('withCredentials')
-                    .that.is.a('boolean')
-                    .that.equals(false);
-                expect(xhrResult.responseText)
-                    .to.be.a('string');
-                expect(xhrResult.status)
-                    .to.equal(200);
-                expect(xhrResult.responseXML)
-                    .to.have.property('firstChild')
-                    .that.does.not.equal(undefined);
-                done();
-            },
-            onerror: function(message, requestUrl, xhrResult) {
-                assert.fail(xhrResult.status, 200, message, requestUrl);
-                done();
-            },
             withCredentials: true,
             retryWithoutCredentials: true,
             requireValidXML: true
+        }).then(({ result, xhr }) => {
+            expect(result, 'A second XHR instance is created to re-request without credentials').to.not.equal(xhr);
+            expect(result)
+                .to.have.property('withCredentials')
+                .which.is.a('boolean')
+                .which.equals(false);
+            expect(result.responseText)
+                .to.be.a('string');
+            expect(result.status)
+                .to.equal(200);
+            expect(result.responseXML)
+                .to.have.property('firstChild')
+                .which.does.not.equal(undefined);
         });
     });
 
-    it('supports a custom xhr argument', function (done) {
+    it('supports a custom xhr argument', function () {
         const customXhr = new window.XMLHttpRequest();
-        const xmlHttpRequest = ajax({
+        return expectSuccess({
             xhr: customXhr,
-            url: '/base/test/files/playlist.json',
-            oncomplete: function (xhrResult) {
-                expect(xhrResult).to.equal(customXhr);
-                expect(xhrResult.status).to.equal(200);
-                done();
-            },
-            onerror: function(message, requestUrl, xhrResult) {
-                assert.fail(xhrResult.status, 200, message, requestUrl);
-                done();
-            }
+            url: '/base/test/files/playlist.json'
+        }).then(({ result, xhr }) => {
+            expect(xhr).to.equal(customXhr);
+            expect(result).to.equal(customXhr);
+            expect(result.status).to.equal(200);
         });
-        expect(xmlHttpRequest).to.equal(customXhr);
     });
 
-    it('supports a requestFilter xhr argument', function (done) {
+    it('supports a requestFilter xhr argument', function () {
         const customXhr = new window.XMLHttpRequest();
-        const xmlHttpRequest = ajax({
+        return expectSuccess({
             requestFilter: function(request) {
                 expect(request).to.have.property('url').which.equals('/base/test/files/playlist.json');
                 expect(request).to.have.property('xhr');
                 return customXhr;
             },
-            url: '/base/test/files/playlist.json',
-            oncomplete: function (xhrResult) {
-                expect(xhrResult).to.equal(customXhr);
-                expect(xhrResult.status).to.equal(200);
-                done();
-            },
-            onerror: function(message, requestUrl, xhrResult) {
-                assert.fail(xhrResult.status, 200, message, requestUrl);
-                done();
-            }
-        });
-        expect(xmlHttpRequest).to.equal(customXhr);
-    });
-
-    it('error "Error loading file" (bad request)', function (done) {
-        ajax({
-            oncomplete: function () {
-                assert.fail('XHR request completed', '"Error loading file" Error');
-                done();
-            },
-            onerror: function(message, requestUrl, xhrResult) {
-                expect(xhrResult.status).to.equal(0);
-                expect(message).to.equal('Error loading file');
-                done();
-            }
+            url: '/base/test/files/playlist.json'
+        }).then(({ result, xhr }) => {
+            expect(xhr).to.equal(customXhr);
+            expect(result).to.equal(customXhr);
+            expect(result.status).to.equal(200);
         });
     });
 
-    it('error "Invalid XML"', function (done) {
-        ajax({
-            url: '/base/test/files/invalid.xml',
-            oncomplete: function () {
-                assert.fail('XHR request completed', '"Invalid XML" Error');
-                done();
-            },
-            onerror: function (message, requestUrl, xhrResult) {
-                expect(xhrResult.status).to.equal(200);
-                expect(message).to.equal('Invalid XML');
-                done();
-            },
+    it('error "Error loading file" (bad request)', function () {
+        return expectError({}, success => {
+            return new Error(`Expected bad request to fail with "Error loading file". Got ${success.status}`);
+        }).then(({ message, url, result }) => {
+            expect(message).to.equal('Error loading file');
+            expect(url).to.equal(undefined);
+            expect(result.status).to.equal(0);
+        });
+    });
+
+    it('error "Invalid XML"', function () {
+        const url = '/base/test/files/invalid.xml';
+        return expectError({
+            url,
             requireValidXML: true
+        }, success => {
+            return new Error(`Expected bad request to fail with "Invalid XML". Got ${success.status}`);
+        }).then(({ message, url: u, result }) => {
+            expect(message).to.equal('Invalid XML');
+            expect(u).to.equal(url);
+            expect(result.status).to.equal(200);
         });
     });
 
-    it('error "Invalid JSON"', function (done) {
-        ajax({
-            url: '/base/test/files/invalid.xml',
-            oncomplete: function() {
-                assert.fail('XHR request completed', '"Invalid JSON" Error');
-                done();
-            },
-            onerror: function (message, requestUrl, xhrResult) {
-                expect(xhrResult.status).to.equal(200);
-                expect(message).to.equal('Invalid JSON');
-                done();
-            },
+    it('error "Invalid JSON"', function () {
+        const url = '/base/test/files/invalid.xml';
+        return expectError({
+            url,
             responseType: 'json'
+        }, success => {
+            return new Error(`Expected bad request to fail with "Invalid JSON". Got ${success.status}`);
+        }).then(({ message, url: u, result }) => {
+            expect(message).to.equal('Invalid JSON');
+            expect(u).to.equal(url);
+            expect(result.status).to.equal(200);
         });
     });
 
-    it('error "File not found" (404) - Integration Test', function (done) {
-        ajax({
-            url: 'foobar',
-            oncomplete: function() {
-                assert.fail('XHR request completed', '"File not found" Error');
-                done();
-            },
-            onerror: function (message, requestUrl, xhrResult) {
-                expect(xhrResult.status).to.equal(404);
-                expect(message).to.equal('File not found');
-                done();
-            }
+    it('error "File not found" (404) - Integration Test', function () {
+        const url = 'foobar';
+        return expectError({
+            url
+        }, success => {
+            return new Error(`Expected bad request to fail with "File not found". Got ${success.status}`);
+        }).then(({ message, url: u, result }) => {
+            expect(message).to.equal('File not found');
+            expect(u).to.equal(url);
+            expect(result.status).to.equal(404);
         });
     });
 });


### PR DESCRIPTION
### This PR will...

- Implement request (1-6), network (400-599) and format (600+) error codes for ajax utils.
- Add a `PlayerError` parameter to the `onerror` ajax callback
- Move `crossdomain(uri)` function into helpers.js since we only keep it around to maintain the `utils` interface.
- Update ajax unit tests, maintaining existing coverage through promises, and adding coverage for error codes, and new errors
 
### Why is this Pull Request needed?

Provide standardized error objects for errors returned by the ajax util.

### Are there any points in the code the reviewer needs to double check?

Some errors are not tested because they require modification to browser functionality that I don't want to tamper with or cannot mock in our tests. If there are specific tests or assertions we want to make, let's discuss.
 
### Are there any Pull Requests open in other repos which need to be merged with this?

No

#### Addresses Issue(s):

JW8-1445

