### PR TITLE
Implement html5 standard errors

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -15,6 +15,7 @@ import Tracks from 'providers/tracks-mixin';
 import endOfRange from 'utils/time-ranges';
 import createPlayPromise from 'providers/utils/play-promise';
 import { map } from 'utils/underscore';
+import { PlayerError } from 'api/errors';
 
 const clearTimeout = window.clearTimeout;
 const MIN_DVR_DURATION = 120;
@@ -774,9 +775,10 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
 
     function checkStreamEnded() {
         if (_stale && _this.atEdgeOfLiveStream()) {
-            _this.trigger(MEDIA_ERROR, {
-                message: 'The live stream is either down or has ended'
-            });
+            _this.trigger(
+                MEDIA_ERROR,
+                new PlayerError('The live stream is either down or has ended', HTML5_ERROR_LIVE_STREAM_DOWN_OR_ENDED)
+            );
             return true;
         }
 
@@ -796,3 +798,10 @@ VideoProvider.getName = function() {
 };
 
 export default VideoProvider;
+
+/**
+ *
+ @enum {ErrorCode} - The HTML5 live stream is down or has ended.
+ */
+const HTML5_ERROR_LIVE_STREAM_DOWN_OR_ENDED = 220001;
+

--- a/src/js/providers/video-listener-mixin.js
+++ b/src/js/providers/video-listener-mixin.js
@@ -164,17 +164,17 @@ const VideoListenerMixin = {
         }
     },
     error() {
-        const code = (this.video.error && this.video.error.code) || -1;
-        const message = ({
-            1: 'Unknown operation aborted',
-            2: 'Unknown network error',
-            3: 'Unknown decode error',
-            4: 'File could not be played'
-        }[code] || 'Unknown');
+        const errorCode = (this.video.error && this.video.error.code) || -1;
+        const [message, code] = ({
+            1: ['Unknown operation aborted', 1],
+            2: ['Unknown network error', 0],
+            3: ['Unknown decode error', 2],
+            4: ['File could not be played', 3]
+        }[errorCode] || ['Unknown', 0]);
 
         this.trigger(
             MEDIA_ERROR,
-            new PlayerError(`Error loading media ${message}`, HTML5_BASE_MEDIA_ERROR + Math.max(code, 0))
+            new PlayerError(`Error loading media ${message}`, HTML5_BASE_MEDIA_ERROR + code, this.video.error)
         );
     }
 };

--- a/src/js/providers/video-listener-mixin.js
+++ b/src/js/providers/video-listener-mixin.js
@@ -165,16 +165,19 @@ const VideoListenerMixin = {
     },
     error() {
         const errorCode = (this.video.error && this.video.error.code) || -1;
-        const [message, code] = ({
-            1: ['Unknown operation aborted', 1],
-            2: ['Unknown network error', 0],
-            3: ['Unknown decode error', 2],
-            4: ['File could not be played', 3]
-        }[errorCode] || ['Unknown', 0]);
+        const errorData = [
+            ['Unknown', 0],
+            ['Unknown operation aborted', 1],
+            ['Unknown network error', 0],
+            ['Unknown decode error', 2],
+            ['File could not be played', 3]
+        ][errorCode] || ['Unknown', 0];
+        // Error code 2 from the video element is a network error
+        const code = errorData[1] += (errorCode === 2 ? HTML5_NETWORK_ERROR : HTML5_BASE_MEDIA_ERROR);
 
         this.trigger(
             MEDIA_ERROR,
-            new PlayerError(`Error loading media ${message}`, HTML5_BASE_MEDIA_ERROR + code, this.video.error)
+            new PlayerError(`Error loading media ${errorData[0]}`, code, this.video.error)
         );
     }
 };
@@ -186,3 +189,9 @@ export default VideoListenerMixin;
  @enum {ErrorCode} - The HTML5 media element encountered an error.
  */
 const HTML5_BASE_MEDIA_ERROR = 224000;
+
+/**
+ *
+ @enum {ErrorCode} - The HTML5 media element encountered a network error.
+ */
+const HTML5_NETWORK_ERROR = 221000;

--- a/src/js/providers/video-listener-mixin.js
+++ b/src/js/providers/video-listener-mixin.js
@@ -3,6 +3,7 @@ import { STATE_IDLE, STATE_COMPLETE, STATE_STALLED, STATE_LOADING, STATE_PLAYING
     MEDIA_BUFFER, MEDIA_META, MEDIA_TIME, MEDIA_SEEKED, MEDIA_VOLUME, MEDIA_MUTE, MEDIA_COMPLETE
 } from 'events/events';
 import utils from 'utils/helpers';
+import { PlayerError } from 'api/errors';
 
 // This will trigger the events required by jwplayer model to
 //  properly follow the state of the video tag
@@ -170,11 +171,18 @@ const VideoListenerMixin = {
             3: 'Unknown decode error',
             4: 'File could not be played'
         }[code] || 'Unknown');
-        this.trigger(MEDIA_ERROR, {
-            code: code,
-            message: 'Error loading media: ' + message
-        });
+
+        this.trigger(
+            MEDIA_ERROR,
+            new PlayerError(`Error loading media ${message}`, HTML5_BASE_MEDIA_ERROR + Math.max(code, 0))
+        );
     }
 };
 
 export default VideoListenerMixin;
+
+/**
+ *
+ @enum {ErrorCode} - The HTML5 media element encountered an error.
+ */
+const HTML5_BASE_MEDIA_ERROR = 224000;


### PR DESCRIPTION
### This PR will...
- Implement `live stream down or ended` error
- Implement media element errors

### Why is this Pull Request needed?
So that we can standardize & track html5 errors

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/5289

#### Addresses Issue(s):

JW8-1553

