### PR TITLE
Set fullscreen on change event for screen.orientation

### DIFF
--- a/src/js/view/utils/views-manager.js
+++ b/src/js/view/utils/views-manager.js
@@ -1,9 +1,9 @@
 import activeTab from 'utils/active-tab';
 import { requestAnimationFrame, cancelAnimationFrame } from 'utils/request-animation-frame';
-import { Browser, OS } from 'environment/environment';
 
 const views = [];
 const observed = {};
+const hasOrientation = 'screen' in window && 'orientation' in window.screen;
 
 let intersectionObserver;
 let responsiveRepaintRequestId = -1;
@@ -57,9 +57,7 @@ function onOrientationChange() {
                 // Set fullscreen to false when going back to portrait while paused and return early
                 view.api.setFullscreen(false);
                 return;
-            }
-
-            if (state === 'playing') {
+            } else if (state === 'playing') {
                 view.api.setFullscreen(isLandscape);
             }
         }
@@ -77,7 +75,7 @@ document.addEventListener('webkitvisibilitychange', onVisibilityChange);
 window.addEventListener('resize', scheduleResponsiveRedraw);
 window.addEventListener('orientationchange', scheduleResponsiveRedraw);
 
-if (OS.android && Browser.chrome) {
+if (hasOrientation) {
     window.screen.orientation.addEventListener('change', onOrientationChange);
 }
 
@@ -87,7 +85,7 @@ window.addEventListener('beforeunload', () => {
     window.removeEventListener('resize', scheduleResponsiveRedraw);
     window.removeEventListener('orientationchange', scheduleResponsiveRedraw);
 
-    if (OS.android && Browser.chrome) {
+    if (hasOrientation) {
         window.screen.orientation.removeEventListener('change', onOrientationChange);
     }
 });

--- a/src/js/view/utils/views-manager.js
+++ b/src/js/view/utils/views-manager.js
@@ -1,9 +1,11 @@
 import activeTab from 'utils/active-tab';
 import { requestAnimationFrame, cancelAnimationFrame } from 'utils/request-animation-frame';
+import { Browser, OS } from 'environment/environment';
 
 const views = [];
 const observed = {};
 const hasOrientation = 'screen' in window && 'orientation' in window.screen;
+const isAndroidChrome = OS.android && Browser.chrome;
 
 let intersectionObserver;
 let responsiveRepaintRequestId = -1;
@@ -75,7 +77,7 @@ document.addEventListener('webkitvisibilitychange', onVisibilityChange);
 window.addEventListener('resize', scheduleResponsiveRedraw);
 window.addEventListener('orientationchange', scheduleResponsiveRedraw);
 
-if (hasOrientation) {
+if (isAndroidChrome && hasOrientation) {
     window.screen.orientation.addEventListener('change', onOrientationChange);
 }
 
@@ -85,7 +87,7 @@ window.addEventListener('beforeunload', () => {
     window.removeEventListener('resize', scheduleResponsiveRedraw);
     window.removeEventListener('orientationchange', scheduleResponsiveRedraw);
 
-    if (hasOrientation) {
+    if (isAndroidChrome && hasOrientation) {
         window.screen.orientation.removeEventListener('change', onOrientationChange);
     }
 });

--- a/src/js/view/utils/views-manager.js
+++ b/src/js/view/utils/views-manager.js
@@ -61,6 +61,7 @@ function onOrientationChange() {
                 return;
             } else if (state === 'playing') {
                 view.api.setFullscreen(isLandscape);
+                return;
             }
         }
     });

--- a/src/js/view/utils/views-manager.js
+++ b/src/js/view/utils/views-manager.js
@@ -55,7 +55,7 @@ function onOrientationChange() {
             const orientation = window.screen.orientation.type;
             const isLandscape = orientation === 'landscape-primary' || orientation === 'landscape-secondary';
 
-            if (!isLandscape && state === 'paused') {
+            if (!isLandscape && state === 'paused' && view.api.getFullscreen()) {
                 // Set fullscreen to false when going back to portrait while paused and return early
                 view.api.setFullscreen(false);
                 return;


### PR DESCRIPTION
### This PR will...

Attach an event listener to screen.orientation to set fullscreen using the api when the viewer switches from portrait to landscape (works turning your phone clockwise and counter clockwise). Sets it to false when going from landscape to portrait 

- Player must be at least 75% visible
- Player exits from fullscreen if video is paused 

### Why is this Pull Request needed?

New feature to improve user experience

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-1380
