### PR TITLE
Make out of bounds HTTP status code consistent

### DIFF
--- a/src/js/providers/utils/network-error-parser.js
+++ b/src/js/providers/utils/network-error-parser.js
@@ -3,7 +3,7 @@ export default function parseNetworkError(baseCode, statusCode, url = '', respon
     let code = baseCode + 1000;
 
     if (statusCode > 0) {
-        // Restrict status code range between 400 and 599 in order to avoid conflicting codes; 600 otherwise
+        // Restrict status code range between 400 and 599 in order to avoid conflicting codes; 6 otherwise
         message = badStatusMessage(statusCode, responseText);
         code += clampStatus(statusCode);
     } else if (url.substring(0, 5) === 'http:' && document.location.protocol === 'https:') {
@@ -33,5 +33,5 @@ function badStatusMessage(statusCode, responseText = '') {
     return message;
 }
 
-export const clampStatus = code => (code >= 400 && code < 600) ? code : 600;
+export const clampStatus = code => (code >= 400 && code < 600) ? code : 6;
 

--- a/src/js/providers/utils/network-error-parser.js
+++ b/src/js/providers/utils/network-error-parser.js
@@ -3,7 +3,7 @@ export default function parseNetworkError(baseCode, statusCode, url = '', respon
     let code = baseCode + 1000;
 
     if (statusCode > 0) {
-        // Restrict status code range between 400 and 600 in order to avoid conflicting codes; 10 otherwise
+        // Restrict status code range between 400 and 599 in order to avoid conflicting codes; 600 otherwise
         message = badStatusMessage(statusCode, responseText);
         code += clampStatus(statusCode);
     } else if (url.substring(0, 5) === 'http:' && document.location.protocol === 'https:') {
@@ -33,5 +33,5 @@ function badStatusMessage(statusCode, responseText = '') {
     return message;
 }
 
-export const clampStatus = code => (code >= 400 && code <= 600) ? code : 10;
+export const clampStatus = code => (code >= 400 && code < 600) ? code : 600;
 

--- a/src/js/utils/ajax.js
+++ b/src/js/utils/ajax.js
@@ -7,7 +7,7 @@ const ERROR_XHR_UNDEFINED = 2;
 const ERROR_XHR_OPEN = 3;
 const ERROR_XHR_SEND = 4;
 const ERROR_XHR_FILTER = 5;
-const ERROR_XHR_UNKNOWN = 600;
+const ERROR_XHR_UNKNOWN = 6;
 
 // Network Responses with http status 400-599
 // will produce an error with the http status code

--- a/src/js/utils/ajax.js
+++ b/src/js/utils/ajax.js
@@ -7,7 +7,7 @@ const ERROR_XHR_UNDEFINED = 2;
 const ERROR_XHR_OPEN = 3;
 const ERROR_XHR_SEND = 4;
 const ERROR_XHR_FILTER = 5;
-const ERROR_XHR_UNKNOWN = 6;
+const ERROR_XHR_UNKNOWN = 600;
 
 // Network Responses with http status 400-599
 // will produce an error with the http status code

--- a/test/unit/network-error-parser-test.js
+++ b/test/unit/network-error-parser-test.js
@@ -17,7 +17,7 @@ describe('network error parser', function () {
     });
 
     it('appends a code of 10 if the status code is < 400 or > 600', function () {
-        expect(parseNetworkError(900000, 601).code).to.equal(901010);
-        expect(parseNetworkError(900000, 399).code).to.equal(901010);
+        expect(parseNetworkError(900000, 601).code).to.equal(901600);
+        expect(parseNetworkError(900000, 399).code).to.equal(901600);
     })
 });

--- a/test/unit/network-error-parser-test.js
+++ b/test/unit/network-error-parser-test.js
@@ -17,7 +17,7 @@ describe('network error parser', function () {
     });
 
     it('appends a code of 10 if the status code is < 400 or > 600', function () {
-        expect(parseNetworkError(900000, 601).code).to.equal(901600);
-        expect(parseNetworkError(900000, 399).code).to.equal(901600);
+        expect(parseNetworkError(900000, 601).code).to.equal(901006);
+        expect(parseNetworkError(900000, 399).code).to.equal(901006);
     })
 });


### PR DESCRIPTION
### This PR will...
- replace the `10` network error code with `6`
### Why is this Pull Request needed?
- When an http request returns a status code outside of the 400 - 599 range, we want the code to be `6`, and we want it to be consistent across modules. 
### Are there any points in the code the reviewer needs to double check?
n/a
### Are there any Pull Requests open in other repos which need to be merged with this?
[Commercial](https://github.com/jwplayer/jwplayer-commercial/compare/improvement/consistent-http-status-out-of-bounds-code?expand=1)
#### Addresses Issue(s):
JW8-1659

