### PR TITLE
Disable nextUp when it's value is set to null in the model

### DIFF
--- a/src/js/view/controls/nextuptooltip.js
+++ b/src/js/view/controls/nextuptooltip.js
@@ -140,7 +140,9 @@ export default class NextUpTooltip {
     onNextUp(model, nextUp) {
         this.reset();
         if (!nextUp) {
-            return;
+            nextUp = {
+                showNextUp: false
+            };
         }
 
         this.enabled = !!(nextUp.title || nextUp.image);


### PR DESCRIPTION
This will clear the nextup tooltip when related encounters a feed error and sets `nextUp` to null.

https://github.com/jwplayer/jwplayer-plugin-related/pull/320

JW8-1717