### PR TITLE
Persist pointer over media when setControls(false)

### DIFF
--- a/src/css/controls/flags/user-inactive.less
+++ b/src/css/controls/flags/user-inactive.less
@@ -15,7 +15,7 @@
         }
 
         .jw-media {
-            cursor: none;
+            cursor: default;
             /* cursor hiding on media elements for Safari */
             -webkit-cursor-visibility: auto-hide;
         }


### PR DESCRIPTION
### This PR will...

Fix a bug in which, after using setControls(false), the pointer style was set to 'none'.

### Why is this Pull Request needed?

To prevent the above behavior, and ensure that there is always a pointer over the JW Player.

### Are there any points in the code the reviewer needs to double check?

N/A

### Are there any Pull Requests open in other repos which need to be merged with this?

No

#### Addresses Issue(s):

JW8-1626

