### PR TITLE
Default network error message key is "This video file cannot be played."

### DIFF
--- a/src/js/providers/utils/network-error-parser.js
+++ b/src/js/providers/utils/network-error-parser.js
@@ -1,18 +1,18 @@
 import { MSG_PROTECTED_CONTENT, MSG_CANT_PLAY_VIDEO } from 'api/errors';
 
-export default function parseNetworkError(baseCode, statusCode, url = '') {
+export default function parseNetworkError(baseCode, statusCode, url) {
     let code = baseCode + 1000;
-    let key;
+    let key = MSG_CANT_PLAY_VIDEO;
 
     if (statusCode > 0) {
         // Restrict status code range between 400 and 599 in order to avoid conflicting codes; 6 otherwise
-        key = statusCode === 403 ? MSG_PROTECTED_CONTENT : MSG_CANT_PLAY_VIDEO;
+        if (statusCode === 403) {
+            key = MSG_PROTECTED_CONTENT;
+        }
         code += clampStatus(statusCode);
-    } else if (url.substring(0, 5) === 'http:' && document.location.protocol === 'https:') {
-        key = MSG_CANT_PLAY_VIDEO;
+    } else if (('' + url).substring(0, 5) === 'http:' && document.location.protocol === 'https:') {
         code += 12;
     } else if (statusCode === 0) {
-        key = MSG_CANT_PLAY_VIDEO;
         code += 11;
     }
 

--- a/test/unit/events-middleware-test.js
+++ b/test/unit/events-middleware-test.js
@@ -1,4 +1,3 @@
-import _ from 'test/underscore';
 import middleware from 'controller/events-middleware';
 
 describe('events-middleware', function() {

--- a/test/unit/network-error-parser-test.js
+++ b/test/unit/network-error-parser-test.js
@@ -1,23 +1,44 @@
 import parseNetworkError from 'providers/utils/network-error-parser';
 
 describe('network error parser', function () {
-    it('appends the status code if the status code is > 0', function () {
-        const actual = parseNetworkError(900000, 404).code;
-        expect(actual).to.equal(901404);
+
+    it('appends the status code if the status code is > 0 with default message key', function () {
+        const { code, key } = parseNetworkError(900000, 404);
+        expect(code).to.equal(901404);
+        expect(key).to.equal('cantPlayVideo');
     });
 
-    it('appends a code of 11 if the status code is 0', function () {
-        const actual = parseNetworkError(900000, 0).code;
-        expect(actual).to.equal(901011);
+    it('appends the status code if the status code is 403 with protected content message key', function () {
+        const { code, key } = parseNetworkError(900000, 403);
+        expect(code).to.equal(901403);
+        expect(key).to.equal('protectedContent');
     });
 
-    it('appends nothing if the status is below 0', function () {
-        const actual = parseNetworkError(900000, -1).code;
-        expect(actual).to.equal(901000);
+    it('appends a code of 11 if the status code is 0 with default message key', function () {
+        const { code, key } = parseNetworkError(900000, 0);
+        expect(code).to.equal(901011);
+        expect(key).to.equal('cantPlayVideo');
+    });
+
+    it('checks for access control errors insecure content with default message key', function () {
+        const { code, key } = parseNetworkError(900000, 0, 'https:');
+        // location.protocol cannot be stubbed so for now only only assert +12 when tests are run over https
+        if (document.location.protocol === 'https:') {
+            expect(code).to.equal(901012);
+        } else {
+            expect(code).to.equal(901011);
+        }
+        expect(key).to.equal('cantPlayVideo');
+    });
+
+    it('appends nothing if the status is below 0 with default message key', function () {
+        const { code, key } = parseNetworkError(900000, -1);
+        expect(code).to.equal(901000);
+        expect(key).to.equal('cantPlayVideo');
     });
 
     it('appends a code of 10 if the status code is < 400 or > 600', function () {
         expect(parseNetworkError(900000, 601).code).to.equal(901006);
         expect(parseNetworkError(900000, 399).code).to.equal(901006);
-    })
+    });
 });


### PR DESCRIPTION
### This PR will...
Always return 'cantPlayVideo' as the default `key` from `parseNetworkError`.

### Why is this Pull Request needed?
`parseNetworkError` should always return a message key. It prevents us from having to import `MSG_CANT_PLAY_VIDEO` everywhere that `parseNetworkError` is used (which is only in commercial).

### Are there any points in the code the reviewer needs to double check?
We should move these modules to jwplayer-commercial because they are not used anywhere in this project. I don't want to do that now since merging module changes will cause other open PRs for the upcoming release to fail if they are out of sync.

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/5551

#### Addresses Issue(s):

JW8-1786
