### PR TITLE
Optimize strings utils

### DIFF
--- a/src/js/utils/strings.js
+++ b/src/js/utils/strings.js
@@ -1,4 +1,6 @@
-import { isValidNumber, isString, map } from 'utils/underscore';
+import { isValidNumber, isString } from 'utils/underscore';
+
+const parseFloat = window.parseFloat;
 
 export function trim(inputString) {
     return inputString.replace(/^\s+|\s+$/g, '');
@@ -15,22 +17,13 @@ export function pad(str, length, padder) {
 
 // Get the value of a case-insensitive attribute in an XML node
 export function xmlAttribute(xml, attribute) {
-    for (let attrib = 0; attrib < xml.attributes.length; attrib++) {
-        if (xml.attributes[attrib].name && xml.attributes[attrib].name.toLowerCase() === attribute.toLowerCase()) {
-            return xml.attributes[attrib].value.toString();
+    const attributes = xml.attributes;
+    for (let attrib = 0; attrib < attributes.length; attrib++) {
+        if (attributes[attrib].name && attributes[attrib].name.toLowerCase() === attribute.toLowerCase()) {
+            return attributes[attrib].value.toString();
         }
     }
     return '';
-}
-
-// This does not return the file extension, instead it returns a media type extension
-function getAzureFileFormat(path) {
-    if ((/[(,]format=m3u8-/i).test(path)) {
-        return 'm3u8';
-    } else if ((/[(,]format=mpd-/i).test(path)) {
-        return 'mpd';
-    }
-    return false;
 }
 
 export function extension(path) {
@@ -38,9 +31,9 @@ export function extension(path) {
         return '';
     }
 
-    const azureFormat = getAzureFileFormat(path);
-    if (azureFormat) {
-        return azureFormat;
+    const azureFormatMatches = (/[(,]format=(m3u8|mpd)-/i).exec(path);
+    if (azureFormatMatches) {
+        return azureFormatMatches[1];
     }
 
     path = path.split('?')[0].split('#')[0];
@@ -51,8 +44,8 @@ export function extension(path) {
 
 // Convert seconds to HH:MN:SS.sss
 export function hms(secondsNumber) {
-    const h = parseInt(secondsNumber / 3600);
-    const m = parseInt(secondsNumber / 60) % 60;
+    const h = (secondsNumber / 3600) | 0;
+    const m = ((secondsNumber / 60) | 0) % 60;
     const s = secondsNumber % 60;
     return pad(h, 2) + ':' + pad(m, 2) + ':' + pad(s.toFixed(3), 6);
 }
@@ -66,16 +59,17 @@ export function seconds(str, frameRate) {
         return str;
     }
 
-    str = str.replace(',', '.');
-    const arr = str.split(':');
+    const input = str.replace(',', '.');
+    const lastChar = input.slice(-1);
+    const arr = input.split(':');
     const arrLength = arr.length;
     let sec = 0;
-    if (str.slice(-1) === 's') {
-        sec = parseFloat(str);
-    } else if (str.slice(-1) === 'm') {
-        sec = parseFloat(str) * 60;
-    } else if (str.slice(-1) === 'h') {
-        sec = parseFloat(str) * 3600;
+    if (lastChar === 's') {
+        sec = parseFloat(input);
+    } else if (lastChar === 'm') {
+        sec = parseFloat(input) * 60;
+    } else if (lastChar === 'h') {
+        sec = parseFloat(input) * 3600;
     } else if (arrLength > 1) {
         let secIndex = arrLength - 1;
         if (arrLength === 4) {
@@ -91,7 +85,7 @@ export function seconds(str, frameRate) {
             sec += parseFloat(arr[secIndex - 2]) * 3600;
         }
     } else {
-        sec = parseFloat(str);
+        sec = parseFloat(input);
     }
     if (!isValidNumber(sec)) {
         return 0;
@@ -112,13 +106,9 @@ export function offsetToSeconds(offset, duration, frameRate) {
 }
 
 export function prefix(arr, add) {
-    return map(arr, function(val) {
-        return add + val;
-    });
+    return arr.map(val => add + val);
 }
 
 export function suffix(arr, add) {
-    return map(arr, function(val) {
-        return val + add;
-    });
+    return arr.map(val => val + add);
 }


### PR DESCRIPTION
### This PR will...
Optimize strings utils for minification and runtime execution.

### Why is this Pull Request needed?
The stings utils actually takes a up a significant amount of space in jwplayer.js when inspected with [source-map-explorer](https://github.com/danvk/source-map-explorer)

This builds release with source maps, removes any report previously created, and then creates a new html report.
```
$ webpack --env.release --env.devtool=source-map && rm -f ./reports/source-map-jwplayer.html && source-map-explorer --html ./bin-release/jwplayer.js > ./reports/source-map-jwplayer.html
```
( look at the html )

The follow up is just a list of sizes per file
```
$ source-map-explorer --tsv ./bin-release/jwplayer.js
webpack/bootstrap                           3159
jwplayer/src/js/utils/underscore.js         6945
jwplayer/src/js/utils/strings.js            3462 (after changes)
jwplayer/src/js/events/events.js            1696
jwplayer/src/js/api/errors.js                856
jwplayer/src/js/parsers/parsers.js           328
node_modules/promise-polyfill/src/index.js  2718
```

A lot of this is just due to the lack of assignment for properties we access multiple times in a function, or functions and regex that can be inlined (see changes).


