### PR TITLE
Handle dom exceptions in setup and between items

### DIFF
--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -13,7 +13,6 @@ import ErrorContainer from 'view/error-container';
 import MediaElementPool from 'program/media-element-pool';
 import SharedMediaPool from 'program/shared-media-pool';
 import { PlayerError, SETUP_ERROR_LOADING_PLAYLIST, SETUP_ERROR_UNKNOWN, MSG_TECHNICAL_ERROR } from 'api/errors';
-import { isValidNumber } from 'utils/underscore';
 
 const ModelShim = function() {};
 Object.assign(ModelShim.prototype, SimpleModel);
@@ -246,7 +245,7 @@ function setupError(core, error) {
         let errorEvent = error;
         const model = core._model || core.modelShim;
 
-        if (!isValidNumber(error.code)) {
+        if (!(error instanceof PlayerError) || !error.code) {
             // Transform any unhandled error into a PlayerError so emitted events adhere to a uniform structure
             errorEvent = new PlayerError(MSG_TECHNICAL_ERROR, SETUP_ERROR_UNKNOWN, error);
         }
@@ -270,6 +269,9 @@ function setupError(core, error) {
 function logError(model, error) {
     if (!error || !error.code) {
         return;
+    }
+    if (error.sourceError) {
+        console.error(error.sourceError);
     }
     console.error(PlayerError.logMessage(error.code));
 }

--- a/src/js/api/errors.js
+++ b/src/js/api/errors.js
@@ -45,7 +45,7 @@ export const ERROR_LOADING_PLAYLIST = 202000;
 export const SETUP_ERROR_LOADING_PROVIDER = 104000;
 
 /**
- * @enum {ErrorCode} An error occurred setting up the current playlist item.
+ * @enum {ErrorCode} An error occurred when switching playlist items.
  */
 export const ERROR_LOADING_PLAYLIST_ITEM = 203000;
 

--- a/src/js/api/errors.js
+++ b/src/js/api/errors.js
@@ -45,12 +45,17 @@ export const ERROR_LOADING_PLAYLIST = 202000;
 export const SETUP_ERROR_LOADING_PROVIDER = 104000;
 
 /**
- * @enum {ErrorCode} Between playlist items, the required provider could not be loaded be.
+ * @enum {ErrorCode} An error occurred setting up the current playlist item.
  */
 export const ERROR_LOADING_PLAYLIST_ITEM = 203000;
 
 /**
- * @enum {ErrorCode} Using the load API, the required provider could not be loaded.
+ * @enum {ErrorCode} The current playlist item has no source media.
+ */
+export const ERROR_PLAYLIST_ITEM_MISSING_SOURCE = 203640;
+
+/**
+ * @enum {ErrorCode} Between playlist items, the required provider could not be loaded.
  */
 export const ERROR_LOADING_PROVIDER = 204000;
 
@@ -128,8 +133,18 @@ export class PlayerError {
         }
         return `JW Player Error ${code}. For more information see https://developer.jwplayer.com/jw-player/docs/developer-guide/api/errors-reference#${codeStr}`;
     }
+}
 
-    static compose(code, superCode) {
-        return (code || 0) + superCode;
+export function convertToPlayerError(key, code, error) {
+    if (!(error instanceof PlayerError) || !error.code) {
+        // Transform any unhandled error into a PlayerError so emitted events adhere to a uniform structure
+        return new PlayerError(key, code, error);
     }
+    return error;
+}
+
+export function composePlayerError(error, superCode) {
+    const playerError = convertToPlayerError(MSG_TECHNICAL_ERROR, superCode, error);
+    playerError.code = (error.code || 0) + superCode;
+    return playerError;
 }

--- a/src/js/api/setup-steps.js
+++ b/src/js/api/setup-steps.js
@@ -4,7 +4,8 @@ import PlaylistLoader from 'playlist/loader';
 import Playlist, { filterPlaylist, validatePlaylist } from 'playlist/playlist';
 import ScriptLoader from 'utils/scriptloader';
 import { bundleContainsProviders } from 'api/core-loader';
-import { PlayerError, SETUP_ERROR_LOADING_PLAYLIST, SETUP_ERROR_LOADING_PROVIDER } from 'api/errors';
+import { composePlayerError,
+    SETUP_ERROR_LOADING_PLAYLIST, SETUP_ERROR_LOADING_PROVIDER } from 'api/errors';
 
 export function loadPlaylist(_model) {
     const playlist = _model.get('playlist');
@@ -19,8 +20,7 @@ export function loadPlaylist(_model) {
             });
             playlistLoader.on(ERROR, e => {
                 setPlaylistAttributes(_model, [], {});
-                e.code = PlayerError.compose(e.code, SETUP_ERROR_LOADING_PLAYLIST);
-                reject(e);
+                reject(composePlayerError(e, SETUP_ERROR_LOADING_PLAYLIST));
             });
             playlistLoader.load(playlist);
         });
