### PR TITLE
Assign preload from playlist level to item level

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -4,6 +4,7 @@ import setConfig from 'api/set-config';
 import ApiQueueDecorator from 'api/api-queue';
 import PlaylistLoader from 'playlist/loader';
 import Playlist, { filterPlaylist, validatePlaylist, normalizePlaylistItem } from 'playlist/playlist';
+import Item from 'playlist/item';
 import InstreamAdapter from 'controller/instream-adapter';
 import Captions from 'controller/captions';
 import Model from 'controller/model';
@@ -919,7 +920,7 @@ Object.assign(Controller.prototype, {
         };
 
         this.setPlaylistItem = function (index, item) {
-            item = normalizePlaylistItem(_model, item, item.feedData || {});
+            item = normalizePlaylistItem(_model, new Item(item), item.feedData || {});
 
             if (item) {
                 const playlist = _model.get('playlist');

--- a/src/js/playlist/playlist.js
+++ b/src/js/playlist/playlist.js
@@ -30,13 +30,11 @@ export function normalizePlaylistItem(model, item, feedData) {
     const preload = model.get('preload');
     const playlistItem = Object.assign({}, item);
 
-    item.preload = getPreload(item.preload, preload);
+    playlistItem.preload = getPreload(item.preload, preload);
 
     playlistItem.allSources = formatSources(item, model);
 
     playlistItem.sources = filterSources(playlistItem.allSources, providers);
-
-    playlistItem.feedData = feedData;
 
     if (!playlistItem.sources.length) {
         return;

--- a/test/mock/mock-model.js
+++ b/test/mock/mock-model.js
@@ -144,6 +144,8 @@ Object.assign(MockModel.prototype, SimpleModel, {
         this.set('defaultPlaybackRate', rate);
         this.set('playbackRate', rate);
     },
+    getProviders() {
+    },
 });
 
 // Represents the state of the provider/media element

--- a/test/unit/playlist-test.js
+++ b/test/unit/playlist-test.js
@@ -82,19 +82,19 @@ describe('playlist', function() {
 
         it('assigns preload to the item', function () {
             const actual = normalizePlaylistItem(model, item, {});
-            expect(actual.preload).to.equal('metadata');
+            expect(actual).to.have.property('preload').to.equal('metadata');
         });
 
         it('doesnt assign preload to the item if its already on the item', function () {
             item.preload = 'auto';
             const actual = normalizePlaylistItem(model, item, {});
-            expect(actual.preload).to.equal('auto');
+            expect(actual).to.have.property('preload').to.equal('auto');
         });
 
         it('assigns preload to the item from the model if not defined', function () {
             model.attributes.preload = 'none';
             const actual = normalizePlaylistItem(model, item, {});
-            expect(actual.preload).to.equal('none');
+            expect(actual).to.have.property('preload').to.equal('none');
         });
 
         it('returns undefined if sources arent available', function() {
@@ -102,5 +102,28 @@ describe('playlist', function() {
             const actual = normalizePlaylistItem(model, item, {});
             expect(actual).to.equal(undefined);
         });
+
+        it('assigns feed data on the item to an empty object', function () {
+            const feedData = {};
+            const actual = normalizePlaylistItem(model, item, feedData);
+            expect(_.isEqual(feedData, actual.feedData)).to.be.true;
+
+        });
+
+        it('assigns feed data on the item to a feed', function () {
+            const feedData = {
+                playlist: [mp4.starscape, mp4.starscape, mp4.starscape]
+            };
+            const actual = normalizePlaylistItem(model, item, feedData);
+            expect(actual).to.have.property('feedData');
+            expect(_.isEqual(actual.feedData, feedData)).to.be.true;
+        });
+
+        it('assigns file property to item', function() {
+            const actual = normalizePlaylistItem(model, item, {});
+            expect(actual).to.have.property('file');
+            expect(_.isEqual(item.sources[0].file, actual.file)).to.be.true;
+        });
+
     });
 });

--- a/test/unit/playlist-test.js
+++ b/test/unit/playlist-test.js
@@ -1,10 +1,11 @@
-import Playlist, { validatePlaylist } from 'playlist/playlist';
+import Playlist, { validatePlaylist, normalizePlaylistItem } from 'playlist/playlist';
 import Item from 'playlist/item';
 import Source from 'playlist/source';
 import _ from 'test/underscore';
 import mp4 from 'data/mp4';
 import track from 'playlist/track';
 import { MSG_CANT_PLAY_VIDEO } from 'api/errors';
+import MockModel from 'mock/mock-model'
 
 function isValidPlaylistItem(playlistItem) {
     return _.isObject(playlistItem) && _.isArray(playlistItem.sources) && _.isArray(playlistItem.tracks);
@@ -56,6 +57,32 @@ describe('playlist', function() {
                 expect(e.code).to.equal(630);
                 expect(e.sourceError).to.not.exist;
             }
+        });
+    });
+
+    describe.only('normalizePlaylistItem', function () {
+        let item;
+        let model;
+        beforeEach(function () {
+            model = new MockModel();
+            model.setup({});
+            item = new Item({
+                sources: [
+                    {
+                        file: 'foo.mp4'
+                    }
+                ]
+            });
+        });
+
+        it('returns a different object', function () {
+           const actual = normalizePlaylistItem(model, item);
+           expect(Object.is(item, actual)).to.be.false;
+        });
+
+        it('assigns preload to the item', function () {
+            const actual = normalizePlaylistItem(model, item);
+            expect(actual.preload).to.equal('auto');
         });
     });
 });

