### PR TITLE
Validate volume and mute values

### DIFF
--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -113,8 +113,9 @@ const Config = function(options, persisted) {
     __webpack_public_path__ = config.base;
     config.width = _normalizeSize(config.width);
     config.height = _normalizeSize(config.height);
-
     config.aspectratio = _evaluateAspectRatio(config.aspectratio, config.width);
+    config.volume = isValidNumber(config.volume) ? config.volume : Defaults.volume;
+    config.mute = !!config.mute;
 
     let rateControls = config.playbackRateControls;
 

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -89,9 +89,12 @@ const Model = function() {
     };
 
     this.setVolume = function(volume) {
-        volume = Math.round(volume);
-        this.set('volume', volume);
-        const mute = (volume === 0);
+        if (!isValidNumber(volume)) {
+            return;
+        }
+        const vol = Math.max(Math.min(volume, 100), 0);
+        this.set('volume', vol);
+        const mute = (vol === 0);
         if (mute !== (this.getMute())) {
             this.setMute(mute);
         }
@@ -105,7 +108,7 @@ const Model = function() {
         if (mute === undefined) {
             mute = !(this.getMute());
         }
-        this.set('mute', mute);
+        this.set('mute', !!mute);
         if (!mute) {
             const volume = Math.max(10, this.get('volume'));
             this.set('autostartMuted', false);

--- a/src/js/program/media-element-pool.js
+++ b/src/js/program/media-element-pool.js
@@ -54,8 +54,9 @@ export default function MediaElementPool() {
             }
         },
         syncVolume: function (volume) {
+            const vol = Math.max(Math.min(volume / 100, 1), 0);
             elements.forEach(e => {
-                e.volume = volume / 100;
+                e.volume = vol;
             });
         },
         syncMute(muted) {

--- a/src/js/providers/video-actions-mixin.js
+++ b/src/js/providers/video-actions-mixin.js
@@ -6,8 +6,7 @@ const VideoActionsMixin = {
     container: null,
 
     volume(vol) {
-        vol = Math.max(Math.min(vol / 100, 1), 0);
-        this.video.volume = vol;
+        this.video.volume = Math.max(Math.min(vol / 100, 1), 0);
     },
 
     mute(state) {

--- a/test/unit/media-pool-tests.js
+++ b/test/unit/media-pool-tests.js
@@ -34,6 +34,13 @@ describe('Media Element Pool', function () {
         }
     });
 
+    it('handles invalid volume values', function () {
+        mediaPool.syncVolume(-50000);
+        for (let i = 0; i < numTags; i++) {
+            expect(mediaPool.getPrimedElement().volume).to.equal(0);
+        }
+    });
+
     it('provides an exclusive element to ad pools', function () {
         const adElement = mediaPool.getAdElement();
         expect(adElement).to.not.equal(null);


### PR DESCRIPTION
### This PR will...

- Clamp volume between 0 and 100
- Convert mute to a boolean
- Ignore invalid volume input

### Why is this Pull Request needed?

Prevent `DOMException` errors from being thrown by setting `video.volume` to a non-normal value.

#### Addresses Issue(s):

JW8-1696

