### PR TITLE
Only trigger the "remove" event on api instances that have been setup

### DIFF
--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -46,7 +46,9 @@ function resetPlayer(api, core) {
     Object.keys(plugins).forEach(key => {
         delete plugins[key];
     });
-    api.trigger('remove');
+    if (core.get('setupConfig')) {
+        api.trigger('remove');
+    }
     api.off();
     core.playerDestroy();
     core.getContainer().removeAttribute('data-jwplayer-id');

--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -169,6 +169,9 @@ Object.assign(CoreShim.prototype, {
 
     // These methods read from the model
     get(property) {
+        if (!this.modelShim) {
+            return;
+        }
         if (property in this.mediaShim) {
             return this.mediaShim[property];
         }

--- a/test/unit/api-test.js
+++ b/test/unit/api-test.js
@@ -120,19 +120,23 @@ describe('Api', function() {
 
     it('can be removed and reused', function() {
         return new Promise((resolve, reject) => {
-            const api = createApi('player');
+            const removeSpy0 = sinon.spy();
+            const removeSpy1 = sinon.spy();
 
-            let removeCount = 0;
-            api.on('remove', (event) => {
-                expect(++removeCount, 'first remove event callback is triggered first once').to.equal(1);
-                expect(event.type, 'event type is "remove"').to.equal('remove');
-                expect(this, 'callback context is the removed api instance').to.equal(api);
-            });
+            const api = createApi('player').on('remove', removeSpy0);
 
             api.remove();
 
+            expect(removeSpy0, 'remove is not called if api was never setup').to.have.callCount(0);
+
+            api.setup({}).on('remove', removeSpy1).remove();
+            
             api.setup({}).on('remove', () => {
-                expect(++removeCount, 'second remove event callback is triggered second').to.equal(2);
+                expect(removeSpy1, 'remove callback is triggered once').to.have.callCount(1);
+                expect(removeSpy1, 'event type is "remove"').to.be.calledWithMatch({
+                    type: 'remove'
+                });
+                expect(removeSpy1, 'callback context is the removed api instance').to.be.be.calledOn(api);
                 resolve();
             }).on('ready setupError', reject).remove();
         });

--- a/test/unit/api-test.js
+++ b/test/unit/api-test.js
@@ -23,6 +23,8 @@ function createApi(id) {
 
 describe('Api', function() {
 
+    this.timeout(6000);
+
     beforeEach(function() {
         utils.log = sinon.stub();
         console.error = sinon.stub();
@@ -130,7 +132,7 @@ describe('Api', function() {
             expect(removeSpy0, 'remove is not called if api was never setup').to.have.callCount(0);
 
             api.setup({}).on('remove', removeSpy1).remove();
-            
+
             api.setup({}).on('remove', () => {
                 expect(removeSpy1, 'remove callback is triggered once').to.have.callCount(1);
                 expect(removeSpy1, 'event type is "remove"').to.be.calledWithMatch({

--- a/test/unit/controls/settings-menu-test.js
+++ b/test/unit/controls/settings-menu-test.js
@@ -8,11 +8,11 @@ describe('SettingsMenu', function() {
     let controlbar;
     let settingsMenu;
 
-    before(function() {
-        sinon.stub(menu, 'SettingsMenu');
-    });
+    const sandbox = sinon.sandbox.create();
 
     beforeEach(function() {
+        sandbox.stub(menu, 'SettingsMenu');
+
         controlbar = {};
         controlbar.on = sinon.stub();
         controlbar.elements = {
@@ -27,11 +27,16 @@ describe('SettingsMenu', function() {
             removeSubmenu: sinon.spy(),
             getSubmenu: sinon.spy(),
             activateFirstSubmenu: sinon.spy(),
-            activateSubmenu: sinon.spy()
+            activateSubmenu: sinon.spy(),
+            destroy: sinon.spy()
         };
         settingsMenu.element.returns(document.createElement('div'));
 
         menu.SettingsMenu.returns(settingsMenu);
+    });
+
+    afterEach(function() {
+        sandbox.restore();
     });
 
     describe('createSettingsMenu', function() {

--- a/test/unit/setup-test.js
+++ b/test/unit/setup-test.js
@@ -170,4 +170,47 @@ describe('api.setup', function() {
             expect(event.type).to.equal('ready');
         });
     });
+
+    it('triggers "remove" if the api has been previously setup', function() {
+        const removeSpy1 = sinon.spy();
+        const removeSpy2 = sinon.spy();
+
+        const container = document.querySelector('#player');
+        const api = new Api(container);
+
+        return new Promise((resolve, reject) => {
+            api.setup({
+                events: {
+                    remove: removeSpy1
+                },
+                preload: 'none',
+                file: 'http://playertest.longtailvideo.com/mp4.mp4'
+            }).on('ready', function(event) {
+                resolve({ api, event });
+            }).on('setupError', function(event) {
+                reject(new Error('Expected "ready" after setup. Got "setupError" with:' +
+                    JSON.stringify(event)));
+            });
+        }).then(() => {
+            expect(removeSpy1, 'first setup').to.have.callCount(0);
+
+            return new Promise((resolve, reject) => {
+                api.setup({
+                    events: {
+                        remove: removeSpy2
+                    },
+                    preload: 'none',
+                    file: 'http://playertest.longtailvideo.com/mp4.mp4'
+                }).on('ready', function(event) {
+                    resolve({ api, event });
+                }).on('setupError', function(event) {
+                    reject(new Error('Expected "ready" after setup. Got "setupError" with:' +
+                        JSON.stringify(event)));
+                });
+            });
+        }).then(() => {
+            expect(removeSpy1, 'second setup: first listener').to.have.callCount(1);
+            expect(removeSpy2, 'second setup: second listener').to.have.callCount(0);
+        });
+    });
 });


### PR DESCRIPTION
### Why is this Pull Request needed?

This is a follow up to https://github.com/jwplayer/jwplayer/pull/3004 which adds tests, and changes the behavior for the "remove" event to only fire when resetting an api that has been setup.

This means that on first setup we will continue to receive events starting with "ready", "playlist"... and will not get a "remove" event before "ready" until the after the second time that setup is called on an api instance.

#### Addresses Issue(s):
JW8-1414

