### PR TITLE
Call userActive on mouseout without relatedTarget when in iFrame

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -424,7 +424,9 @@ function View(_api, _model) {
     }
 
     function outHandler(event) {
-        if (_controls && _controls.showing && event.relatedTarget && !_playerElement.contains(event.relatedTarget)) {
+        // If controls are showing and mouse moves out to relatedTarget not within playerElement, call userActive().
+        // Also call userActive() if event does not contain relatedTarget if player is in iFrame. (relatedTarget = null)
+        if (_controls && _controls.showing && ((event.relatedTarget && !_playerElement.contains(event.relatedTarget)) || (!event.relatedTarget && Features.iframe))) {
             _controls.userActive();
         }
     }


### PR DESCRIPTION
JW8-1629

### This PR will...

Call `userActive()` even if `relatedTarget = null` as long as player detects it is in an iFrame.

### Why is this Pull Request needed?

Currently, when the player is in an iFrame, mousing out of the player from the controls was not being recognized as a `mouseout` event and controls would not fade away.

### Are there any points in the code the reviewer needs to double check?

n/a

### Are there any Pull Requests open in other repos which need to be merged with this?

n/a

#### Addresses Issue(s):

JW8-1629

