### PR TITLE
Fix captions scaling for iOS devices in fullscreen

### DIFF
--- a/src/js/view/captionsrenderer.js
+++ b/src/js/view/captionsrenderer.js
@@ -214,21 +214,32 @@ const CaptionsRenderer = function (viewModel) {
         const fontSize = Math.round(height * _fontScale);
 
         if (_model.get('renderCaptionsNatively')) {
-            let fullscreenScale = 1;
-
-            // Scale captions correctly when in fullscreen on iOS devices
-            if (OS.iOS && _model.get('fullscreen')) {
-                // iOS device is in portrait mode when window.orientation = 0 || 180
-                const portraitMode = !(window.orientation % 180);
-                const fullscreenWidth = portraitMode ? window.screen.availWidth : window.screen.availHeight;
-                fullscreenScale = fullscreenWidth / _model.get('containerWidth');
-            }
-            _setShadowDOMFontSize(_model.get('id'), Math.ceil(fontSize * fullscreenScale));
+            _setShadowDOMFontSize(_model.get('id'), getFontSizeNative(fontSize));
         } else {
             style(_display, {
                 fontSize: fontSize + 'px'
             });
         }
+    }
+
+    function getFontSizeNative(fontSize) {
+        // Scale captions correctly when in fullscreen on iOS devices
+        const video = _model.get('mediaElement');
+        if (video && OS.iOS && _model.get('fullscreen')) {
+            const { videoWidth, videoHeight } = video;
+            // iOS device is in portrait mode when window.orientation = 0 || 180
+            const portraitMode = !(window.orientation % 180);
+            const { screen } = window;
+            const screenWidth = portraitMode ? screen.availWidth : screen.availHeight;
+            const screenHeight = portraitMode ? screen.availHeight : screen.availWidth;
+            if (screenWidth && screenHeight && videoWidth && videoHeight) {
+                const aspectScreen = screenWidth / screenHeight;
+                const aspectVideo = videoWidth / videoHeight;
+                const height = (aspectScreen > aspectVideo) ? screenHeight : videoHeight * screenWidth / videoWidth;
+                return Math.round(height * _fontScale);
+            }
+        }
+        return fontSize;
     }
 
     function _setupCaptionStyles(playerId, textStyle) {

--- a/src/js/view/captionsrenderer.js
+++ b/src/js/view/captionsrenderer.js
@@ -1,4 +1,4 @@
-import { Browser } from 'environment/environment';
+import { Browser, OS } from 'environment/environment';
 import { chunkLoadErrorHandler } from '../api/core-loader';
 import Events from 'utils/backbone.events';
 import { ERROR } from 'events/events';
@@ -214,7 +214,16 @@ const CaptionsRenderer = function (viewModel) {
         const fontSize = Math.round(height * _fontScale);
 
         if (_model.get('renderCaptionsNatively')) {
-            _setShadowDOMFontSize(_model.get('id'), fontSize);
+            let fullscreenScale = 1;
+
+            // Scale captions correctly when in fullscreen on iOS devices
+            if (OS.iOS && _model.get('fullscreen')) {
+                // iOS device is in portrait mode when window.orientation = 0 || 180
+                const portraitMode = !(window.orientation % 180);
+                const fullscreenWidth = portraitMode ? window.screen.availWidth : window.screen.availHeight;
+                fullscreenScale = fullscreenWidth / _model.get('containerWidth');
+            }
+            _setShadowDOMFontSize(_model.get('id'), Math.ceil(fontSize * fullscreenScale));
         } else {
             style(_display, {
                 fontSize: fontSize + 'px'


### PR DESCRIPTION
### This PR will...
Scale captions in fullscreen on iOS devices.
### Why is this Pull Request needed?
When the player enters fullscreen, the font size should scale with the video player. The scaling worked in fullscreen in desktop browsers and on android devices, but iOS needs to be treated differently. This addresses https://github.com/jwplayer/jwplayer/issues/2884.
### Are there any points in the code the reviewer needs to double check?
No, but this did surface that we calculate font size of an in-line player based on the player container, not the video dimensions, so that maybe something to revisit in the future.
### Are there any Pull Requests open in other repos which need to be merged with this?
No
#### Addresses Issue(s):
JW8-1700

