### PR TITLE
Standardize unknown setup errors

### DIFF
--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -13,7 +13,8 @@ import ErrorContainer from 'view/error-container';
 import MediaElementPool from 'program/media-element-pool';
 import SharedMediaPool from 'program/shared-media-pool';
 import { Features } from 'environment/environment';
-import { PlayerError, SETUP_ERROR_LOADING_PLAYLIST } from 'api/errors';
+import { PlayerError, SETUP_ERROR_LOADING_PLAYLIST, SETUP_ERROR_UNKNOWN } from 'api/errors';
+import { isValidNumber } from 'utils/underscore';
 
 const ModelShim = function() {};
 Object.assign(ModelShim.prototype, SimpleModel);
@@ -238,7 +239,8 @@ Object.assign(CoreShim.prototype, {
 
 function setupError(core, error) {
     resolved.then(() => {
-        const { message, code } = error;
+        const { message } = error;
+        const code = isValidNumber(error.code) ? error.code : SETUP_ERROR_UNKNOWN;
         const errorContainer = ErrorContainer(core, message);
         if (ErrorContainer.cloneIcon) {
             errorContainer.querySelector('.jw-icon').appendChild(ErrorContainer.cloneIcon('error'));

--- a/src/js/api/errors.js
+++ b/src/js/api/errors.js
@@ -1,8 +1,8 @@
 import { isValidNumber } from 'utils/underscore';
 /**
- * @typedef {number} ErrorCode
- * @module errors
+ * @type {ErrorCode} Base code for a setup failure.
  **/
+export const SETUP_ERROR_UNKNOWN = 100000;
 
 /**
  * @type {ErrorCode} Setup failed because it took longer than 30 seconds.

--- a/test/unit/core-shim-test.js
+++ b/test/unit/core-shim-test.js
@@ -1,15 +1,59 @@
+import sinon from 'sinon';
 import CoreShim from 'api/core-shim';
+import { SETUP_ERROR } from 'events/events';
 
 describe('CoreShim', function() {
+    let core;
+    let sandbox = sinon.sandbox.create();
+    beforeEach(function() {
+        core = new CoreShim(document.createElement('div'));
+    });
 
     it('is a constructor', function() {
-        const core = new CoreShim();
         expect(core).to.be.an('object');
     });
 
     it('implements event methods on and off', function() {
-        const core = new CoreShim();
         expect(core).to.have.property('on').which.is.a('function');
         expect(core).to.have.property('off').which.is.a('function');
+    });
+
+    it('sets the setupError code to 100000 if passed an error with no code', function () {
+        sandbox.stub(core.setup, 'start').callsFake(() => Promise.reject({ message: 'foo' }));
+        const expectError = new Promise((resolve, reject) => {
+            core.on(SETUP_ERROR, e => resolve(e));
+        })
+            .then(e => {
+                expect(e.code).to.equal(100000);
+            })
+
+        core.init({}, {});
+        return expectError;
+    });
+
+    it('sets the setupError code to 100000 if passed an error with a non-numerical code', function () {
+        sandbox.stub(core.setup, 'start').callsFake(() => Promise.reject({ message: 'foo', code: 'foo' }));
+        const expectError = new Promise((resolve, reject) => {
+            core.on(SETUP_ERROR, e => resolve(e));
+        })
+            .then(e => {
+                expect(e.code).to.equal(100000);
+            })
+
+        core.init({}, {});
+        return expectError;
+    });
+
+    it('passes through a valid error code', function () {
+        sandbox.stub(core.setup, 'start').callsFake(() => Promise.reject({ message: 'foo', code: 424242 }));
+        const expectError = new Promise((resolve, reject) => {
+            core.on(SETUP_ERROR, e => resolve(e));
+        })
+            .then(e => {
+                expect(e.code).to.equal(424242);
+            })
+
+        core.init({}, {});
+        return expectError;
     });
 });

--- a/test/unit/core-shim-test.js
+++ b/test/unit/core-shim-test.js
@@ -9,6 +9,20 @@ describe('CoreShim', function() {
         core = new CoreShim(document.createElement('div'));
     });
 
+    function expectError(expectedCode) {
+        sandbox.stub(core.setup, 'start').callsFake(() => Promise.reject({ message: 'foo', code: expectedCode }));
+        const expectError =
+            new Promise((resolve, reject) => {
+                core.on(SETUP_ERROR, e => resolve(e));
+            })
+                .then(e => {
+                    expect(e.code).to.equal(expectedCode);
+                })
+
+        core.init({}, {});
+        return expectError;
+    }
+
     it('is a constructor', function() {
         expect(core).to.be.an('object');
     });
@@ -19,41 +33,14 @@ describe('CoreShim', function() {
     });
 
     it('sets the setupError code to 100000 if passed an error with no code', function () {
-        sandbox.stub(core.setup, 'start').callsFake(() => Promise.reject({ message: 'foo' }));
-        const expectError = new Promise((resolve, reject) => {
-            core.on(SETUP_ERROR, e => resolve(e));
-        })
-            .then(e => {
-                expect(e.code).to.equal(100000);
-            })
-
-        core.init({}, {});
-        return expectError;
+        return expectError(100000);
     });
 
     it('sets the setupError code to 100000 if passed an error with a non-numerical code', function () {
-        sandbox.stub(core.setup, 'start').callsFake(() => Promise.reject({ message: 'foo', code: 'foo' }));
-        const expectError = new Promise((resolve, reject) => {
-            core.on(SETUP_ERROR, e => resolve(e));
-        })
-            .then(e => {
-                expect(e.code).to.equal(100000);
-            })
-
-        core.init({}, {});
-        return expectError;
+        return expectError(100000);
     });
 
     it('passes through a valid error code', function () {
-        sandbox.stub(core.setup, 'start').callsFake(() => Promise.reject({ message: 'foo', code: 424242 }));
-        const expectError = new Promise((resolve, reject) => {
-            core.on(SETUP_ERROR, e => resolve(e));
-        })
-            .then(e => {
-                expect(e.code).to.equal(424242);
-            })
-
-        core.init({}, {});
-        return expectError;
+        return expectError(424242);
     });
 });


### PR DESCRIPTION
### This PR will...
- Set invalid or uncoded setup errors as code `100000`
- Add tests

### Why is this Pull Request needed?
So that all setup errors have a code

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-1452

