### PR TITLE
Resolve plugin promise when plugins config key is not a url

### DIFF
--- a/src/js/plugins/loader.js
+++ b/src/js/plugins/loader.js
@@ -11,6 +11,7 @@ function configurePlugin(pluginObj, pluginConfig, api) {
     const pluginInstance = pluginObj.getNewInstance(api, pluginOptions, div);
 
     api.addPlugin(pluginName, pluginInstance);
+    return pluginInstance;
 }
 
 const PluginLoader = function() {
@@ -27,7 +28,7 @@ const PluginLoader = function() {
                     if (model.attributes._destroyed) {
                         return;
                     }
-                    configurePlugin(plugin, pluginConfig, api);
+                    return configurePlugin(plugin, pluginConfig, api);
                 }).catch(error => {
                     pluginsModel.removePlugin(pluginUrl);
                     if (!(error instanceof Error)) {

--- a/src/js/plugins/plugin.js
+++ b/src/js/plugins/plugin.js
@@ -1,4 +1,4 @@
-import Promise, { resolved } from 'polyfills/promise';
+import Promise from 'polyfills/promise';
 import ScriptLoader from 'utils/scriptloader';
 import { getAbsolutePath } from 'utils/parser';
 import { extension } from 'utils/strings';
@@ -46,7 +46,8 @@ const Plugin = function(url) {
 Object.assign(Plugin.prototype, {
     load() {
         if (getPluginPathType(this.url) === PLUGIN_PATH_TYPE_CDN) {
-            return resolved;
+            this.resolve(this);
+            return this.promise;
         }
         const loader = new ScriptLoader(getJSPath(this.url));
         this.loader = loader;

--- a/src/js/plugins/plugins.js
+++ b/src/js/plugins/plugins.js
@@ -19,18 +19,19 @@ export default function loadPlugins(model, api) {
     const pluginLoader = model.pluginLoader =
         model.pluginLoader || new PluginsLoader();
 
-    return pluginLoader.load(api, pluginsModel, pluginsConfig, model).then(events => {
+    return pluginLoader.load(api, pluginsModel, pluginsConfig, model).then(results => {
         if (model.attributes._destroyed) {
             // Player and plugin loader was replaced
             return;
         }
-        if (events) {
-            events.forEach(object => {
+        if (results) {
+            results.forEach(object => {
                 if (object instanceof Error) {
                     log(object.message);
                 }
             });
         }
         delete window.jwplayerPluginJsonp;
+        return results;
     });
 }


### PR DESCRIPTION
### This PR will...
Handle `plugins` blocks in the config which configure plugins expected to be registered.

### Why is this Pull Request needed?

If a plugin is not loaded there is no timeout mechanism to reject it's loading/registration promise. These plugin's promises must be resolved immediately, to allow the setup process to attempt to instantiate the plugin; If it was not registered, fail with the exception "PluginClass is not a constructor" as we did before. 

The two tests that are added cover both cases where a config for a registered and unregistered plugin were added. The results of the plugins loader - an array of plugin or Error instances -  is now returned by `loadPlugins` to make the plugins tests more robust.

#### Addresses Issue(s):
JW8-1721

