### PR TITLE
[ADS-1233] Set itemReady when ad is playing.

### DIFF
--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -445,7 +445,7 @@ class ProgramController extends Eventable {
      * @memberOf ProgramController
      */
     _activateBackgroundMedia() {
-        const { background, background: { nextLoadPromise } } = this;
+        const { background, background: { nextLoadPromise }, model } = this;
         // Activating this item means that any media already loaded in the background will no longer be needed
         this._destroyMediaController(background.currentMedia);
         background.currentMedia = null;
@@ -455,6 +455,7 @@ class ProgramController extends Eventable {
             }
             background.clearNext();
             if (this.adPlaying) {
+                model.attributes.itemReady = true;
                 background.currentMedia = nextMediaController;
             } else {
                 this._setActiveMedia(nextMediaController);


### PR DESCRIPTION
### This PR will...
Revert part of 7a07c90, where `itemReady` was no longer set to `true` when an ad is playing. This causes the controls (play, pause, audio track, captions, quality, and fullscreen) to be [enqueued](https://github.com/jwplayer/jwplayer/blob/master/src/js/controller/controller.js#L1003) rather then executed on subsequent playlist items.

### Why is this Pull Request needed?
Fix ad controls.

### Are there any points in the code the reviewer needs to double check?
Setting `itemReady` to `true` when playing ads causes issues with VR videos, but that's already a current issue (see JW8-1578). This PR does not break JW8-1332.

### Are there any Pull Requests open in other repos which need to be merged with this?
N/A

#### Addresses Issue(s):
ADS-1233