### PR TITLE
Support new google cast button

### DIFF
--- a/src/css/controls/imports/controlbar.less
+++ b/src/css/controls/imports/controlbar.less
@@ -98,7 +98,7 @@
     margin: 0;
     padding: 0;
 
-    button {
+    google-cast-launcher {
         background-color: transparent;
         border: none;
         padding: 0;

--- a/src/css/shared-imports/mixins.less
+++ b/src/css/shared-imports/mixins.less
@@ -185,7 +185,7 @@
         */
 
         .jw-icon-cast {
-            button {
+            google-cast-launcher {
                 --connected-color: @active-color;
                 --disconnected-color: @inactive-color;
 
@@ -198,12 +198,12 @@
                 }
             }
 
-            &:focus button {
+            &:focus google-cast-launcher {
                 --connected-color: @active-color;
                 --disconnected-color: @hover-color;
             }
 
-            &:hover button {
+            &:hover google-cast-launcher {
                 --connected-color: @hover-color;
                 --disconnected-color: @hover-color;
             }

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -56,7 +56,7 @@ function createCastButton(castToggle, localization) {
     }
 
 
-    const castButton = document.createElement('button', 'google-cast-button');
+    const castButton = document.createElement('google-cast-launcher');
     setAttribute(castButton, 'type', 'button');
     setAttribute(castButton, 'tabindex', '-1');
 

--- a/src/js/view/utils/skin.js
+++ b/src/js/view/utils/skin.js
@@ -134,7 +134,7 @@ export function handleColorOverrides(playerId, skin) {
 
             // Chromecast overrides
             // Can't use addStyle since it will camel case the style name
-            css(`#${playerId} .jw-icon-cast button.jw-off`, `{--disconnected-color: ${config.icons}}`, playerId);
+            css(`#${playerId} .jw-icon-cast google-cast-launcher.jw-off`, `{--disconnected-color: ${config.icons}}`, playerId);
         }
         if (config.iconsActive) {
             addStyle([
@@ -157,14 +157,14 @@ export function handleColorOverrides(playerId, skin) {
 
             // Chromecast overrides
             // Can't use addStyle since it will camel case the style name
-            css(`#${playerId} .jw-icon-cast:hover button.jw-off`, `{--disconnected-color: ${config.iconsActive}}`, playerId);
-            css(`#${playerId} .jw-icon-cast:focus button.jw-off`, `{--disconnected-color: ${config.iconsActive}}`, playerId);
-            css(`#${playerId} .jw-icon-cast button.jw-off:focus`, `{--disconnected-color: ${config.iconsActive}}`, playerId);
+            css(`#${playerId} .jw-icon-cast:hover google-cast-launcher.jw-off`, `{--disconnected-color: ${config.iconsActive}}`, playerId);
+            css(`#${playerId} .jw-icon-cast:focus google-cast-launcher.jw-off`, `{--disconnected-color: ${config.iconsActive}}`, playerId);
+            css(`#${playerId} .jw-icon-cast google-cast-launcher.jw-off:focus`, `{--disconnected-color: ${config.iconsActive}}`, playerId);
 
-            css(`#${playerId} .jw-icon-cast button`, `{--connected-color: ${config.iconsActive}}`, playerId);
-            css(`#${playerId} .jw-icon-cast button:focus`, `{--connected-color: ${config.iconsActive}}`, playerId);
-            css(`#${playerId} .jw-icon-cast:hover button`, `{--connected-color: ${config.iconsActive}}`, playerId);
-            css(`#${playerId} .jw-icon-cast:focus button`, `{--connected-color: ${config.iconsActive}}`, playerId);
+            css(`#${playerId} .jw-icon-cast google-cast-launcher`, `{--connected-color: ${config.iconsActive}}`, playerId);
+            css(`#${playerId} .jw-icon-cast google-cast-launcher:focus`, `{--connected-color: ${config.iconsActive}}`, playerId);
+            css(`#${playerId} .jw-icon-cast:hover google-cast-launcher`, `{--connected-color: ${config.iconsActive}}`, playerId);
+            css(`#${playerId} .jw-icon-cast:focus google-cast-launcher`, `{--connected-color: ${config.iconsActive}}`, playerId);
         }
 
         // A space is purposefully left before '.jw-settings-topbar' since extendParent is set to true in order to append ':not(.jw-state-idle)'


### PR DESCRIPTION
### This PR will...
Support the new google cast button
https://developers.google.com/cast/docs/chrome_sender_integrate#cast_button

### Why is this Pull Request needed?
The old cast button uses the v0 custom components API which will be deprecated. This change is forward compatible with the new v1 custom component API and is officially supported by the Cast SDK.

### Are there any points in the code the reviewer needs to double check?
This is simple change that renames the old cast button.google-cast-button to the new google-cast-launcher syntax. Please check if there are other instances where this needs to be renamed.

### Are there any Pull Requests open in other repos which need to be merged with this?
no

#### Addresses Issue(s):
Users not being able to use React JS which automatically uses new v1 custom component syntax. crbug.com/843421

JW8-1815

