### PR TITLE
Log errors via static PlayerError method, attach errorEvent listener to core model after initilization

### DIFF
--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -119,6 +119,9 @@ Object.assign(CoreShim.prototype, {
             this.setup(config, api, this.originalContainer, this._events, commandQueue, mediaPool);
 
             const coreModel = this._model;
+            // Switch the error log handlers after the real model has been set
+            model.off('change:errorEvent', logError);
+            coreModel.on('change:errorEvent', logError);
             storage.track(coreModel);
 
             // Set the active playlist item after plugins are loaded and the view is setup
@@ -264,7 +267,7 @@ function logError(model, error) {
     if (!error || !error.code) {
         return;
     }
-    console.error(error.logMessage);
+    console.error(PlayerError.logMessage(error.code));
 }
 
 export function showView(core, viewElement) {

--- a/src/js/api/errors.js
+++ b/src/js/api/errors.js
@@ -84,8 +84,7 @@ export class PlayerError {
         this.sourceError = sourceError;
     }
 
-    get logMessage() {
-        const code = this.code;
+    static logMessage(code) {
         const suffix = code % 1000;
         const prefix = Math.floor((code - suffix) / 1000);
         let codeStr = code;
@@ -93,7 +92,7 @@ export class PlayerError {
         if (suffix >= 400 && suffix < 600) {
             codeStr = `${prefix}400-${prefix}599`;
         }
-        return `JW Player Error ${this.code}. For more information see https://developer.jwplayer.com/jw-player/docs/developer-guide/api/errors-reference#${codeStr}`;
+        return `JW Player Error ${code}. For more information see https://developer.jwplayer.com/jw-player/docs/developer-guide/api/errors-reference#${codeStr}`;
     }
 
     static compose(code, superCode) {

--- a/test/unit/errors/player-error-test.js
+++ b/test/unit/errors/player-error-test.js
@@ -4,12 +4,12 @@ describe('PlayerError', function () {
     describe('get logMessage', function () {
         it('returns a string containing the code and a URL with the code appended as a hash', function () {
             const error = new PlayerError('', 123999);
-            expect(error.logMessage).to.equal(generateCopy(123999, 123999));
+            expect(PlayerError.logMessage(error.code)).to.equal(generateCopy(123999, 123999));
         });
 
         it('squishes the code hash when parsing a network error', function () {
             const error = new PlayerError('', 123404);
-            expect(error.logMessage).to.equal(generateCopy(123404, '123400-123599'));
+            expect(PlayerError.logMessage(error.code)).to.equal(generateCopy(123404, '123400-123599'));
         });
     });
 });


### PR DESCRIPTION
### Why is this Pull Request needed?
So that provider errors are logged. Provider errors trigger through the core model (after initialization), and loose the getter (because of `Object.assign`)

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-1542

