### PR TITLE
Set Aria Label and Tabindex on timeslider to focus on the timeslider

### DIFF
--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -88,6 +88,9 @@ class TimeSlider extends Slider {
     setup() {
         super.setup.apply(this, arguments);
 
+        this.element().setAttribute('aria-label', 'Time Slider');
+        this.element().setAttribute('tabindex', '0');
+
         this._model
             .on('change:duration', this.onDuration, this)
             .on('change:cues', this.addCues, this)


### PR DESCRIPTION
### This PR will...

Set the aria label and tabindex on the timeslider to allow accessibility users to focus on the timeslider when tabbing through the player.

### Why is this Pull Request needed?

New feature to improve accessibility 

### Are there any points in the code the reviewer needs to double check?

Setting the tabindex on the timesliders container includes the time and chapter tooltips because they are insider the timeslider container: 

![screen shot 2018-05-11 at 2 59 54 pm](https://user-images.githubusercontent.com/6787010/40002398-a4a41a34-575e-11e8-8fb6-f52c78d6c23b.png)

<img width="960" alt="screen shot 2018-05-11 at 2 59 09 pm" src="https://user-images.githubusercontent.com/6787010/40002405-aa74aad2-575e-11e8-9d1f-e6032d5141b9.png">

If we dont want to include those, i can put it on "jw-progress" instead so we just get the timeslider without tooltips:

![screen shot 2018-05-11 at 5 39 46 pm](https://user-images.githubusercontent.com/6787010/40002440-c9dc4e5c-575e-11e8-8379-d67af3b22f42.png)

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-1381

