### PR TITLE
Remove call to updateProgramSoundSettings

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -487,8 +487,6 @@ Object.assign(Controller.prototype, {
                 // Only apply autostartMuted on un-muted autostart attempt.
                 if (result === AUTOPLAY_MUTED && !_this.getMute()) {
                     _model.set('autostartMuted', true);
-                    updateProgramSoundSettings();
-
                     _model.once('change:autostartMuted', function(model) {
                         model.off('change:viewable', _checkPlayOnViewable);
                         _this.trigger(MEDIA_MUTE, { mute: _model.getMute() });


### PR DESCRIPTION
### This PR will...

Remove call to ```updateProgramSoundSettings``` function in ```controller.js```

### Why is this Pull Request needed?

Calling ```updateProgramSoundSettings``` when payback starts and an ad is playing with ```"autoplayadsmuted": true,``` in the ```advertising``` block in the config, enqueues an extra API call for mute. If the viewer had already unmuted the video before the ad finished, we dequeue the API call for mute which will toggle ```jw-off``` on the mute element making it look like the video is muted, but sound is playing.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-1806

