### PR TITLE
Implement article matching mvp

### DIFF
--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -150,7 +150,7 @@ Object.assign(CoreShim.prototype, {
             if (!this.setup) {
                 return;
             }
-            setupError(this, error);
+            setupError(this, api, error);
         });
     },
     playerDestroy() {
@@ -255,7 +255,7 @@ Object.assign(CoreShim.prototype, {
     }
 });
 
-function setupError(core, error) {
+function setupError(core, api, error) {
     resolved.then(() => {
         const playerError = convertToPlayerError(MSG_TECHNICAL_ERROR, SETUP_ERROR_UNKNOWN, error);
         const model = core._model || core.modelShim;
@@ -264,16 +264,25 @@ function setupError(core, error) {
         playerError.message = playerError.message || model.get('localization').errors[playerError.key];
         delete playerError.key;
 
-        const errorContainer = ErrorContainer(core, playerError);
-        if (ErrorContainer.cloneIcon) {
-            errorContainer.querySelector('.jw-icon').appendChild(ErrorContainer.cloneIcon('error'));
+        const contextual = model.get('contextual');
+        // Remove (and hide) the player if it failed to set up in contextual mode; otherwise, show the error view
+        if (!contextual) {
+            const errorContainer = ErrorContainer(core, playerError);
+            if (ErrorContainer.cloneIcon) {
+                errorContainer.querySelector('.jw-icon').appendChild(ErrorContainer.cloneIcon('error'));
+            }
+            showView(core, errorContainer);
         }
-        showView(core, errorContainer);
 
         model.set('errorEvent', playerError);
         model.set('state', STATE_ERROR);
 
         core.trigger(SETUP_ERROR, playerError);
+
+        // Trigger remove after SETUP_ERROR so that any event listeners receive the event before being detached
+        if (contextual) {
+            api.remove();
+        }
     });
 }
 

--- a/test/unit/setup-test.js
+++ b/test/unit/setup-test.js
@@ -213,4 +213,19 @@ describe('api.setup', function() {
             expect(removeSpy2, 'second setup: second listener').to.have.callCount(0);
         });
     });
+
+    describe('contextual setup error', function () {
+        it('removes and hides when encountering a setupError in contextual mode', function () {
+            const removeSpy = sinon.spy();
+            return expectSetupError({
+                playlist: [],
+                contextual: true,
+                events: {
+                    remove: removeSpy
+                }
+            }).then(() => {
+                expect(removeSpy).to.have.callCount(1);
+            });
+        });
+    });
 });


### PR DESCRIPTION
### This PR will...
- Remove the player when encountering a setup error with a contextual feeds

### Why is this Pull Request needed?
So that contextual player errors do not detract from the articles they're embedded in

### Are there any points in the code the reviewer needs to double check?
Is there a better way to not show the error view, and to call remove on setupError when the player is contextual?

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/5612

#### Addresses Issue(s):

 JW8-1800

