### PR TITLE
Set player element role to "application"

### DIFF
--- a/src/templates/player.js
+++ b/src/templates/player.js
@@ -1,6 +1,6 @@
 export default (id, ariaLabel = '') => {
     return (
-        `<div id="${id}" class="jwplayer jw-reset jw-state-setup" tabindex="0" aria-label="${ariaLabel}">` +
+        `<div id="${id}" class="jwplayer jw-reset jw-state-setup" tabindex="0" aria-label="${ariaLabel}" role="application">` +
             `<div class="jw-aspect jw-reset"></div>` +
             `<div class="jw-media jw-reset"></div>` +
             `<div class="jw-preview jw-reset"></div>` +


### PR DESCRIPTION
### This PR will...

set the jwplayer element's role to "application" so that any keystrokes that occur within the player are not intercepted by screen readers.

### Why is this Pull Request needed?

Screen readers such as JAWS will intercept the ENTER and SPACE key, stopping the player from pausing or playing. By adding `role="application"`, it tells the screen reader not to do so. 

### Are there any points in the code the reviewer needs to double check?

Using `role="application"` should be used sparingly and wisely. According to the spec, it seems to make sense that the player is considered an application.

https://www.w3.org/TR/aria-in-html/#using-application

```
You only want to use role=application if the content you’re providing consists of only focusable, 
interactive controls, and of those, mostly advanced widgets that emulate a real desktop application. 
```

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-1614

