### PR TITLE
Prevent captions renderer from setting shadowDOMFontSize in Safari iOS

### DIFF
--- a/src/js/view/captionsrenderer.js
+++ b/src/js/view/captionsrenderer.js
@@ -1,4 +1,4 @@
-import { Browser } from 'environment/environment';
+import { Browser, OS } from 'environment/environment';
 import { chunkLoadErrorHandler } from '../api/core-loader';
 import Events from 'utils/backbone.events';
 import { ERROR } from 'events/events';
@@ -213,7 +213,7 @@ const CaptionsRenderer = function (viewModel) {
 
         const fontSize = Math.round(height * _fontScale);
 
-        if (_model.get('renderCaptionsNatively')) {
+        if (_model.get('renderCaptionsNatively') && (!OS.iOS && !Browser.safari)) {
             _setShadowDOMFontSize(_model.get('id'), fontSize);
         } else {
             style(_display, {


### PR DESCRIPTION
JW8-1700

### This PR will...

Prevent the captions renderer from setting the `shadowDOMFontSize` in Safari for iOS.

### Why is this Pull Request needed?

The captions were appearing too small when bringing the player full screen in Safari for iOS.

### Are there any points in the code the reviewer needs to double check?

n/a

### Are there any Pull Requests open in other repos which need to be merged with this?

n/a

#### Addresses Issue(s):

JW8-1700

