### PR TITLE
Add jw-reset to Google Chromecast button

### DIFF
--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -59,7 +59,7 @@ function createCastButton(castToggle, localization) {
     const castButton = document.createElement('button', 'google-cast-button');
     setAttribute(castButton, 'type', 'button');
     setAttribute(castButton, 'tabindex', '-1');
-    castButton.className += " jw-reset";
+    castButton.className += ' jw-reset';
 
     const element = document.createElement('div');
     element.className = 'jw-reset jw-icon jw-icon-inline jw-icon-cast jw-button-color';

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -59,7 +59,7 @@ function createCastButton(castToggle, localization) {
     const castButton = document.createElement('button', 'google-cast-button');
     setAttribute(castButton, 'type', 'button');
     setAttribute(castButton, 'tabindex', '-1');
-    castButton.classList.add('jw-reset');
+    castButton.className += " jw-reset"
 
     const element = document.createElement('div');
     element.className = 'jw-reset jw-icon jw-icon-inline jw-icon-cast jw-button-color';

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -59,7 +59,7 @@ function createCastButton(castToggle, localization) {
     const castButton = document.createElement('button', 'google-cast-button');
     setAttribute(castButton, 'type', 'button');
     setAttribute(castButton, 'tabindex', '-1');
-    castButton.className += " jw-reset"
+    castButton.className += " jw-reset";
 
     const element = document.createElement('div');
     element.className = 'jw-reset jw-icon jw-icon-inline jw-icon-cast jw-button-color';

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -59,6 +59,7 @@ function createCastButton(castToggle, localization) {
     const castButton = document.createElement('button', 'google-cast-button');
     setAttribute(castButton, 'type', 'button');
     setAttribute(castButton, 'tabindex', '-1');
+    castButton.classList.add('jw-reset');
 
     const element = document.createElement('div');
     element.className = 'jw-reset jw-icon jw-icon-inline jw-icon-cast jw-button-color';


### PR DESCRIPTION
### This PR will...

Adds the ```jw-reset``` class to the Google Chromecast button.

This will prevent any external CSS styles from causing disparity between the Chromecast button and other controlbar buttons.

### Why is this Pull Request needed?

On certain production sites, Chromecast button was misaligned with other buttons.

### Are there any points in the code the reviewer needs to double check?

N/A

### Are there any Pull Requests open in other repos which need to be merged with this?

No

#### Addresses Issue(s):

JW8-1639

