### PR TITLE
Avoid appending generic Playlist error copy to all playlist errors 

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -388,7 +388,6 @@ Object.assign(Controller.prototype, {
                 if (e.code >= 151 && e.code <= 162) {
                     e.code = PlayerError.compose(e.code, ERROR_LOADING_PROVIDER);
                 } else {
-                    e.message = `Playlist error: ${e.message}`;
                     e.code = PlayerError.compose(e.code, ERROR_LOADING_PLAYLIST);
                 }
                 _this.triggerError(e);

--- a/src/js/playlist/playlist.js
+++ b/src/js/playlist/playlist.js
@@ -46,7 +46,7 @@ export function filterPlaylist(playlist, model, feedData) {
 
 export function validatePlaylist(playlist) {
     if (!Array.isArray(playlist) || playlist.length === 0) {
-        throw new PlayerError('No playable sources found', 630);
+        throw new PlayerError('Playlist error: No playable sources found', 630);
     }
 }
 export const fixSources = (item, model) => filterSources(formatSources(item, model), model.getProviders());

--- a/test/unit/playlist-filtering-test.js
+++ b/test/unit/playlist-filtering-test.js
@@ -185,13 +185,13 @@ describe('playlist.validatePlaylist', function() {
             validatePlaylist([]);
         };
 
-        expect(validateEmptyPlaylist).to.throw('No playable sources found');
+        expect(validateEmptyPlaylist).to.throw('Playlist error: No playable sources found');
 
         const validateInvalidPlaylist = function() {
             validatePlaylist(null);
         };
 
-        expect(validateInvalidPlaylist).to.throw('No playable sources found');
+        expect(validateInvalidPlaylist).to.throw('Playlist error: No playable sources found');
     });
 
 

--- a/test/unit/playlist-test.js
+++ b/test/unit/playlist-test.js
@@ -51,7 +51,7 @@ describe('playlist', function() {
                 validatePlaylist(playlist);
                 expect.fail('Should have thrown an error');
             } catch (e) {
-                expect(e.message).to.equal('No playable sources found');
+                expect(e.message).to.equal('Playlist error: No playable sources found');
                 expect(e.code).to.equal(630);
                 expect(e.sourceError).to.not.exist;
             }

--- a/test/unit/setup-test.js
+++ b/test/unit/setup-test.js
@@ -75,7 +75,7 @@ describe('api.setup', function() {
             // playlist is undefined
         }).then(({ event }) => {
             expect(event.code).to.equal(102630);
-            expect(event.message).to.equal('No playable sources found');
+            expect(event.message).to.equal('Playlist error: No playable sources found');
         });
     });
 
@@ -84,7 +84,7 @@ describe('api.setup', function() {
             playlist: ''
         }).then(({ event }) => {
             expect(event.code).to.equal(102630);
-            expect(event.message).to.equal('No playable sources found');
+            expect(event.message).to.equal('Playlist error: No playable sources found');
         });
     });
 
@@ -93,7 +93,7 @@ describe('api.setup', function() {
             playlist: 1
         }).then(({ event }) => {
             expect(event.code).to.equal(102630);
-            expect(event.message).to.equal('No playable sources found');
+            expect(event.message).to.equal('Playlist error: No playable sources found');
         });
     });
 
@@ -102,7 +102,7 @@ describe('api.setup', function() {
             playlist: true
         }).then(({ event }) => {
             expect(event.code).to.equal(102630);
-            expect(event.message).to.equal('No playable sources found');
+            expect(event.message).to.equal('Playlist error: No playable sources found');
         });
     });
 
@@ -111,7 +111,7 @@ describe('api.setup', function() {
             playlist: []
         }).then(({ event }) => {
             expect(event.code).to.equal(102630);
-            expect(event.message).to.equal('No playable sources found');
+            expect(event.message).to.equal('Playlist error: No playable sources found');
         });
     });
 
@@ -123,7 +123,7 @@ describe('api.setup', function() {
 
             expect(playlist).to.be.an('array').that.has.lengthOf(0);
             expect(event.code).to.equal(102630);
-            expect(event.message).to.equal('No playable sources found');
+            expect(event.message).to.equal('Playlist error: No playable sources found');
         });
     });
 


### PR DESCRIPTION
### This PR will...
- Remove generic `Playlist error:` append to all playlist errors

### Why is this Pull Request needed?
To avoid extra copy; playlist loader errors already begin with `Error loading playlist:`

### Are there any points in the code the reviewer needs to double check?
Are there any errors for which we need to add this copy? According to the error breakdown I think I covered the only instance of `Playlist error:`

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-1508

