### PR TITLE
[ADS-1002] Emit preload event for next playlistItem.

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -22,7 +22,7 @@ import { INITIAL_MEDIA_STATE } from 'model/player-model';
 import { PLAYER_STATE, STATE_BUFFERING, STATE_IDLE, STATE_COMPLETE, STATE_PAUSED, STATE_PLAYING, STATE_ERROR, STATE_LOADING,
     STATE_STALLED, AUTOSTART_NOT_ALLOWED, MEDIA_BEFOREPLAY, PLAYLIST_LOADED, ERROR, PLAYLIST_COMPLETE, CAPTIONS_CHANGED, READY,
     MEDIA_ERROR, MEDIA_COMPLETE, CAST_SESSION, FULLSCREEN, PLAYLIST_ITEM, MEDIA_VOLUME, MEDIA_MUTE, PLAYBACK_RATE_CHANGED,
-    CAPTIONS_LIST, RESIZE, MEDIA_VISUAL_QUALITY } from 'events/events';
+    CAPTIONS_LIST, RESIZE, MEDIA_VISUAL_QUALITY, PRELOAD } from 'events/events';
 import ProgramController from 'program/program-controller';
 import initQoe from 'controller/qoe';
 import { BACKGROUND_LOAD_OFFSET } from 'program/program-constants';
@@ -188,6 +188,7 @@ Object.assign(Controller.prototype, {
                     if (allowPreload && position && duration > 0 && position >= duration - BACKGROUND_LOAD_OFFSET) {
                         mediaModel.off('change:position', onPosition, this);
                         _programController.backgroundLoad(item);
+                        _this.trigger(PRELOAD, { index, item });
                     } else if (recsAuto) {
                         item = _model.get('nextUp');
                     }

--- a/src/js/events/events.js
+++ b/src/js/events/events.js
@@ -360,6 +360,11 @@ export const AUDIO_TRACK_CHANGED = 'audioTrackChanged';
 */
 export const PLAYBACK_RATE_CHANGED = 'playbackRateChanged';
 
+/**
+ * Fired when a playlist item is preloaded.
+ */
+export const PRELOAD = 'preload';
+
 // View Component Actions
 
 /**


### PR DESCRIPTION
### This PR will...
Emit a "preload" event when background loading a playlistItem.

### Why is this Pull Request needed?
Signal to the ads plugins to preload ads for the playlistItem.

### Are there any points in the code the reviewer needs to double check?
@robwalch Do we want the event to have a more specific name? 

### Are there any Pull Requests open in other repos which need to be merged with this?
N/A

#### Addresses Issue(s):
ADS-1002