--- a/test/unit/playlist-test.js
+++ b/test/unit/playlist-test.js
@@ -5,7 +5,7 @@ import _ from 'test/underscore';
 import mp4 from 'data/mp4';
 import track from 'playlist/track';
 import { MSG_CANT_PLAY_VIDEO } from 'api/errors';
-import MockModel from 'mock/mock-model'
+import MockModel from 'mock/mock-model';
 
 function isValidPlaylistItem(playlistItem) {
     return _.isObject(playlistItem) && _.isArray(playlistItem.sources) && _.isArray(playlistItem.tracks);
@@ -60,7 +60,7 @@ describe('playlist', function() {
         });
     });
 
-    describe.only('normalizePlaylistItem', function () {
+    describe('normalizePlaylistItem', function () {
         let item;
         let model;
         beforeEach(function () {
@@ -76,13 +76,31 @@ describe('playlist', function() {
         });
 
         it('returns a different object', function () {
-           const actual = normalizePlaylistItem(model, item);
-           expect(Object.is(item, actual)).to.be.false;
+            const actual = normalizePlaylistItem(model, item, {});
+            expect(Object.is(item, actual)).to.be.false;
         });
 
         it('assigns preload to the item', function () {
-            const actual = normalizePlaylistItem(model, item);
+            const actual = normalizePlaylistItem(model, item, {});
+            expect(actual.preload).to.equal('metadata');
+        });
+
+        it('doesnt assign preload to the item if its already on the item', function () {
+            item.preload = 'auto';
+            const actual = normalizePlaylistItem(model, item, {});
             expect(actual.preload).to.equal('auto');
+        });
+
+        it('assigns preload to the item from the model if not defined', function () {
+            model.attributes.preload = 'none';
+            const actual = normalizePlaylistItem(model, item, {});
+            expect(actual.preload).to.equal('none');
+        });
+
+        it('returns undefined if sources arent available', function() {
+            item.sources = [];
+            const actual = normalizePlaylistItem(model, item, {});
+            expect(actual).to.equal(undefined);
         });
     });
 });

--- a/test/unit/playlist-test.js
+++ b/test/unit/playlist-test.js
@@ -77,7 +77,7 @@ describe('playlist', function() {
 
         it('returns a different object', function () {
             const actual = normalizePlaylistItem(model, item, {});
-            expect(Object.is(item, actual)).to.be.false;
+            expect(_.isEqual(item, actual)).to.be.false;
         });
 
         it('assigns preload to the item', function () {


### PR DESCRIPTION
### This PR will...

- Adds unit tests to ```normalizePlaylistItem```
- Checks that preload set on the playlist level will get propagated to item level

### Why is this Pull Request needed?

```normalizePlaylistItem``` wasn't properly copying the ```preload``` property to playlist items returned from the function.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-1804

