### PR TITLE
Added new config option 'backgroundLoading'

### DIFF
--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -1,6 +1,7 @@
 import { loadFrom, getScriptPath } from 'utils/playerutils';
 import { serialize } from 'utils/parser';
-import { isValidNumber, isNumber, pick } from 'utils/underscore';
+import { isValidNumber, isNumber, pick, isBoolean } from 'utils/underscore';
+import { Features } from 'environment/environment';
 
 /* global __webpack_public_path__:true */
 /* eslint camelcase: 0 */
@@ -175,6 +176,8 @@ const Config = function(options, persisted) {
     const parsedBitrateSelection = parseFloat(config.bitrateSelection);
     config.bandwidthEstimate = isValidNumber(parsedBwEstimate) ? parsedBwEstimate : _adjustDefaultBwEstimate(config.defaultBandwidthEstimate);
     config.bitrateSelection = isValidNumber(parsedBitrateSelection) ? parsedBitrateSelection : Defaults.bitrateSelection;
+
+    config.backgroundLoading = isBoolean(config.backgroundLoading) ? config.backgroundLoading : Features.backgroundLoading;
     return config;
 };
 

--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -12,7 +12,6 @@ import { resolved } from 'polyfills/promise';
 import ErrorContainer from 'view/error-container';
 import MediaElementPool from 'program/media-element-pool';
 import SharedMediaPool from 'program/shared-media-pool';
-import { Features } from 'environment/environment';
 import { PlayerError, SETUP_ERROR_LOADING_PLAYLIST, SETUP_ERROR_UNKNOWN } from 'api/errors';
 import { isValidNumber } from 'utils/underscore';
 
