### PR TITLE
Implement standardised playlist errors

### DIFF
--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -13,6 +13,7 @@ import ErrorContainer from 'view/error-container';
 import MediaElementPool from 'program/media-element-pool';
 import SharedMediaPool from 'program/shared-media-pool';
 import { Features } from 'environment/environment';
+import { SETUP_ERROR_LOADING_PLAYLIST } from 'api/errors';
 
 const ModelShim = function() {};
 Object.assign(ModelShim.prototype, SimpleModel);
@@ -119,7 +120,11 @@ Object.assign(CoreShim.prototype, {
             storage.track(coreModel);
 
             // Set the active playlist item after plugins are loaded and the view is setup
-            return this.updatePlaylist(coreModel.get('playlist'), coreModel.get('feedData'));
+            return this.updatePlaylist(coreModel.get('playlist'), coreModel.get('feedData'))
+                .catch((error) => {
+                    error.code += (error.code || 0) + SETUP_ERROR_LOADING_PLAYLIST;
+                    throw error;
+                });
         }).then(() => {
             if (!this.setup) {
                 return;

--- a/src/js/api/errors.js
+++ b/src/js/api/errors.js
@@ -30,6 +30,16 @@ export const SETUP_ERROR_LICENSE_EXPIRED = 100013;
 export const SETUP_ERROR_LOADING_CORE_JS = 101000;
 
 /**
+ * @enum {ErrorCode} Setup failed because the playlist failed to load
+ */
+export const SETUP_ERROR_LOADING_PLAYLIST = 102000;
+
+/**
+ * @enum {ErrorCode} Playback stopped because the playlist failed to load
+ */
+export const ERROR_LOADING_PLAYLIST = 203000;
+
+/**
  * Class representing the jwplayer() API.
  * Creates an instance of the player.
  * @class PlayerError
@@ -38,9 +48,9 @@ export const SETUP_ERROR_LOADING_CORE_JS = 101000;
  * @param {sourceError} [Error] - The lower level error, caught by the player, which resulted in this error.
  */
 export class PlayerError extends Error {
-    constructor(message, code, sourceError) {
+    constructor(message, code, sourceError = null) {
         super(message);
         this.code = isValidNumber(code) ? code : null;
-        this.sourceError = sourceError || null;
+        this.sourceError = sourceError;
     }
 }

--- a/src/js/playlist/loader.js
+++ b/src/js/playlist/loader.js
@@ -3,6 +3,7 @@ import { localName } from 'parsers/parsers';
 import parseRss from 'parsers/rssparser';
 import utils from 'utils/helpers';
 import Events from 'utils/backbone.events';
+import { PlayerError, ERROR_LOADING_PLAYLIST } from 'api/errors';
 
 const PlaylistLoader = function() {
     var _this = Object.assign(this, Events);
@@ -50,20 +51,22 @@ const PlaylistLoader = function() {
                         throw Error;
                     }
                 } catch (e) {
-                    throw new Error('Not a valid RSS/JSON feed');
+                    throw new PlayerError('Not a valid RSS/JSON feed', 21, e);
                 }
             }
 
             _this.trigger(PLAYLIST_LOADED, jsonObj);
         } catch (error) {
-            playlistError(error.message);
+            playlistError(error);
         }
     }
 
-    function playlistError(msg) {
-        _this.trigger(ERROR, {
-            message: msg ? msg : 'Error loading file'
-        });
+    function playlistError(error) {
+        if (!error.code) {
+            error = new PlayerError(error ? error : 'Error loading file', 0);
+        }
+        error.message = `Error loading playlist: ${error.message}`;
+        _this.trigger(ERROR, error);
     }
 };
 

--- a/src/js/playlist/loader.js
+++ b/src/js/playlist/loader.js
@@ -3,13 +3,15 @@ import { localName } from 'parsers/parsers';
 import parseRss from 'parsers/rssparser';
 import utils from 'utils/helpers';
 import Events from 'utils/backbone.events';
-import { PlayerError, ERROR_LOADING_PLAYLIST } from 'api/errors';
+import { PlayerError } from 'api/errors';
 
 const PlaylistLoader = function() {
-    var _this = Object.assign(this, Events);
+    const _this = Object.assign(this, Events);
 
     this.load = function(playlistfile) {
-        utils.ajax(playlistfile, playlistLoaded, playlistError);
+        utils.ajax(playlistfile, playlistLoaded, (message, file, url, error) => {
+            playlistError(error);
+        });
     };
 
     this.destroy = function() {

--- a/src/js/playlist/playlist.js
+++ b/src/js/playlist/playlist.js
@@ -2,6 +2,7 @@ import { getPreload } from './preload';
 import PlaylistItem from 'playlist/item';
 import Source from 'playlist/source';
 import Providers from 'providers/providers';
+import { PlayerError } from 'api/errors';
 
 const Playlist = function(playlist) {
     // Can be either an array of items or a single item.
@@ -42,9 +43,10 @@ export function filterPlaylist(playlist, model, feedData) {
     return list;
 }
 
+
 export function validatePlaylist(playlist) {
     if (!Array.isArray(playlist) || playlist.length === 0) {
-        throw new Error('No playable sources found');
+        throw new PlayerError('No playable sources found', 630);
     }
 }
 export const fixSources = (item, model) => filterSources(formatSources(item, model), model.getProviders());

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -5,9 +5,9 @@ import cancelable from 'utils/cancelable';
 import { MediaControllerListener } from 'program/program-listeners';
 import Eventable from 'utils/eventable';
 import BackgroundMedia from 'program/background-media';
-
 import { ERROR, PLAYER_STATE, STATE_BUFFERING } from 'events/events';
-import { Features } from '../environment/environment';
+import { Features } from 'environment/environment';
+import { PlayerError } from 'api/errors';
 
 /** @private Do not include in JSDocs */
 
@@ -50,7 +50,7 @@ class ProgramController extends Eventable {
         model.setActiveItem(index);
         const source = getSource(item);
         if (!source) {
-            return Promise.reject(new Error('No media'));
+            return Promise.reject(new PlayerError('No media', 640));
         }
 
         // Activate the background media if it's loading the item we want to play

--- a/test/unit/ajax-test.js
+++ b/test/unit/ajax-test.js
@@ -28,12 +28,11 @@ describe('utils.ajax', function() {
             options.oncomplete = (result) => {
                 reject(successHandler(result));
             };
-            options.onerror = (message, url, result, error) => {
+            options.onerror = (message, url, result) => {
                 resolve({
                     message,
                     url,
-                    result,
-                    error
+                    result
                 });
             };
             ajax(options);
@@ -66,11 +65,11 @@ describe('utils.ajax', function() {
 
     it('supports responseType "text" argument', function () {
         return expectSuccess({
-            url: '/base/test/files/playlist.xml',
+            url: '/base/test/files/playlist.json',
             responseType: 'text'
         }).then(({ result, xhr }) => {
             validateXHR(xhr);
-            expect(result).to.have.property('responseText').which.is.a('string').and.has.lengthOf(2401);
+            expect(result).to.have.property('responseText').which.is.a('string').and.has.lengthOf(161);
             expect(result).to.have.property('status').which.equals(200);
         });
     });
@@ -88,7 +87,6 @@ describe('utils.ajax', function() {
     });
 
     it('supports timeout argument', function () {
-        const errorMessage = 'Timeout';
         const nonce = Math.random().toFixed(20).substr(2);
 
         return expectError({
@@ -97,14 +95,10 @@ describe('utils.ajax', function() {
             responseType: 'text'
         }, success => {
             return new Error(`Expected XHR request to timeout. It succeeded with status ${success.status}.`);
-        }).then(({ message, url, result, error }) => {
-            expect(message).to.equal(errorMessage);
+        }).then(({ message, url, result }) => {
+            expect(message).to.equal('Timeout');
             expect(url).to.be.a('string');
-            validateXHR(result);
             expect(result).to.have.property('status').which.equals(0);
-            expect(error).to.have.property('message').which.equals(errorMessage);
-            expect(error).to.have.property('code').which.equals(1);
-            expect(error).to.have.property('sourceError').which.equals(null);
         });
     });
 
@@ -172,95 +166,54 @@ describe('utils.ajax', function() {
         });
     });
 
-    it('handles bad request exceptions', function () {
-        const errorMessage = 'Error loading file';
-
+    it('error "Error loading file" (bad request)', function () {
         return expectError({}, success => {
             return new Error(`Expected bad request to fail with "Error loading file". Got ${success.status}`);
-        }).then(({ message, url, result, error }) => {
-            expect(message).to.equal(errorMessage);
+        }).then(({ message, url, result }) => {
+            expect(message).to.equal('Error loading file');
             expect(url).to.equal(undefined);
             expect(result.status).to.equal(0);
-            expect(error).to.have.property('message').which.equals(errorMessage);
-            expect(error).to.have.property('code').which.equals(3);
-            expect(error).to.have.property('sourceError').which.does.not.equal(null);
-        });
-    });
-
-    it('handles requestFilter exceptions', function () {
-        const errorMessage = 'Error loading file';
-        const url = '/base/test/files/playlist.json';
-
-        return expectError({
-            requestFilter: function() {
-                throw new Error('Bad request filter');
-            },
-            url
-        }, success => {
-            return new Error(`Expected bad filter to fail with "Error loading file". Got ${success.status}`);
-        }).then(({ message, url: u, result, error }) => {
-            expect(message).to.equal(errorMessage);
-            expect(u).to.equal(url);
-            expect(result.status).to.equal(0);
-            expect(error).to.have.property('message').which.equals(errorMessage);
-            expect(error).to.have.property('code').which.equals(5);
-            expect(error).to.have.property('sourceError').which.does.not.equal(null);
         });
     });
 
     it('error "Invalid XML"', function () {
-        const errorMessage = 'Invalid XML';
         const url = '/base/test/files/invalid.xml';
-
         return expectError({
             url,
             requireValidXML: true
         }, success => {
             return new Error(`Expected bad request to fail with "Invalid XML". Got ${success.status}`);
-        }).then(({ message, url: u, result, error }) => {
-            expect(message).to.equal(errorMessage);
+        }).then(({ message, url: u, result }) => {
+            expect(message).to.equal('Invalid XML');
             expect(u).to.equal(url);
             expect(result.status).to.equal(200);
-            expect(error).to.have.property('message').which.equals(errorMessage);
-            expect(error).to.have.property('code').which.equals(602);
-            expect(error).to.have.property('sourceError').which.equals(null);
         });
     });
 
     it('error "Invalid JSON"', function () {
-        const errorMessage = 'Invalid JSON';
         const url = '/base/test/files/invalid.xml';
-
         return expectError({
             url,
             responseType: 'json'
         }, success => {
             return new Error(`Expected bad request to fail with "Invalid JSON". Got ${success.status}`);
-        }).then(({ message, url: u, result, error }) => {
-            expect(message).to.equal(errorMessage);
+        }).then(({ message, url: u, result }) => {
+            expect(message).to.equal('Invalid JSON');
             expect(u).to.equal(url);
             expect(result.status).to.equal(200);
-            expect(error).to.have.property('message').which.equals(errorMessage);
-            expect(error).to.have.property('code').which.equals(611);
-            expect(error).to.have.property('sourceError').which.does.not.equal(null);
         });
     });
 
     it('error "File not found" (404) - Integration Test', function () {
-        const errorMessage = 'File not found';
         const url = 'foobar';
-
         return expectError({
             url
         }, success => {
             return new Error(`Expected bad request to fail with "File not found". Got ${success.status}`);
-        }).then(({ message, url: u, result, error }) => {
-            expect(message).to.equal(errorMessage);
+        }).then(({ message, url: u, result }) => {
+            expect(message).to.equal('File not found');
             expect(u).to.equal(url);
             expect(result.status).to.equal(404);
-            expect(error).to.have.property('message').which.equals(errorMessage);
-            expect(error).to.have.property('code').which.equals(404);
-            expect(error).to.have.property('sourceError').which.equals(null);
         });
     });
 });

--- a/test/unit/playlist-loader-test.js
+++ b/test/unit/playlist-loader-test.js
@@ -4,7 +4,7 @@ import { PLAYLIST_LOADED, ERROR } from 'events/events';
 describe('playlist/loader', function() {
     this.timeout(5000);
 
-    it('Test JSON feed', function (done) {
+    it('loads a valid JSON feed', function (done) {
         const loader = new PlaylistLoader();
         const expectedJSON = [{
             file: 'http://content.bitsontherun.com/videos/3XnJSIm4-52qL9xLP.mp4'
@@ -26,7 +26,7 @@ describe('playlist/loader', function() {
         loader.load('/base/test/files/playlist.json');
     });
 
-    it('Test XML feed', function (done) {
+    it('loads a valid XML feed', function (done) {
         const loader = new PlaylistLoader();
         const mediaid = 'TQjoCPTk';
         loader.on(PLAYLIST_LOADED, function (data) {
@@ -43,19 +43,26 @@ describe('playlist/loader', function() {
         loader.load('/base/test/files/playlist.xml');
     });
 
-    it('Test invalid feed', function (done) {
+    it('throws a PlayerError when loading an invalid JSON feed', function (done) {
         const loader = new PlaylistLoader();
+        let numCalls = 0;
+        let expectedCalls = 2;
 
         loader.on(PLAYLIST_LOADED, function (data) {
             expect(false, 'No error was fired with invalid JSON feed ' + data).to.be.true;
             done();
         });
 
-        loader.on(ERROR, function() {
+        loader.on(ERROR, function(e) {
             expect(true, 'Invalid JSON feed successfully fired error').to.be.true;
-            done();
+            expect(e.code).to.equal(21);
+            expect(e.message).to.equal('Error loading playlist: Not a valid RSS/JSON feed');
+            numCalls += 1;
+            if (numCalls === expectedCalls) {
+                done();
+            }
         });
-
+        loader.load('/base/test/files/invalid.xml');
         loader.load('/base/test/files/invalid.json');
     });
 });

--- a/test/unit/playlist-test.js
+++ b/test/unit/playlist-test.js
@@ -1,24 +1,23 @@
-import Playlist from 'playlist/playlist';
+import Playlist, { validatePlaylist } from 'playlist/playlist';
 import Item from 'playlist/item';
 import Source from 'playlist/source';
 import _ from 'test/underscore';
 import mp4 from 'data/mp4';
 import track from 'playlist/track';
+import { PlayerError } from 'api/errors';
 
 function isValidPlaylistItem(playlistItem) {
     return _.isObject(playlistItem) && _.isArray(playlistItem.sources) && _.isArray(playlistItem.tracks);
 }
 
 describe('playlist', function() {
-
-    it('Test initialized successfully', function() {
-
+    it('initializes a valid playlist', function() {
         expect(typeof Item, 'item is defined').to.equal('function');
         expect(typeof Source, 'source is defined').to.equal('function');
         expect(typeof track, 'track is defined').to.equal('function');
     });
 
-    it('Test constructor with single item', function() {
+    it('constructs a playlist from a single item', function() {
         var p;
 
         p = Playlist(mp4.starscape);
@@ -32,7 +31,7 @@ describe('playlist', function() {
         expect(isValidPlaylistItem(p[0]), 'Initialize with just file name').to.be.true;
     });
 
-    it('Test constructor with array of items', function() {
+    it('constructs a playlist from an arry of items', function() {
         var p;
         var arr = [mp4.starscape, mp4.starscape, mp4.starscape];
 
@@ -45,5 +44,18 @@ describe('playlist', function() {
         // TODO: inconsistent, this is the only case where it returns an empty array
         p = Playlist([]);
         expect(_.isArray(p) && p.length === 0, 'Initialize with an empty array as argument').to.be.true;
+    });
+
+    it('throws a PlayerError if given a non-array object or empty array', function () {
+        [{}, [], null, undefined, ''].forEach(playlist => {
+            try {
+                validatePlaylist(playlist);
+                expect.fail('Should have thrown an error');
+            } catch (e) {
+                expect(e.message).to.equal('No playable sources found');
+                expect(e.code).to.equal(630);
+                expect(e.sourceError).to.not.exist;
+            }
+        });
     });
 });

--- a/test/unit/program-controller-test.js
+++ b/test/unit/program-controller-test.js
@@ -405,6 +405,23 @@ describe('ProgramController', function () {
                 expect(model.trigger.lastCall).to.have.been.calledWith('change:itemReady', model, true);
             });
     });
+
+    describe('errors', function () {
+        it('throws a PlayerError when attempting to set an item with no source as active', function () {
+            model.attributes.playlist = [{}];
+            return new Promise((resolve, reject) => {
+                programController.setActiveItem(0)
+                    .then(() => {
+                        reject(new Error('Should have thrown an error'));
+                    })
+                    .catch(e => {
+                        expect(e.code).to.equal(640);
+                        expect(e.message).to.equal('No media');
+                        resolve();
+                    });
+            });
+        });
+    });
 });
 
 function expectAllEventsTriggered(callbackSpy) {

--- a/test/unit/setup-test.js
+++ b/test/unit/setup-test.js
@@ -74,7 +74,7 @@ describe('api.setup', function() {
         return expectSetupError({
             // playlist is undefined
         }).then(({ event }) => {
-            expect(event.code).to.equal(undefined);
+            expect(event.code).to.equal(102630);
             expect(event.message).to.equal('No playable sources found');
         });
     });
@@ -83,7 +83,7 @@ describe('api.setup', function() {
         return expectSetupError({
             playlist: ''
         }).then(({ event }) => {
-            expect(event.code).to.equal(undefined);
+            expect(event.code).to.equal(102630);
             expect(event.message).to.equal('No playable sources found');
         });
     });
@@ -92,7 +92,7 @@ describe('api.setup', function() {
         return expectSetupError({
             playlist: 1
         }).then(({ event }) => {
-            expect(event.code).to.equal(undefined);
+            expect(event.code).to.equal(102630);
             expect(event.message).to.equal('No playable sources found');
         });
     });
@@ -101,7 +101,7 @@ describe('api.setup', function() {
         return expectSetupError({
             playlist: true
         }).then(({ event }) => {
-            expect(event.code).to.equal(undefined);
+            expect(event.code).to.equal(102630);
             expect(event.message).to.equal('No playable sources found');
         });
     });
@@ -110,7 +110,7 @@ describe('api.setup', function() {
         return expectSetupError({
             playlist: []
         }).then(({ event }) => {
-            expect(event.code).to.equal(undefined);
+            expect(event.code).to.equal(102630);
             expect(event.message).to.equal('No playable sources found');
         });
     });
@@ -122,7 +122,7 @@ describe('api.setup', function() {
             const playlist = api.getPlaylist();
 
             expect(playlist).to.be.an('array').that.has.lengthOf(0);
-            expect(event.code).to.equal(undefined);
+            expect(event.code).to.equal(102630);
             expect(event.message).to.equal('No playable sources found');
         });
     });


### PR DESCRIPTION
### This PR will...
- Implement error codes `102630`, `102640`, `203630`, `203640`, `102021`, `203021`
- Pass through standardized errors from `ajax.js`
- Add/update test

### Why is this Pull Request needed?
So that playlist error codes are trackable

### Are there any points in the code the reviewer needs to double check?
Did I miss any errors or tests? Can any of the tests be improved?

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-1446

