### PR TITLE
Set reason as 'File Not Found' when ajax request returns 404

### DIFF
--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -37,7 +37,7 @@ const Captions = function(_model) {
                     _addTrack(track);
                     loadFile(track, (vttCues) => {
                         _addVTTCuesToTrack(track, vttCues);
-                    }, (key, file, url, error) => {
+                    }, (key, url, xhr, error) => {
                         if (error.code === 404) {
                             this.trigger(ERROR, {
                                 message: 'Captions failed to load',

--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -38,12 +38,10 @@ const Captions = function(_model) {
                     loadFile(track, (vttCues) => {
                         _addVTTCuesToTrack(track, vttCues);
                     }, (key, url, xhr, error) => {
-                        if (error.code === 404) {
-                            this.trigger(ERROR, {
-                                message: 'Captions failed to load',
-                                reason: 'File not found'
-                            });
-                        }
+                        this.trigger(ERROR, {
+                            message: 'Captions failed to load',
+                            reason: error.code === 404 ? 'File not found' : key
+                        });
                     });
                 }
             }

--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -37,13 +37,11 @@ const Captions = function(_model) {
                     _addTrack(track);
                     loadFile(track, (vttCues) => {
                         _addVTTCuesToTrack(track, vttCues);
-                    }, (key, file, url, error) => {
-                        if (error.code === 404) {
-                            this.trigger(ERROR, {
-                                message: 'Captions failed to load',
-                                reason: 'File not found'
-                            });
-                        }
+                    }, (error) => {
+                        this.trigger(ERROR, {
+                            message: 'Captions failed to load',
+                            reason: error
+                        });
                     });
                 }
             }

--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -40,7 +40,7 @@ const Captions = function(_model) {
                     }, (key, url, xhr, error) => {
                         this.trigger(ERROR, {
                             message: 'Captions failed to load',
-                            reason: error.code === 404 ? 'File not found' : key
+                            sourceError: error
                         });
                     });
                 }

--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -37,11 +37,13 @@ const Captions = function(_model) {
                     _addTrack(track);
                     loadFile(track, (vttCues) => {
                         _addVTTCuesToTrack(track, vttCues);
-                    }, (error) => {
-                        this.trigger(ERROR, {
-                            message: 'Captions failed to load',
-                            reason: error
-                        });
+                    }, (key, file, url, error) => {
+                        if (error.code === 404) {
+                            this.trigger(ERROR, {
+                                message: 'Captions failed to load',
+                                reason: 'File not found'
+                            });
+                        }
                     });
                 }
             }

--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -459,13 +459,11 @@ function addTextTracks(tracksArray) {
                 (vttCues) => {
                     this.addVTTCuesToTrack(textTrackAny, vttCues);
                 },
-                (key, file, url, error) => {
-                    if (error.code === 404) {
-                        this.trigger(ERROR, {
-                            message: 'Captions failed to load',
-                            reason: 'File not found'
-                        });
-                    }
+                (error) => {
+                    this.trigger(ERROR, {
+                        message: 'Captions failed to load',
+                        reason: error
+                    });
                 });
         }
     });

--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -459,7 +459,7 @@ function addTextTracks(tracksArray) {
                 (vttCues) => {
                     this.addVTTCuesToTrack(textTrackAny, vttCues);
                 },
-                (key, file, url, error) => {
+                (key, url, xhr, error) => {
                     if (error.code === 404) {
                         this.trigger(ERROR, {
                             message: 'Captions failed to load',

--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -462,7 +462,7 @@ function addTextTracks(tracksArray) {
                 (key, url, xhr, error) => {
                     this.trigger(ERROR, {
                         message: 'Captions failed to load',
-                        reason: error.code === 404 ? 'File not found' : key
+                        sourceError: error
                     });
                 });
         }

--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -460,12 +460,10 @@ function addTextTracks(tracksArray) {
                     this.addVTTCuesToTrack(textTrackAny, vttCues);
                 },
                 (key, url, xhr, error) => {
-                    if (error.code === 404) {
-                        this.trigger(ERROR, {
-                            message: 'Captions failed to load',
-                            reason: 'File not found'
-                        });
-                    }
+                    this.trigger(ERROR, {
+                        message: 'Captions failed to load',
+                        reason: error.code === 404 ? 'File not found' : key
+                    });
                 });
         }
     });

--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -459,11 +459,13 @@ function addTextTracks(tracksArray) {
                 (vttCues) => {
                     this.addVTTCuesToTrack(textTrackAny, vttCues);
                 },
-                (error) => {
-                    this.trigger(ERROR, {
-                        message: 'Captions failed to load',
-                        reason: error
-                    });
+                (key, file, url, error) => {
+                    if (error.code === 404) {
+                        this.trigger(ERROR, {
+                            message: 'Captions failed to load',
+                            reason: 'File not found'
+                        });
+                    }
                 });
         }
     });


### PR DESCRIPTION
### This PR will...

Change reason on error event from 'cantPlayVideo' to 'File Not Found' when ajax request for captions file returns 404

### Why is this Pull Request needed?

The wrong reason was being shown for not fatal captions events?

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-1690

