### PR TITLE
Prime video tags on first user-gesture

### DIFF
--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -12,6 +12,7 @@ import { resolved } from 'polyfills/promise';
 import ErrorContainer from 'view/error-container';
 import MediaElementPool from 'program/media-element-pool';
 import SharedMediaPool from 'program/shared-media-pool';
+import UI, { getElementWindow } from 'utils/ui';
 import { PlayerError, composePlayerError, convertToPlayerError,
     SETUP_ERROR_LOADING_PLAYLIST, SETUP_ERROR_UNKNOWN, MSG_TECHNICAL_ERROR } from 'api/errors';
 
@@ -95,7 +96,12 @@ Object.assign(CoreShim.prototype, {
         if (!model.get('backgroundLoading')) {
             mediaPool = SharedMediaPool(mediaPool.getPrimedElement(), mediaPool);
         }
-        mediaPool.prime();
+
+        const primeUi = new UI(getElementWindow(this.originalContainer)).once('gesture', () => {
+            mediaPool.prime();
+            primeUi.destroy();
+        });
+
 
         model.on('change:errorEvent', logError);
 

--- a/src/js/program/media-element-pool.js
+++ b/src/js/program/media-element-pool.js
@@ -8,6 +8,7 @@ export default function MediaElementPool() {
         const mediaElement = createMediaElement();
         elements.push(mediaElement);
         pool.push(mediaElement);
+        primeMediaElementForPlayback(mediaElement);
     }
 
     // Reserve an element exclusively for ads
@@ -16,9 +17,18 @@ export default function MediaElementPool() {
     // Reserve an element exclusively for feature testing.
     const testElement = pool.shift();
 
+    let primed = false;
+
     return {
+        primed() {
+            return primed;
+        },
         prime() {
             elements.forEach(primeMediaElementForPlayback);
+            primed = true;
+        },
+        played() {
+            primed = true;
         },
         getPrimedElement() {
             if (pool.length) {

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -326,16 +326,6 @@ class ProgramController extends Eventable {
     }
 
     /**
-     * Primes media elements so that they can autoplay without further user gesture.
-     * A primed element is required for media to load in the background.
-     * This method does not prime elements who already have a source set ("safe prime").
-     * @returns {void}
-     */
-    primeMediaElements() {
-        this.mediaPool.prime();
-    }
-
-    /**
      * Removes all event listeners and destroys all media.
      * @returns {void}
      */

--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -298,10 +298,16 @@ const eventRegisters = {
                 triggerSimpleEvent(ui, ENTER, e);
             }
         });
+    },
+    gesture(ui) {
+        const gesture = 'gesture';
+        const triggerGesture = (e) => triggerEvent(ui, gesture, e);
+        addEventListener(ui, gesture, 'click', triggerGesture);
+        addEventListener(ui, gesture, 'keydown', triggerGesture);
     }
 };
 
-function getElementWindow(element) {
+export function getElementWindow(element) {
     const document = element.ownerDocument || element;
     return (document.defaultView || document.parentWindow || window);
 }


### PR DESCRIPTION
### This PR will...

Cleanup video tag priming and add event listeners on the player container's window or document to prime videos on first gesture (click or keydown).

### Why is this Pull Request needed?

These changes allow playback to start programmatically (not in a gesture event) provided the user triggered at least one gesture event since the `jwplayer().setup()` was called.

This will help in cases where playback should start when a player comes into view by scrolling down the page after the user has interacted with the page, or after dismissing a dialog or ad, and those interactions did not directly result in `video.play()` being called.

With these changes, browsers with autoplay restrictions that require a gesture to call `video.play()` or `video.load()` to enable unmuted playback should produce less "playAttemptFailed" events - provided there is an interaction with the page after player setup (iOS, Safari, and Android Chrome (prior to v65)). 

### Notes?

This line in the controller prevents uncaught promise exceptions that result from calling `jwplayer().play()` on "playlistItem"
`this.play = (meta) => _play(meta).catch(noop);`

#### Testing
1. This setup will attempt to play one second after setup, but result in a "playAttemptFailed" even on mobile devices with audio unmuted. As long as you tap anywhere on the page within that second, playback will start.
```js
{
    events: {
        playlistItem: function() {
            setTimeout(this.play, 1000);
        }
    },
    playlist: "//cdn.jwplayer.com/v2/playlists/ThjcbXPb&sources=mp4&poster_width=320"
}
```
2. See test/squash/bootstrap.html?primary=html5&edition=ads&feature=autostart_viewable/autostart_when_viewable&suite=Autostart

### Are there any Pull Requests open in other repos which need to be merged with this?

These changes depend on updates to UI.js made in https://github.com/jwplayer/jwplayer/pull/2991. Once merged this branch should be rebased against master.

#### Addresses Issue(s):

JW8-1584

