### PR TITLE
Prevent 406000 range error codes

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -353,7 +353,11 @@ Object.assign(Controller.prototype, {
                             return _this.updatePlaylist(Playlist(data.playlist), data);
                         }
                     });
-                    loadPromise = _loadPlaylist(item).then(updatePlaylistCancelable.async);
+                    loadPromise = _loadPlaylist(item)
+                        .catch(e => {
+                            _this.triggerError(e);
+                        })
+                        .then(updatePlaylistCancelable.async);
                     break;
                 }
                 case 'object':

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -353,11 +353,7 @@ Object.assign(Controller.prototype, {
                             return _this.updatePlaylist(Playlist(data.playlist), data);
                         }
                     });
-                    loadPromise = _loadPlaylist(item)
-                        .catch(e => {
-                            _this.triggerError(e);
-                        })
-                        .then(updatePlaylistCancelable.async);
+                    loadPromise = _loadPlaylist(item).then(updatePlaylistCancelable.async);
                     break;
                 }
                 case 'object':
@@ -388,10 +384,7 @@ Object.assign(Controller.prototype, {
                 loader.on(PLAYLIST_LOADED, function(data) {
                     resolve(data);
                 });
-                loader.on(ERROR, function(error) {
-                    error.code = PlayerError.compose(error.code, ERROR_LOADING_PROVIDER);
-                    reject(error);
-                }, this);
+                loader.on(ERROR, reject, this);
                 loader.load(toLoad);
             });
         }


### PR DESCRIPTION
### This PR will...
add a catch block to `_loadPlaylist` to immediately trigger an error.
### Why is this Pull Request needed?
When an error occurs in `_loadPlaylist`, it gets added to `ERROR_LOADING_PROVIDER` (204,000) and is then thrown again, at which point it is caught by `loadPromise`'s catch block and summed to `ERROR_LOADING_PLAYLIST` (202,000), creating an error that is out of bounds. 
### Are there any points in the code the reviewer needs to double check?
n/a
### Are there any Pull Requests open in other repos which need to be merged with this?
n/a
#### Addresses Issue(s):
JW8-1679

