### PR TITLE
Avoid nesting the standard error within the setup error event object …

### DIFF
--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -240,19 +240,19 @@ Object.assign(CoreShim.prototype, {
 function setupError(core, error) {
     resolved.then(() => {
         const { message } = error;
-        const code = isValidNumber(error.code) ? error.code : SETUP_ERROR_UNKNOWN;
+        error.code = isValidNumber(error.code) ? error.code : SETUP_ERROR_UNKNOWN;
+
         const errorContainer = ErrorContainer(core, message);
         if (ErrorContainer.cloneIcon) {
             errorContainer.querySelector('.jw-icon').appendChild(ErrorContainer.cloneIcon('error'));
         }
         showView(core, errorContainer);
 
-        const errorEvent = { message, code, error };
         const model = core._model || core.modelShim;
-        model.set('errorEvent', errorEvent);
+        model.set('errorEvent', error);
         model.set('state', STATE_ERROR);
 
-        core.trigger(SETUP_ERROR, errorEvent);
+        core.trigger(SETUP_ERROR, error);
     });
 }
 


### PR DESCRIPTION
### This PR will...
- Remove the `errorEvent` object
- Assign `code` directly to the error - covers the case where it doesn't exist

### Why is this Pull Request needed?
So that errors are not nested within themselves

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-1649

