### PR TITLE
Only allow one plugin loader per api/model instance

### DIFF
--- a/src/js/api/Setup.js
+++ b/src/js/api/Setup.js
@@ -37,6 +37,7 @@ const Setup = function(_model) {
 
     this.destroy = function() {
         clearTimeout(_setupFailureTimeout);
+        _model.set('_destroyed', true);
         _model = null;
     };
 

--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -143,6 +143,7 @@ Object.assign(CoreShim.prototype, {
         this.off();
         this._events =
             this._model =
+            this.modelShim =
             this.originalContainer =
             this.apiQueue =
             this.setup = null;

--- a/src/js/plugins/loader.js
+++ b/src/js/plugins/loader.js
@@ -14,7 +14,7 @@ function configurePlugin(pluginObj, pluginConfig, api) {
 }
 
 const PluginLoader = function () {
-    this.load = function (api, pluginsModel, pluginsConfig) {
+    this.load = function (api, pluginsModel, pluginsConfig, model) {
         // Must be a hash map
         if (!pluginsConfig || typeof pluginsConfig !== 'object') {
             return resolved;
@@ -25,6 +25,9 @@ const PluginLoader = function () {
                 const plugin = pluginsModel.addPlugin(pluginUrl, true);
                 const pluginConfig = pluginsConfig[pluginUrl];
                 return plugin.load().then(() => {
+                    if (model.attributes._destroyed) {
+                        return;
+                    }
                     configurePlugin(plugin, pluginConfig, api);
                 }).catch(error => {
                     if (!(error instanceof Error)) {

--- a/src/js/plugins/plugins.js
+++ b/src/js/plugins/plugins.js
@@ -3,12 +3,6 @@ import PluginsModel from 'plugins/model';
 import { log } from 'utils/helpers';
 
 const pluginsModel = new PluginsModel();
-const pluginLoaders = {};
-
-function getPluginLoader(id) {
-    pluginLoaders[id] = new PluginsLoader();
-    return pluginLoaders[id];
-}
 
 export const registerPlugin = function(name, minimumVersion, pluginClass) {
     let plugin = pluginsModel.addPlugin(name);
@@ -18,14 +12,15 @@ export const registerPlugin = function(name, minimumVersion, pluginClass) {
 };
 
 export default function loadPlugins(model, api) {
-    const playerId = model.get('id');
     const pluginsConfig = model.get('plugins');
 
     window.jwplayerPluginJsonp = registerPlugin;
 
-    const pluginLoader = getPluginLoader(playerId);
-    return pluginLoader.load(api, pluginsModel, pluginsConfig).then(events => {
-        if (pluginLoader !== pluginLoaders[playerId]) {
+    const pluginLoader = model.pluginLoader =
+        model.pluginLoader || new PluginsLoader();
+
+    return pluginLoader.load(api, pluginsModel, pluginsConfig, model).then(events => {
+        if (model.attributes._destroyed) {
             // Player and plugin loader was replaced
             return;
         }


### PR DESCRIPTION
### This PR will...

Prevent multiple plugin instances of the same plugin from being created for one player instance when setup is called several times during setup.

### Why is this Pull Request needed?

The plugin loader instance was not bound by id rather than a specific player instance or model, so async calls started for one instance could resolve to another if the first one was replaced.

### Are there any Pull Requests open in other repos which need to be merged with this?

Test page https://github.com/jwplayer/jwplayer-commercial/pull/5208

#### Addresses Issue(s):

JW8-###

