### PR TITLE
Cleanup default provider methods

### DIFF
--- a/src/js/providers/default.js
+++ b/src/js/providers/default.js
@@ -44,13 +44,14 @@ const DefaultProvider = {
     setVisibility: noop,
     setFullscreen: noop,
     getFullscreen: returnFalse,
+    supportsFullscreen: returnFalse,
 
     // If setContainer has been set, this returns the element.
     //  It's value is used to determine if we should remove the <video> element when setting a new provider.
     getContainer: noop,
 
     // Sets the parent element, causing provider to append <video> into it
-    setContainer: returnFalse,
+    setContainer: noop,
 
     getName: returnName,
 
@@ -78,25 +79,26 @@ const DefaultProvider = {
         return null;
     },
 
-    // TODO :: The following are targets for removal after refactoring
-    checkComplete: noop,
+    // TODO: Deprecate provider.setControls(bool) with Flash. It's used to toggle the cursor when the swf is in focus.
     setControls: noop,
+
     attachMedia: noop,
     detachMedia: noop,
     init: noop,
 
-    setState: function(state) {
-        this.state = state;
+    setState: function(newstate) {
+        this.state = newstate;
 
         this.trigger(PLAYER_STATE, {
-            newstate: state
+            newstate
         });
     },
 
-    sendMediaType: function(levels) {
-        const { type, mimeType } = levels[0];
-        const isAudioFile = (type === 'oga' || type === 'aac' || type === 'mp3' ||
-            type === 'mpeg' || type === 'vorbis' || (mimeType && mimeType.indexOf('audio/') === 0));
+    sendMediaType: function(sources) {
+        const { type, mimeType } = sources[0];
+
+        const isAudioFile = (type === 'aac' || type === 'mp3' || type === 'mpeg' ||
+            (mimeType && mimeType.indexOf('audio/') === 0));
 
         this.trigger(MEDIA_TYPE, {
             mediaType: isAudioFile ? 'audio' : 'video'


### PR DESCRIPTION
### This PR will...
Fixes some of the defaults applied to all providers registered with the player:
- `setContainer` has no return value
- `supportsFullscreen` is required and should return `false` by default
- `setControls` should be deprecated with Flash. Clarify this with a comment. The methods following it are being used.
- 'oga' and 'vorbis' are not specific to audio and do not need to be included in our `sendMediaType` (which really belongs in a mixin, not here, but save that for another time)

### Why is this Pull Request needed?

Providers registered with the player should implement these methods and if they do not, these are the defaults.

