### PR TITLE
Preload video after first gesture

### DIFF
--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -38,6 +38,7 @@ const CoreShim = function(originalContainer) {
         'playlistNext',
         'playlistPrev',
         'next',
+        'preload',
 
         // These should just update state that could be acted on later, but need to be queued given v7 model
         'setConfig',
@@ -99,9 +100,9 @@ Object.assign(CoreShim.prototype, {
 
         const primeUi = new UI(getElementWindow(this.originalContainer)).once('gesture', () => {
             mediaPool.prime();
+            this.preload();
             primeUi.destroy();
         });
-
 
         model.on('change:errorEvent', logError);
 

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -288,8 +288,12 @@ Object.assign(Controller.prototype, {
                 viewable: viewable
             });
 
+            preload();
+        }
+
+        function preload() {
             // Only attempt to preload if this is the first player on the page or viewable
-            if (instances[0] !== _api && viewable !== 1) {
+            if (instances[0] !== _api && _model.get('viewable') !== 1) {
                 return;
             }
             if (_model.get('state') === 'idle' && _model.get('autostart') === false) {
@@ -772,6 +776,8 @@ Object.assign(Controller.prototype, {
             _programController.mute = _model.getMute();
             _programController.volume = _model.get('volume');
         }
+
+        this.preload = preload;
 
         /** Controller API / public methods **/
         this.load = _load;


### PR DESCRIPTION
### This PR will...
Preload video on or after first gesture when the player sets up. The preload command will load content according to the player's preload settings (calling `preload()` with `preload: 'none'` does not preload any content).

### Why is this Pull Request needed?
This change allows for content to be preloaded on first interaction, when preloading was previously blocked by the browser's autoplay policy.

#### Addresses Issue(s):
JW8-1584
