### PR TITLE
Implement standard error logging 

### DIFF
--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -97,6 +97,8 @@ Object.assign(CoreShim.prototype, {
         }
         mediaPool.prime();
 
+        model.on('change:errorEvent', logError);
+
         return this.setup.start(api).then(allPromises => {
             const CoreMixin = allPromises[0];
             if (!this.setup) {
@@ -105,7 +107,7 @@ Object.assign(CoreShim.prototype, {
             }
             const config = this.modelShim.clone();
             // Exit if embed config encountered an error
-            if (config.error instanceof Error) {
+            if (config.error) {
                 throw config.error;
             }
             // copy queued commands
@@ -256,6 +258,13 @@ function setupError(core, error) {
 
         core.trigger(SETUP_ERROR, errorEvent);
     });
+}
+
+function logError(model, error) {
+    if (!error || !error.code) {
+        return;
+    }
+    console.error(error.logMessage);
 }
 
 export function showView(core, viewElement) {

--- a/src/js/api/errors.js
+++ b/src/js/api/errors.js
@@ -78,13 +78,21 @@ export const FLASH_MEDIA_ERROR = 214000;
  * @param {code} [ErrorCode] - The error code.
  * @param {sourceError} [Error] - The lower level error, caught by the player, which resulted in this error.
  */
-export class PlayerError extends Error {
+export class PlayerError {
     constructor(message, code, sourceError = null) {
-        // Avoid passing message via super so that we can define an enumerable message property on PlayerError
-        super();
-        this.code = isValidNumber(code) ? code : null;
+        this.code = isValidNumber(code) ? code : 0;
         this.message = message;
         this.sourceError = sourceError;
+    }
+
+    get logMessage() {
+        let codeStr = this.code.toString();
+        const prefix = codeStr.slice(0, 3);
+        const suffix = codeStr.slice(-3);
+        if (suffix >= 400 && suffix < 600) {
+            codeStr = `${prefix}400-${prefix}599`;
+        }
+        return `JW Player Error ${this.code}. For more information see https://developer.jwplayer.com/jw-player/docs/developer-guide/api/errors-reference#${codeStr}`;
     }
 
     static compose(code, superCode) {

--- a/test/unit/errors/player-error-test.js
+++ b/test/unit/errors/player-error-test.js
@@ -1,0 +1,19 @@
+import { PlayerError } from 'api/errors';
+
+describe('PlayerError', function () {
+    describe('get logMessage', function () {
+        it('returns a string containing the code and a URL with the code appended as a hash', function () {
+            const error = new PlayerError('', 123999);
+            expect(error.logMessage).to.equal(generateCopy(123999, 123999));
+        });
+
+        it('squishes the code hash when parsing a network error', function () {
+            const error = new PlayerError('', 123404);
+            expect(error.logMessage).to.equal(generateCopy(123404, '123400-123599'));
+        });
+    });
+});
+
+function generateCopy(code, hash) {
+    return `JW Player Error ${code}. For more information see https://developer.jwplayer.com/jw-player/docs/developer-guide/api/errors-reference#${hash}`;
+}


### PR DESCRIPTION
### This PR will...
- Log `errorEvent` changes in core-shim, if the error is a Player error
- Implement function to generate a log message from a Player error

### Why is this Pull Request needed?
So that developers reading the console can be directed to documentation about any thrown errors

### Are there any points in the code the reviewer needs to double check?
Should I add more guard checks to `get logMessage`?

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-1542

