### PR TITLE
Prevent "playAttemptFailed" events from firing after the playlist item has changed

### DIFF
--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -145,16 +145,18 @@ export default class MediaController extends Eventable {
                 syncPlayerWithMediaModel(mediaModel);
             }
         }).catch(error => {
-            model.set('playRejected', true);
-            const videoTagPaused = provider && provider.video && provider.video.paused;
-            if (videoTagPaused) {
-                mediaModel.set('mediaState', STATE_PAUSED);
+            if (this.item && mediaModel === model.mediaModel) {
+                model.set('playRejected', true);
+                const videoTagPaused = provider && provider.video && provider.video.paused;
+                if (videoTagPaused) {
+                    mediaModel.set('mediaState', STATE_PAUSED);
+                }
+                this.trigger(MEDIA_PLAY_ATTEMPT_FAILED, {
+                    error,
+                    item,
+                    playReason
+                });
             }
-            this.trigger(MEDIA_PLAY_ATTEMPT_FAILED, {
-                error,
-                item,
-                playReason
-            });
         });
     }
 


### PR DESCRIPTION
### This PR will...

Do not trigger "playAttemptFailed" if the media controller is destroy…ed or the active mediaModel has changed.

### Why is this Pull Request needed?

We don't want "playAttemptFailed" events firing after the playlist item has changed. If an item was skipped, then the play was cancelled intentionally. "playAttemptFailed" is intended to signal that the current item could not be autostarted and requires a gesture from the user to start. 

#### Addresses Issue(s):

JW8-1633
