### PR TITLE
Implement standard errors for provider load failures

### DIFF
--- a/src/js/api/errors.js
+++ b/src/js/api/errors.js
@@ -30,11 +30,6 @@ export const SETUP_ERROR_LICENSE_EXPIRED = 100013;
 export const SETUP_ERROR_LOADING_CORE_JS = 101000;
 
 /**
- * @enum {ErrorCode} Setup failed because the playlist failed to load
- */
-export const SETUP_ERROR_LOADING_PLAYLIST = 102000;
-
-/**
  * @enum {ErrorCode} Setup failed because the initial provider failed to load
  */
 export const SETUP_ERROR_LOADING_PROVIDER = 104000;

--- a/src/js/api/errors.js
+++ b/src/js/api/errors.js
@@ -30,6 +30,21 @@ export const SETUP_ERROR_LICENSE_EXPIRED = 100013;
 export const SETUP_ERROR_LOADING_CORE_JS = 101000;
 
 /**
+ * @enum {ErrorCode} Setup failed because the playlist failed to load
+ */
+export const SETUP_ERROR_LOADING_PLAYLIST = 102000;
+
+/**
+ * @enum {ErrorCode} Setup failed because the initial provider failed to load
+ */
+export const SETUP_ERROR_LOADING_PROVIDER = 104000;
+
+/**
+ * @enum {ErrorCode} The required provider could not be loaded
+ */
+export const ERROR_LOADING_PROVIDER = 204000;
+
+/**
  * Class representing the jwplayer() API.
  * Creates an instance of the player.
  * @class PlayerError

--- a/src/js/api/setup-steps.js
+++ b/src/js/api/setup-steps.js
@@ -4,6 +4,7 @@ import PlaylistLoader from 'playlist/loader';
 import Playlist, { filterPlaylist, validatePlaylist } from 'playlist/playlist';
 import ScriptLoader from 'utils/scriptloader';
 import { bundleContainsProviders } from 'api/core-loader';
+import { SETUP_ERROR_LOADING_PLAYLIST, SETUP_ERROR_LOADING_PROVIDER } from 'api/errors';
 
 export function loadPlaylist(_model) {
     const playlist = _model.get('playlist');
@@ -59,7 +60,11 @@ function loadProvider(_model) {
         if (bundleContainsProviders.html5 && name === 'html5') {
             return bundleContainsProviders.html5;
         }
-        return providersManager.load(name);
+        return providersManager.load(name)
+            .catch(e => {
+                e.code = (e.code || 0) + SETUP_ERROR_LOADING_PROVIDER;
+                throw e;
+            });
     });
 }
 

--- a/src/js/api/setup-steps.js
+++ b/src/js/api/setup-steps.js
@@ -4,7 +4,7 @@ import PlaylistLoader from 'playlist/loader';
 import Playlist, { filterPlaylist, validatePlaylist } from 'playlist/playlist';
 import ScriptLoader from 'utils/scriptloader';
 import { bundleContainsProviders } from 'api/core-loader';
-import { SETUP_ERROR_LOADING_PLAYLIST, SETUP_ERROR_LOADING_PROVIDER } from 'api/errors';
+import { SETUP_ERROR_LOADING_PROVIDER } from 'api/errors';
 
 export function loadPlaylist(_model) {
     const playlist = _model.get('playlist');

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -7,7 +7,8 @@ import Eventable from 'utils/eventable';
 import BackgroundMedia from 'program/background-media';
 
 import { ERROR, PLAYER_STATE, STATE_BUFFERING } from 'events/events';
-import { Features } from '../environment/environment';
+import { Features } from 'environment/environment';
+import { PlayerError, ERROR_LOADING_PROVIDER } from 'api/errors';
 
 /** @private Do not include in JSDocs */
 
@@ -403,7 +404,11 @@ class ProgramController extends Eventable {
         }
 
         return providers.load(name)
