### PR TITLE
Only modify item.starttime when attached equals false

### DIFF
--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -101,7 +101,7 @@ export default class MediaController extends Eventable {
     }
 
     detach() {
-        const { item, mediaModel, provider } = this;
+        const { provider } = this;
         this.thenPlayPromise.cancel();
         provider.detachMedia();
         this.attached = false;

--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -105,13 +105,6 @@ export default class MediaController extends Eventable {
         this.thenPlayPromise.cancel();
         provider.detachMedia();
         this.attached = false;
-
-        // If detaching to play a midroll (pos > 0), ensure that the player resumes at the detached time by setting starttime
-        // We don't need to do this for prerolls because the player re-attaches at time 0 by default
-        const pos = mediaModel.get('position');
-        if (pos) {
-            item.starttime = pos;
-        }
     }
 
     // Executes the playPromise

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -573,6 +573,15 @@ class ProgramController extends Eventable {
             mediaController.attach();
         } else {
             mediaController.detach();
+
+            const { item, mediaModel } = mediaController;
+
+            // If detaching to play a midroll (pos > 0), ensure that the player resumes at the detached time by setting starttime
+            // We don't need to do this for prerolls because the player re-attaches at time 0 by default
+            const pos = mediaModel.get('position');
+            if (pos) {
+                item.starttime = pos;
+            }
         }
     }
 


### PR DESCRIPTION
### This PR will...

- Move the logic for setting `starttime` on an item outside of `mediaController.detach()` and set it after we call the detach function 

### Why is this Pull Request needed?

- ```detatch()``` should not be responsible for setting the starttime in this case
- Prevents starttime on the new active item from being set on the item being detached in a playlist

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-1688


