### PR TITLE
Recycle the video tag when casting

### DIFF
--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -202,6 +202,8 @@ class ProgramController extends Eventable {
         const playlistItem = Object.assign({}, item);
         playlistItem.starttime = model.mediaModel.get('position');
 
+        this._destroyActiveMedia();
+
         const castMediaController = new MediaController(castProvider, model);
         castMediaController.activeItem = playlistItem;
         this._setActiveMedia(castMediaController);


### PR DESCRIPTION
### This PR will...
Recycle media elements used by the current provider when casting with ChromeCast begins.

### Why is this Pull Request needed?
When disconnecting from a cast session, if the media pool is empty, the user will see an error:

<img width="780" alt="screen shot 2018-06-05 at 6 25 23 pm" src="https://user-images.githubusercontent.com/333258/41006427-78ba88e8-68ef-11e8-8993-cc863c044f44.png">

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/5331

#### Addresses Issue(s):

JW8-1670

