### PR TITLE
Handle Error Completing Setup

### DIFF
--- a/src/js/api/errors.js
+++ b/src/js/api/errors.js
@@ -35,6 +35,11 @@ export const SETUP_ERROR_LOADING_CORE_JS = 101000;
 export const SETUP_ERROR_LOADING_PLAYLIST = 102000;
 
 /**
+ * @enum {ErrorCode} An exception occured while completing player setup.
+ */
+export const ERROR_COMPLETING_SETUP = 200001;
+
+/**
  * @enum {ErrorCode} Playback stopped because the playlist failed to load.
  */
 export const ERROR_LOADING_PLAYLIST = 202000;

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -191,15 +191,17 @@ Object.assign(Controller.prototype, {
             // Fire 'ready' once the view has resized so that player width and height are available
             // (requires the container to be in the DOM)
             _view.once(RESIZE, () => {
-                resolved.then(_playerReadyNotify).catch((error) => {
+                try {
+                    playerReadyNotify();
+                } catch (error) {
                     _this.triggerError(convertToPlayerError(MSG_TECHNICAL_ERROR, ERROR_COMPLETING_SETUP, error));
-                });
+                }
             });
 
             _view.init();
         };
 
-        function _playerReadyNotify() {
+        function playerReadyNotify() {
             _model.change('visibility', _updateViewable);
             eventsReadyQueue.off();
 

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -26,8 +26,8 @@ import { PLAYER_STATE, STATE_BUFFERING, STATE_IDLE, STATE_COMPLETE, STATE_PAUSED
 import ProgramController from 'program/program-controller';
 import initQoe from 'controller/qoe';
 import { BACKGROUND_LOAD_OFFSET } from 'program/program-constants';
-import { composePlayerError, convertToPlayerError, MSG_CANT_PLAY_VIDEO,
-    ERROR_LOADING_PLAYLIST, ERROR_LOADING_PROVIDER, ERROR_LOADING_PLAYLIST_ITEM } from 'api/errors';
+import { composePlayerError, convertToPlayerError, MSG_CANT_PLAY_VIDEO, MSG_TECHNICAL_ERROR,
+    ERROR_COMPLETING_SETUP, ERROR_LOADING_PLAYLIST, ERROR_LOADING_PROVIDER, ERROR_LOADING_PLAYLIST_ITEM } from 'api/errors';
 
 // The model stores a different state than the provider
 function normalizeState(newstate) {
@@ -190,7 +190,11 @@ Object.assign(Controller.prototype, {
 
             // Fire 'ready' once the view has resized so that player width and height are available
             // (requires the container to be in the DOM)
-            _view.once(RESIZE, _playerReadyNotify);
+            _view.once(RESIZE, () => {
+                resolved.then(_playerReadyNotify).catch((error) => {
+                    _this.triggerError(convertToPlayerError(MSG_TECHNICAL_ERROR, ERROR_COMPLETING_SETUP, error));
+                });
+            });
 
             _view.init();
         };


### PR DESCRIPTION
### This PR will...
Handle exceptions in `playerReadyNotify` as a new player error rather than a setup error.

### Why is this Pull Request needed?

When the player is setup with `jwplayer().setup()`, the expectation is that the setup process will complete with either a "ready" event or a "setupError" event. If an exception is thrown as setup completes, during the "ready", "playlist" or "playlistItem" events, in debug mode (set `jwplayer.debug = true` before setup), then the player should handle the exception gracefully with an "error" event, rather than a "setupError" event.

*Steps to reproduce:*
```js
// enable debug to not catch exceptions thrown in event handlers
jwplayer.debug = true;

// then
jwplayer().setup({ file: '//video' }).on('playlistItem', function() {
   throw new Error('This should not result in a setup error.');
});

// or
jwplayer().setup({
  file: '//video',
  events: {
    playlistItem: function() { throw new Error('This should not result in a setup error.'); }
  }
});
```

*Actual:*
Player fires "ready", "playlist", then "setupError" with code 100,000.

*Expected:*
Player fires "ready", "playlist", then "error" with new error code 200,001.

*Note* When `jwplayer.debug` is not set or set to false, the exception is caught and logged to the console correctly.

#### Addresses Issue(s):
JW8-1774


