### PR TITLE
Set meta.starttime to playlistitem.starttime

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -430,7 +430,7 @@ Object.assign(Controller.prototype, {
                 _beforePlay = true;
                 _this.trigger(MEDIA_BEFOREPLAY, {
                     playReason,
-                    startTime: meta && meta.startTime ? meta.startTime : _model.get('playlistItem').starttime
+                    startTime: meta && meta.startTime ? (meta.startTime || 0) : _model.get('playlistItem').starttime
                 });
                 _beforePlay = false;
 

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -430,7 +430,7 @@ Object.assign(Controller.prototype, {
                 _beforePlay = true;
                 _this.trigger(MEDIA_BEFOREPLAY, {
                     playReason,
-                    startTime: meta && meta.startTime ? (meta.startTime || 0) : _model.get('playlistItem').starttime
+                    startTime: meta && meta.startTime ? meta.startTime : _model.get('playlistItem').starttime
                 });
                 _beforePlay = false;
 

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -18,7 +18,7 @@ import { OS } from 'environment/environment';
 import { streamType } from 'providers/utils/stream-type';
 import Promise, { resolved } from 'polyfills/promise';
 import cancelable from 'utils/cancelable';
-import { isUndefined, isBoolean } from 'utils/underscore';
+import { isUndefined, isBoolean, isValidNumber } from 'utils/underscore';
 import { INITIAL_MEDIA_STATE } from 'model/player-model';
 import { PLAYER_STATE, STATE_BUFFERING, STATE_IDLE, STATE_COMPLETE, STATE_PAUSED, STATE_PLAYING, STATE_ERROR, STATE_LOADING,
     STATE_STALLED, AUTOSTART_NOT_ALLOWED, MEDIA_BEFOREPLAY, PLAYLIST_LOADED, ERROR, PLAYLIST_COMPLETE, CAPTIONS_CHANGED, READY,
@@ -408,7 +408,9 @@ Object.assign(Controller.prototype, {
             }
 
             const playReason = _getReason(meta);
-            const startTime = meta ? meta.startTime : null;
+
+            const startTime = meta.startTime = isValidNumber(meta.startTime) ? meta.startTime : _model.get('playlistItem').starttime;
+
             _model.set('playReason', playReason);
             // Stop autoplay behavior if the video is started by the user or an api call
             if (playReason === 'interaction' || playReason === 'external') {

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -410,7 +410,7 @@ Object.assign(Controller.prototype, {
             const playReason = _getReason(meta);
             let startTime;
             
-            if (meta) {
+            if (meta && meta === Object(meta)) {
                 startTime = meta.startTime = isValidNumber(meta.startTime) ? meta.startTime : _model.get('playlistItem').starttime;
             } else {
                 startTime = null;

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -408,8 +408,13 @@ Object.assign(Controller.prototype, {
             }
 
             const playReason = _getReason(meta);
-
-            const startTime = meta.startTime = isValidNumber(meta.startTime) ? meta.startTime : _model.get('playlistItem').starttime;
+            let startTime;
+            
+            if (meta) {
+                startTime = meta.startTime = isValidNumber(meta.startTime) ? meta.startTime : _model.get('playlistItem').starttime;
+            } else {
+                startTime = null;
+            }
 
             _model.set('playReason', playReason);
             // Stop autoplay behavior if the video is started by the user or an api call

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -18,7 +18,7 @@ import { OS } from 'environment/environment';
 import { streamType } from 'providers/utils/stream-type';
 import Promise, { resolved } from 'polyfills/promise';
 import cancelable from 'utils/cancelable';
-import { isUndefined, isBoolean, isValidNumber } from 'utils/underscore';
+import { isUndefined, isBoolean } from 'utils/underscore';
 import { INITIAL_MEDIA_STATE } from 'model/player-model';
 import { PLAYER_STATE, STATE_BUFFERING, STATE_IDLE, STATE_COMPLETE, STATE_PAUSED, STATE_PLAYING, STATE_ERROR, STATE_LOADING,
     STATE_STALLED, AUTOSTART_NOT_ALLOWED, MEDIA_BEFOREPLAY, PLAYLIST_LOADED, ERROR, PLAYLIST_COMPLETE, CAPTIONS_CHANGED, READY,
@@ -408,14 +408,6 @@ Object.assign(Controller.prototype, {
             }
 
             const playReason = _getReason(meta);
-            let startTime;
-            
-            if (meta && meta === Object(meta)) {
-                startTime = meta.startTime = isValidNumber(meta.startTime) ? meta.startTime : _model.get('playlistItem').starttime;
-            } else {
-                startTime = null;
-            }
-
             _model.set('playReason', playReason);
             // Stop autoplay behavior if the video is started by the user or an api call
             if (playReason === 'interaction' || playReason === 'external') {
@@ -438,7 +430,7 @@ Object.assign(Controller.prototype, {
                 _beforePlay = true;
                 _this.trigger(MEDIA_BEFOREPLAY, {
                     playReason,
-                    startTime
+                    startTime: meta && meta.startTime ? meta.startTime : _model.get('playlistItem').starttime
                 });
                 _beforePlay = false;
 


### PR DESCRIPTION
### This PR will...

- Set ```meta.startTime``` to ```playlistItem.starttime``` when attempting playback

### Why is this Pull Request needed?

We currently don't set ```meta.startTime``` in the ```_play``` method and use that property for "startOnSeek" ad rules (pre and none are currently ignored because of this)

### Are there any points in the code the reviewer needs to double check?

Original PR: https://github.com/jwplayer/jwplayer/pull/2781

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-1688

