### PR TITLE
Guard against 'handleEvent' exceptions in Edge 15

### DIFF
--- a/src/js/view/controls/rightclick.js
+++ b/src/js/view/controls/rightclick.js
@@ -207,10 +207,14 @@ export default class RightClick {
         }
 
         if (this.playerElement) {
-            this.playerElement.removeEventListener('touchstart', this.startLongPressHandler);
-            this.playerElement.removeEventListener('touchmove', this.cancelLongPressHandler);
-            this.playerElement.removeEventListener('touchend', this.cancelLongPressHandler);
-            this.playerElement.removeEventListener('touchcancel', this.cancelLongPressHandler);
+            if (this.startLongPressHandler) {
+                this.playerElement.removeEventListener('touchstart', this.startLongPressHandler);
+            }
+            if (this.cancelLongPressHandler) {
+                this.playerElement.removeEventListener('touchmove', this.cancelLongPressHandler);
+                this.playerElement.removeEventListener('touchend', this.cancelLongPressHandler);
+                this.playerElement.removeEventListener('touchcancel', this.cancelLongPressHandler);
+            }
             this.playerElement.oncontextmenu = null;
             this.playerElement = null;
         }


### PR DESCRIPTION
### This PR will...
Prevent `removeEventListener` from being called with an undefined handler argument.

### Why is this Pull Request needed?
A bug in Edge 15 and earlier throws an exception when `removeEventListener` is invoked this way. JavaScript exception affect player functionality and analytics.

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-plugin-related/pull/289

#### Addresses Issue(s):
JW8-1667

