### PR TITLE
Play pause video on Android to prime tags already preloading

### DIFF
--- a/src/js/program/media-element-pool.js
+++ b/src/js/program/media-element-pool.js
@@ -73,17 +73,17 @@ function primeMediaElementForPlayback(mediaElement) {
         mediaElement.load();
     } else if (OS.android && !mediaElement.parentNode) {
         // If the player sets up without a gesture and preloads, the background tag may not be primed for playback.
-        // We need to load again on Android in order to play without another gesture. But make sure we're only reloading
-        // a tag which hasn't begun playback yet
-        // Clear the src for MSE providers who have already preloaded so that we do a full reload
-        // The HTML5 provider already reloads identical sources, so we don't always need to reset if for non-blobs
-        if (mediaElement.src.indexOf('blob') > -1) {
-            mediaElement.removeAttribute('src');
-        }
-
+        // We need to prime on Android in order to play without another gesture, for tags which have not begun playback.
+        // Since calling load() would empty source buffers, use play() to prime and pause once resolved.
         const played = mediaElement.played;
         if (!played || (played && !played.length)) {
-            mediaElement.load();
+            const playPromise = mediaElement.play();
+            const pause = () => mediaElement.pause();
+            if (playPromise) {
+                playPromise.then(pause);
+            } else {
+                pause();
+            }
         }
     }
 }


### PR DESCRIPTION
### This PR will...
Change our video tag priming workaround for Android so that it does not empty the video tag.

This PR build should be used to verify if this fix addresses issues we've found on Android Chrome with preroll content, and MSE players and/or DRM content.

### Why is this Pull Request needed?
So that preloading is not thrown away, and internal players do not have to setup twice on Android.

### Are there any points in the code the reviewer needs to double check?
Pausing asynchronously when the play promise resolves could be problematic, if the promise resolves late, like once the video is actually expected to play. We might want to listen for additional calls to play and ignore this handler if that happens.

#### Addresses Issue(s):

JW8-1584 JW8-1594

