### PR TITLE
Only forward and queue mute changes

### DIFF
--- a/src/js/program/program-listeners.js
+++ b/src/js/program/program-listeners.js
@@ -22,6 +22,12 @@ export function ProviderListener(mediaController) {
             case MEDIA_VISUAL_QUALITY:
                 mediaModel.set(MEDIA_VISUAL_QUALITY, Object.assign({}, data));
                 return;
+            case MEDIA_MUTE:
+                // Only forward and queue mute changes
+                if (data[type] === mediaController.model.getMute()) {
+                    return;
+                }
+                break;
             case PLAYER_STATE: {
                 if (data.newstate === STATE_IDLE) {
                     mediaController.thenPlayPromise.cancel();

--- a/src/js/program/program-listeners.js
+++ b/src/js/program/program-listeners.js
@@ -119,10 +119,7 @@ export function MediaControllerListener(model, programController) {
                 model.set(type, data[type]);
                 return;
             case MEDIA_MUTE:
-                if (!model.get('autostartMuted')) {
-                    // Don't persist mute state with muted autostart
-                    model.set(type, data[type]);
-                }
+                model.set(type, data[type]);
                 return;
             case MEDIA_RATE_CHANGE:
                 model.set('playbackRate', data.playbackRate);


### PR DESCRIPTION
### Why is this Pull Request needed?
When playback autostarts muted with a preroll, the background video fires a "volumechange" event asynchronously after being muted and after being backgrounded. The `ProviderListener`'s call to `trigger` is then queued until after the ad break. If audio is unmuted during the ad playback the reverse "volumechange" event is not fired (this may be a bug in Chrome since it is fired only when dev tools are open) so we never get a second unmute `trigger` added to the event queue. As a result a mute event is flushed after the break telling the player the video has been muted but has since been unmuted resulting in the UI and media being out of sync.

This change prevents us from forwarding or queuing mute events that match the player's global mute state so that we avoid this situation entirely. Since mute true events will not be forwarded when autostartMuted is true, we no longer need to check for it in the `MediaControllerListener` handler.

#### Addresses Issue(s):
JW8-1806

