### PR TITLE
Volume & Seek Slider Accessibility

### DIFF
--- a/src/css/controls/imports/slider.less
+++ b/src/css/controls/imports/slider.less
@@ -116,6 +116,7 @@
     background: transparent none;
     padding: 0 12px;
     z-index: 1;
+    outline: none;
 
     .jw-rail,
     .jw-buffer,

--- a/src/css/controls/imports/slider.less
+++ b/src/css/controls/imports/slider.less
@@ -136,6 +136,7 @@
     }
 
     &:hover,
+    &:focus,
     .jw-flag-dragging &,
     .jw-flag-touch & {
         .jw-rail,

--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -86,9 +86,6 @@ export function toggleClass(element, c, toggleTo) {
 }
 
 export function setAttribute(element, name, value) {
-    if (!element) {
-        return;
-    }
     element.setAttribute(name, value);
 }
 

--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -85,6 +85,13 @@ export function toggleClass(element, c, toggleTo) {
     }
 }
 
+export function setAttribute(element, name, value) {
+    if (!element) {
+        return;
+    }
+    element.setAttribute(name, value);
+}
+
 export function emptyElement(element) {
     while (element.firstChild) {
         element.removeChild(element.firstChild);

--- a/src/js/utils/helpers.js
+++ b/src/js/utils/helpers.js
@@ -40,7 +40,7 @@ import { ajax } from 'utils/ajax';
 
 export const log = (typeof console.log === 'function') ? console.log.bind(console) : function() {};
 
-const between = function (num, min, max) {
+export const between = function (num, min, max) {
     return Math.max(Math.min(num, max), min);
 };
 

--- a/src/js/view/controls/components/volumetooltip.js
+++ b/src/js/view/controls/components/volumetooltip.js
@@ -15,6 +15,7 @@ export default class VolumeTooltip extends Tooltip {
 
         this.volumeSlider.on('update', function (evt) {
             this.trigger('update', evt);
+            this.el.focus();
         }, this);
 
         new UI(this.el, { useHover: true, directSelect: true, useFocus: true })

--- a/test/unit/controlbar-test.js
+++ b/test/unit/controlbar-test.js
@@ -1,7 +1,7 @@
 import ControlBar from 'view/controls/controlbar';
 import SimpleModel from 'model/simplemodel';
 import sinon from 'sinon';
-import utils from 'utils/helpers';
+import * as utils from 'utils/dom';
 
 const model = Object.assign({}, SimpleModel);
 model.change = sinon.stub();
@@ -111,20 +111,24 @@ describe('Control Bar', function() {
 
         it('should do nothing if there is no captions button', function() {
             const toggledReturn = controlBar.toggleCaptionsButtonState();
-            utils.toggleClass = sinon.spy();
+            const toggleClass = sinon.stub(utils, 'toggleClass');
 
-            expect(utils.toggleClass.notCalled).to.be.true;
+            expect(toggleClass.notCalled).to.be.true;
             expect(toggledReturn).to.be.undefined;
+
+            toggleClass.restore();
         });
 
         it('should toggle the captions button when the button is present', function() {
-            const captionsElement = {element: () => {}}
+            const captionsElement = { element: () => {} };
             controlBar.elements.captionsButton = captionsElement;
-            utils.toggleClass = sinon.spy();
+            const toggleClass = sinon.stub(utils, 'toggleClass');
 
             controlBar.toggleCaptionsButtonState();
-            expect(utils.toggleClass.called).to.be.true;
-            expect(utils.toggleClass.calledWith(captionsElement));
+            expect(toggleClass.called).to.be.true;
+            expect(toggleClass.calledWith(captionsElement));
+
+            toggleClass.restore();
         });
 
     });

--- a/test/unit/dom-test.js
+++ b/test/unit/dom-test.js
@@ -4,6 +4,7 @@ import {
     removeClass,
     replaceClass,
     toggleClass,
+    setAttribute,
     classList,
     styleDimension,
     createElement,
@@ -50,7 +51,6 @@ describe('dom', function() {
         expect(element.className, 'Removed lass class from element').to.equal('');
     });
 
-
     it('replaceClass', function() {
         const element = document.createElement('div');
 
@@ -69,6 +69,16 @@ describe('dom', function() {
         element.className = 'class1 class2 classB';
         replaceClass(element, /class\d/g, '');
         expect(element.className, 'Replaces classes when pattern matches any class').to.equal('classB');
+    });
+
+    it('setAttribute', function() {
+        const element = document.createElement('div');
+
+        setAttribute(element, 'a', 'b');
+        expect(element.getAttribute('a')).to.equal('b');
+
+        setAttribute(element, 'a', 1);
+        expect(element.getAttribute('a')).to.equal('1');
     });
 
     it('createElement', function() {
@@ -172,4 +182,5 @@ describe('dom', function() {
         element.style.height = '400px';
         expect('bounds should not be empty when element has layout').to.not.equal(bounds(element), emptyBound);
     });
+
 });


### PR DESCRIPTION
### This PR will...

- Add the `slider` role to the time slider so that VoiceOver will read out the `aria-valuetext` attribute whenever it is in focus and updated
- Add the `status` role to the volume button so that VoiceOver will read out the `aria-label` attribute when it is updated, even when not in focus
- Make the time slider be focusable
- Remove the time slider focus ring
- create a `setAttribute` util method in `dom.js`

### Why is this Pull Request needed?

To improve player accessibility, we want users who have VoiceOver enabled to be aware of the current volume when interacting with the volume slider, and the current position when interacting with the seek slider. 

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

- For VoiceOver will only read out the `aria-valuetext` attribute when the element is focused

#### Addresses Issue(s):

JW8-1382 & JW8-1381

