### PR TITLE
Trigger 'remove' when player is reset for plugins

### DIFF
--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -46,6 +46,7 @@ function resetPlayer(api, core) {
     Object.keys(plugins).forEach(key => {
         delete plugins[key];
     });
+    api.trigger('remove');
     api.off();
     core.playerDestroy();
     core.getContainer().removeAttribute('data-jwplayer-id');
@@ -215,10 +216,6 @@ export default function Api(element) {
         remove() {
             // Remove from array of players
             removePlayer(this);
-
-            // TODO: [EDIT] This should be fired after `resetPlayer`. Why is it fired before?
-            // terminate state
-            this.trigger('remove');
 
             // Unbind listeners and destroy controller/model/...
             resetPlayer(this, core);

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -907,7 +907,6 @@ Object.assign(Controller.prototype, {
         };
 
         this.playerDestroy = function () {
-            this.trigger('destroyPlugin', {});
             this.off();
             this.stop();
             showView(this, this.originalContainer);


### PR DESCRIPTION
### This PR will...
Trigger 'remove' when player is reset so that plugins are notifies that the api instance is no longer in use.

### Why is this Pull Request needed?
Previously this event was only fired when calling `api.remove()`. Now it will also be invoked when `api.setup()` is called as well, since all internals and listeners of the instance have been reset.

This will also notify the analytics plugin that the current player session has ended.

### Are there any Pull Requests open in other repos which need to be merged with this?
These changes are needed for related to cleanup external elements when the player is removed or reset.

https://github.com/jwplayer/jwplayer-plugin-related/pull/310

#### Addresses Issue(s):

JW8-1414


