### PR TITLE
Improve font scaling for captions rendering

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -217,6 +217,7 @@ function View(_api, _model) {
 
         _model.on(`change:${MEDIA_VISUAL_QUALITY}`, () => {
             _resizeMedia();
+            _captionsRenderer.resize();
         });
 
         const playerViewModel = _model.player;


### PR DESCRIPTION
### This PR will...
Improve font scaling for captions rendering by:

- Using the container when not in fullscreen.
- Using the screen dimensions when in fullscreen on mobile devices
- Rounding to 1DP to match browser precision
- Scaling based on the video's aspect ratio relative to its container

### Why is this Pull Request needed?
We recently improved scaling for iOS in full screen. This expands the solution to all environments.
### Are there any points in the code the reviewer needs to double check?
Calling `_captionsRenderer.resize()` after the visual quality event ensures that we set the correct font size as soon as the video height is determined. Not sure if this has any other side effects when future visual quality events occur.
### Are there any Pull Requests open in other repos which need to be merged with this?
No
#### Addresses Issue(s):
JW8-1794

