### PR TITLE
UI.js refactor

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -149,7 +149,7 @@ module.exports = function(grunt) {
                 browsers: ['Safari']
             },
             browserstack: {
-                browsers: ['chrome', 'firefox', 'edge', 'ie11_windows']
+                browsers: ['chrome', 'firefox', 'edge', 'ie11']
             },
             browserstack_chrome: {
                 browsers: ['chrome']
@@ -161,7 +161,13 @@ module.exports = function(grunt) {
                 browsers: ['edge']
             },
             browserstack_ie11: {
-                browsers: ['ie11_windows']
+                browsers: ['ie11']
+            },
+            browserstack_iphone: {
+                browsers: ['iphone']
+            },
+            browserstack_android: {
+                browsers: ['android']
             }
         },
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -76,9 +76,28 @@ module.exports = function(config) {
         'mocha',
         'coverage-istanbul'
     ];
+    let browsers = [
+        'ChromeHeadless',
+        'Chrome',
+        'Safari',
+        'Firefox',
+        'edge',
+        'ie11',
+        'iphone',
+        'android'
+    ];
     if (isJenkins) {
         testReporters.push('junit');
         process.env.CHROME_BIN = puppeteer.executablePath();
+        browsers = [
+            'ChromeHeadless',
+            'chrome',
+            'firefox',
+            'edge',
+            'ie11',
+            'iphone',
+            'android'
+        ];
     }
     const packageInfo = JSON.parse(require('fs').readFileSync('package.json', 'utf8'));
 
@@ -98,23 +117,18 @@ module.exports = function(config) {
         // LOG_DEBUG (useful for writing karma server network status messages to stdio)
         logLevel: config.LOG_INFO,
 
-        browsers: [
-            'ChromeHeadless',
-            'Chrome',
-            // 'Safari', // experiencing issues with safari-launcher@1.0.0 and Safari 9.1.1
-            'Firefox'
-        ],
+        browsers,
 
         customLaunchers: require('./test/karma/browserstack-launchers'),
 
         browserStack: {
-            username: env.BS_USERNAME,
-            accessKey: env.BS_AUTHKEY,
+            username: env.BS_USERNAME || env.BROWSERSTACK_USERNAME,
+            accessKey: env.BS_AUTHKEY || env.BROWSERSTACK_ACCESS_KEY,
             name: 'Unit Tests',
             project: 'jwplayer',
-            build: '' + (env.JOB_NAME || 'local') + ' ' +
-            (env.BUILD_NUMBER || env.USER) + ' ' +
-            (env.GIT_BRANCH || '') + ' ' + packageInfo.version,
+            build: env.BROWSERSTACK_BUILD || ('' + (env.JOB_NAME || 'local') + ' ' +
+            (env.BUILD_NUMBER || env.USER || env.GITHUB_USER) + ' ' +
+            (env.GIT_BRANCH || 'jwplayer') + ' ' + packageInfo.version),
             timeout: 300 // 5 minutes
         },
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -128,7 +128,8 @@ module.exports = function(config) {
             project: 'jwplayer',
             build: env.BROWSERSTACK_BUILD || ('' + (env.JOB_NAME || 'local') + ' ' +
             (env.BUILD_NUMBER || env.USER || env.GITHUB_USER) + ' ' +
-            (env.GIT_BRANCH || 'jwplayer') + ' ' + packageInfo.version),
+            (env.GIT_BRANCH || 'jwplayer') + ' ' + packageInfo.version) + ' ' +
+            (new Date()).toISOString(),
             timeout: 300 // 5 minutes
         },
 

