### PR TITLE
Set intersection ratio to the view instead of the model

### DIFF
--- a/src/js/view/utils/views-manager.js
+++ b/src/js/view/utils/views-manager.js
@@ -3,6 +3,7 @@ import { requestAnimationFrame, cancelAnimationFrame } from 'utils/request-anima
 import { Browser, OS } from 'environment/environment';
 
 const views = [];
+const widgets = [];
 const observed = {};
 const hasOrientation = 'screen' in window && 'orientation' in window.screen;
 const isAndroidChrome = OS.android && Browser.chrome;
@@ -21,7 +22,14 @@ function lazyInitIntersectionObserver() {
                     for (let j = views.length; j--;) {
                         let view = views[j];
                         if (entry.target === view.getContainer()) {
-                            view.setIntersectionRatio(entry.intersectionRatio);
+                            view.setIntersection(entry);
+                            break;
+                        }
+                    }
+                    for (let k = widgets.length; k--;) {
+                        let widget = widgets[k];
+                        if (entry.target === widget.getContainer()) {
+                            widget.setIntersection(entry);
                             break;
                         }
                     }
@@ -101,6 +109,15 @@ export default {
         const index = views.indexOf(view);
         if (index !== -1) {
             views.splice(index, 1);
+        }
+    },
+    addWidget: function(widget) {
+        widgets.push(widget);
+    },
+    removeWidget: function(widget) {
+        const index = widgets.indexOf(widget);
+        if (index !== -1) {
+            widgets.splice(index, 1);
         }
     },
     size: function() {

--- a/src/js/view/utils/views-manager.js
+++ b/src/js/view/utils/views-manager.js
@@ -21,7 +21,7 @@ function lazyInitIntersectionObserver() {
                     for (let j = views.length; j--;) {
                         let view = views[j];
                         if (entry.target === view.getContainer()) {
-                            view.model.set('intersectionRatio', entry.intersectionRatio);
+                            view.setIntersectionRatio(entry.intersectionRatio);
                             break;
                         }
                     }

--- a/src/js/view/utils/views-manager.js
+++ b/src/js/view/utils/views-manager.js
@@ -27,8 +27,9 @@ function lazyInitIntersectionObserver() {
     }
 }
 
-function matchIntersection(entry, group) {
-    for (const view in group) {
+function matchIntersection(entry, views) {
+    for (let i = views.length; i--;) {
+        const view = views[i];
         if (entry.target === view.getContainer()) {
             view.setIntersection(entry);
             break;

--- a/src/js/view/utils/views-manager.js
+++ b/src/js/view/utils/views-manager.js
@@ -19,23 +19,20 @@ function lazyInitIntersectionObserver() {
             if (entries && entries.length) {
                 for (let i = entries.length; i--;) {
                     const entry = entries[i];
-                    for (let j = views.length; j--;) {
-                        let view = views[j];
-                        if (entry.target === view.getContainer()) {
-                            view.setIntersection(entry);
-                            break;
-                        }
-                    }
-                    for (let k = widgets.length; k--;) {
-                        let widget = widgets[k];
-                        if (entry.target === widget.getContainer()) {
-                            widget.setIntersection(entry);
-                            break;
-                        }
-                    }
+                    matchIntersection(entry, views);
+                    matchIntersection(entry, widgets);
                 }
             }
         }, { threshold: [0, 0.25, 0.5, 0.75, 1] });
+    }
+}
+
+function matchIntersection(entry, group) {
+    for (const view in group) {
+        if (entry.target === view.getContainer()) {
+            view.setIntersection(entry);
+            break;
+        }
     }
 }
 
@@ -81,6 +78,13 @@ function onVisibilityChange() {
     });
 }
 
+function removeFromGroup(view, group) {
+    const index = group.indexOf(view);
+    if (index !== -1) {
+        group.splice(index, 1);
+    }
+}
+
 document.addEventListener('visibilitychange', onVisibilityChange);
 document.addEventListener('webkitvisibilitychange', onVisibilityChange);
 window.addEventListener('resize', scheduleResponsiveRedraw);
@@ -106,19 +110,13 @@ export default {
         views.push(view);
     },
     remove: function(view) {
-        const index = views.indexOf(view);
-        if (index !== -1) {
-            views.splice(index, 1);
-        }
+        removeFromGroup(view, views);
     },
     addWidget: function(widget) {
         widgets.push(widget);
     },
     removeWidget: function(widget) {
-        const index = widgets.indexOf(widget);
-        if (index !== -1) {
-            widgets.splice(index, 1);
-        }
+        removeFromGroup(widget, widgets);
     },
     size: function() {
         return views.length;

--- a/src/js/view/utils/views-manager.js
+++ b/src/js/view/utils/views-manager.js
@@ -27,9 +27,9 @@ function lazyInitIntersectionObserver() {
     }
 }
 
-function matchIntersection(entry, views) {
-    for (let i = views.length; i--;) {
-        const view = views[i];
+function matchIntersection(entry, group) {
+    for (let i = group.length; i--;) {
+        const view = group[i];
         if (entry.target === view.getContainer()) {
             view.setIntersection(entry);
             break;

--- a/src/js/view/utils/visibility.js
+++ b/src/js/view/utils/visibility.js
@@ -1,4 +1,4 @@
-export default function getVisibility(model, element) {
+export default function getVisibility(model, element, intersectionRatio) {
     // Set visibility to 1 if we're in fullscreen
     if (model.get('fullscreen')) {
         return 1;
@@ -8,8 +8,6 @@ export default function getVisibility(model, element) {
     if (!model.get('activeTab')) {
         return 0;
     }
-    // Otherwise, set it to the intersection ratio reported from the intersection observer
-    let intersectionRatio = model.get('intersectionRatio');
 
     if (intersectionRatio === undefined) {
         // Get intersectionRatio through brute force

--- a/src/js/view/utils/visibility.js
+++ b/src/js/view/utils/visibility.js
@@ -1,4 +1,4 @@
-export default function getVisibility(model, element, intersectionRatio) {
+export default function getVisibility(model, element) {
     // Set visibility to 1 if we're in fullscreen
     if (model.get('fullscreen')) {
         return 1;
@@ -8,6 +8,8 @@ export default function getVisibility(model, element, intersectionRatio) {
     if (!model.get('activeTab')) {
         return 0;
     }
+    // Otherwise, set it to the intersection ratio reported from the intersection observer
+    let intersectionRatio = model.get('intersectionRatio');
 
     if (intersectionRatio === undefined) {
         // Get intersectionRatio through brute force

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -73,6 +73,7 @@ function View(_api, _model) {
 
     let _breakpoint = null;
     let _controls;
+    let _intersectionRatio;
 
     function reasonInteraction() {
         return { reason: 'interaction' };
@@ -269,7 +270,7 @@ function View(_api, _model) {
     };
 
     function updateVisibility() {
-        _model.set('visibility', getVisibility(_model, _playerElement));
+        _model.set('visibility', getVisibility(_model, _playerElement, _intersectionRatio));
     }
 
     this.init = function() {
@@ -278,7 +279,6 @@ function View(_api, _model) {
         _model.on('change:fullscreen', _fullscreen);
         _model.on('change:activeTab', updateVisibility);
         _model.on('change:fullscreen', updateVisibility);
-        _model.on('change:intersectionRatio', updateVisibility);
         _model.on('change:visibility', redraw);
         _model.on('instreamMode', (instreamMode) => {
             if (instreamMode) {
@@ -803,6 +803,11 @@ function View(_api, _model) {
         _captionsRenderer.clear();
         _captionsRenderer.setup(_model.get('id'), captionsStyle);
         _captionsRenderer.resize();
+    };
+
+    this.setIntersectionRatio = function (intersectionRatio) {
+        _intersectionRatio = intersectionRatio;
+        updateVisibility();
     };
 
     this.destroy = function () {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -73,7 +73,6 @@ function View(_api, _model) {
 
     let _breakpoint = null;
     let _controls;
-    let _intersectionRatio;
 
     function reasonInteraction() {
         return { reason: 'interaction' };
@@ -270,7 +269,7 @@ function View(_api, _model) {
     };
 
     function updateVisibility() {
-        _model.set('visibility', getVisibility(_model, _playerElement, _intersectionRatio));
+        _model.set('visibility', getVisibility(_model, _playerElement));
     }
 
     this.init = function() {
@@ -279,6 +278,7 @@ function View(_api, _model) {
         _model.on('change:fullscreen', _fullscreen);
         _model.on('change:activeTab', updateVisibility);
         _model.on('change:fullscreen', updateVisibility);
+        _model.on('change:intersectionRatio', updateVisibility);
         _model.on('change:visibility', redraw);
         _model.on('instreamMode', (instreamMode) => {
             if (instreamMode) {
@@ -805,9 +805,8 @@ function View(_api, _model) {
         _captionsRenderer.resize();
     };
 
-    this.setIntersectionRatio = function (intersectionRatio) {
-        _intersectionRatio = intersectionRatio;
-        updateVisibility();
+    this.setIntersection = function (entry) {
+        _model.set('intersectionRatio', entry.intersectionRatio);
     };
 
     this.destroy = function () {


### PR DESCRIPTION
### This PR will...
- differentiate widgets from views in the views-manager
- view-manager commands the view to set the intersection ratio to the model.
### Why is this Pull Request needed?
As we add new views for the related plugin, it's preferable to allow the view-manager to set the intersection on a view instead of reading it from a shared model.
### Are there any points in the code the reviewer needs to double check?
I couldn't come up with a better name than `matchIntersection`
### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):
JW8-1418

