### PR TITLE
Add player model "controlsEnabled"

### DIFF
--- a/src/js/model/player-model.js
+++ b/src/js/model/player-model.js
@@ -8,7 +8,8 @@ export const INITIAL_PLAYER_STATE = {
     playbackRate: 1,
     playRejected: false,
     state: STATE_IDLE,
-    itemReady: false
+    itemReady: false,
+    controlsEnabled: false
 };
 
 export const INITIAL_MEDIA_STATE = {

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -338,6 +338,8 @@ export default class Controls {
         this.playerContainer.appendChild(this.div);
 
         this.addBackdrop();
+
+        model.set('controlsEnabled', true);
     }
 
     disable(model) {
@@ -350,6 +352,8 @@ export default class Controls {
 
         clearTimeout(this.activeTimeout);
         this.activeTimeout = -1;
+
+        model.set('controlsEnabled', false);
 
         if (this.div.parentNode) {
             removeClass(this.playerContainer, 'jw-flag-touch');

--- a/test/data/model-properties.js
+++ b/test/data/model-properties.js
@@ -72,6 +72,7 @@ export default {
     autostart: false,
     base: '',
     controls: true,
+    controlsEnabled: true,
     stretching: 'uniform',
     defaultPlaybackRate: 1.0,
     displaytitle: true,


### PR DESCRIPTION
### This PR will...
Add a "controlsEnabled" model property that is toggled with the presence of the .jw-controls element.

### Why is this Pull Request needed?
So that related views can defer querying of player control elements until the controls are present in the DOM.

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-plugin-related/pull/308

#### Addresses Issue(s):
JW8-1748

