### PR TITLE
Add Flash errors to export

### DIFF
--- a/src/js/api/errors.js
+++ b/src/js/api/errors.js
@@ -40,6 +40,22 @@ export const SETUP_ERROR_LOADING_PLAYLIST = 102000;
 export const ERROR_LOADING_PLAYLIST = 202000;
 
 /**
+ * @enum {ErrorCode} An error occurred duing Flash setup
+ */
+export const FLASH_SETUP_ERROR = 210001;
+
+/**
+ * @enum {ErrorCode} An error occurred during Flash playback
+ */
+export const FLASH_ERROR = 210000;
+
+/**
+ * @enum {ErrorCode} A media error occurred during Flash playback
+ */
+export const FLASH_MEDIA_ERROR = 214000;
+
+
+/**
  * Class representing the jwplayer() API.
  * Creates an instance of the player.
  * @class PlayerError

--- a/src/js/api/errors.js
+++ b/src/js/api/errors.js
@@ -40,17 +40,17 @@ export const SETUP_ERROR_LOADING_PLAYLIST = 102000;
 export const ERROR_LOADING_PLAYLIST = 202000;
 
 /**
- * @enum {ErrorCode} An error occurred duing Flash setup
+ * @enum {ErrorCode} An error occurred duing Flash setup.
  */
 export const FLASH_SETUP_ERROR = 210001;
 
 /**
- * @enum {ErrorCode} An error occurred during Flash playback
+ * @enum {ErrorCode} An error occurred during Flash playback.
  */
 export const FLASH_ERROR = 210000;
 
 /**
- * @enum {ErrorCode} A media error occurred during Flash playback
+ * @enum {ErrorCode} A media error occurred during Flash playback.
  */
 export const FLASH_MEDIA_ERROR = 214000;
 


### PR DESCRIPTION
### Why is this Pull Request needed?
So that flash.js in Commercial can used named exports as error codes

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/5216

#### Addresses Issue(s):

JW8-1552

