### PR TITLE
Only reset item.starttime on "time" (not on "bufferChange")

### DIFF
--- a/src/js/program/program-listeners.js
+++ b/src/js/program/program-listeners.js
@@ -63,7 +63,7 @@ export function ProviderListener(mediaController) {
                 if (isValidNumber(duration)) {
                     mediaModel.set('duration', duration);
                 }
-                if (isNumber(mediaController.item.starttime)) {
+                if (type === MEDIA_TIME && isNumber(mediaController.item.starttime)) {
                     delete mediaController.item.starttime;
                 }
                 break;


### PR DESCRIPTION
### This PR will...
Don't remove `item.starttime` on "bufferChange".

### Why is this Pull Request needed?
The html5 provider fires "bufferChange" on duration change from the video tag. `MEDIA_BUFFER` falls through to the `MEDIA_TIME` case to update the duration and position in the media model. `item.starttime` is cleared so that it's only used once but it should only be cleared on time after playback has started not on bufferChange. The html5 provider requires `item.starttime` on load to seek on start. This fix allows start on seek to work properly with the html5 provider. 

#### Addresses Issue(s):
JW8-1688


