### PR TITLE
Round playback rates to hundredths instead of quarters

### DIFF
--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -1,3 +1,4 @@
+import { roundToHundredths } from 'utils/math';
 import { loadFrom, getScriptPath } from 'utils/playerutils';
 import { serialize } from 'utils/parser';
 import { isValidNumber, isNumber, pick, isBoolean } from 'utils/underscore';
@@ -126,7 +127,7 @@ const Config = function(options, persisted) {
             rates = rateControls;
         }
         rates = rates.filter(rate => isNumber(rate) && rate >= 0.25 && rate <= 4)
-            .map(rate => Math.round(rate * 4) / 4);
+            .map(rate => roundToHundredths(rate));
 
         if (rates.indexOf(1) < 0) {
             rates.push(1);

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -1,4 +1,3 @@
-import { roundToHundredths } from 'utils/math';
 import { loadFrom, getScriptPath } from 'utils/playerutils';
 import { serialize } from 'utils/parser';
 import { isValidNumber, isNumber, pick, isBoolean } from 'utils/underscore';
@@ -127,7 +126,7 @@ const Config = function(options, persisted) {
             rates = rateControls;
         }
         rates = rates.filter(rate => isNumber(rate) && rate >= 0.25 && rate <= 4)
-            .map(rate => roundToHundredths(rate));
+            .map(rate => Math.round(rate * 100) / 100);
 
         if (rates.indexOf(1) < 0) {
             rates.push(1);

--- a/src/js/utils/math.js
+++ b/src/js/utils/math.js
@@ -3,3 +3,9 @@
 export const between = function (num, min, max) {
     return Math.max(Math.min(num, max), min);
 };
+
+// Round a given number to the hundredths-place
+// Used for playbackRates
+export const roundToHundredths = function (num) {
+    return parseFloat(num.toPrecision(2));
+};

--- a/src/js/utils/math.js
+++ b/src/js/utils/math.js
@@ -3,9 +3,3 @@
 export const between = function (num, min, max) {
     return Math.max(Math.min(num, max), min);
 };
-
-// Round a given number to the hundredths-place
-// Used for playbackRates
-export const roundToHundredths = function (num) {
-    return parseFloat(num.toPrecision(2));
-};

--- a/test/unit/api-config-test.js
+++ b/test/unit/api-config-test.js
@@ -136,12 +136,13 @@ describe('API Config', function() {
     describe('playbackRates', function() {
 
         it('should round custom playback rates to nearest hundredth', function() {
-            let rates = [ 0.5, 0.6512, 1 ];
+            let rates = [ 0.999, 0.6512, 0.667, 0.664 ];
             rates = rates.filter(rate => rate >= 0.25 && rate <= 4)
                 .map(rate => Math.round(rate * 100) / 100);
-            expect(rates[0]).to.equal(0.50);
+            expect(rates[0]).to.equal(1);
             expect(rates[1]).to.equal(0.65);
-            expect(rates[2]).to.equal(1.00);
+            expect(rates[2]).to.equal(0.67);
+            expect(rates[3]).to.equal(0.66);
         });
     });
 

--- a/test/unit/api-config-test.js
+++ b/test/unit/api-config-test.js
@@ -133,6 +133,18 @@ describe('API Config', function() {
         });
     });
 
+    describe('playbackRates', function() {
+
+        it('should round custom playback rates to nearest hundredth', function() {
+            let rates = [ 0.5, 0.6512, 1 ];
+            rates = rates.filter(rate => rate >= 0.25 && rate <= 4)
+                .map(rate => Math.round(rate * 100) / 100);
+            expect(rates[0]).to.equal(0.50);
+            expect(rates[1]).to.equal(0.65);
+            expect(rates[2]).to.equal(1.00);
+        });
+    });
+
     describe('base url', function() {
 
         it('should update base to cdn or script location', function() {

--- a/test/unit/api-config-test.js
+++ b/test/unit/api-config-test.js
@@ -136,13 +136,14 @@ describe('API Config', function() {
     describe('playbackRates', function() {
 
         it('should round custom playback rates to nearest hundredth', function() {
-            let rates = [ 0.999, 0.6512, 0.667, 0.664 ];
-            rates = rates.filter(rate => rate >= 0.25 && rate <= 4)
-                .map(rate => Math.round(rate * 100) / 100);
-            expect(rates[0]).to.equal(1);
-            expect(rates[1]).to.equal(0.65);
-            expect(rates[2]).to.equal(0.67);
-            expect(rates[3]).to.equal(0.66);
+            let x = new Config({
+                playbackRateControls: true,
+                playbackRates: [ 0.999, 0.6512, 0.667, 0.664 ]
+            });
+            expect(x.playbackRates[0]).to.equal(0.65);
+            expect(x.playbackRates[1]).to.equal(0.66);
+            expect(x.playbackRates[2]).to.equal(0.67);
+            expect(x.playbackRates[3]).to.equal(1);
         });
     });
 


### PR DESCRIPTION
### This PR will...

When publishers supply custom playback rates in their player setup, this will clean them by rounding to nearest hundredths.

### Why is this Pull Request needed?

Prior to this, the rates would be rounded to the nearest quarter (i.e. 0.25, 0.75, etc). Publishers want more fine-grained control than this.

### Are there any points in the code the reviewer needs to double check?

n/a

### Are there any Pull Requests open in other repos which need to be merged with this?

n/a

#### Addresses Issue(s):

JW8-1666

