### PR TITLE
Short-circuit toggleClass when element is null

### DIFF
--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -70,6 +70,9 @@ export function replaceClass(element, pattern, replaceWith) {
 }
 
 export function toggleClass(element, c, toggleTo) {
+    if (!element) {
+        return;
+    }
     const hasIt = hasClass(element, c);
     toggleTo = isBoolean(toggleTo) ? toggleTo : !hasIt;
 


### PR DESCRIPTION
### This PR will...
short-circuit `toggleClass` if element is null.
### Why is this Pull Request needed?
An exception occurs when the player is chromeless and related calls `toggleClass` on an inexistent element.
### Are there any points in the code the reviewer needs to double check?
Is it the caller's responsibility to check if the element exists before calling `toggleClass` ? 
### Are there any Pull Requests open in other repos which need to be merged with this?
[Related PR](https://github.com/jwplayer/jwplayer-plugin-related/pull/303) to prevent unnecessary code from executing if chromeless
#### Addresses Issue(s):

JW8-1748

