### PR TITLE
Set tabindex to -1 on video element

### DIFF
--- a/src/js/program/media-element-pool.js
+++ b/src/js/program/media-element-pool.js
@@ -92,6 +92,7 @@ function createMediaElement() {
     const mediaElement = document.createElement('video');
 
     mediaElement.className = 'jw-video jw-reset';
+    mediaElement.setAttribute('tabindex', '-1');
     mediaElement.setAttribute('disableRemotePlayback', '');
     mediaElement.setAttribute('webkit-playsinline', '');
     mediaElement.setAttribute('playsinline', '');


### PR DESCRIPTION
### This PR will...

Explicitly set the tabindex to -1 on video element to make sure it isnt reachable when tabbing through the player

### Why is this Pull Request needed?

Firefox assumes the next element should be focusable sequentially even though tabindex isn't specified while chrome leaves it alone. Chrome has the desired behavior so to keep it consistent, we should explicitly set it with the value -1.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-935