@@ -93,7 +92,7 @@ Object.assign(CoreShim.prototype, {
 
         // Create/get click-to-play media element, and call .load() to unblock user-gesture to play requirement
         let mediaPool = MediaElementPool();
-        if (!Features.backgroundLoading) {
+        if (!model.get('backgroundLoading')) {
             mediaPool = SharedMediaPool(mediaPool.getPrimedElement(), mediaPool);
         }
         mediaPool.prime();

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -13,7 +13,7 @@ import changeStateEvent from 'events/change-state-event';
 import eventsMiddleware from 'controller/events-middleware';
 import Events from 'utils/backbone.events';
 import { AUTOPLAY_DISABLED, AUTOPLAY_MUTED, canAutoplay, startPlayback } from 'utils/can-autoplay';
-import { OS, Features } from 'environment/environment';
+import { OS } from 'environment/environment';
 import { streamType } from 'providers/utils/stream-type';
 import Promise, { resolved } from 'polyfills/promise';
 import cancelable from 'utils/cancelable';
@@ -72,6 +72,8 @@ Object.assign(Controller.prototype, {
         };
 
         _model.setup(config);
+
+        const _backgroundLoading = _model.get('backgroundLoading');
 
         const viewModel = new ViewModel(_model);
 
@@ -178,7 +180,7 @@ Object.assign(Controller.prototype, {
             const index = model.get('item') + 1;
             const recsAuto = (model.get('related') || {}).oncomplete === 'autoplay';
             let item = model.get('playlist')[index];
-            if ((item || recsAuto) && Features.backgroundLoading) {
+            if ((item || recsAuto) && _backgroundLoading) {
                 const onPosition = (changedMediaModel, position) => {
                     // Do not background load DAI items because that item will be dynamically replaced before play
                     const allowPreload = (item && !item.daiSetting);
@@ -468,7 +470,7 @@ Object.assign(Controller.prototype, {
                 if (_interruptPlay) {
                     // Force tags to prime if we're about to play an ad
                     // Resetting the source in order to prime is OK since we'll be switching it anyway
-                    if (_inInteraction(window.event) && !Features.backgroundLoading) {
+                    if (_inInteraction(window.event) && !_backgroundLoading) {
                         _model.get('mediaElement').load();
                     }
                     _interruptPlay = false;
@@ -754,7 +756,7 @@ Object.assign(Controller.prototype, {
                 _interruptPlay = true;
             }
 
-            if (Features.backgroundLoading) {
+            if (_backgroundLoading) {
                 _programController.backgroundActiveMedia();
             } else {
                 _programController.attached = false;
@@ -764,7 +766,7 @@ Object.assign(Controller.prototype, {
         function _attachMedia() {
             // Called after instream ends
 
-            if (Features.backgroundLoading) {
+            if (_backgroundLoading) {
                 _programController.restoreBackgroundMedia();
             } else {
                 _programController.attached = true;

--- a/src/js/program/ad-program-controller.js
+++ b/src/js/program/ad-program-controller.js
@@ -1,4 +1,3 @@
-import { Features } from 'environment/environment';
 import { ERROR, FULLSCREEN, MEDIA_COMPLETE, PLAYER_STATE, STATE_PLAYING, STATE_PAUSED } from 'events/events';
 import ProgramController from 'program/program-controller';
 import Model from 'controller/model';
@@ -11,13 +10,14 @@ export default class AdProgramController extends ProgramController {
         const adModel = this.model = new Model();
         this.playerModel = model;
         this.provider = null;
+        this.backgroundLoading = model.get('backgroundLoading');
 
         adModel.mediaModel.attributes.mediaType = 'video';
 
         // Ad plugins must use only one element, and must use the same element during playback of an item
         // (i.e. prerolls, midrolls, and postrolls must use the same tag)
         let mediaElement;
-        if (Features.backgroundLoading) {
+        if (this.backgroundLoading) {
             // The media pool has reserves an element for ads to use. It is reserved on setup and is not used by other media
             mediaElement = mediaPool.getAdElement();
         } else {
@@ -145,7 +145,7 @@ export default class AdProgramController extends ProgramController {
 
         // We only use one media element from ads; getPrimedElement will return it
         const mediaElement = mediaPool.getPrimedElement();
-        if (!Features.backgroundLoading) {
+        if (!this.backgroundLoading) {
             if (mediaElement) {
                 mediaElement.removeEventListener('emptied', this.srcResetListener);
                 // Reset the player media model if the src was changed externally

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -6,7 +6,6 @@ import { MediaControllerListener } from 'program/program-listeners';
 import Eventable from 'utils/eventable';
 import BackgroundMedia from 'program/background-media';
 import { ERROR, PLAYER_STATE, STATE_BUFFERING } from 'events/events';
-import { Features } from 'environment/environment';
 import { PlayerError } from 'api/errors';
 
 /** @private Do not include in JSDocs */
@@ -28,8 +27,9 @@ class ProgramController extends Eventable {
         this.model = model;
         this.providers = new Providers(model.getConfiguration());
         this.loadPromise = resolved;
+        this.backgroundLoading = model.get('backgroundLoading');
 
-        if (!Features.backgroundLoading) {
+        if (!this.backgroundLoading) {
             // If background loading is not supported, set the shared media element
             model.set('mediaElement', this.mediaPool.getPrimedElement());
         }
@@ -527,7 +527,7 @@ class ProgramController extends Eventable {
      * @returns {HTMLVideoElement|null} The first video element in the pool, or null if the pool is empty.
      */
     get primedElement() {
-        if (!Features.backgroundLoading) {
+        if (!this.backgroundLoading) {
             // If background loading is not supported, the model will always contain the shared media element
             // Prime it so that playback after changing the active item does not require further gestures
             const { model } = this;

--- a/test/data/model-properties.js
+++ b/test/data/model-properties.js
@@ -1,3 +1,5 @@
+import { Features } from 'environment/environment';
+
 export const optionalProperties = {
     aspectratio: 1.0,
     fullscreen: false,
@@ -103,5 +105,6 @@ export default {
     liveTimeout: null,
     setupConfig: {},
     bandwidthEstimate: null,
-    bitrateSelection: null
+    bitrateSelection: null,
+    backgroundLoading: Features.backgroundLoading
 };

--- a/test/unit/program-controller-test.js
+++ b/test/unit/program-controller-test.js
@@ -11,7 +11,8 @@ const defaultConfig = {
     mediaContainer: null,
     volume: 20,
     mute: false,
-    edition: 'enterprise'
+    edition: 'enterprise',
+    backgroundLoading: Features.backgroundLoading
 };
 
 const mp4Item = {


### PR DESCRIPTION
### This PR will...

* Add a new configuration option `backgroundLoading`, this will default to Features.backgroundLoading
* Updates core-shim, controller, ad-program-controller, and program-controller to use model.get('backgroundLoading') instead of Features.backgroundLoading

### Why is this Pull Request needed?

To allow the disabling of backgroundLoading when necessary

### Are there any points in the code the reviewer needs to double check?

No

### Are there any Pull Requests open in other repos which need to be merged with this?

No

#### Addresses Issue(s):

JW8-1640

