### PR TITLE
Cleanup utils imports

### DIFF
--- a/src/js/controller/tracks-loader.js
+++ b/src/js/controller/tracks-loader.js
@@ -1,12 +1,12 @@
 import VTTCue from 'parsers/captions/vttcue';
 import { chunkLoadErrorHandler } from '../api/core-loader';
-import utils from 'utils/helpers';
+import { ajax } from 'utils/ajax';
 import { localName } from 'parsers/parsers';
 import srt from 'parsers/captions/srt';
 import dfxp from 'parsers/captions/dfxp';
 
 export function loadFile(track, successHandler, errorHandler) {
-    track.xhr = utils.ajax(track.file, function(xhr) {
+    track.xhr = ajax(track.file, function(xhr) {
         xhrSuccess(xhr, track, successHandler, errorHandler);
     }, errorHandler);
 }

--- a/src/js/parsers/jwparser.js
+++ b/src/js/parsers/jwparser.js
@@ -1,6 +1,6 @@
 import { localName, textContent } from 'parsers/parsers';
 import { xmlAttribute } from 'utils/strings';
-import utils from 'utils/helpers';
+import { serialize } from 'utils/parser';
 
 /**
 * Parse a feed item for JWPlayer content.
@@ -36,7 +36,7 @@ const parseEntry = function (obj, itm) {
                     label: xmlAttribute(node, label)
                 });
             } else {
-                itm[_localName] = utils.serialize(textContent(node));
+                itm[_localName] = serialize(textContent(node));
                 if (_localName === 'file' && itm.sources) {
                     // jwplayer namespace file should override existing source
                     // (probably set in MediaParser)

--- a/src/js/parsers/mediaparser.js
+++ b/src/js/parsers/mediaparser.js
@@ -1,6 +1,6 @@
 import { localName, textContent, numChildren } from 'parsers/parsers';
 import { xmlAttribute } from 'utils/strings';
-import utils from 'utils/helpers';
+import { seconds } from 'utils/strings';
 
 /**
  * Parse a MRSS group into a playlistitem (used in RSS and ATOM)
@@ -41,7 +41,7 @@ const mediaparser = function (obj, item) {
             switch (localName(node).toLowerCase()) {
                 case 'content':
                     if (xmlAttribute(node, 'duration')) {
-                        item.duration = utils.seconds(xmlAttribute(node, 'duration'));
+                        item.duration = seconds(xmlAttribute(node, 'duration'));
                     }
                     if (xmlAttribute(node, 'url')) {
                         if (!item.sources) {

--- a/src/js/playlist/loader.js
+++ b/src/js/playlist/loader.js
@@ -1,7 +1,7 @@
 import { PLAYLIST_LOADED, ERROR } from 'events/events';
 import { localName } from 'parsers/parsers';
 import parseRss from 'parsers/rssparser';
-import utils from 'utils/helpers';
+import { ajax } from 'utils/ajax';
 import Events from 'utils/backbone.events';
 import { PlayerError } from 'api/errors';
 
@@ -9,7 +9,7 @@ const PlaylistLoader = function() {
     const _this = Object.assign(this, Events);
 
     this.load = function(playlistfile) {
-        utils.ajax(playlistfile, playlistLoaded, (message, file, url, error) => {
+        ajax(playlistfile, playlistLoaded, (message, file, url, error) => {
             playlistError(error);
         });
     };

--- a/src/js/plugins/model.js
+++ b/src/js/plugins/model.js
@@ -1,5 +1,5 @@
 import Plugin from 'plugins/plugin';
-import { log } from 'utils/helpers';
+import { log } from 'utils/log';
 
 const pluginsRegistered = {};
 

--- a/src/js/plugins/plugins.js
+++ b/src/js/plugins/plugins.js
@@ -1,6 +1,6 @@
 import PluginsLoader from 'plugins/loader';
 import PluginsModel from 'plugins/model';
-import { log } from 'utils/helpers';
+import { log } from 'utils/log';
 
 const pluginsModel = new PluginsModel();
 

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -7,7 +7,7 @@ import VideoEvents from 'providers/video-listener-mixin';
 import VideoAction from 'providers/video-actions-mixin';
 import VideoAttached from 'providers/video-attached-mixin';
 import { style } from 'utils/css';
-import utils from 'utils/helpers';
+import { tryCatch, JwError } from 'utils/trycatch';
 import { emptyElement } from 'utils/dom';
 import DefaultProvider from 'providers/default';
 import Events from 'utils/backbone.events';
@@ -20,6 +20,7 @@ import { PlayerError } from 'api/errors';
 const clearTimeout = window.clearTimeout;
 const MIN_DVR_DURATION = 120;
 const _name = 'html5';
+const noop = function () {};
 
 function _setupListeners(eventsHash, videoTag) {
     Object.keys(eventsHash).forEach(eventName => {
@@ -221,7 +222,7 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
     let _levels;
     let _currentQuality = -1;
     let _fullscreenState = false;
-    let _beforeResumeHandler = utils.noop;
+    let _beforeResumeHandler = noop;
     let _audioTracks = null;
     let _currentAudioTrackIndex = -1;
     let _staleStreamTimeout = -1;
@@ -310,7 +311,7 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
 
     function _getPublicLevels(levels) {
         let publicLevels;
-        if (utils.typeOf(levels) === 'array' && levels.length > 0) {
+        if (Array.isArray(levels) && levels.length > 0) {
             publicLevels = levels.map(function(level, i) {
                 return {
                     label: level.label || i
@@ -461,7 +462,7 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
     };
 
     this.destroy = function() {
-        _beforeResumeHandler = utils.noop;
+        _beforeResumeHandler = noop;
         _removeListeners(MediaEvents, _videotag);
         this.removeTracksListener(_videotag.audioTracks, 'change', _audioTrackChangeHandler);
         this.removeTracksListener(_videotag.textTracks, 'change', _this.textTrackChangeHandler);
@@ -476,7 +477,7 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
             // Playback rate is broken on Android HLS
             _this.supportsPlaybackRate = false;
             // Android HLS doesnt update its times correctly so it always falls in here.  Do not allow it to stall.
-            MediaEvents.waiting = utils.noop;
+            MediaEvents.waiting = noop;
         }
         _this.eventsOn_();
         // the loadeddata event determines the mediaType for HLS sources
@@ -600,7 +601,7 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
         // This implementation is for iOS and Android WebKit only
         // This won't get called if the player container can go fullscreen
         if (state) {
-            const status = utils.tryCatch(function() {
+            const status = tryCatch(function() {
                 const enterFullscreen =
                     _videotag.webkitEnterFullscreen ||
                     _videotag.webkitEnterFullScreen;
@@ -610,7 +611,7 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
 
             });
 
-            if (status instanceof utils.Error) {
+            if (status instanceof JwError) {
                 // object can't go fullscreen
                 return false;
             }

--- a/src/js/providers/video-listener-mixin.js
+++ b/src/js/providers/video-listener-mixin.js
@@ -2,7 +2,7 @@ import { STATE_IDLE, STATE_COMPLETE, STATE_STALLED, STATE_LOADING, STATE_PLAYING
     PROVIDER_FIRST_FRAME, CLICK, MEDIA_BUFFER_FULL, MEDIA_RATE_CHANGE, MEDIA_ERROR,
     MEDIA_BUFFER, MEDIA_META, MEDIA_TIME, MEDIA_SEEKED, MEDIA_VOLUME, MEDIA_MUTE, MEDIA_COMPLETE
 } from 'events/events';
-import utils from 'utils/helpers';
+import { between } from 'utils/math';
 import { PlayerError } from 'api/errors';
 
 // This will trigger the events required by jwplayer model to
@@ -136,7 +136,7 @@ const VideoListenerMixin = {
             return;
         }
 
-        const buffered = utils.between(buf.end(buf.length - 1) / dur, 0, 1);
+        const buffered = between(buf.end(buf.length - 1) / dur, 0, 1);
         this.trigger(MEDIA_BUFFER, {
             bufferPercent: buffered * 100,
             position: this.getCurrentTime(),

--- a/src/js/utils/helpers.js
+++ b/src/js/utils/helpers.js
@@ -37,12 +37,8 @@ import {
     getRgba
 } from 'utils/css';
 import { ajax } from 'utils/ajax';
-
-export const log = (typeof console.log === 'function') ? console.log.bind(console) : function() {};
-
-export const between = function (num, min, max) {
-    return Math.max(Math.min(num, max), min);
-};
+import { between } from 'utils/math';
+import { log } from 'utils/log';
 
 // TODO: deprecate (jwplayer-ads-vast uses utils.crossdomain(url))
 function crossdomain(uri) {

--- a/src/js/utils/log.js
+++ b/src/js/utils/log.js
@@ -1,0 +1,2 @@
+
+export const log = (typeof console.log === 'function') ? console.log.bind(console) : function() {};

--- a/src/js/utils/math.js
+++ b/src/js/utils/math.js
@@ -1,0 +1,5 @@
+
+// Clamp the input number between min max values
+export const between = function (num, min, max) {
+    return Math.max(Math.min(num, max), min);
+};

--- a/src/js/view/controls/components/chapters.mixin.js
+++ b/src/js/view/controls/components/chapters.mixin.js
@@ -1,4 +1,4 @@
-import utils from 'utils/helpers';
+import { ajax } from 'utils/ajax';
 import srt from 'parsers/captions/srt';
 
 class Cue {
@@ -25,7 +25,7 @@ class Cue {
 const ChaptersMixin = {
 
     loadChapters: function (file) {
-        utils.ajax(file, this.chaptersLoaded.bind(this), this.chaptersFailed, {
+        ajax(file, this.chaptersLoaded.bind(this), this.chaptersFailed, {
             plainText: true
         });
     },

--- a/src/js/view/controls/components/slider.js
+++ b/src/js/view/controls/components/slider.js
@@ -2,18 +2,19 @@ import sliderTemplate from 'view/controls/templates/slider';
 import { OS } from 'environment/environment';
 import Events from 'utils/backbone.events';
 import UI from 'utils/ui';
-import utils from 'utils/helpers';
+import { between } from 'utils/dom';
+import { bounds, createElement } from 'utils/dom';
 
 const getRailBounds = function(elementRail) {
-    const bounds = utils.bounds(elementRail);
+    const railBounds = bounds(elementRail);
     // Partial workaround of Android 'inert-visual-viewport'
     // https://bugs.chromium.org/p/chromium/issues/detail?id=489206
     const pageXOffset = window.pageXOffset;
     if (pageXOffset && OS.android && document.body.parentElement.getBoundingClientRect().left >= 0) {
-        bounds.left -= pageXOffset;
-        bounds.right -= pageXOffset;
+        railBounds.left -= pageXOffset;
+        railBounds.right -= pageXOffset;
     }
-    return bounds;
+    return railBounds;
 };
 
 export default class Slider {
@@ -31,7 +32,7 @@ export default class Slider {
     }
 
     setup() {
-        this.el = utils.createElement(sliderTemplate(this.className, 'jw-slider-' + this.orientation));
+        this.el = createElement(sliderTemplate(this.className, 'jw-slider-' + this.orientation));
 
         this.elementRail = this.el.getElementsByClassName('jw-slider-container')[0];
         this.elementBuffer = this.el.getElementsByClassName('jw-buffer')[0];
@@ -58,27 +59,28 @@ export default class Slider {
     }
 
     dragMove(evt) {
-        const bounds = this.railBounds = (this.railBounds) ? this.railBounds : getRailBounds(this.elementRail);
+        const railBounds = this.railBounds = (this.railBounds) ? this.railBounds : getRailBounds(this.elementRail);
         let dimension;
         let percentage;
 
         if (this.orientation === 'horizontal') {
             dimension = evt.pageX;
-            if (dimension < bounds.left) {
+            if (dimension < railBounds.left) {
                 percentage = 0;
-            } else if (dimension > bounds.right) {
+            } else if (dimension > railBounds.right) {
                 percentage = 100;
             } else {
-                percentage = utils.between((dimension - bounds.left) / bounds.width, 0, 1) * 100;
+                percentage = between((dimension - railBounds.left) / railBounds.width, 0, 1) * 100;
             }
         } else {
             dimension = evt.pageY;
-            if (dimension >= bounds.bottom) {
+            if (dimension >= railBounds.bottom) {
                 percentage = 0;
-            } else if (dimension <= bounds.top) {
+            } else if (dimension <= railBounds.top) {
                 percentage = 100;
             } else {
-                percentage = utils.between((bounds.height - (dimension - bounds.top)) / bounds.height, 0, 1) * 100;
+                percentage =
+                    between((railBounds.height - (dimension - railBounds.top)) / railBounds.height, 0, 1) * 100;
             }
         }
 

--- a/src/js/view/controls/components/thumbnails.mixin.js
+++ b/src/js/view/controls/components/thumbnails.mixin.js
@@ -1,5 +1,5 @@
 import { sortedIndex, property, bind } from 'utils/underscore';
-import utils from 'utils/helpers';
+import { ajax } from 'utils/ajax';
 import srt from 'parsers/captions/srt';
 
 function Thumbnail(obj) {
@@ -17,7 +17,7 @@ const ThumbnailsMixin = {
         // Only load the first individual image file so we can get its dimensions. All others are loaded when
         // they're set as background-images.
         this.individualImage = null;
-        utils.ajax(file, this.thumbnailsLoaded.bind(this), this.thumbnailsFailed.bind(this), {
+        ajax(file, this.thumbnailsLoaded.bind(this), this.thumbnailsFailed.bind(this), {
             plainText: true
         });
     },

--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -1,5 +1,5 @@
 import { throttle, each } from 'utils/underscore';
-import { between } from 'utils/helpers';
+import { between } from 'utils/math';
 import { style } from 'utils/css';
 import { timeFormat } from 'utils/parser';
 import { addClass, removeClass, setAttribute, bounds } from 'utils/dom';

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -1,18 +1,17 @@
-import { cloneIcons } from 'view/controls/icons';
 import { Browser, OS } from 'environment/environment';
-import CustomButton from 'view/controls/components/custom-button';
-import { toggleClass, setAttribute } from 'utils/dom';
-import utils from 'utils/helpers';
-import { each } from 'utils/underscore';
 import { USER_ACTION, STATE_PLAYING } from 'events/events';
-import Events from 'utils/backbone.events';
-import UI from 'utils/ui';
-import ariaLabel from 'utils/aria';
+import { cloneIcons } from 'view/controls/icons';
+import CustomButton from 'view/controls/components/custom-button';
 import TimeSlider from 'view/controls/components/timeslider';
 import VolumeTooltip from 'view/controls/components/volumetooltip';
 import button from 'view/controls/components/button';
 import { SimpleTooltip } from 'view/controls/components/simple-tooltip';
-import { prependChild } from 'utils/dom';
+import ariaLabel from 'utils/aria';
+import Events from 'utils/backbone.events';
+import { prependChild, setAttribute, toggleClass } from 'utils/dom';
+import { timeFormat } from 'utils/parser';
+import UI from 'utils/ui';
+import { each } from 'utils/underscore';
 
 function text(name, role) {
     const element = document.createElement('span');
@@ -376,19 +375,19 @@ export default class Controlbar {
         if (model.get('streamType') === 'DVR') {
             const currentPosition = Math.ceil(position);
             const dvrSeekLimit = this._model.get('dvrSeekLimit');
-            let time = currentPosition >= -dvrSeekLimit ? '' : '-' + utils.timeFormat(-(position + dvrSeekLimit));
+            let time = currentPosition >= -dvrSeekLimit ? '' : '-' + timeFormat(-(position + dvrSeekLimit));
             elapsedTime = countdownTime = time;
             model.set('dvrLive', currentPosition >= -dvrSeekLimit);
         } else {
-            elapsedTime = utils.timeFormat(position);
-            countdownTime = utils.timeFormat(duration - position);
+            elapsedTime = timeFormat(position);
+            countdownTime = timeFormat(duration - position);
         }
         this.elements.elapsed.textContent = elapsedTime;
         this.elements.countdown.textContent = countdownTime;
     }
 
     onDuration(model, val) {
-        this.elements.duration.textContent = utils.timeFormat(Math.abs(val));
+        this.elements.duration.textContent = timeFormat(Math.abs(val));
     }
 
     onFullscreen(model, val) {

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -1,7 +1,8 @@
 import { OS } from 'environment/environment';
 import { DISPLAY_CLICK, USER_ACTION, STATE_PAUSED, STATE_PLAYING, STATE_ERROR } from 'events/events';
 import Events from 'utils/backbone.events';
-import utils from 'utils/helpers';
+import { between } from 'utils/math';
+import { addClass, removeClass, toggleClass } from 'utils/dom';
 import { now } from 'utils/date';
 import button from 'view/controls/components/button';
 import Controlbar from 'view/controls/controlbar';
@@ -101,11 +102,11 @@ export default class Controls {
 
         // Touch UI mode when we're on mobile and we have a percentage height or we can fit the large UI in
         this.infoOverlay = new InfoOverlay(element, model, api, visible => {
-            utils.toggleClass(this.div, 'jw-info-open', visible);
+            toggleClass(this.div, 'jw-info-open', visible);
         });
         this.rightClickMenu = new RightClick(this.infoOverlay);
         if (touchMode) {
-            utils.addClass(this.playerContainer, 'jw-flag-touch');
+            addClass(this.playerContainer, 'jw-flag-touch');
             this.rightClickMenu.setup(model, this.playerContainer, this.playerContainer);
         } else {
             model.change('flashBlocked', (modelChanged, isBlocked) => {
@@ -144,7 +145,7 @@ export default class Controls {
             const settingsInteraction = { reason: 'settingsInteraction' };
             const isKeyEvent = (evt && evt.sourceEvent || evt || {}).type === 'keydown';
 
-            utils.toggleClass(this.div, 'jw-settings-open', visible);
+            toggleClass(this.div, 'jw-settings-open', visible);
             if (getBreakpoint(model.get('containerWidth')) < 2) {
                 if (visible && state === STATE_PLAYING) {
                     // Pause playback on open if we're currently playing
@@ -190,7 +191,7 @@ export default class Controls {
                 // Set mute state in the controlbar
                 controlbar.renderVolume(true, _model.get('volume'));
                 // Hide the controlbar until the autostart flag is removed
-                utils.addClass(this.playerContainer, 'jw-flag-autostart');
+                addClass(this.playerContainer, 'jw-flag-autostart');
 
                 _model.on('change:autostartFailed change:autostartMuted change:mute', unmuteCallback, this);
                 this.unmuteCallback = unmuteCallback;
@@ -209,12 +210,12 @@ export default class Controls {
                 min = max;
                 max = Math.max(position, -dvrSeekLimit);
             }
-            const newSeek = utils.between(position + amount, min, max);
+            const newSeek = between(position + amount, min, max);
             api.seek(newSeek, reasonInteraction());
         }
 
         function adjustVolume(amount) {
-            const newVol = utils.between(model.get('volume') + amount, 0, 100);
+            const newVol = between(model.get('volume') + amount, 0, 100);
             api.setVolume(newVol);
         }
 
@@ -351,7 +352,7 @@ export default class Controls {
         this.activeTimeout = -1;
 
         if (this.div.parentNode) {
-            utils.removeClass(this.playerContainer, 'jw-flag-touch');
+            removeClass(this.playerContainer, 'jw-flag-touch');
             this.playerContainer.removeChild(this.div);
         }
         if (this.rightClickMenu) {
@@ -426,7 +427,7 @@ export default class Controls {
             this.mute.hide();
         }
 
-        utils.removeClass(this.playerContainer, 'jw-flag-autostart');
+        removeClass(this.playerContainer, 'jw-flag-autostart');
         this.userActive();
     }
 
@@ -452,7 +453,7 @@ export default class Controls {
             this.inactiveTime = 0;
         }
         if (!this.showing) {
-            utils.removeClass(this.playerContainer, 'jw-flag-user-inactive');
+            removeClass(this.playerContainer, 'jw-flag-user-inactive');
             this.showing = true;
             this.trigger('userActive');
         }
@@ -466,7 +467,7 @@ export default class Controls {
         }
         this.inactiveTime = 0;
         this.showing = false;
-        utils.addClass(this.playerContainer, 'jw-flag-user-inactive');
+        addClass(this.playerContainer, 'jw-flag-user-inactive');
         this.trigger('userInactive');
     }
 
@@ -492,14 +493,14 @@ export default class Controls {
         if (this.settingsMenu) {
             this.settingsMenu.close();
         }
-        utils.removeClass(this.playerContainer, 'jw-flag-autostart');
+        removeClass(this.playerContainer, 'jw-flag-autostart');
     }
 
     destroyInstream(model) {
         this.instreamState = null;
         this.addBackdrop();
         if (model.get('autostartMuted')) {
-            utils.addClass(this.playerContainer, 'jw-flag-autostart');
+            addClass(this.playerContainer, 'jw-flag-autostart');
         }
     }
 }

--- a/src/js/view/controls/display-container.js
+++ b/src/js/view/controls/display-container.js
@@ -3,11 +3,11 @@ import RewindDisplayIcon from 'view/controls/rewind-display-icon';
 import PlayDisplayIcon from 'view/controls/play-display-icon';
 import NextDisplayIcon from 'view/controls/next-display-icon';
 import { cloneIcons } from 'view/controls/icons';
-import utils from 'utils/helpers';
+import { createElement } from 'utils/dom';
 
 export default class DisplayContainer {
     constructor(model, api) {
-        this.el = utils.createElement(displayContainerTemplate(model.get('localization')));
+        this.el = createElement(displayContainerTemplate(model.get('localization')));
 
         const container = this.el.querySelector('.jw-display-controls');
         const buttons = {};

--- a/src/js/view/controls/nextuptooltip.js
+++ b/src/js/view/controls/nextuptooltip.js
@@ -1,9 +1,10 @@
 import nextUpTemplate from 'view/controls/templates/nextup';
-import { toggleClass } from 'utils/dom';
+import { style } from 'utils/css';
+import { createElement, toggleClass } from 'utils/dom';
 import UI from 'utils/ui';
 import Events from 'utils/backbone.events';
-import utils from 'utils/helpers';
 import { cloneIcon } from 'view/controls/icons';
+import { seconds } from 'utils/strings';
 
 export default class NextUpTooltip {
     constructor(_model, _api, playerElement) {
@@ -22,7 +23,7 @@ export default class NextUpTooltip {
     setup(context) {
         this.container = context.createElement('div');
         this.container.className = 'jw-nextup-container jw-reset';
-        const element = utils.createElement(nextUpTemplate());
+        const element = createElement(nextUpTemplate());
         element.querySelector('.jw-nextup-close').appendChild(cloneIcon('close'));
         this.addContent(element);
 
@@ -109,7 +110,7 @@ export default class NextUpTooltip {
             toggleClass(this.content, 'jw-nextup-thumbnail-visible', !!nextUpItem.image);
             if (nextUpItem.image) {
                 const thumbnailStyle = this.loadThumbnail(nextUpItem.image);
-                utils.style(this.thumbnail, thumbnailStyle);
+                style(this.thumbnail, thumbnailStyle);
             }
 
             // Set header
@@ -119,13 +120,13 @@ export default class NextUpTooltip {
             // Set title
             this.title = this.content.querySelector('.jw-nextup-title');
             const title = nextUpItem.title;
-            this.title.innerText = title ? utils.createElement(title).textContent : '';
+            this.title.innerText = title ? createElement(title).textContent : '';
 
             // Set duration
             if (nextUpItem.duration) {
                 this.duration = this.content.querySelector('.jw-nextup-duration');
                 const duration = nextUpItem.duration;
-                this.duration.innerText = duration ? utils.createElement(duration).textContent : '';
+                this.duration.innerText = duration ? createElement(duration).textContent : '';
             }
 
         }, 500);
@@ -155,7 +156,7 @@ export default class NextUpTooltip {
         }
 
         // Use nextupoffset if set or default to 10 seconds from the end of playback
-        let offset = utils.seconds(model.get('nextupoffset') || -10);
+        let offset = seconds(model.get('nextupoffset') || -10);
         if (offset < 0) {
             // Determine offset from the end. Duration may change.
             offset += duration;


### PR DESCRIPTION
### This PR will...
- Replace utils/helpers imports with individual util function imports
- Moves `log` and `between` into new "utils/log.js" and "utils/math.js" modules respectively

### Why is this Pull Request needed?

So that we don't have a module import export spaghetti where modules like controlbar import parts or parents of modules imported by it's own dependencies. And for minification of imported util function names.

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/5309
