### PR TITLE
Hide time tooltip after scrubbing on mobile

### DIFF
--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -114,7 +114,7 @@ class TimeSlider extends Slider {
         // Show the tooltip on while dragging (touch) moving(mouse), or moving over(mouse)
         this.elementUI = new UI(this.el, { useHover: true, useMove: true })
             .on('drag move over', this.showTimeTooltip, this)
-            .on('out', this.hideTimeTooltip, this)
+            .on('dragEnd out', this.hideTimeTooltip, this)
             .on('click', () => this.el.focus());
 
         this.el.addEventListener('focus', () => this.updateAriaText());


### PR DESCRIPTION
### This PR will...

trigger the tooltip to hide on the `dragEnd` event

### Why is this Pull Request needed?

This was accidentally removed when working on the time slider accessibility ticket. Without it, the tooltip continues to be displayed after scrubbing on touch devices.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-1672
