### PR TITLE
Route media-controller events through instream during ads mode

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -867,7 +867,7 @@ Object.assign(Controller.prototype, {
         this.attachMedia = _attachMedia;
 
         // Program Controller passthroughs
-        this.removeEvents = () => _programController.removeEvents();
+        this.routeEvents = (target) => _programController.routeEvents(target);
         this.forwardEvents = () => _programController.forwardEvents();
         this.playVideo = (playReason) => _programController.playVideo(playReason);
         this.stopVideo = () => _programController.stopVideo();

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -16,7 +16,7 @@ const _defaultOptions = {
 
 /**
  * InstreamAdapter JW Player instream API. Instantiated via jwplayer().createInstream(). Only one instance can be
- * created per player. It is destoryed via jwplayer()instreamDestroy().
+ * created per player. It is destroyed via jwplayer().instreamDestroy().
  * @param {Controller} _controller - The player controller instance
  * @param {Model} _model - The player model instance
  * @param {View} _view - The player view instance
@@ -127,7 +127,12 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
         if (_inited || _destroyed) {
             return;
         }
-        _controller.removeEvents();
+        // Forward current provider events through instream
+        _controller.routeEvents({
+            mediaControllerListener: (type, data) => {
+                this.trigger(type, data);
+            }
+        });
         _model.set('instream', _adProgram);
         _adProgram.model.set('state', STATE_PLAYING);
         _addClickHandler(clickThroughUrl);
@@ -196,9 +201,11 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
      */
     this.setState = function(event) {
         const { newstate } = event;
-        event.oldstate = _adProgram.model.get('state');
+        const adModel = _adProgram.model;
 
-        _adProgram.model.set('state', newstate);
+        event.oldstate = adModel.get('state');
+
+        adModel.set('state', newstate);
 
         if (newstate === STATE_PLAYING) {
             _controller.trigger(AD_PLAY, event);

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -299,25 +299,31 @@ class ProgramController extends Eventable {
      * @returns {void}
      */
     forwardEvents() {
-        if (!this.mediaController) {
+        const { mediaController } = this;
+        if (!mediaController) {
             return;
         }
 
-        forwardEvents(this);
+        forwardEvents(mediaController, this);
     }
 
     /**
-     * Remove the 'all' events listener that forwards events from the media-controller
+     * Remove the 'all' events listener that forwards events from the media-controller.
+     * If a target is specified, route all events to target.mediaControllerListener.
+     * @param {Object} [target] - Optional argument that must contain a mediaControllerListener method.
      * @returns {void}
      */
-    removeEvents() {
+    routeEvents(target) {
         const { mediaController } = this;
 
         if (!mediaController) {
             return;
         }
 
-        mediaController.off('all', this.mediaControllerListener, this);
+        mediaController.off();
+        if (target) {
+            forwardEvents(mediaController, target);
+        }
     }
 
     /**
@@ -358,7 +364,7 @@ class ProgramController extends Eventable {
         model.setMediaModel(mediaModel);
         model.setProvider(provider);
 
-        forwardEvents(this);
+        forwardEvents(mediaController, this);
         model.set('itemReady', true);
     }
 
@@ -706,10 +712,9 @@ function assignMediaContainer(model, mediaController) {
     }
 }
 
-function forwardEvents(programController) {
-    const { mediaController, mediaControllerListener } = programController;
-    mediaController.off('all', mediaControllerListener, programController);
-    mediaController.on('all', mediaControllerListener, programController);
+function forwardEvents(mediaController, target) {
+    const { mediaControllerListener } = target;
+    mediaController.off().on('all', mediaControllerListener, target);
 }
 
 function getSource(item) {

--- a/src/js/program/program-listeners.js
+++ b/src/js/program/program-listeners.js
@@ -31,10 +31,7 @@ export function ProviderListener(mediaController) {
                 const previousState = mediaModel.attributes.mediaState;
                 mediaModel.attributes.mediaState = data.newstate;
                 mediaModel.trigger('change:mediaState', mediaModel, data.newstate, previousState);
-                // This "return" is important because
-                //  we are choosing to not propagate model event.
-                //  Instead letting the master controller do so
-                return;
+                break;
             }
             case MEDIA_COMPLETE:
                 mediaController.beforeComplete = true;
@@ -103,6 +100,11 @@ export function ProviderListener(mediaController) {
 export function MediaControllerListener(model, programController) {
     return function (type, data) {
         switch (type) {
+            case PLAYER_STATE:
+                // This "return" is important because
+                //  we are choosing to not propagate model event.
+                //  Instead letting the master controller do so
+                return;
             case 'flashThrottle': {
                 const throttled = (data.state !== 'resume');
                 model.set('flashThrottle', throttled);

--- a/test/unit/api-queue-test.js
+++ b/test/unit/api-queue-test.js
@@ -102,7 +102,7 @@ describe('ApiQueueDecorator', function () {
         expect(b).to.have.callCount(1);
     });
 
-    it('destory() removes decorators and empties the queue', function() {
+    it('destroy() removes decorators and empties the queue', function() {
         const queue = new ApiQueueDecorator(stub, ['a', 'b'], () => true);
 
         stub.a();


### PR DESCRIPTION
### This PR will...

- Replace `removeEvents` with `routeEvents ` allowing instream to forward events from current media-controller when in ads mode
- Fix "destory" typos

### Why is this Pull Request needed?

So that SSAI ad plugins can set ad state according to state changes in the current provider, and handle other provider events such as "meta".

### Are there any points in the code the reviewer needs to double check?

"state" events are now forwarded by the mediaController, but not through the programController. This is to allow complete routing.

These changes also assume that the only event listener we ever attach to a mediaController is the "all" listener in programController with forwardEvents and routeEvents.

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-ads-dai/pull/36

#### Addresses Issue(s):

ADS-272

