### PR TITLE
Idle button text variants 

### DIFF
--- a/src/css/controls/imports/idle-variants.less
+++ b/src/css/controls/imports/idle-variants.less
@@ -18,6 +18,7 @@
                 text-align: center;
                 text-indent: 0.35em;
                 top: 100%;
+                white-space: nowrap;
                 width: 100%;
             }
 

--- a/src/css/controls/imports/idle-variants.less
+++ b/src/css/controls/imports/idle-variants.less
@@ -19,7 +19,6 @@
                 text-indent: 0.35em;
                 top: 100%;
                 white-space: nowrap;
-                width: 100%;
             }
 
             .jw-svg-icon-play {

--- a/src/css/controls/imports/idle-variants.less
+++ b/src/css/controls/imports/idle-variants.less
@@ -45,9 +45,7 @@
             position: relative;
             -webkit-font-smoothing: antialiased;
 
-            &::after {
-                content: "Play";
-                display: block;
+            .jw-idle-icon-text {
                 line-height: 1;
                 position: absolute;
                 text-align: center;

--- a/src/css/controls/imports/idle-variants.less
+++ b/src/css/controls/imports/idle-variants.less
@@ -2,47 +2,14 @@
 
 .jw-state-idle {
     .jw-icon-display {
-        &[class*="jw-ab-idle"] {
+        &.jw-ab-idle-label {
             border-radius: 50%;
             color: @white;
-            transition: background-color @default-transition;
-            transition-property: background-color, filter;
-
-            .jw-svg-icon-play {
-                transform: scale(0.7, 0.7);
-            }
-        }
-
-        &.jw-ab-idle-stroke {
-            box-shadow: inset 0 0 0 3px currentColor;
-
-            &:hover {
-                background-color: fade(@white, 50%);
-            }
-
-            &,
-            & .jw-svg-icon-play {
-                filter: drop-shadow(1px 1px 2px fade(@black, 40%));
-            }
-        }
-
-        &.jw-ab-idle-fill {
-            filter: drop-shadow(0 0 10px fade(@black, 40%));
-            background-color: fade(@black, 30%);
-
-            .jw-svg-icon-play {
-                filter: drop-shadow(0 0 2px rgba(12, 26, 71, 0.2));
-            }
-
-            &:hover {
-                background-color: fade(@black, 70%);
-            }
-        }
-
-        &.jw-ab-idle-label {
             filter: drop-shadow(1px 1px 5px rgba(12, 26, 71, 0.25));
             font: normal 16px/1 Arial, Helvetica, sans-serif;
             position: relative;
+            transition: background-color @default-transition;
+            transition-property: background-color, filter;
             -webkit-font-smoothing: antialiased;
 
             .jw-idle-icon-text {
@@ -52,6 +19,10 @@
                 text-indent: 0.35em;
                 top: 100%;
                 width: 100%;
+            }
+
+            .jw-svg-icon-play {
+                transform: scale(0.7, 0.7);
             }
 
             .jw-breakpoint-0& {

--- a/src/js/view/controls/play-display-icon.js
+++ b/src/js/view/controls/play-display-icon.js
@@ -1,6 +1,6 @@
 import Events from 'utils/backbone.events';
 import UI from 'utils/ui';
-import { addClass, removeClass } from 'utils/dom';
+import { addClass, removeClass, createElement } from 'utils/dom';
 
 export default class PlayDisplayIcon {
     constructor(_model, api, element) {
@@ -8,7 +8,7 @@ export default class PlayDisplayIcon {
 
         const localization = _model.get('localization');
         const iconDisplay = element.getElementsByClassName('jw-icon-display')[0];
-        const idleButton = _model.get('idleButton');
+        const idleButtonText = _model.get('idleButtonText');
         element.style.cursor = 'pointer';
         this.icon = iconDisplay;
         this.el = element;
@@ -43,25 +43,33 @@ export default class PlayDisplayIcon {
                 iconDisplay.removeAttribute('aria-label');
             }
 
-            this.toggleIdleClass(oldState, newState, idleButton);
+            this.toggleIdleClass(oldState, newState, idleButtonText);
         });
 
-        this.toggleIdleClass('', 'idle', idleButton);
+        this.toggleIdleClass('', 'idle', idleButtonText);
     }
 
     element() {
         return this.el;
     }
 
-    toggleIdleClass(oldState, newState, idleButton) {
-        if (!(idleButton === 'stroke' || idleButton === 'fill' || idleButton === 'label')) {
+    toggleIdleClass(oldState, newState, idleButtonText) {
+        if (idleButtonText !== 'Click to Play' && idleButtonText !== 'Play' && idleButtonText !== 'Watch Now') {
             return;
         }
 
+        let element = this.icon.getElementsByClassName('jw-idle-icon-text')[0];
+        if (!element) {
+            element = createElement(`<span class="jw-idle-icon-text"></span>`);
+            this.icon.appendChild(element);
+        }
+
         if (oldState === 'idle') {
-            removeClass(this.icon, 'jw-ab-idle-' + idleButton);
+            removeClass(this.icon, 'jw-ab-idle-label');
+            element.textContent = '';
         } else if (newState === 'idle') {
-            addClass(this.icon, 'jw-ab-idle-' + idleButton);
+            addClass(this.icon, 'jw-ab-idle-label');
+            element.textContent = idleButtonText;
         }
     }
 }

--- a/src/js/view/controls/play-display-icon.js
+++ b/src/js/view/controls/play-display-icon.js
@@ -54,7 +54,7 @@ export default class PlayDisplayIcon {
     }
 
     toggleIdleClass(oldState, newState, idleButtonText) {
-        if (idleButtonText !== 'Click to Play' && idleButtonText !== 'Play' && idleButtonText !== 'Watch Now') {
+        if (!/^(click to play|play|watch now)$/i.test(idleButtonText)) {
             return;
         }
 

--- a/src/js/view/controls/play-display-icon.js
+++ b/src/js/view/controls/play-display-icon.js
@@ -17,7 +17,7 @@ export default class PlayDisplayIcon {
             this.trigger(evt.type);
         });
 
-        _model.on('change:state', (model, newState, oldState) => {
+        _model.on('change:state', (model, newState) => {
             let newStateLabel;
             switch (newState) {
                 case 'buffering':
@@ -43,17 +43,17 @@ export default class PlayDisplayIcon {
                 iconDisplay.removeAttribute('aria-label');
             }
 
-            this.toggleIdleClass(oldState, newState, idleButtonText);
+            this.toggleIdleClass(newState, idleButtonText);
         });
 
-        this.toggleIdleClass('', 'idle', idleButtonText);
+        this.toggleIdleClass(_model.get('state'), idleButtonText);
     }
 
     element() {
         return this.el;
     }
 
-    toggleIdleClass(oldState, newState, idleButtonText) {
+    toggleIdleClass(state, idleButtonText) {
         if (!/^(click to play|play|watch now)$/i.test(idleButtonText)) {
             return;
         }
@@ -64,12 +64,12 @@ export default class PlayDisplayIcon {
             this.icon.appendChild(element);
         }
 
-        if (oldState === 'idle') {
-            removeClass(this.icon, 'jw-ab-idle-label');
-            element.textContent = '';
-        } else if (newState === 'idle') {
+        if (state === 'idle') {
             addClass(this.icon, 'jw-ab-idle-label');
             element.textContent = idleButtonText;
+        } else {
+            removeClass(this.icon, 'jw-ab-idle-label');
+            element.textContent = '';
         }
     }
 }

--- a/test/unit/play-display-icon-test.js
+++ b/test/unit/play-display-icon-test.js
@@ -6,6 +6,7 @@ describe('PlayDisplayIcon', function() {
     let displayIcon;
     let element;
     let icon;
+    let svg;
     const localization = {
         playback: 'Start Playback',
         replay: 'Replay',
@@ -16,8 +17,12 @@ describe('PlayDisplayIcon', function() {
     beforeEach(function() {
         model = Object.assign({}, SimpleModel);
         model.set('localization', localization);
+        model.set('state', 'idle');
+        svg = document.createElement('svg');
+        svg.className = 'jw-svg-icon jw-svg-icon-pause';
         icon = document.createElement('div');
         icon.className = 'jw-icon-display';
+        icon.appendChild(svg);
         element = document.createElement('div');
         element.appendChild(icon);
     });
@@ -28,7 +33,8 @@ describe('PlayDisplayIcon', function() {
             displayIcon = new PlayDisplayIcon(model, {}, element);
 
             expect(displayIcon.icon.className).to.not.include('jw-ab-idle-label');
-            expect(displayIcon.icon.lastChild).to.equal(null);
+            expect(displayIcon.icon.lastChild.className).to.not.include('jw-idle-icon-text');
+
         });
 
         it('should not add class if config is invalid', function() {
@@ -37,7 +43,7 @@ describe('PlayDisplayIcon', function() {
             displayIcon = new PlayDisplayIcon(model, {}, element);
 
             expect(displayIcon.icon.className).to.not.include('jw-ab-idle-label');
-            expect(displayIcon.icon.lastChild).to.equal(null);
+            expect(displayIcon.icon.lastChild.className).to.not.include('jw-idle-icon-text');
         });
 
         it('should add class and text if config is "Watch Now"', function() {
@@ -86,7 +92,6 @@ describe('PlayDisplayIcon', function() {
         });
 
         it('should remove class and text if old state is idle (start playback)', function() {
-            model.set('state', 'idle');
             model.set('idleButtonText', 'Watch Now');
 
             displayIcon = new PlayDisplayIcon(model, {}, element);
@@ -101,6 +106,7 @@ describe('PlayDisplayIcon', function() {
         it('should add playback aria label if new state is idle (stop playback)', function() {
             displayIcon = new PlayDisplayIcon(model, {}, element);
 
+            model.set('state', 'complete');
             model.set('state', 'idle');
 
             expect(displayIcon.icon.getAttribute('aria-label')).to.equal(localization.playback);

--- a/test/unit/play-display-icon-test.js
+++ b/test/unit/play-display-icon-test.js
@@ -27,72 +27,73 @@ describe('PlayDisplayIcon', function() {
         it('should not add class if config is not set', function() {
             displayIcon = new PlayDisplayIcon(model, {}, element);
 
-            expect(icon.className).to.not.include('jw-ab-idle-');
-        });
-
-        it('should not add class if config is default', function() {
-            model.set('idleButton', 'default');
-
-            displayIcon = new PlayDisplayIcon(model, {}, element);
-
-            expect(icon.className).to.not.include('jw-ab-idle-');
+            expect(displayIcon.icon.className).to.not.include('jw-ab-idle-label');
         });
 
         it('should not add class if config is invalid', function() {
-            model.set('idleButton', 'invalid');
+            model.set('idleButtonText', 'invalid text');
 
             displayIcon = new PlayDisplayIcon(model, {}, element);
 
-            expect(icon.className).to.not.include('jw-ab-idle-');
+            expect(displayIcon.icon.className).to.not.include('jw-ab-idle-label');
         });
 
-        it('should add class if config is stroke', function() {
-            model.set('idleButton', 'stroke');
+        it('should add class and text if config is "Watch Now"', function() {
+            model.set('idleButtonText', 'Watch Now');
 
             displayIcon = new PlayDisplayIcon(model, {}, element);
 
-            expect(icon.className).to.include('jw-ab-idle-stroke');
+            expect(displayIcon.icon.className).to.include('jw-ab-idle-label');
+            expect(displayIcon.icon.lastChild.className).to.include('jw-idle-icon-text');
+            expect(displayIcon.icon.lastChild.textContent).to.equal('Watch Now');
         });
 
-        it('should add class if config is fill', function() {
-            model.set('idleButton', 'fill');
+        it('should add class and text if config is "Click to Play"', function () {
+            model.set('idleButtonText', 'Click to Play');
 
             displayIcon = new PlayDisplayIcon(model, {}, element);
 
-            expect(icon.className).to.include('jw-ab-idle-fill');
+            expect(displayIcon.icon.className).to.include('jw-ab-idle-label');
+            expect(displayIcon.icon.lastChild.className).to.include('jw-idle-icon-text');
+            expect(displayIcon.icon.lastChild.textContent).to.equal('Click to Play');
         });
 
-        it('should add class if config is label', function() {
-            model.set('idleButton', 'label');
+        it('should add class and text if config is "Play"', function () {
+            model.set('idleButtonText', 'Play');
 
             displayIcon = new PlayDisplayIcon(model, {}, element);
 
-            expect(icon.className).to.include('jw-ab-idle-label');
+            expect(displayIcon.icon.className).to.include('jw-ab-idle-label');
+            expect(displayIcon.icon.lastChild.className).to.include('jw-idle-icon-text');
+            expect(displayIcon.icon.lastChild.textContent).to.equal('Play');
         });
     });
 
     describe('on state change', function() {
 
-        it('should add class if new state is idle (stop playback)', function() {
+        it('should add class and text if new state is idle (stop playback)', function() {
             model.set('state', 'playing');
-            model.set('idleButton', 'stroke');
+            model.set('idleButtonText', 'Watch Now');
 
             displayIcon = new PlayDisplayIcon(model, {}, element);
 
             model.set('state', 'idle');
-
-            expect(icon.className).to.include('jw-ab-idle-stroke');
+            expect(displayIcon.icon.className).to.include('jw-ab-idle-label');
+            expect(displayIcon.icon.lastChild.className).to.include('jw-idle-icon-text');
+            expect(displayIcon.icon.lastChild.textContent).to.equal('Watch Now');
         });
 
-        it('should remove class if old state is idle (start playback)', function() {
+        it('should remove class and text if old state is idle (start playback)', function() {
             model.set('state', 'idle');
-            model.set('idleButton', 'stroke');
+            model.set('idleButtonText', 'Watch Now');
 
             displayIcon = new PlayDisplayIcon(model, {}, element);
 
             model.set('state', 'playing');
 
-            expect(icon.className).to.not.include('jw-ab-idle-stroke');
+            expect(displayIcon.icon.className).to.not.include('jw-ab-idle-label');
+            expect(displayIcon.icon.lastChild.className).to.include('jw-idle-icon-text');
+            expect(displayIcon.icon.lastChild.textContent).to.equal('');
         });
 
         it('should add playback aria label if new state is idle (stop playback)', function() {
@@ -100,7 +101,7 @@ describe('PlayDisplayIcon', function() {
 
             model.set('state', 'idle');
 
-            expect(icon.getAttribute('aria-label')).to.equal(localization.playback);
+            expect(displayIcon.icon.getAttribute('aria-label')).to.equal(localization.playback);
         });
 
         it('should add pause aria label if old state is idle (start playback)', function() {
@@ -108,7 +109,7 @@ describe('PlayDisplayIcon', function() {
 
             model.set('state', 'playing');
 
-            expect(icon.getAttribute('aria-label')).to.equal(localization.pause);
+            expect(displayIcon.icon.getAttribute('aria-label')).to.equal(localization.pause);
         });
 
         it('should remove aria label if new state label is empty', function() {
@@ -117,7 +118,7 @@ describe('PlayDisplayIcon', function() {
 
             model.set('state', 'complete');
 
-            expect(icon.getAttribute('aria-label')).to.equal(null);
+            expect(displayIcon.icon.getAttribute('aria-label')).to.equal(null);
         });
 
         it('should remove aria label if new state is invalid', function() {
@@ -125,7 +126,7 @@ describe('PlayDisplayIcon', function() {
 
             model.set('state', 'invalid');
 
-            expect(icon.getAttribute('aria-label')).to.equal(null);
+            expect(displayIcon.icon.getAttribute('aria-label')).to.equal(null);
         });
     });
 });

--- a/test/unit/play-display-icon-test.js
+++ b/test/unit/play-display-icon-test.js
@@ -28,6 +28,7 @@ describe('PlayDisplayIcon', function() {
             displayIcon = new PlayDisplayIcon(model, {}, element);
 
             expect(displayIcon.icon.className).to.not.include('jw-ab-idle-label');
+            expect(displayIcon.icon.lastChild).to.equal(null);
         });
 
         it('should not add class if config is invalid', function() {
@@ -36,6 +37,7 @@ describe('PlayDisplayIcon', function() {
             displayIcon = new PlayDisplayIcon(model, {}, element);
 
             expect(displayIcon.icon.className).to.not.include('jw-ab-idle-label');
+            expect(displayIcon.icon.lastChild).to.equal(null);
         });
 
         it('should add class and text if config is "Watch Now"', function() {


### PR DESCRIPTION
### This PR will...

- Add a new variants to the idle button a/b test by setting "idleButtonText" in the config to the appropriate value
- Add new unit tests for new variants
- Remove old css for old idle button variants

### Why is this Pull Request needed?

To test which text attracts users to play video

### Are there any points in the code the reviewer needs to double check?

@radium-v the text beneath the play button gets misaligned on the smaller breakpoints (0 and 1). Any css I can add to fix this? 

![screen shot 2018-05-31 at 5 52 37 pm](https://user-images.githubusercontent.com/6787010/40810630-5d7c51e8-64fc-11e8-936f-cfb48b64cd9e.png)

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/borg/pull/486

#### Addresses Issue(s):

JW8-1646

