### PR TITLE
Fix orientation detection on mobile devices for captions font resizing

### DIFF
--- a/src/js/view/captionsrenderer.js
+++ b/src/js/view/captionsrenderer.js
@@ -237,11 +237,18 @@ const CaptionsRenderer = function (viewModel) {
 
             // Use screen dimensions when in fullscreen on mobile devices
             if (_model.get('fullscreen') && OS.mobile) {
-                // device is in portrait mode when window.orientation = 0 || 180
-                const portraitMode = !(window.orientation % 180);
                 const { screen } = window;
-                containerHeight = portraitMode ? screen.availHeight : screen.availWidth;
-                containerWidth = portraitMode ? screen.availWidth : screen.availHeight;
+                if (screen.orientation) {
+                    containerHeight = screen.availHeight;
+                    containerWidth = screen.availWidth;
+                } else {
+                    // availHeight and availWidth don't change in iOS when the orientation changes
+                    // iOS device is in portrait mode when window.orientation = 0 || 180
+                    const portraitMode = !(window.orientation % 180);
+                    containerHeight = portraitMode ? screen.availHeight : screen.availWidth;
+                    containerWidth = portraitMode ? screen.availWidth : screen.availHeight;
+                }
+
             }
 
             if (containerWidth && containerHeight && videoWidth && videoHeight) {


### PR DESCRIPTION
### This PR will...
Detect orientation correctly on mobile devices that support the `screen.orientation` API.
### Why is this Pull Request needed?
`screen.availWidth` and `screen.availHeight` do not get updated when an iOS device is rotated. However, they do on Android devices. Detecting if the `screen.orientation` API is supported gives us confidence that the device's height and width will change when the orientation changes.
### Are there any points in the code the reviewer needs to double check?
No, but we've discovered that there's a font scaling bug in iOS 11.4. The code in this PR does not introduce the bug, nor is it a regression. I'll be filing an issue with webkit.
### Are there any Pull Requests open in other repos which need to be merged with this?
No.
#### Addresses Issue(s):
 JW8-1794

