### PR TITLE
Prevent styling control bar with background transparent

### DIFF
--- a/src/js/view/utils/skin.js
+++ b/src/js/view/utils/skin.js
@@ -279,18 +279,18 @@ export function handleColorOverrides(playerId, skin) {
 }
 
 function isTransparent(color) {
-if (color.toLowerCase() === 'transparent') {
-    return true;
-}
+    if (color.toLowerCase() === 'transparent') {
+        return true;
+    }
 
-let channels;
-if (color.indexOf('(') > -1) {
-    channels = color.match(/(0\.\d+)|\d+/g);
-}
+    let channels;
+    if (color.indexOf('(') > -1) {
+        channels = color.match(/(0\.\d+)|\d+/g);
+    }
 
-if (color.indexOf('#') > -1) {
-    channels = color.match(/([0-9A-F]{2})+?/gi);
-}
+    if (color.indexOf('#') > -1) {
+        channels = color.match(/([0-9A-F]{2})+?/gi);
+    }
 
-return channels && channels.length > 3 && parseFloat(channels.splice(3, 1)[0]) === 0 || false;
+    return channels && channels.length > 3 && parseFloat(channels.splice(3, 1)[0]) === 0 || false;
 }

--- a/src/js/view/utils/skin.js
+++ b/src/js/view/utils/skin.js
@@ -97,7 +97,7 @@ export function handleColorOverrides(playerId, skin) {
     // Using background instead of background-color so we don't have to clear gradients with background-image
 
     if (skin.controlbar) {
-        styleControlbar(skin.controlbar);
+        styleControlbar(skin.controlbar);   
     }
     if (skin.timeslider) {
         styleTimeslider(skin.timeslider);
@@ -168,11 +168,14 @@ export function handleColorOverrides(playerId, skin) {
         }
 
         // A space is purposefully left before '.jw-settings-topbar' since extendParent is set to true in order to append ':not(.jw-state-idle)'
-        addStyle([
-            ' .jw-settings-topbar',
-            ':not(.jw-state-idle) .jw-controlbar',
-            '.jw-flag-audio-player .jw-controlbar'
-        ], 'background', config.background, true);
+        // Prevent assigning if transparent, as this negatively impacts sub menu
+        if (config.background !== 'transparent' || getRgba(config.background) !== 'rgb(0, 0, 0)') {
+            addStyle([
+                ' .jw-settings-topbar',
+                ':not(.jw-state-idle) .jw-controlbar',
+                '.jw-flag-audio-player .jw-controlbar'
+            ], 'background', config.background, true);
+        }
     }
 
     function styleTimeslider(config) {

--- a/src/js/view/utils/skin.js
+++ b/src/js/view/utils/skin.js
@@ -169,7 +169,7 @@ export function handleColorOverrides(playerId, skin) {
 
         // A space is purposefully left before '.jw-settings-topbar' since extendParent is set to true in order to append ':not(.jw-state-idle)'
         // Prevent assigning if transparent, as this negatively impacts sub menu
-        if (!isTransparent(config.background)) {
+        if (config.background && !isTransparent(config.background)) {
             addStyle([
                 ' .jw-settings-topbar',
                 ':not(.jw-state-idle) .jw-controlbar',

--- a/src/js/view/utils/skin.js
+++ b/src/js/view/utils/skin.js
@@ -169,7 +169,7 @@ export function handleColorOverrides(playerId, skin) {
 
         // A space is purposefully left before '.jw-settings-topbar' since extendParent is set to true in order to append ':not(.jw-state-idle)'
         // Prevent assigning if transparent, as this negatively impacts sub menu
-        if (config.background !== 'transparent' || getRgba(config.background) !== 'rgb(0, 0, 0)') {
+        if (!isTransparent(config.background)) {
             addStyle([
                 ' .jw-settings-topbar',
                 ':not(.jw-state-idle) .jw-controlbar',
@@ -276,4 +276,21 @@ export function handleColorOverrides(playerId, skin) {
             css(`#${playerId} .jw-color-inactive-hover:hover`, inactiveColorSet, playerId);
         }
     }
+}
+
+function isTransparent(color) {
+if (color.toLowerCase() === 'transparent') {
+    return true;
+}
+
+let channels;
+if (color.indexOf('(') > -1) {
+    channels = color.match(/(0\.\d+)|\d+/g);
+}
+
+if (color.indexOf('#') > -1) {
+    channels = color.match(/([0-9A-F]{2})+?/gi);
+}
+
+return channels && channels.length > 3 && parseFloat(channels.splice(3, 1)[0]) === 0 || false;
 }


### PR DESCRIPTION
### This PR will...

Prevent an issue in which, when setting ```controlbar.background: 'transparent'```, the submenu is negatively impacted (losing its transparency).

This PR addresses this issue by preventing writing the CSS rule when ```controlbar.background: transparent``` is detected.

### Why is this Pull Request needed?

When setting ```controlbar.background: transparent```, the submenu loses its transparency.

### Are there any points in the code the reviewer needs to double check?

In speaking with @radium-v , it's my understanding that the better solution would be to decouple the submenu from the controlbar so that this issue would not exist in the first place.

That being said, this is a short term patch. I am unsure if this fully covers the scenario, as I do not test hex values, etc. I do not believe any method exists in the css utils that would allow this test (getRbga does not seem to cover this). 

### Are there any Pull Requests open in other repos which need to be merged with this?

No

#### Addresses Issue(s):

JW8-1663

