### PR TITLE
Fix initial playback rate menu selection

### DIFF
--- a/src/js/view/controls/components/settings/submenu.js
+++ b/src/js/view/controls/components/settings/submenu.js
@@ -95,7 +95,7 @@ export default function SettingsSubmenu(name, categoryButton, isDefault) {
             categoryButtonElement.setAttribute('aria-checked', 'false');
             active = false;
         },
-        activateItem(itemOrdinal = 0) {
+        activateItem(itemOrdinal) {
             const item = contentItems[itemOrdinal];
             if (!item || item.active) {
                 return;

--- a/src/js/view/controls/settings-menu.js
+++ b/src/js/view/controls/settings-menu.js
@@ -128,7 +128,7 @@ export function setupSubmenuListeners(settingsMenu, controlbar, viewModel, api) 
             settingsMenu,
             playbackRates,
             (playbackRate) => api.setPlaybackRate(playbackRate),
-            model.get('playbackRate'),
+            playbackRates.indexOf(model.get('playbackRate')),
             model.get('localization').playbackRates
         );
     };


### PR DESCRIPTION
### This PR will...

Remove the default parameter value of `0` from submenu `activateItem(itemOrdinal)`, and correct the value we pass in for this argument in the playback rate menu to be an index and not a playback rate.

### Why is this Pull Request needed?

Removing unnecessary default parameters keeps the build smaller.

The wrong playback rate could be selected by default in the rates menu if the second option does not match "1" or the default rate.