-            .then(ProviderConstructor => makeMediaController(ProviderConstructor));
+            .then(ProviderConstructor => makeMediaController(ProviderConstructor))
+            .catch(e => {
+                e.code = (e.code || 0) + ERROR_LOADING_PROVIDER;
+                throw e;
+            });
     }
 
     /**

--- a/test/unit/program-controller-test.js
+++ b/test/unit/program-controller-test.js
@@ -71,9 +71,10 @@ const providerPlayerModelEvents = [
 ];
 
 describe('ProgramController', function () {
-
+    const sandbox = sinon.sandbox.create();
     let model = null;
     let programController = null;
+
 
     beforeEach(function () {
         const config = Object.assign({}, defaultConfig, {
@@ -96,10 +97,11 @@ describe('ProgramController', function () {
         model.destroy();
         model = null;
         programController = null;
+        sandbox.restore();
     });
 
     it('forwards provider events', function() {
-        const callback = sinon.spy();
+        const callback = sandbox.spy();
         const context = {};
         programController.on('all', callback, context);
         programController.stopVideo();
@@ -116,7 +118,7 @@ describe('ProgramController', function () {
     });
 
     it('does not forward provider events when provider is backgrounded', function() {
-        const callback = sinon.spy();
+        const callback = sandbox.spy();
         programController.on('all', callback, {});
         programController.stopVideo();
         return programController.setActiveItem(0)
@@ -132,7 +134,7 @@ describe('ProgramController', function () {
     });
 
     it('does not forward provider events when provider is detached', function() {
-        const callback = sinon.spy();
+        const callback = sandbox.spy();
         programController.on('all', callback, {});
         programController.stopVideo();
         return programController.setActiveItem(0)
@@ -148,7 +150,7 @@ describe('ProgramController', function () {
     });
 
     it('does not forward provider events when program-controller is destroyed', function() {
-        const callback = sinon.spy();
+        const callback = sandbox.spy();
         programController.on('all', callback, {});
         programController.stopVideo();
         const itemPromise = programController.setActiveItem(0)
@@ -164,7 +166,7 @@ describe('ProgramController', function () {
     });
 
     it('forwards queued provider events when provider is foregrounded', function() {
-        const callback = sinon.spy();
+        const callback = sandbox.spy();
         programController.on('all', callback, {});
         programController.stopVideo();
         return programController.setActiveItem(0)
@@ -182,7 +184,7 @@ describe('ProgramController', function () {
     });
 
     it('forwards queued provider events when provider is reattached', function() {
-        const callback = sinon.spy();
+        const callback = sandbox.spy();
         programController.on('all', callback, {});
         programController.stopVideo();
         return programController.setActiveItem(0)
@@ -204,7 +206,7 @@ describe('ProgramController', function () {
         const { backgroundLoading } = Features;
         let call = 1;
 
-        sinon.spy(model, 'trigger');
+        sandbox.spy(model, 'trigger');
         return programController.setActiveItem(0)
             .then(function () {
                 const provider = programController.mediaController.provider;
@@ -242,10 +244,10 @@ describe('ProgramController', function () {
             .then(function () {
                 const provider = programController.mediaController.provider;
 
-                sinon.spy(model, 'set');
-                sinon.spy(model, 'trigger');
-                sinon.spy(model, 'persistQualityLevel');
-                sinon.spy(model, 'persistVideoSubtitleTrack');
+                sandbox.spy(model, 'set');
+                sandbox.spy(model, 'trigger');
+                sandbox.spy(model, 'persistQualityLevel');
+                sandbox.spy(model, 'persistVideoSubtitleTrack');
                 providerPlayerModelEvents.forEach(event => {
                     provider.trigger(event.type, event);
                 });
@@ -273,10 +275,10 @@ describe('ProgramController', function () {
                 const provider = programController.mediaController.provider;
 
                 programController.backgroundActiveMedia();
-                sinon.spy(model, 'set');
-                sinon.spy(model, 'trigger');
-                sinon.spy(model, 'persistQualityLevel');
-                sinon.spy(model, 'persistVideoSubtitleTrack');
+                sandbox.spy(model, 'set');
+                sandbox.spy(model, 'trigger');
+                sandbox.spy(model, 'persistQualityLevel');
+                sandbox.spy(model, 'persistVideoSubtitleTrack');
                 providerPlayerModelEvents.forEach(event => {
                     provider.trigger(event.type, event);
                 });
@@ -293,10 +295,10 @@ describe('ProgramController', function () {
                 const provider = programController.mediaController.provider;
 
                 programController.attached = false;
-                sinon.spy(model, 'set');
-                sinon.spy(model, 'trigger');
-                sinon.spy(model, 'persistQualityLevel');
-                sinon.spy(model, 'persistVideoSubtitleTrack');
+                sandbox.spy(model, 'set');
+                sandbox.spy(model, 'trigger');
+                sandbox.spy(model, 'persistQualityLevel');
+                sandbox.spy(model, 'persistVideoSubtitleTrack');
                 providerPlayerModelEvents.forEach(event => {
                     provider.trigger(event.type, event);
                 });
@@ -313,10 +315,10 @@ describe('ProgramController', function () {
                 const provider = programController.mediaController.provider;
 
                 programController.backgroundActiveMedia();
-                sinon.spy(model, 'set');
-                sinon.spy(model, 'trigger');
-                sinon.spy(model, 'persistQualityLevel');
-                sinon.spy(model, 'persistVideoSubtitleTrack');
+                sandbox.spy(model, 'set');
+                sandbox.spy(model, 'trigger');
+                sandbox.spy(model, 'persistQualityLevel');
+                sandbox.spy(model, 'persistVideoSubtitleTrack');
                 providerPlayerModelEvents.forEach(event => {
                     provider.trigger(event.type, event);
                 });
@@ -341,10 +343,10 @@ describe('ProgramController', function () {
                 const provider = programController.mediaController.provider;
 
                 programController.attached = false;
-                sinon.spy(model, 'set');
-                sinon.spy(model, 'trigger');
-                sinon.spy(model, 'persistQualityLevel');
-                sinon.spy(model, 'persistVideoSubtitleTrack');
+                sandbox.spy(model, 'set');
+                sandbox.spy(model, 'trigger');
+                sandbox.spy(model, 'persistQualityLevel');
+                sandbox.spy(model, 'persistVideoSubtitleTrack');
                 providerPlayerModelEvents.forEach(event => {
                     provider.trigger(event.type, event);
                 });
@@ -369,10 +371,10 @@ describe('ProgramController', function () {
                 const provider = programController.mediaController.provider;
 
                 programController.backgroundActiveMedia();
-                sinon.spy(model, 'set');
-                sinon.spy(model, 'trigger');
-                sinon.spy(model, 'persistQualityLevel');
-                sinon.spy(model, 'persistVideoSubtitleTrack');
+                sandbox.spy(model, 'set');
+                sandbox.spy(model, 'trigger');
+                sandbox.spy(model, 'persistQualityLevel');
+                sandbox.spy(model, 'persistVideoSubtitleTrack');
                 providerPlayerModelEvents.forEach(event => {
                     provider.trigger(event.type, event);
                 });
@@ -392,7 +394,7 @@ describe('ProgramController', function () {
     });
 
     it('fires itemReady for background loaded items', function() {
-        sinon.spy(model, 'trigger');
+        sandbox.spy(model, 'trigger');
         return programController.setActiveItem(0)
             .then(function () {
                 expect(model.trigger).to.have.callCount(6);
@@ -404,6 +406,31 @@ describe('ProgramController', function () {
                 expect(model.trigger).to.have.callCount(14);
                 expect(model.trigger.lastCall).to.have.been.calledWith('change:itemReady', model, true);
             });
+    });
+
+    describe('errors', function () {
+        it('throws a PlayerError after failing to load a provider', function () {
+            const providersMock = {
+                load() {
+                    return Promise.reject({});
+                },
+                choose() {
+                    return {};
+                }
+            };
+
+            programController.providers = providersMock;
+            return new Promise((resolve, reject) => {
+                programController._setupMediaController('foo')
+                    .then(() => {
+                        reject(new Error('Should have thrown an error'));
+                    })
+                    .catch(e => {
+                        expect(e.code).to.equal(204000);
+                        resolve();
+                    });
+            });
+        });
     });
 });
 


### PR DESCRIPTION
### This PR will...
- Add codes to errors thrown by `providers.load` found in `program-controller` and during `setup-steps`

### Why is this Pull Request needed?
So that we can track provider load failures

### Are there any points in the code the reviewer needs to double check?
Did I miss any codes?

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-1508

