### PR TITLE
Plugins with the same name should only load and be registered once

### DIFF
--- a/src/js/plugins/loader.js
+++ b/src/js/plugins/loader.js
@@ -13,8 +13,8 @@ function configurePlugin(pluginObj, pluginConfig, api) {
     api.addPlugin(pluginName, pluginInstance);
 }
 
-const PluginLoader = function () {
-    this.load = function (api, pluginsModel, pluginsConfig, model) {
+const PluginLoader = function() {
+    this.load = function(api, pluginsModel, pluginsConfig, model) {
         // Must be a hash map
         if (!pluginsConfig || typeof pluginsConfig !== 'object') {
             return resolved;
@@ -22,14 +22,14 @@ const PluginLoader = function () {
 
         return Promise.all(Object.keys(pluginsConfig).filter(pluginUrl => pluginUrl)
             .map(pluginUrl => {
-                const plugin = pluginsModel.addPlugin(pluginUrl, true);
                 const pluginConfig = pluginsConfig[pluginUrl];
-                return plugin.load().then(() => {
+                return pluginsModel.setupPlugin(pluginUrl).then((plugin) => {
                     if (model.attributes._destroyed) {
                         return;
                     }
                     configurePlugin(plugin, pluginConfig, api);
                 }).catch(error => {
+                    pluginsModel.removePlugin(pluginUrl);
                     if (!(error instanceof Error)) {
                         return new Error(`Error in ${pluginUrl} "${error}"`);
                     }

--- a/src/js/plugins/model.js
+++ b/src/js/plugins/model.js
@@ -4,27 +4,46 @@ import { log } from 'utils/log';
 const pluginsRegistered = {};
 
 // Extract a plugin name from a string
-const getPluginName = function (url) {
+const getPluginName = function(url) {
     // Regex locates the characters after the last slash, until it encounters a dash.
     return url.replace(/^(.*\/)?([^-]*)-?.*\.(js)$/, '$2');
 };
 
-const PluginModel = function () {
-    this.addPlugin = function (url, fromLoader) {
-        const pluginName = getPluginName(url);
-        let plugin = pluginsRegistered[pluginName];
-        if (!plugin) {
-            plugin = new Plugin(url);
-            pluginsRegistered[pluginName] = plugin;
-        } else if (fromLoader && plugin.url !== url) {
-            log(`JW Plugin "${pluginName}" already loaded from "${plugin.url}". Ignoring "${url}."`);
-        }
-        return plugin;
-    };
+const PluginModel = function() {};
+const prototype = PluginModel.prototype;
 
-    this.getPlugins = function () {
-        return pluginsRegistered;
-    };
+prototype.setupPlugin = function(url) {
+    const registeredPlugin = this.getPlugin(url);
+    if (registeredPlugin) {
+        if (registeredPlugin.url !== url) {
+            log(`JW Plugin "${getPluginName(url)}" already loaded from "${registeredPlugin.url}". Ignoring "${url}."`);
+        }
+        return registeredPlugin.promise;
+    }
+    const plugin = this.addPlugin(url);
+    return plugin.load().then(() => plugin.promise);
+};
+
+prototype.addPlugin = function(url) {
+    const pluginName = getPluginName(url);
+    let plugin = pluginsRegistered[pluginName];
+    if (!plugin) {
+        plugin = new Plugin(url);
+        pluginsRegistered[pluginName] = plugin;
+    }
+    return plugin;
+};
+
+prototype.getPlugin = function(url) {
+    return pluginsRegistered[getPluginName(url)];
+};
+
+prototype.removePlugin = function(url) {
+    delete pluginsRegistered[getPluginName(url)];
+};
+
+prototype.getPlugins = function() {
+    return pluginsRegistered;
 };
 
 export default PluginModel;

--- a/src/js/plugins/plugin.js
+++ b/src/js/plugins/plugin.js
@@ -37,8 +37,9 @@ function getJSPath(url) {
 
 const Plugin = function(url) {
     this.url = url;
-    this.promise = new Promise((resolve) => {
+    this.promise = new Promise((resolve, reject) => {
         this.resolve = resolve;
+        this.reject = reject;
     });
 };
 
@@ -49,7 +50,10 @@ Object.assign(Plugin.prototype, {
         }
         const loader = new ScriptLoader(getJSPath(this.url));
         this.loader = loader;
-        return loader.load();
+        return loader.load().catch(error => {
+            this.reject(error);
+            throw error;
+        });
     },
 
     registerPlugin(name, minimumVersion, pluginClass) {

--- a/src/js/plugins/plugin.js
+++ b/src/js/plugins/plugin.js
@@ -1,4 +1,4 @@
-import { resolved } from 'polyfills/promise';
+import Promise, { resolved } from 'polyfills/promise';
 import ScriptLoader from 'utils/scriptloader';
 import { getAbsolutePath } from 'utils/parser';
 import { extension } from 'utils/strings';
@@ -37,6 +37,9 @@ function getJSPath(url) {
 
 const Plugin = function(url) {
     this.url = url;
+    this.promise = new Promise((resolve) => {
+        this.resolve = resolve;
+    });
 };
 
 Object.assign(Plugin.prototype, {
@@ -53,6 +56,7 @@ Object.assign(Plugin.prototype, {
         this.name = name;
         this.target = minimumVersion;
         this.js = pluginClass;
+        this.resolve(this);
     },
 
     getNewInstance(api, config, div) {

--- a/test/files/plugin1.js
+++ b/test/files/plugin1.js
@@ -1,0 +1,16 @@
+/* eslint no-var: 0 */
+(function(global) {
+    var registerPlugin = global.jwplayerPluginJsonp ||
+        (global.jwplayer && global.jwplayer().registerPlugin) ||
+        (function() {});
+
+    var PluginClass = function() {};
+    var noop = function() {};
+    PluginClass.prototype.on = noop;
+    PluginClass.prototype.once = noop;
+    PluginClass.prototype.off = noop;
+    PluginClass.prototype.trigger = noop;
+    PluginClass.prototype.resize = noop;
+
+    registerPlugin('plugin1', '8.0', PluginClass);
+}(window));

--- a/test/files/plugin2.js
+++ b/test/files/plugin2.js
@@ -1,0 +1,16 @@
+/* eslint no-var: 0 */
+(function(global) {
+    var registerPlugin = global.jwplayerPluginJsonp ||
+        (global.jwplayer && global.jwplayer().registerPlugin) ||
+        (function() {});
+
+    var PluginClass = function() {};
+    var noop = function() {};
+    PluginClass.prototype.on = noop;
+    PluginClass.prototype.once = noop;
+    PluginClass.prototype.off = noop;
+    PluginClass.prototype.trigger = noop;
+    PluginClass.prototype.resize = noop;
+
+    registerPlugin('plugin2', '8.0', PluginClass);
+}(window));

--- a/test/unit/plugins-test.js
+++ b/test/unit/plugins-test.js
@@ -1,0 +1,282 @@
+import loadPlugins, { registerPlugin } from 'plugins/plugins';
+import PluginsModel from 'plugins/model';
+import SimpleModel from 'model/simplemodel';
+import sinon from 'sinon';
+
+// Any instance of PluginsModel provides access to registered plugins
+const globalPluginsModel = new PluginsModel();
+
+const mockApi = () => ({
+    id: 'player',
+    addPlugin: sinon.spy()
+});
+
+function MockModel(attributes) {
+    Object.assign(this, SimpleModel);
+    this.attributes = attributes || {};
+}
+
+function getFullyQualifiedUrl(path) {
+    const a = document.createElement('a');
+    a.href = path;
+    return a.href;
+}
+
+function getDocumentHeadScripts() {
+    return Array.prototype.slice.call(document.head.querySelectorAll('script'));
+}
+function getScriptForPlugin(path) {
+    const url = getFullyQualifiedUrl(path);
+    return getDocumentHeadScripts().filter((tag) => (tag.src === url))[0];
+}
+
+function removeAllPlugins() {
+    const registeredPlugins = globalPluginsModel.getPlugins();
+    Object.keys(registeredPlugins).map(property => {
+        const plugin = registeredPlugins[property];
+        delete registeredPlugins[property];
+        return plugin;
+    }).filter(plugin => (plugin.url !== plugin.name)).forEach(plugin => {
+        const tag = getScriptForPlugin(plugin.url);
+        if (tag) {
+            document.head.removeChild(tag);
+        }
+    });
+    // remove tags that errored on load
+    getDocumentHeadScripts().forEach(tag => {
+        if (/\/plugin1.js$/.test(tag.src)) {
+            document.head.removeChild(tag);
+        }
+    });
+}
+
+describe('registerPlugin()', function() {
+    this.timeout(5000);
+
+    beforeEach(removeAllPlugins);
+
+    afterEach(removeAllPlugins);
+
+    it('adds plugin constructors to the registry', function () {
+        const PluginClass = function () {};
+        registerPlugin('plug', '8.0', PluginClass);
+
+        const registeredPlugins = globalPluginsModel.getPlugins();
+
+        expect(registeredPlugins).to.be.an('object');
+        expect(registeredPlugins).to.have.property('plug');
+
+        expect(registeredPlugins.plug).to.be.an('object');
+        expect(registeredPlugins.plug).to.have.property('js').which.equals(PluginClass);
+        expect(registeredPlugins.plug).to.have.property('name').which.equals('plug');
+        expect(registeredPlugins.plug).to.have.property('target').which.equals('8.0');
+        expect(registeredPlugins.plug).to.have.property('url').which.equals('plug');
+    });
+
+});
+
+describe('loadPlugins()', function() {
+    this.timeout(5000);
+
+    beforeEach(removeAllPlugins);
+
+    afterEach(removeAllPlugins);
+
+    it('retrieves all plugins in the model and instantiates them', function() {
+        const pluginList = [
+            '/base/test/files/plugin1.js',
+            '/base/test/files/plugin2.js'
+        ];
+        const api = mockApi();
+        const model = new MockModel({
+            plugins: pluginList.reduce((plugins, url) => (plugins[url] = {} && plugins), {})
+        });
+        const scripts = getDocumentHeadScripts();
+        return loadPlugins(model, api).then(() => {
+            const registeredPlugins = globalPluginsModel.getPlugins();
+
+            expect(Object.keys(registeredPlugins), 'registered plugins').to.have.lengthOf(2);
+            expect(registeredPlugins).to.have.property('plugin1')
+                .which.has.property('url').which.equals(pluginList[0]);
+            expect(registeredPlugins).to.have.property('plugin2')
+                .which.has.property('url').which.equals(pluginList[1]);
+
+            expect(getDocumentHeadScripts(), 'script tags').to.have.lengthOf(scripts.length + 2);
+
+            const tag1 = getScriptForPlugin(registeredPlugins.plugin1.url);
+            const tag2 = getScriptForPlugin(registeredPlugins.plugin2.url);
+            expect(tag1).to.exist;
+            expect(tag2).to.exist;
+
+            expect(api.addPlugin).to.have.callCount(2);
+
+            const calls = [ api.addPlugin.getCall(0), api.addPlugin.getCall(1) ]
+                .sort((a) => (a.args[0] === 'plugin1' ? -1 : 1));
+
+            expect(calls[0].args[0]).to.equal('plugin1');
+            expect(calls[1].args[0]).to.equal('plugin2');
+            expect(calls[0].args[1]).to.be.an.instanceOf(registeredPlugins.plugin1.js);
+            expect(calls[1].args[1]).to.be.an.instanceOf(registeredPlugins.plugin2.js);
+        });
+    });
+
+    it('only loads the same plugin once', function() {
+        const api = mockApi();
+        const model = new MockModel({
+            plugins: {
+                '/base/test/files/plugin1.js': {}
+            }
+        });
+        const scripts = getDocumentHeadScripts();
+        return loadPlugins(model, api).then(() => loadPlugins(model, api)).then(() => {
+            const registeredPlugins = globalPluginsModel.getPlugins();
+            expect(Object.keys(registeredPlugins), 'one plugin was registered').to.have.lengthOf(1);
+            expect(registeredPlugins).to.have.property('plugin1');
+
+            expect(getDocumentHeadScripts(), 'one script tag was appended').to.have.lengthOf(scripts.length + 1);
+
+            const tag1 = getScriptForPlugin(registeredPlugins.plugin1.url);
+            expect(tag1).to.exist;
+
+            expect(api.addPlugin, 'two instances were added').to.have.callCount(2);
+        });
+    });
+
+    it('only loads the same plugin once', function() {
+        const api = mockApi();
+        const model = new MockModel({
+            plugins: {
+                '/base/test/files/plugin1.js': {}
+            }
+        });
+        const scripts = getDocumentHeadScripts();
+        return loadPlugins(model, api).then(() => loadPlugins(model, api)).then(() => {
+            const registeredPlugins = globalPluginsModel.getPlugins();
+            expect(Object.keys(registeredPlugins), 'one plugin was registered').to.have.lengthOf(1);
+            expect(registeredPlugins).to.have.property('plugin1');
+
+            expect(getDocumentHeadScripts(), 'one script tag was appended').to.have.lengthOf(scripts.length + 1);
+
+            const tag1 = getScriptForPlugin(registeredPlugins.plugin1.url);
+            expect(tag1).to.exist;
+
+            expect(api.addPlugin, 'two instances were added').to.have.callCount(2);
+        });
+    });
+
+    it('does not load plugins already registered', function() {
+        const scripts = getDocumentHeadScripts();
+        const FirstPluginClass = function () {};
+        registerPlugin('plugin1', '8.0', FirstPluginClass);
+
+        const registeredPlugins = globalPluginsModel.getPlugins();
+        expect(Object.keys(registeredPlugins), 'one plugin was registered').to.have.lengthOf(1);
+        expect(registeredPlugins).to.have.property('plugin1');
+
+        const api = mockApi();
+        const model = new MockModel({
+            plugins: {
+                '/base/test/files/plugin1.js': {}
+            }
+        });
+        return loadPlugins(model, api).then(() => {
+            const secondRegisteredPlugins = globalPluginsModel.getPlugins();
+            expect(Object.keys(secondRegisteredPlugins), 'no addtional plugins were registered').to.have.lengthOf(1);
+            expect(secondRegisteredPlugins).to.have.property('plugin1');
+            expect(secondRegisteredPlugins.plugin1).to.have.property('js').which.equals(FirstPluginClass);
+
+            expect(getDocumentHeadScripts(), 'no scripts were appended').to.have.lengthOf(scripts.length);
+
+            expect(api.addPlugin, 'once instance was added').to.have.callCount(1);
+        });
+    });
+
+    it('loads one plugin with the same name, but instantiates both', function() {
+        const api = mockApi();
+        const model = new MockModel({
+            plugins: {
+                '/base/test/files/plugin1.js': {},
+                '/base/test/plugin1.js': {}
+            }
+        });
+        const scripts = getDocumentHeadScripts();
+        return loadPlugins(model, api).then(() => {
+            const registeredPlugins = globalPluginsModel.getPlugins();
+            expect(Object.keys(registeredPlugins), 'one plugin was registered').to.have.lengthOf(1);
+            expect(registeredPlugins).to.have.property('plugin1');
+
+            expect(getDocumentHeadScripts(), 'one script tag was appended').to.have.lengthOf(scripts.length + 1);
+            const tag1 = getScriptForPlugin(registeredPlugins.plugin1.url);
+            expect(tag1).to.exist;
+
+            expect(api.addPlugin,
+                'Since the config called for two plugin1 instances, two were be created').to.have.callCount(2);
+        });
+    });
+
+    it('will reload the same plugin if previous attempts were unsuccessful', function() {
+        const api = mockApi();
+        const firstModel = new MockModel({
+            plugins: {
+                '/base/test/plugin1.js': {}
+            }
+        });
+        const scripts = getDocumentHeadScripts();
+        return loadPlugins(firstModel, api).then(() => {
+            const registeredPlugins = globalPluginsModel.getPlugins();
+            expect(Object.keys(registeredPlugins), 'registeredPlugins').to.have.lengthOf(0);
+            expect(getDocumentHeadScripts(), 'script loader does not remove tags that failed to load').to.have.lengthOf(scripts.length + 1);
+            const secondModel = new MockModel({
+                plugins: {
+                    '/base/test/files/plugin1.js': {}
+                }
+            });
+            return loadPlugins(secondModel, api);
+        }).then(() => {
+            const registeredPlugins = globalPluginsModel.getPlugins();
+
+            expect(Object.keys(registeredPlugins), 'registered plugins').to.have.lengthOf(1);
+            expect(registeredPlugins).to.have.property('plugin1');
+
+            expect(getDocumentHeadScripts(), 'script tags').to.have.lengthOf(scripts.length + 2);
+
+            const tag1 = getScriptForPlugin(registeredPlugins.plugin1.url);
+            expect(tag1).to.exist;
+
+            expect(api.addPlugin).to.have.callCount(1);
+        });
+    });
+
+    it('registers loaded plugin, but does not instantiate them when player is destroyed', function() {
+        const pluginList = [
+            '/base/test/files/plugin1.js',
+            '/base/test/files/plugin2.js'
+        ];
+        const api = mockApi();
+        const model = new MockModel({
+            plugins: pluginList.reduce((plugins, url) => (plugins[url] = {} && plugins), {})
+        });
+        const scripts = getDocumentHeadScripts();
+        const promise = loadPlugins(model, api);
+        model.attributes._destroyed = true;
+        return promise.then(() => {
+            const registeredPlugins = globalPluginsModel.getPlugins();
+
+            expect(Object.keys(registeredPlugins), 'registered plugins').to.have.lengthOf(2);
+            expect(registeredPlugins).to.have.property('plugin1')
+                .which.has.property('url').which.equals(pluginList[0]);
+            expect(registeredPlugins).to.have.property('plugin2')
+                .which.has.property('url').which.equals(pluginList[1]);
+
+            expect(getDocumentHeadScripts(), 'script tags').to.have.lengthOf(scripts.length + 2);
+
+            const tag1 = getScriptForPlugin(registeredPlugins.plugin1.url);
+            const tag2 = getScriptForPlugin(registeredPlugins.plugin2.url);
+            expect(tag1).to.exist;
+            expect(tag2).to.exist;
+
+            expect(api.addPlugin).to.have.callCount(0);
+        });
+    });
+
+});

--- a/test/unit/plugins-test.js
+++ b/test/unit/plugins-test.js
@@ -247,6 +247,28 @@ describe('loadPlugins()', function() {
         });
     });
 
+    it('handles request failure across multiple instances', function() {
+        const api = mockApi();
+        const model = new MockModel({
+            plugins: {
+                '/base/test/plugin1.js': {}
+            }
+        });
+        const scripts = getDocumentHeadScripts();
+        return Promise.all([
+            loadPlugins(model, api),
+            loadPlugins(model, api),
+            loadPlugins(model, api),
+            loadPlugins(model, api),
+            loadPlugins(model, api)
+        ]).then(() => {
+            const registeredPlugins = globalPluginsModel.getPlugins();
+            expect(Object.keys(registeredPlugins), 'registeredPlugins').to.have.lengthOf(0);
+            expect(getDocumentHeadScripts(), 'script loader does not remove tags that failed to load').to.have.lengthOf(scripts.length + 1);
+            expect(api.addPlugin).to.have.callCount(0);
+        });
+    });
+
     it('registers loaded plugin, but does not instantiate them when player is destroyed', function() {
         const pluginList = [
             '/base/test/files/plugin1.js',

--- a/test/unit/setup-test.js
+++ b/test/unit/setup-test.js
@@ -8,7 +8,8 @@ describe('api.setup', function() {
      * It verifies "setupError" and "ready" events for config.playlist values.
     */
 
-    this.timeout(3000);
+    this.timeout(6000);
+
     const errorMessage = 'This video file cannot be played.';
 
     beforeEach(() => {


### PR DESCRIPTION
### This PR will...
Ensure that individual plugins are only loaded and registered once.
Remove registered plugins that fail to load or instantiate (allowing new player setups to retry).

### Why is this Pull Request needed?
If the player is setup multiple times it should not reload javascript for a plugin that is already been registered.

### How do jwplayer plugins work?

There are two ways plugins can be registered in the player.
1. inline by calling `jwplayer.api.registerPlugin(name, minimumVersion, pluginClass)`
2. async by through `jwplayer().setup({ plugins: { 'path/to/plugin.js': pluginInstanceOptions  }})`

The commercial player automatically converts specific configuration blocks like `advertising` to a `plugins` entry:
```js
advertising: { client: 'vast' }
// becomes
plugins: { 'path/to/vast.js': { /* advertising block */ } }
```
Plugins already in the registry can be addressed by name:
```js
jwplayer.api.registerPlugin('myPlugin', '8.0', function(playerApi, options, div) { /* plugin implementation*/ });
// in jwplayer.setup({})
plugins: { 'myPlugin': { /* options */ } }
```

During setup, the player looks at all entries in the `plugins` block, extracts the plugin name (path/**name**.js) from the url key and adds the plugin to the library's plugin registry.

All players on the page share this registry. **These changes ensure that we do not reload plugins already in the registry, and if loading or instantiation fails, remove the plugin from the registry.**

There can be multiple plugins in the registry, but only those found in the player setup options will be instantiated for the player being setup. Simply registering a plugin does not bind it to all subsequent player setups.

Each plugin that is not found in the registry is then loaded. It is expected that plugin.js files will execute `registerPlugin` once loaded, adding their class function `plugin.js` to the plugin object in the registry.

Finally each plugin class is instantiated for the new player being setup. The plugin class's constructor receives three arguments:
1. The player instance (`api`)
2. The plugin options (`config`)
3. The overlay container (`div`) which can be used to render DOM elements between the player's media and controls elements.

```js
    // plugins/plugin.js
    const PluginClass = this.js;
    const pluginInstance = new PluginClass(api, config, div);
```

#### Addresses Issue(s):
JW8-1721 #2981