@@ -68,8 +68,7 @@ function loadProvider(_model) {
         }
         return providersManager.load(name)
             .catch(e => {
-                e.code = PlayerError.compose(e.code, SETUP_ERROR_LOADING_PROVIDER);
-                throw e;
+                throw composePlayerError(e, SETUP_ERROR_LOADING_PROVIDER);
             });
     });
 }

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -5,8 +5,8 @@ import cancelable from 'utils/cancelable';
 import { MediaControllerListener } from 'program/program-listeners';
 import Eventable from 'utils/eventable';
 import BackgroundMedia from 'program/background-media';
-import { ERROR, PLAYER_STATE, STATE_BUFFERING } from 'events/events';
-import { PlayerError, MSG_CANT_PLAY_VIDEO } from 'api/errors';
+import { PLAYER_STATE, STATE_BUFFERING } from 'events/events';
+import { PlayerError, MSG_CANT_PLAY_VIDEO, ERROR_PLAYLIST_ITEM_MISSING_SOURCE } from 'api/errors';
 
 /** @private Do not include in JSDocs */
 
@@ -50,7 +50,7 @@ class ProgramController extends Eventable {
         model.setActiveItem(index);
         const source = getSource(item);
         if (!source) {
-            return Promise.reject(new PlayerError(MSG_CANT_PLAY_VIDEO, 640));
+            return Promise.reject(new PlayerError(MSG_CANT_PLAY_VIDEO, ERROR_PLAYLIST_ITEM_MISSING_SOURCE));
         }
 
         // Activate the background media if it's loading the item we want to play
@@ -135,9 +135,6 @@ class ProgramController extends Eventable {
             playPromise = this.loadPromise
                 .catch(error => {
                     thenPlayPromise.cancel();
-                    // Required provider was not loaded
-                    error.message = `Could not play video: ${error.message}`;
-                    model.trigger(ERROR, error);
                     // Fail the playPromise to trigger "playAttemptFailed"
                     throw error;
                 })

--- a/test/unit/errors/core-loader-error-tests.js
+++ b/test/unit/errors/core-loader-error-tests.js
@@ -1,4 +1,3 @@
-import sinon from 'sinon';
 import { chunkLoadErrorHandler } from 'api/core-loader';
 
 describe('core-loader errors', function () {


### PR DESCRIPTION
### This PR will...

Handle `DOMException` instances in places where we catch errors. 

Two new methods are exported from "api/errors""
- `convertToPlayerError` takes an error and if it is not a `PlayerError` converts it to one with the default error type (key) and code provided.
- `composePlayerError` replaces the static `PlayerError.compose` call. It uses `convertToPlayerError` to make sure the error code is writeable before attempting to change it.

The error handling in controller and program-controller has been cleaned up a little:
- The catch on `_item` has been moved to inside `_item` on `setActiveItem`. There is no point in throwing from `_item` since methods that call it do not pass on it's promise.
- `setActiveItem` is where all provider and item related errors are caught. This handles errors in all places `_item` is called in the controller. These errors are intercepted here before `_load`. 
- `_load` only catches playlist errors.

### Why is this Pull Request needed?

`DOMException` object's `message` and `code` properties are read-only. If a promise chain errors as the result of one of these, we need to convert it to a `PlayerError`.

### Are there any points in the code the reviewer needs to double check?

Static class methods are only useful for public API. Exporting function work the same and their names can be minified.

### Are there any Pull Requests open in other repos which need to be merged with this?

No.

#### Addresses Issue(s):

JW8-1692