--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -71,11 +71,12 @@ const UI = function (elem, options) {
     }
 
     function interactStartHandler(evt) {
+        if (isRightClick(evt)) {
+            return;
+        }
         const target = evt.target;
         _startX = getCoord(evt, 'X');
         _startY = getCoord(evt, 'Y');
-
-        if (!isRightClick(evt)) {
 
             if (evt.type === 'pointerdown' && evt.isPrimary) {
                 if (options.preventScrolling) {
@@ -102,7 +103,6 @@ const UI = function (elem, options) {
                 setEventListener(_touchListenerTarget, 'touchmove', interactDragHandler, listenerOptions);
                 setEventListener(_touchListenerTarget, 'touchcancel', interactEndHandler);
                 setEventListener(_touchListenerTarget, 'touchend', interactEndHandler);
-            }
 
             // Prevent scrolling the screen while dragging on mobile.
             if (options.preventScrolling) {
@@ -152,7 +152,6 @@ const UI = function (elem, options) {
             _touchListenerTarget.removeEventListener('touchcancel', interactEndHandler);
             _touchListenerTarget.removeEventListener('touchend', interactEndHandler);
         }
-
         if (_hasMoved) {
             triggerEvent(_this, DRAG_END, evt);
         }
@@ -178,7 +177,6 @@ const UI = function (elem, options) {
                 }
             }
         }
-
         _touchListenerTarget = null;
         _hasMoved = false;
     }
@@ -404,13 +402,7 @@ function getCoord(e, c) {
     return /^touch/.test(e.type) ? (e.originalEvent || e).changedTouches[0]['page' + c] : e['page' + c];
 }
 
-function isRightClick(evt) {
-    const e = evt || window.event;
-
-    if (!(evt instanceof MouseEvent)) {
-        return false;
-    }
-
+function isRightClick(e) {
     if ('which' in e) {
         // Gecko (Firefox), WebKit (Safari/Chrome) & Opera
         return (e.which === 3);
@@ -418,7 +410,6 @@ function isRightClick(evt) {
         // IE and Opera
         return (e.button === 2);
     }
-
     return false;
 }
 

--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -312,7 +312,7 @@ function addEventListener(ui, triggerName, domEventName, handler, options) {
         listeners = ui.handlers[triggerName] = {};
     }
     if (listeners[domEventName]) {
-        throw new Error('Only one listener per event is allowed in ui.js');
+        throw new Error(`${triggerName} ${domEventName} already registered`);
     }
     listeners[domEventName] = handler;
 

--- a/src/js/view/controls/components/settings/content-item.js
+++ b/src/js/view/controls/components/settings/content-item.js
@@ -5,8 +5,7 @@ import UI from 'utils/ui';
 export default function SettingsContentItem(name, content, action) {
     let active;
     const contentItemElement = createElement(ContentItemTemplate(content));
-    const contentItemUI = new UI(contentItemElement);
-    contentItemUI.on('click tap enter', (evt) => {
+    const contentItemUI = new UI(contentItemElement).on('click tap enter', (evt) => {
         action(evt);
     });
 

--- a/src/js/view/controls/components/slider.js
+++ b/src/js/view/controls/components/slider.js
@@ -39,13 +39,11 @@ export default class Slider {
         this.elementProgress = this.el.getElementsByClassName('jw-progress')[0];
         this.elementThumb = this.el.getElementsByClassName('jw-knob')[0];
 
-        this.userInteract = new UI(this.element(), { preventScrolling: true });
-
-        this.userInteract.on('dragStart', this.dragStartListener);
-        this.userInteract.on('drag', this.dragMoveListener);
-        this.userInteract.on('dragEnd', this.dragEndListener);
-
-        this.userInteract.on('tap click', this.tapListener);
+        this.userInteract = new UI(this.element(), { preventScrolling: true })
+            .on('dragStart', this.dragStartListener)
+            .on('drag', this.dragMoveListener)
+            .on('dragEnd', this.dragEndListener)
+            .on('tap click', this.tapListener);
     }
 
     dragStart() {

--- a/src/js/view/controls/components/slider.js
+++ b/src/js/view/controls/components/slider.js
@@ -23,12 +23,6 @@ export default class Slider {
 
         this.className = className + ' jw-background-color jw-reset';
         this.orientation = orientation;
-
-        this.dragStartListener = this.dragStart.bind(this);
-        this.dragMoveListener = this.dragMove.bind(this);
-        this.dragEndListener = this.dragEnd.bind(this);
-
-        this.tapListener = this.tap.bind(this);
     }
 
     setup() {
@@ -39,11 +33,11 @@ export default class Slider {
         this.elementProgress = this.el.getElementsByClassName('jw-progress')[0];
         this.elementThumb = this.el.getElementsByClassName('jw-knob')[0];
 
-        this.userInteract = new UI(this.element(), { preventScrolling: true })
-            .on('dragStart', this.dragStartListener)
-            .on('drag', this.dragMoveListener)
-            .on('dragEnd', this.dragEndListener)
-            .on('tap click', this.tapListener);
+        this.ui = new UI(this.element(), { preventScrolling: true })
+            .on('dragStart', this.dragStart, this)
+            .on('drag', this.dragMove, this)
+            .on('dragEnd', this.dragEnd, this)
+            .on('click tap', this.tap, this);
     }
 
     dragStart() {

--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -112,7 +112,7 @@ class TimeSlider extends Slider {
         this.elementRail.appendChild(this.timeTip.element());
 
         // Show the tooltip on while dragging (touch) moving(mouse), or moving over(mouse)
-        this.elementUI = new UI(this.el, { useHover: true, useMove: true })
+        this.elementUI = new UI(this.el)
             .on('drag move over', this.showTimeTooltip, this)
             .on('dragEnd out', this.hideTimeTooltip, this)
             .on('click', () => this.el.focus());

--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -112,7 +112,7 @@ class TimeSlider extends Slider {
         this.elementRail.appendChild(this.timeTip.element());
 
         // Show the tooltip on while dragging (touch) moving(mouse), or moving over(mouse)
-        this.elementUI = new UI(this.el)
+        this.ui = (this.ui || new UI(this.el))
             .on('move', this.showTimeTooltip, this)
             .on('dragEnd out', this.hideTimeTooltip, this)
             .on('click', () => this.el.focus());

--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -113,7 +113,7 @@ class TimeSlider extends Slider {
 
         // Show the tooltip on while dragging (touch) moving(mouse), or moving over(mouse)
         this.elementUI = new UI(this.el)
-            .on('drag move over', this.showTimeTooltip, this)
+            .on('move', this.showTimeTooltip, this)
             .on('dragEnd out', this.hideTimeTooltip, this)
             .on('click', () => this.el.focus());
 

--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -3,7 +3,7 @@ import { between } from 'utils/math';
 import { style } from 'utils/css';
 import { timeFormat } from 'utils/parser';
 import { addClass, removeClass, setAttribute, bounds } from 'utils/dom';
-import UI, { getPointerType } from 'utils/ui';
+import UI from 'utils/ui';
 import Slider from 'view/controls/components/slider';
 import Tooltip from 'view/controls/components/tooltip';
 import ChaptersMixin from 'view/controls/components/chapters.mixin';
@@ -230,7 +230,7 @@ class TimeSlider extends Slider {
 
         // With touch events, we never will get the hover events on the cues that cause cues to be active.
         // Therefore use the info we about the scroll position to detect if there is a nearby cue to be active.
-        if (getPointerType(evt.sourceEvent) === 'touch') {
+        if (evt.pointerType === 'touch') {
             this.activeCue = this.cues.reduce((closeCue, cue) => {
                 if (Math.abs(position - (parseInt(cue.pct) / 100 * railBounds.width)) < this.mobileHoverDistance) {
                     return cue;

--- a/src/js/view/controls/components/volumetooltip.js
+++ b/src/js/view/controls/components/volumetooltip.js
@@ -18,7 +18,7 @@ export default class VolumeTooltip extends Tooltip {
             this.el.focus();
         }, this);
 
-        new UI(this.el, { directSelect: true })
+        this.ui = new UI(this.el, { directSelect: true })
             .on('click enter', this.toggleValue, this)
             .on('tap', this.toggleOpenState, this)
             .on('over focus', this.openTooltip, this)

--- a/src/js/view/controls/components/volumetooltip.js
+++ b/src/js/view/controls/components/volumetooltip.js
@@ -18,11 +18,11 @@ export default class VolumeTooltip extends Tooltip {
             this.el.focus();
         }, this);
 
-        new UI(this.el, { useHover: true, directSelect: true, useFocus: true })
+        new UI(this.el, { directSelect: true })
             .on('click enter', this.toggleValue, this)
             .on('tap', this.toggleOpenState, this)
-            .on('over', this.openTooltip, this)
-            .on('out', this.closeTooltip, this);
+            .on('over focus', this.openTooltip, this)
+            .on('out blur', this.closeTooltip, this);
 
         this._model.on('change:volume', this.onVolume, this);
     }

--- a/src/js/view/controls/next-display-icon.js
+++ b/src/js/view/controls/next-display-icon.js
@@ -3,7 +3,7 @@ import UI from 'utils/ui';
 export default class NextDisplayIcon {
     constructor(model, api, element) {
 
-        new UI(element).on('click tap enter', function() {
+        this.ui = new UI(element).on('click tap enter', function() {
             api.next();
         });
 

--- a/src/js/view/controls/nextuptooltip.js
+++ b/src/js/view/controls/nextuptooltip.js
@@ -53,14 +53,12 @@ export default class NextUpTooltip {
         }, this);
 
         // Close button
-        new UI(this.closeButton, { directSelect: true })
-            .on('click tap enter', function() {
-                this.nextUpSticky = false;
-                this.toggle(false);
-            }, this);
+        new UI(this.closeButton, { directSelect: true }).on('click tap enter', function() {
+            this.nextUpSticky = false;
+            this.toggle(false);
+        }, this);
         // Tooltip
-        new UI(this.tooltip)
-            .on('click tap', this.click, this);
+        new UI(this.tooltip).on('click tap', this.click, this);
     }
 
     loadThumbnail(url) {

--- a/src/js/view/logo.js
+++ b/src/js/view/logo.js
@@ -83,14 +83,12 @@ export default function Logo(_model) {
 
         _img.src = _settings.file;
 
-        const logoInteractHandler = new UI(_logo);
-
         if (_settings.link) {
             _logo.setAttribute('tabindex', '0');
             _logo.setAttribute('aria-label', 'Logo');
         }
 
-        logoInteractHandler.on('click tap enter', function (evt) {
+        this.ui = new UI(_logo).on('click tap enter', function (evt) {
             if (evt && evt.stopPropagation) {
                 evt.stopPropagation();
             }

--- a/src/js/view/utils/clickhandler.js
+++ b/src/js/view/utils/clickhandler.js
@@ -10,16 +10,14 @@ export default class ClickHandler {
         this.domElement = element;
         this.model = model;
 
-        this.ui = new UI(element, { enableDoubleTap: true, useMove: true }).on({
-            'click tap': this.clickHandler,
-            'doubleClick doubleTap': function() {
+        this.ui = new UI(element, { enableDoubleTap: true }).on('click tap', this.clickHandler, this)
+            .on('doubleClick doubleTap', function() {
                 if (this.alternateDoubleClickHandler) {
                     this.alternateDoubleClickHandler();
                     return;
                 }
                 this.trigger('doubleClick');
-            }
-        }, this);
+            }, this);
     }
 
     destroy() {

--- a/src/js/view/utils/clickhandler.js
+++ b/src/js/view/utils/clickhandler.js
@@ -10,7 +10,7 @@ export default class ClickHandler {
         this.domElement = element;
         this.model = model;
 
-        this.ui = new UI(element, { enableDoubleTap: true }).on('click tap', this.clickHandler, this)
+        this.ui = new UI(element).on('click tap', this.clickHandler, this)
             .on('doubleClick doubleTap', function() {
                 if (this.alternateDoubleClickHandler) {
                     this.alternateDoubleClickHandler();

--- a/test/karma/browserstack-launchers.js
+++ b/test/karma/browserstack-launchers.js
@@ -2,18 +2,18 @@ module.exports = {
     firefox: {
         base: 'BrowserStack',
         browser: 'firefox',
-        os: 'OS X',
-        os_version: 'Yosemite'
+        os: 'Windows',
+        os_version: '10'
     },
 
     chrome: {
         base: 'BrowserStack',
         browser: 'chrome',
-        os: 'OS X',
-        os_version: 'Yosemite'
+        os: 'Windows',
+        os_version: '10'
     },
 
-    ie11_windows: {
+    ie11: {
         base: 'BrowserStack',
         browser: 'ie',
         browser_version: '11.0',
@@ -26,5 +26,23 @@ module.exports = {
         browser: 'edge',
         os: 'Windows',
         os_version: '10'
+    },
+
+    iphone: {
+        base: 'BrowserStack',
+        device: 'iPhone 7',
+        device_browser: 'safari',
+        os: 'iOS',
+        os_version: '10.0',
+        real_mobile: true
+    },
+
+    android: {
+        base: 'BrowserStack',
+        device: 'Samsung Galaxy S8',
+        device_browser: 'chrome',
+        os: 'android',
+        os_version: '7.0',
+        real_mobile: true
     }
 };

--- a/test/unit/ajax-test.js
+++ b/test/unit/ajax-test.js
@@ -2,7 +2,7 @@ import { ajax } from 'utils/ajax';
 import * as errors from 'api/errors';
 
 describe('utils.ajax', function() {
-    this.timeout(5000);
+    this.timeout(8000);
 
     function validateXHR(xhr) {
         expect(xhr).to.be.instanceOf(window.XMLHttpRequest);

--- a/test/unit/jwplayer-selectplayer-test.js
+++ b/test/unit/jwplayer-selectplayer-test.js
@@ -1,5 +1,4 @@
 import _ from 'test/underscore';
-import $ from 'jquery';
 import jwplayer from 'jwplayer';
 
 function testInstanceOfApi(api) {
@@ -11,8 +10,13 @@ function testInstanceOfApi(api) {
 describe('jwplayer function', function() {
 
     beforeEach(function() {
-        // remove fixture
-        $('body').append('<div id="test-container"><div id="player"></div></div>');
+        // add fixture
+        const fixture = document.createElement('div');
+        fixture.id = 'test-container';
+        const playerContainer = document.createElement('div');
+        playerContainer.id = 'player';
+        fixture.appendChild(playerContainer);
+        document.body.appendChild(fixture);
     });
 
     afterEach(function() {
@@ -24,7 +28,8 @@ describe('jwplayer function', function() {
             }
         }
         // remove fixture
-        $('#test-container').remove();
+        const fixture = document.querySelector('#test-container');
+        document.body.removeChild(fixture);
     });
 
     it('is defined', function() {
@@ -60,12 +65,12 @@ describe('jwplayer function', function() {
     });
 
     it('returns a new api instance when given an element with an id', function() {
-        const element = $('#player')[0];
+        const element = document.querySelector('#player');
         testInstanceOfApi(jwplayer(element));
     });
 
     it('returns a new api instance when given an element with no id not in the DOM', function() {
-        const element = $('<div></div>')[0];
+        const element = document.createElement('div');
         const x = testInstanceOfApi(jwplayer(element));
 
         // FIXME: this only works with one player whose id is empty ""
@@ -74,10 +79,10 @@ describe('jwplayer function', function() {
     });
 
     it('returns the same api instance for matching queries', function() {
-        const element = $('#player')[0];
+        const element = document.querySelector('#player');
 
         const x = jwplayer('player');
-        const y = jwplayer($('<div></div>')[0]);
+        const y = jwplayer(document.createElement('div'));
 
         const uniquePlayers = _.uniq([
             x,

--- a/test/unit/program-controller-test.js
+++ b/test/unit/program-controller-test.js
@@ -418,15 +418,16 @@ describe('ProgramController', function () {
 
     it('fires itemReady for background loaded items', function() {
         sandbox.spy(model, 'trigger');
+        const changeMediaElement = model.get('backgroundLoading') ? 1 : 0;
         return programController.setActiveItem(0)
             .then(function () {
-                expect(model.trigger).to.have.callCount(6);
+                expect(model.trigger).to.have.callCount(5 + changeMediaElement);
                 expect(model.trigger.lastCall).to.have.been.calledWith('change:itemReady', model, true);
                 programController.backgroundLoad(mp4Item);
             })
             .then(() => programController.setActiveItem(1))
             .then(function () {
-                expect(model.trigger).to.have.callCount(13);
+                expect(model.trigger).to.have.callCount(11 + changeMediaElement * 2);
                 expect(model.trigger.lastCall).to.have.been.calledWith('change:itemReady', model, true);
             });
     });

--- a/test/unit/ui-test.js
+++ b/test/unit/ui-test.js
@@ -575,7 +575,7 @@ describe('UI', function() {
     it('preventScrolling uses setPointerCapture and preventDefault', function() {
         const ui = new UI(button, {
             preventScrolling: true
-        });
+        }).on('drag');
         let result;
         let event;
         if (USE_POINTER_EVENTS) {
@@ -651,21 +651,18 @@ describe('UI', function() {
 
         spyOnDomEventListenerMethods([ button ]);
         ui = new UI(button);
-        if (USE_POINTER_EVENTS || !USE_MOUSE_EVENTS) {
-            expect(button.addEventListener, 'button without options').to.have.callCount(1);
-        } else {
-            expect(button.addEventListener, 'button without options').to.have.callCount(2);
-        }
+        expect(button.addEventListener, 'button without options').to.have.callCount(0);
         ui.destroy();
 
         spyOnDomEventListenerMethods([ button ]);
-        ui = new UI(button).on('enter over out focus blur move', () => {});
+        ui = new UI(button)
+            .on('click tap doubleClick doubleTap dragStart drag dragEnd enter over out focus blur move', () => {});
         if (USE_POINTER_EVENTS) {
-            expect(button.addEventListener, 'button with useFocus, useHover, useMove').to.have.callCount(7);
+            expect(button.addEventListener, 'button with all listeners').to.have.callCount(7);
         } else if (!USE_MOUSE_EVENTS) {
-            expect(button.addEventListener, 'button with useFocus, useHover, useMove').to.have.callCount(4);
+            expect(button.addEventListener, 'button with all listeners').to.have.callCount(4);
         } else {
-            expect(button.addEventListener, 'button with useFocus, useHover, useMove').to.have.callCount(8);
+            expect(button.addEventListener, 'button with all listeners').to.have.callCount(8);
         }
         ui.destroy();
     });
@@ -673,14 +670,17 @@ describe('UI', function() {
     it('remove event listeners with off()', function() {
         spyOnDomEventListenerMethods([ button ]);
         const ui = new UI(button)
-            .on('enter over out focus blur move', () => {})
+            .on('click tap doubleClick doubleTap dragStart drag dragEnd enter over out focus blur move', () => {})
             .off();
         if (USE_POINTER_EVENTS) {
-            expect(button.removeEventListener, 'button with useFocus, useHover, useMove').to.have.callCount(6);
+            expect(button.addEventListener, 'button with all listeners').to.have.callCount(7);
+            expect(button.removeEventListener, 'button with all listeners').to.have.callCount(7);
         } else if (!USE_MOUSE_EVENTS) {
-            expect(button.removeEventListener, 'button with useFocus, useHover, useMove').to.have.callCount(3);
+            expect(button.addEventListener, 'button with all listeners').to.have.callCount(4);
+            expect(button.removeEventListener, 'button with all listeners').to.have.callCount(4);
         } else {
-            expect(button.removeEventListener, 'button with useFocus, useHover, useMove').to.have.callCount(6);
+            expect(button.addEventListener, 'button with all listeners').to.have.callCount(8);
+            expect(button.removeEventListener, 'button with all listeners').to.have.callCount(8);
         }
         ui.destroy();
     });
@@ -688,14 +688,17 @@ describe('UI', function() {
     it('removes all event listeners on destroy', function() {
         spyOnDomEventListenerMethods([ button ]);
 
-        const ui = new UI(button).on('enter over out focus blur move', () => {});
+        const ui = new UI(button).on('click tap doubleClick doubleTap dragStart drag dragEnd enter over out focus blur move', () => {});
         ui.destroy();
         if (USE_POINTER_EVENTS) {
-            expect(button.removeEventListener, 'button').to.have.callCount(12);
+            expect(button.addEventListener, 'button with all listeners').to.have.callCount(7);
+            expect(button.removeEventListener, 'button with all listeners').to.have.callCount(7);
         } else if (!USE_MOUSE_EVENTS) {
-            expect(button.removeEventListener, 'button').to.have.callCount(5);
+            expect(button.addEventListener, 'button with all listeners').to.have.callCount(4);
+            expect(button.removeEventListener, 'button with all listeners').to.have.callCount(4);
         } else {
-            expect(button.removeEventListener, 'button').to.have.callCount(8);
+            expect(button.addEventListener, 'button with all listeners').to.have.callCount(8);
+            expect(button.removeEventListener, 'button with all listeners').to.have.callCount(8);
         }
     });
 

--- a/test/unit/ui-test.js
+++ b/test/unit/ui-test.js
@@ -127,6 +127,7 @@ describe('UI', function() {
         expect(clickSpy).to.have.callCount(1);
         expect(clickSpy).calledWith({
             type: 'click',
+            pointerType: 'mouse',
             pageX: 0,
             pageY: 0,
             sourceEvent,
@@ -152,7 +153,7 @@ describe('UI', function() {
             });
             startResult = button.dispatchEvent(new PointerEvent('pointerdown', pointerTouchOptions));
             sourceEvent = new PointerEvent('pointerup', pointerTouchOptions);
-        } else if (TouchEvent) {
+        } else if (TOUCH_SUPPORT) {
             const touch = new Touch({
                 identifier: 1,
                 target: button
@@ -176,6 +177,7 @@ describe('UI', function() {
         expect(tapSpy).to.have.callCount(1);
         expect(tapSpy).calledWith({
             type: 'tap',
+            pointerType: 'touch',
             pageX: 0,
             pageY: 0,
             sourceEvent,
@@ -225,6 +227,7 @@ describe('UI', function() {
         expect(doubleClickSpy).to.have.callCount(1);
         expect(doubleClickSpy).calledWith({
             type: 'doubleClick',
+            pointerType: 'mouse',
             pageX: 0,
             pageY: 0,
             sourceEvent,
@@ -255,7 +258,7 @@ describe('UI', function() {
             button.dispatchEvent(new PointerEvent('pointerdown', pointerTouchOptions));
             sourceEvent = new PointerEvent('pointerup', pointerTouchOptions);
             button.dispatchEvent(sourceEvent);
-        } else if (TouchEvent) {
+        } else if (TOUCH_SUPPORT) {
             const touch = new Touch({
                 identifier: 1,
                 target: button
@@ -280,6 +283,7 @@ describe('UI', function() {
         expect(doubleTapSpy).to.have.callCount(1);
         expect(doubleTapSpy).calledWith({
             type: 'doubleTap',
+            pointerType: 'touch',
             pageX: 0,
             pageY: 0,
             sourceEvent,
@@ -310,7 +314,7 @@ describe('UI', function() {
             moveSourceEvent = new PointerEvent('pointermove', xyCoords(5, 5, pointerOptions));
             upSourceEvent = new PointerEvent('pointerup', pointerOptions);
             // TODO: cover 'pointercancel'
-        } else if (TouchEvent) {
+        } else if (TOUCH_SUPPORT) {
             const touch = new Touch(xyCoords(0, 0, {
                 identifier: 1,
                 target: button
@@ -347,8 +351,10 @@ describe('UI', function() {
 
         expect(startResult, 'preventDefault not called').to.equal(true);
         expect(dragStartSpy, 'dragStart listener').to.have.callCount(1);
+        const pointerType = (USE_POINTER_EVENTS || !TOUCH_SUPPORT) ? 'mouse': 'touch';
         expect(dragStartSpy).calledWith({
             type: 'dragStart',
+            pointerType,
             pageX: 5,
             pageY: 5,
             sourceEvent: moveSourceEvent,
@@ -358,6 +364,7 @@ describe('UI', function() {
         expect(dragSpy, 'drag listener').to.have.callCount(1);
         expect(dragSpy).calledWith({
             type: 'drag',
+            pointerType,
             pageX: 5,
             pageY: 5,
             sourceEvent: moveSourceEvent,
@@ -367,6 +374,7 @@ describe('UI', function() {
         expect(dragEndSpy, 'dragEnd listener').to.have.callCount(1);
         expect(dragEndSpy).calledWith({
             type: 'dragEnd',
+            pointerType,
             pageX: 5,
             pageY: 5,
             sourceEvent: upSourceEvent,
@@ -417,6 +425,7 @@ describe('UI', function() {
         expect(overSpy, 'over listener').to.have.callCount(1);
         expect(overSpy).calledWith({
             type: 'over',
+            pointerType: 'mouse',
             pageX: 0,
             pageY: 0,
             sourceEvent: overSourceEvent,
@@ -426,6 +435,7 @@ describe('UI', function() {
         expect(outSpy, 'out listener').to.have.callCount(1);
         expect(outSpy).calledWith({
             type: 'out',
+            pointerType: 'mouse',
             pageX: 0,
             pageY: 0,
             sourceEvent: outSourceEvent,
@@ -435,6 +445,7 @@ describe('UI', function() {
         expect(moveSpy, 'move listener').to.have.callCount(1);
         expect(moveSpy).calledWith({
             type: 'move',
+            pointerType: 'mouse',
             pageX: 0,
             pageY: 0,
             sourceEvent: moveSourceEvent,

--- a/test/unit/ui-test.js
+++ b/test/unit/ui-test.js
@@ -1,0 +1,657 @@
+import UI from 'utils/ui';
+import { Browser, OS } from 'environment/environment';
+import sinon from 'sinon';
+
+const TouchEvent = window.TouchEvent;
+const Touch = window.Touch;
+
+describe('UI', function() {
+
+    const TOUCH_SUPPORT = ('ontouchstart' in window);
+    const USE_POINTER_EVENTS = ('PointerEvent' in window) && !OS.android;
+    const USE_MOUSE_EVENTS = !USE_POINTER_EVENTS && !(TOUCH_SUPPORT && OS.mobile);
+
+    let sandbox;
+    let button;
+
+    // Polyfill Event constructors in IE to avoid TypeError "Object doesn't support this action".
+    let FocusEvent = window.FocusEvent;
+    let KeyboardEvent = window.KeyboardEvent;
+    let PointerEvent = window.PointerEvent;
+    if (Browser.ie && typeof window.CustomEvent !== 'function') {
+        FocusEvent = KeyboardEvent = PointerEvent = function(inType, params) {
+            params = params || {};
+            const e = document.createEvent('CustomEvent');
+            e.initCustomEvent(inType, Boolean(params.bubbles), Boolean(params.cancelable), params.detail);
+            Object.assign(e, params);
+            return e;
+        };
+        FocusEvent.prototype = window.UIEvent.prototype;
+        KeyboardEvent.prototype = window.UIEvent.prototype;
+        PointerEvent.prototype = window.MouseEvent.prototype;
+    }
+
+    beforeEach(function() {
+        sandbox = sinon.sandbox.create();
+
+        // add fixture
+        const fixture = document.createElement('div');
+        fixture.id = 'test-container';
+        button = document.createElement('div');
+        button.id = 'button';
+        fixture.appendChild(button);
+        document.body.appendChild(fixture);
+    });
+
+    afterEach(function() {
+        sandbox.restore();
+
+        // remove fixture
+        const fixture = document.querySelector('#test-container');
+        document.body.removeChild(fixture);
+    });
+
+    function spyOnDomEventListenerMethods(elements) {
+        elements.forEach(element => {
+            element.addEventListener.restore && element.addEventListener.restore();
+            element.removeEventListener.restore && element.removeEventListener.restore();
+            sandbox.spy(element, 'addEventListener');
+            sandbox.spy(element, 'removeEventListener');
+        });
+    }
+
+    function xyCoords(x, y, obj) {
+        return Object.assign(obj || {}, {
+            clientX: x,
+            clientY: y,
+            pageX: x,
+            pageY: y,
+            screenX: x,
+            screenY: y,
+            x,
+            y
+        });
+    }
+
+    it('is a class', function() {
+        expect(UI).to.be.a('function');
+        expect(UI.constructor).to.be.a('function');
+    });
+
+    it('extends events', function() {
+        const ui = new UI(button);
+        expect(ui).to.have.property('on').which.is.a('function');
+        expect(ui).to.have.property('once').which.is.a('function');
+        expect(ui).to.have.property('off').which.is.a('function');
+        // Why do we expose trigger?
+        expect(ui).to.have.property('trigger').which.is.a('function');
+        ui.destroy();
+    });
+
+    it('implements a destroy method', function() {
+        const ui = new UI(button);
+        expect(ui).to.have.property('destroy').which.is.a('function');
+        ui.destroy();
+    });
+
+    it('triggers click events with pointer and mouse input', function() {
+        if (!USE_POINTER_EVENTS && !USE_MOUSE_EVENTS) {
+            return;
+        }
+        const clickSpy = sandbox.spy();
+        const ui = new UI(button).on('click tap', clickSpy);
+        let startResult;
+        let sourceEvent;
+        if (USE_POINTER_EVENTS) {
+            const pointerMouseOptions = xyCoords(0, 0, {
+                isPrimary: true,
+                pointerType: 'mouse',
+                view: window,
+                bubbles: true,
+                cancelable: true
+            });
+            startResult = button.dispatchEvent(new PointerEvent('pointerdown', pointerMouseOptions));
+            sourceEvent = new PointerEvent('pointerup', pointerMouseOptions);
+        } else {
+            const mouseOptions = xyCoords(0, 0, {
+                view: window,
+                bubbles: true,
+                cancelable: true
+            });
+            startResult = button.dispatchEvent(new MouseEvent('mousedown', mouseOptions));
+            sourceEvent = new MouseEvent('mouseup', mouseOptions);
+        }
+        button.dispatchEvent(sourceEvent);
+
+        expect(startResult, 'preventDefault not called').to.equal(true);
+        expect(clickSpy).to.have.callCount(1);
+        expect(clickSpy).calledWith({
+            type: 'click',
+            pageX: 0,
+            pageY: 0,
+            sourceEvent,
+            target: button,
+            currentTarget: button
+        });
+
+        ui.destroy();
+    });
+
+    it('triggers tap events with pointer and touch input', function() {
+        const tapSpy = sandbox.spy();
+        const ui = new UI(button).on('click tap', tapSpy);
+        let startResult;
+        let sourceEvent;
+        if (USE_POINTER_EVENTS) {
+            const pointerTouchOptions = xyCoords(0, 0, {
+                isPrimary: true,
+                pointerType: 'touch',
+                view: window,
+                bubbles: true,
+                cancelable: true
+            });
+            startResult = button.dispatchEvent(new PointerEvent('pointerdown', pointerTouchOptions));
+            sourceEvent = new PointerEvent('pointerup', pointerTouchOptions);
+        } else if (TouchEvent) {
+            const touch = new Touch({
+                identifier: 1,
+                target: button
+            });
+            const touchOptions = {
+                changedTouches: [ touch ],
+                view: window,
+                bubbles: true,
+                cancelable: true
+            };
+            startResult = button.dispatchEvent(new TouchEvent('touchstart', touchOptions));
+            sourceEvent = new TouchEvent('touchend', touchOptions);
+        } else {
+            // Touch not supported in this browser
+            ui.destroy();
+            return;
+        }
+        button.dispatchEvent(sourceEvent);
+
+        expect(startResult, 'preventDefault not called').to.equal(true);
+        expect(tapSpy).to.have.callCount(1);
+        expect(tapSpy).calledWith({
+            type: 'tap',
+            pageX: 0,
+            pageY: 0,
+            sourceEvent,
+            target: button,
+            currentTarget: button
+        });
+        ui.destroy();
+    });
+
+    it('triggers doubleClick events with pointer and mouse input', function() {
+        if (!USE_POINTER_EVENTS && !USE_MOUSE_EVENTS) {
+            return;
+        }
+        const doubleClickSpy = sandbox.spy();
+        const ui = new UI(button, {
+            enableDoubleTap: true
+        }).on('doubleClick doubleTap', doubleClickSpy);
+        let startResult;
+        let sourceEvent;
+        if (USE_POINTER_EVENTS) {
+            const pointerMouseOptions = xyCoords(0, 0, {
+                isPrimary: true,
+                pointerType: 'mouse',
+                view: window,
+                bubbles: true,
+                cancelable: true
+            });
+            startResult = button.dispatchEvent(new PointerEvent('pointerdown', pointerMouseOptions));
+            button.dispatchEvent(new PointerEvent('pointerup', pointerMouseOptions));
+            button.dispatchEvent(new PointerEvent('pointerdown', pointerMouseOptions));
+            sourceEvent = new PointerEvent('pointerup', pointerMouseOptions);
+            button.dispatchEvent(sourceEvent);
+        } else {
+            const mouseOptions = xyCoords(0, 0, {
+                view: window,
+                bubbles: true,
+                cancelable: true
+            });
+            startResult = button.dispatchEvent(new MouseEvent('mousedown', mouseOptions));
+            button.dispatchEvent(new MouseEvent('mouseup', mouseOptions));
+            button.dispatchEvent(new MouseEvent('mousedown', mouseOptions));
+            sourceEvent = new MouseEvent('mouseup', mouseOptions);
+            button.dispatchEvent(sourceEvent);
+        }
+
+        expect(startResult, 'preventDefault not called').to.equal(true);
+        expect(doubleClickSpy).to.have.callCount(1);
+        expect(doubleClickSpy).calledWith({
+            type: 'doubleClick',
+            pageX: 0,
+            pageY: 0,
+            sourceEvent,
+            target: button,
+            currentTarget: button
+        });
+
+        ui.destroy();
+    });
+
+    it('triggers doubleTap events with pointer and touch input', function() {
+        const doubleTapSpy = sandbox.spy();
+        const ui = new UI(button, {
+            enableDoubleTap: true
+        }).on('doubleClick doubleTap', doubleTapSpy);
+        let startResult;
+        let sourceEvent;
+        if (USE_POINTER_EVENTS) {
+            const pointerTouchOptions = xyCoords(0, 0, {
+                isPrimary: true,
+                pointerType: 'touch',
+                view: window,
+                bubbles: true,
+                cancelable: true
+            });
+            startResult = button.dispatchEvent(new PointerEvent('pointerdown', pointerTouchOptions));
+            button.dispatchEvent(new PointerEvent('pointerup', pointerTouchOptions));
+            button.dispatchEvent(new PointerEvent('pointerdown', pointerTouchOptions));
+            sourceEvent = new PointerEvent('pointerup', pointerTouchOptions);
+            button.dispatchEvent(sourceEvent);
+        } else if (TouchEvent) {
+            const touch = new Touch({
+                identifier: 1,
+                target: button
+            });
+            const touchOptions = {
+                changedTouches: [ touch ],
+                view: window,
+                bubbles: true,
+                cancelable: true
+            };
+            startResult = button.dispatchEvent(new TouchEvent('touchstart', touchOptions));
+            button.dispatchEvent(new TouchEvent('touchend', touchOptions));
+            button.dispatchEvent(new TouchEvent('touchstart', touchOptions));
+            sourceEvent = new TouchEvent('touchend', touchOptions);
+            button.dispatchEvent(sourceEvent);
+        } else {
+            // Touch not supported in this browser
+            ui.destroy();
+            return;
+        }
+        expect(startResult, 'preventDefault not called').to.equal(true);
+        expect(doubleTapSpy).to.have.callCount(1);
+        expect(doubleTapSpy).calledWith({
+            type: 'doubleTap',
+            pageX: 0,
+            pageY: 0,
+            sourceEvent,
+            target: button,
+            currentTarget: button
+        });
+        ui.destroy();
+    });
+
+    it('triggers dragStart, drag and dragEnd events with pointer, mouse and touch input', function() {
+        const dragStartSpy = sandbox.spy();
+        const dragSpy = sandbox.spy();
+        const dragEndSpy = sandbox.spy();
+        const ui = new UI(button).on('dragStart', dragStartSpy).on('drag', dragSpy).on('dragEnd', dragEndSpy);
+        let startResult;
+        let downSourceEvent;
+        let moveSourceEvent;
+        let upSourceEvent;
+        if (USE_POINTER_EVENTS) {
+            const pointerOptions = xyCoords(0, 0, {
+                isPrimary: true,
+                pointerType: 'mouse',
+                view: window,
+                bubbles: true,
+                cancelable: true
+            });
+            downSourceEvent = new PointerEvent('pointerdown', pointerOptions);
+            moveSourceEvent = new PointerEvent('pointermove', xyCoords(5, 5, pointerOptions));
+            upSourceEvent = new PointerEvent('pointerup', pointerOptions);
+        } else if (TouchEvent) {
+            const touch = new Touch(xyCoords(0, 0, {
+                identifier: 1,
+                target: button
+            }));
+            const touchMoved = new Touch(xyCoords(5, 5, {
+                identifier: 1,
+                target: button
+            }));
+            const touchOptions = {
+                changedTouches: [ touch ],
+                view: window,
+                bubbles: true,
+                cancelable: true
+            };
+            const touchMovedOptions = Object.assign({}, touchOptions, {
+                changedTouches: [ touchMoved ]
+            });
+            downSourceEvent = new TouchEvent('touchstart', touchOptions);
+            moveSourceEvent = new TouchEvent('touchmove', touchMovedOptions);
+            upSourceEvent = new TouchEvent('touchend', touchMovedOptions);
+        } else {
+            const mouseOptions = xyCoords(0, 0, {
+                view: window,
+                bubbles: true,
+                cancelable: true
+            });
+            downSourceEvent = new MouseEvent('mousedown', mouseOptions);
+            moveSourceEvent = new MouseEvent('mousemove', xyCoords(5, 5, mouseOptions));
+            upSourceEvent = new MouseEvent('mouseup', mouseOptions);
+        }
+        startResult = button.dispatchEvent(downSourceEvent);
+        button.dispatchEvent(moveSourceEvent);
+        button.dispatchEvent(upSourceEvent);
+
+        expect(startResult, 'preventDefault not called').to.equal(true);
+        expect(dragStartSpy, 'dragStart listener').to.have.callCount(1);
+        expect(dragStartSpy).calledWith({
+            type: 'dragStart',
+            pageX: 5,
+            pageY: 5,
+            sourceEvent: moveSourceEvent,
+            target: button,
+            currentTarget: button
+        });
+        expect(dragSpy, 'drag listener').to.have.callCount(1);
+        expect(dragSpy).calledWith({
+            type: 'drag',
+            pageX: 5,
+            pageY: 5,
+            sourceEvent: moveSourceEvent,
+            target: button,
+            currentTarget: button
+        });
+        expect(dragEndSpy, 'dragEnd listener').to.have.callCount(1);
+        expect(dragEndSpy).calledWith({
+            type: 'dragEnd',
+            pageX: 5,
+            pageY: 5,
+            sourceEvent: upSourceEvent,
+            target: button,
+            currentTarget: button
+        });
+
+        ui.destroy();
+    });
+
+    it('triggers over, out and move events with pointer and mouse input', function() {
+        if (!USE_POINTER_EVENTS && !USE_MOUSE_EVENTS) {
+            return;
+        }
+        const overSpy = sandbox.spy();
+        const outSpy = sandbox.spy();
+        const moveSpy = sandbox.spy();
+        const ui = new UI(button, {
+            useHover: true,
+            useMove: true
+        }).on('over', overSpy).on('out', outSpy).on('move', moveSpy);
+        let overSourceEvent;
+        let outSourceEvent;
+        let moveSourceEvent;
+        if (USE_POINTER_EVENTS) {
+            const pointerOptions = xyCoords(0, 0, {
+                isPrimary: true,
+                pointerType: 'mouse',
+                view: window,
+                bubbles: true,
+                cancelable: true
+            });
+            overSourceEvent = new PointerEvent('pointerover', pointerOptions);
+            outSourceEvent = new PointerEvent('pointerout', pointerOptions);
+            moveSourceEvent = new PointerEvent('pointermove', pointerOptions);
+        } else {
+            const mouseOptions = xyCoords(0, 0, {
+                view: window,
+                bubbles: true,
+                cancelable: true
+            });
+            overSourceEvent = new MouseEvent('mouseover', mouseOptions);
+            outSourceEvent = new MouseEvent('mouseout', mouseOptions);
+            moveSourceEvent = new MouseEvent('mousemove', mouseOptions);
+        }
+        const startResult = button.dispatchEvent(overSourceEvent);
+        button.dispatchEvent(outSourceEvent);
+        button.dispatchEvent(moveSourceEvent);
+
+        expect(startResult, 'preventDefault not called').to.equal(true);
+        expect(overSpy, 'over listener').to.have.callCount(1);
+        expect(overSpy).calledWith({
+            type: 'over',
+            pageX: 0,
+            pageY: 0,
+            sourceEvent: overSourceEvent,
+            target: button,
+            currentTarget: button
+        });
+        expect(outSpy, 'out listener').to.have.callCount(1);
+        expect(outSpy).calledWith({
+            type: 'out',
+            pageX: 0,
+            pageY: 0,
+            sourceEvent: outSourceEvent,
+            target: button,
+            currentTarget: button
+        });
+        expect(moveSpy, 'move listener').to.have.callCount(1);
+        expect(moveSpy).calledWith({
+            type: 'move',
+            pageX: 0,
+            pageY: 0,
+            sourceEvent: moveSourceEvent,
+            target: button,
+            currentTarget: button
+        });
+
+        ui.destroy();
+    });
+
+    it('triggers over and out events with focus and blur input', function() {
+        const overSpy = sandbox.spy();
+        const outSpy = sandbox.spy();
+        const ui = new UI(button, {
+            useFocus: true
+        }).on('over', overSpy).on('out', outSpy);
+        const eventOptions = xyCoords(0, 0, {
+            view: window,
+            bubbles: true,
+            cancelable: true
+        });
+        const overSourceEvent = new FocusEvent('focus', eventOptions);
+        const outSourceEvent = new FocusEvent('blur', eventOptions);
+        const startResult = button.dispatchEvent(overSourceEvent);
+        button.dispatchEvent(outSourceEvent);
+
+        expect(startResult, 'preventDefault not called').to.equal(true);
+        expect(overSpy, 'over listener').to.have.callCount(1);
+        expect(overSpy).calledWithMatch({
+            type: 'over',
+            sourceEvent: overSourceEvent,
+            target: button,
+            currentTarget: button
+        });
+        expect(outSpy, 'out listener').to.have.callCount(1);
+        expect(outSpy).calledWithMatch({
+            type: 'out',
+            sourceEvent: outSourceEvent,
+            target: button,
+            currentTarget: button
+        });
+
+        ui.destroy();
+    });
+
+    it('does not trigger over, out and move events with pointer-touch input', function() {
+        if (!USE_POINTER_EVENTS) {
+            return;
+        }
+        const overSpy = sandbox.spy();
+        const outSpy = sandbox.spy();
+        const moveSpy = sandbox.spy();
+        const ui = new UI(button, {
+            useHover: true,
+            useMove: true
+        }).on('over', overSpy).on('out', outSpy);
+        const pointerOptions = {
+            isPrimary: true,
+            pointerType: 'touch',
+            view: window,
+            bubbles: true,
+            cancelable: true
+        };
+        const result = button.dispatchEvent(new PointerEvent('pointerover', pointerOptions));
+        button.dispatchEvent(new PointerEvent('pointerout', pointerOptions));
+        button.dispatchEvent(new PointerEvent('pointermove', pointerOptions));
+
+        expect(result, 'preventDefault not called').to.equal(true);
+        expect(overSpy).to.have.callCount(0);
+        expect(outSpy).to.have.callCount(0);
+        expect(moveSpy).to.have.callCount(0);
+
+        ui.destroy();
+    });
+
+    it('triggers enter events with keyboard input', function() {
+        if (OS.android) {
+            // 'keydown' listeners are not invoked on android
+            return;
+        }
+        const enterSpy = sandbox.spy();
+        const ui = new UI(button).on('enter', enterSpy);
+        const sourceEvent = new KeyboardEvent('keydown', {
+            keyCode: 13
+        });
+        sandbox.spy(sourceEvent, 'stopPropagation');
+        const result = button.dispatchEvent(sourceEvent);
+        expect(result, 'preventDefault not called').to.equal(true);
+        expect(enterSpy).to.have.callCount(1);
+        expect(enterSpy).calledWithMatch({
+            type: 'enter',
+            sourceEvent,
+            target: button,
+            currentTarget: button
+        });
+        expect(sourceEvent.stopPropagation).to.have.callCount(1);
+
+        ui.destroy();
+    });
+
+    it('preventScrolling uses setPointerCapture and preventDefault', function() {
+        const ui = new UI(button, {
+            preventScrolling: true
+        });
+        let result;
+        let event;
+        if (USE_POINTER_EVENTS) {
+            event = new PointerEvent('pointerdown', {
+                isPrimary: true,
+                pointerType: 'mouse',
+                pointerId: 1,
+                view: window,
+                bubbles: true,
+                cancelable: true
+            });
+            sandbox.stub(button, 'setPointerCapture').callsFake(sinon.spy());
+            sandbox.stub(button, 'releasePointerCapture').callsFake(sinon.spy());
+            sandbox.spy(event, 'preventDefault');
+            result = button.dispatchEvent(event);
+            expect(button.setPointerCapture).to.have.callCount(1);
+        } else if (USE_MOUSE_EVENTS) {
+            event = new MouseEvent('mousedown', {
+                view: window,
+                bubbles: true,
+                cancelable: true
+            });
+            sandbox.spy(event, 'preventDefault');
+            result = button.dispatchEvent(event);
+        } else {
+            const touch = new Touch({
+                identifier: 1,
+                target: button
+            });
+            event = new TouchEvent('touchstart', {
+                changedTouches: [ touch ],
+                view: window,
+                bubbles: true,
+                cancelable: true
+            });
+            sandbox.spy(event, 'preventDefault');
+            result = button.dispatchEvent(event);
+        }
+        if (!Browser.ie && !OS.android) {
+            expect(result, 'preventDefault called').to.equal(false);
+            expect(event.preventDefault).to.have.callCount(1);
+        }
+
+        ui.destroy();
+    });
+
+    it('constructor does not add event listeners to window, document or body ', function() {
+        spyOnDomEventListenerMethods([
+            window,
+            document,
+            document.body,
+            button
+        ]);
+
+        const ui = new UI(button, {
+            useFocus: true,
+            useHover: true,
+            useMove: true
+        });
+        expect(window.addEventListener, 'window').to.have.callCount(0);
+        expect(window.removeEventListener, 'window').to.have.callCount(0);
+        expect(document.addEventListener, 'document').to.have.callCount(0);
+        expect(document.removeEventListener, 'document').to.have.callCount(0);
+        expect(document.body.addEventListener, 'body').to.have.callCount(0);
+        expect(document.body.removeEventListener, 'body').to.have.callCount(0);
+        expect(button.removeEventListener, 'button').to.have.callCount(0);
+        ui.destroy();
+    });
+
+    it('constructor adds event listeners based on options', function() {
+        let ui;
+
+        spyOnDomEventListenerMethods([ button ]);
+        ui = new UI(button);
+        if (USE_POINTER_EVENTS || !USE_MOUSE_EVENTS) {
+            expect(button.addEventListener, 'button without options').to.have.callCount(2);
+        } else {
+            expect(button.addEventListener, 'button without options').to.have.callCount(3);
+        }
+        ui.destroy();
+
+        spyOnDomEventListenerMethods([ button ]);
+        ui = new UI(button, {
+            useFocus: true,
+            useHover: true,
+            useMove: true
+        });
+        if (USE_POINTER_EVENTS) {
+            expect(button.addEventListener, 'button with useFocus, useHover, useMove').to.have.callCount(7);
+        } else if (!USE_MOUSE_EVENTS) {
+            expect(button.addEventListener, 'button with useFocus, useHover, useMove').to.have.callCount(4);
+        } else {
+            expect(button.addEventListener, 'button with useFocus, useHover, useMove').to.have.callCount(8);
+        }
+        ui.destroy();
+    });
+
+    it('removes all event listeners on destroy', function() {
+        spyOnDomEventListenerMethods([ button ]);
+
+        const ui = new UI(button, {
+            useFocus: true,
+            useHover: true,
+            useMove: true
+        });
+        ui.destroy();
+        if (USE_POINTER_EVENTS) {
+            expect(button.removeEventListener, 'button').to.have.callCount(16);
+        } else {
+            expect(button.removeEventListener, 'button').to.have.callCount(9);
+        }
+    });
+
+});

--- a/test/unit/ui-test.js
+++ b/test/unit/ui-test.js
@@ -472,14 +472,14 @@ describe('UI', function() {
 
         expect(startResult, 'preventDefault not called').to.equal(true);
         expect(overSpy, 'over listener').to.have.callCount(1);
-        expect(overSpy).calledWithMatch({
+        expect(overSpy).calledWith({
             type: 'focus',
             sourceEvent: overSourceEvent,
             target: button,
             currentTarget: button
         });
         expect(outSpy, 'out listener').to.have.callCount(1);
-        expect(outSpy).calledWithMatch({
+        expect(outSpy).calledWith({
             type: 'blur',
             sourceEvent: outSourceEvent,
             target: button,
@@ -530,7 +530,7 @@ describe('UI', function() {
         const result = button.dispatchEvent(sourceEvent);
         expect(result, 'preventDefault not called').to.equal(true);
         expect(enterSpy).to.have.callCount(1);
-        expect(enterSpy).calledWithMatch({
+        expect(enterSpy).calledWith({
             type: 'enter',
             sourceEvent,
             target: button,


### PR DESCRIPTION
### This PR will...
- Unit test UI.js
- Make UI a class
- Only add DOM event listeners when on('event') requires it
- Remove the need for options `useHover`, `useFocus`, `useMove` and `enableDoubleTap` (adding the appropriate on('event') listeners will enable these features)
- Always make 'focus' and 'blur' trigger 'focus' and 'blur' instead of 'over' and 'out'
- Use `directSelect` on start rather than end interaction to exit interaction logic early
- Remove use of `instanceof` and references to Input Event classes
- Always specify passive event listener options (faster scrolling and fewer warnings from Chrome)
- Only use `preventDefault` when handling Touch events. It's not required when capturing Pointer events to prevent scrolling.
- Use once UI instance in TimeSlider (sharing with Slider which it extends), and remove redundant 'drag' and 'over' handlers (cutting calls unnecessary calls to `showTimeTooltip`)
- Handle 'rightclick' / longpress in UI.js instead of  rightclick.js
- Cleanup usage of UI
- Cleanup karma browserstack settings

### Why is this Pull Request needed?
These changes reduce the number of DOM event handlers added to each player and simplify the use of UI.js by making perform based on the events each instance must trigger.

These change reduce the following factors at setup:
_(stats gathered using [jwplayer-event-listeners.js snippet](https://gist.github.com/robwalch/7d2165353e2621bb7b21e29863b7ba5e) on [player test](http://player-develop-test-jenkins.longtailvideo.com/builds/lastSuccessfulBuild/archive/test/public/events/?config=//content.jwplatform.com/players/3IkpdgrX-OB6GXakf.js))_
155 -> 146 unique listeners attached to player elements
29 -> 28 "pointerdown" listeners
29 -> 23 "keydown" listeners
2 -> 1 "pointerover" listeners
2 -> 1 "pointermove" listeners
`preventDefault` only used on mobile for "touchstart", "touchmove" and "touchend" events

I investigated using "click" and "dblclick" events to simplify click handling, but dropped the experiment because of performance issues and lack of support in older mobile browsers.

### Are there any Pull Requests open in other repos which need to be merged with this?
Add public/click-to-play/variants.html test page:
https://github.com/jwplayer/jwplayer-commercial/pull/5434

Use passive event options in related (different branch name, can be merged and should be tested independently):
https://github.com/jwplayer/jwplayer-plugin-related/pull/299

#### Addresses Issue(s):
JW8-1623


