### PR TITLE
Fix for IE/Edge play promise polyfill

### DIFF
--- a/src/js/providers/utils/play-promise.js
+++ b/src/js/providers/utils/play-promise.js
@@ -6,10 +6,17 @@ export default function createPlayPromise(video) {
             return reject(new Error('Play refused.'));
         }
         const removeEventListeners = function() {
+            video.removeEventListener('play', playListener);
             video.removeEventListener('playing', listener);
             video.removeEventListener('pause', listener);
             video.removeEventListener('abort', listener);
             video.removeEventListener('error', listener);
+        };
+        const playListener = function() {
+            video.addEventListener('playing', listener);
+            video.addEventListener('abort', listener);
+            video.addEventListener('error', listener);
+            video.addEventListener('pause', listener);
         };
         const listener = function(e) {
             removeEventListeners();
@@ -19,10 +26,6 @@ export default function createPlayPromise(video) {
                 reject(new Error('The play() request was interrupted by a "' + e.type + '" event.'));
             }
         };
-
-        video.addEventListener('playing', listener);
-        video.addEventListener('abort', listener);
-        video.addEventListener('error', listener);
-        video.addEventListener('pause', listener);
+        video.addEventListener('play', playListener);
     });
 }


### PR DESCRIPTION
### This PR will...

Ignore "abort" events fired before the "play" in in the IE/Edge play promise polyfill.

### Why is this Pull Request needed?

IE and Edge do not return a Promise from `mediaElement.play()`. In this case, we create a promise that resolves when playback begins with the "playing" event, or is rejected if playback is interrupted by an "abort", "error" or "pause" event - the play promise polyfill.

The problem is that IE and Edge respond to, and notify us, of changes on the media element asynchronously. Even though we call `mediaElement.play()` and create this promise after changing the `mediaElement.src`, the "abort" event fires after the promise is created, making it look like the play attempt failed. Fortunately "play" is also always fired asynchronously after `mediaElement.play()`, with these other events in order. So as long as we wait for the "play" event to fire first, the play promise polyfill works correctly.

### Are there any points in the code the reviewer needs to double check?

We should verify supported mobile platforms that are missing play promise support (Android browser, and iOS 8.4?). If calling `mediaElement.play()` fires the "play" event synchronously on those platforms, this change could result in the promise not resolving.

#### Addresses Issue(s):

JW8-1483

