### PR TITLE
Read out time and volume once per focus 

### DIFF
--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -94,6 +94,11 @@ class TimeSlider extends Slider {
         this._model
             .on('change:duration', this.onDuration, this)
             .on('change:cues', this.addCues, this)
+            .on('seeked', () => {
+                if (!this._model.get('scrubbing')) {
+                    this.updateAriaText();
+                }
+            })
             .change('playlistItem', this.onPlaylistItem, this)
             .change('position', this.onPosition, this)
             .change('buffer', this.onBuffer, this)
@@ -113,12 +118,6 @@ class TimeSlider extends Slider {
             .on('click', () => this.el.focus());
 
         this.el.addEventListener('focus', () => this.updateAriaText());
-        this._model.on('seeked', () => {
-            if (this._model.get('scrubbing')) {
-                return;
-            }
-            this.updateAriaText();
-        });
     }
 
     update(percent) {

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -139,7 +139,7 @@ export default class Controlbar {
             const volumeTooltipEl = volumeTooltip.element();
             setAttribute(volumeTooltipEl, 'aria-valuemin', 0);
             setAttribute(volumeTooltipEl, 'aria-valuemax', 100);
-            setAttribute(volumeTooltipEl, 'role', 'status');
+            setAttribute(volumeTooltipEl, 'role', 'slider');
         }
 
         const nextButton = button('jw-icon-next', () => {
@@ -348,11 +348,13 @@ export default class Controlbar {
             toggleClass(mute.element(), 'jw-full', !muted);
         }
         if (volumeTooltip) {
+            const volume = muted ? 0 : vol;
             const volumeTooltipEl = volumeTooltip.element();
-            volumeTooltip.volumeSlider.render(muted ? 0 : vol);
+            volumeTooltip.volumeSlider.render(volume);
             toggleClass(volumeTooltipEl, 'jw-off', muted);
             toggleClass(volumeTooltipEl, 'jw-full', vol >= 75 && !muted);
-            setAttribute(volumeTooltipEl, 'aria-label', `volume ${muted ? 0 : vol}%`);
+            setAttribute(volumeTooltipEl, 'aria-valuenow', volume);
+            setAttribute(volumeTooltipEl, 'aria-valuetext', `Volume ${volume}%`);
         }
     }
 


### PR DESCRIPTION
### This PR will...

- Trigger the `aria-valuetext` to be updated after a seek occurs or when the time slider has focus
- The volume will now be read out only when the volume button is in focus, making it more consistent to the time slider

### Why is this Pull Request needed?

When using a screen reader, if the `aria-valuetext` attribute is updated while an element is in focus, the text will be read out loud. We do not want it to read out load every second, but only when it becomes in focus or after a seek occurs.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-1382