### PR TITLE
Always render the cues gathered from the current positon 

### DIFF
--- a/src/js/view/captionsrenderer.js
+++ b/src/js/view/captionsrenderer.js
@@ -4,7 +4,7 @@ import Events from 'utils/backbone.events';
 import { ERROR } from 'events/events';
 import { css, style, getRgba } from 'utils/css';
 import { addClass, removeClass, empty } from 'utils/dom';
-import { identity, difference, isNumber, isFinite, filter } from 'utils/underscore';
+import { identity, isNumber, isFinite, filter } from 'utils/underscore';
 import { MEDIA_SEEK, MEDIA_TIME } from 'events/events';
 
 let _WebVTT;
@@ -87,9 +87,7 @@ const CaptionsRenderer = function (viewModel) {
             return;
         }
 
-        const cues = this.getCurrentCues(track.data, pos);
-
-        this.updateCurrentCues(cues);
+        _currentCues = this.getCurrentCues(track.data, pos);
         this.renderCues(true);
     };
 
@@ -97,18 +95,6 @@ const CaptionsRenderer = function (viewModel) {
         return filter(allCues, function (cue) {
             return pos >= (cue.startTime) && (!cue.endTime || pos <= cue.endTime);
         });
-    };
-
-    this.updateCurrentCues = function (cues) {
-        // Render with vtt.js if there are cues, clear if there are none
-        if (!cues.length) {
-            _currentCues = [];
-        } else if (difference(cues, _currentCues).length) {
-            addClass(_captionsWindow, 'jw-captions-window-active');
-            _currentCues = cues;
-        }
-
-        return _currentCues;
     };
 
     this.getAlignmentPosition = function (track, timeEvent) {

--- a/test/unit/captionsrenderer-test.js
+++ b/test/unit/captionsrenderer-test.js
@@ -29,23 +29,3 @@ describe('CaptionsRenderer.getCurrentCues', function() {
     });
 });
 
-describe('CaptionsRenderer.updateCurrentCues', function() {
-
-    it('should set current cues ', function() {
-        let cues = [
-            new VTTCue(0, 3, 'HG: Morning, Rob.')
-        ];
-        expect(captionsRenderer.updateCurrentCues(cues).length, '').to.equal(1);
-
-        cues = [
-            new VTTCue(12, 15, 'EG: Hey, Jo...'),
-            new VTTCue(13, 14, 'JB: Yeah?'),
-            new VTTCue(13, 14, 'JP: Yeah?')
-        ];
-        expect(captionsRenderer.updateCurrentCues(cues).length, '').to.equal(3);
-
-        cues = [];
-        expect(captionsRenderer.updateCurrentCues(cues).length, '').to.equal(0);
-    });
-});
-


### PR DESCRIPTION
### This PR will...
- Remove the `updateCurrentCues` method and always render the cues from the current position

### Why is this Pull Request needed?
So that cues whose end time have been are cleared. `updateCurrentCues` currently has two branches:

1. If the new cues array is empty, it sets `_currentCues` to empty
2. If the new cues array has an item not in `_currentCues`, `_currentCues` becomes the new array
3. Otherwise, `_currentCues` remains unchanged

This bug is present in case 2. The captions track has a cue which persists for the entire stream (0s-25s), with shorter cues spaced in between. The last of these shorter cues ends at 15s. At that time, the arrays look like this:

`new: [{ 0-25}]`
`current: [{0-25}, {10-15}]`

With the difference being: `[]`. The difference function used here is defined as all items in the new array not present in the current array. Therefore `updateCurrentCues` enters case 3 and keeps `_currentCues` the same. Thus the cue which should have ended at 15 remains rendered.

My solution is to remove this method and always assign `_currentCues` to the new cue array. This solution still fulfills conditions 1 and 2 of `_updateCurrentCues`, and resolves the bug associated with case 3. 

### Are there any points in the code the reviewer needs to double check?
I dug through the annotations and coulnd't find why we wouldn't always render the current cues array. I found https://jwplayer.atlassian.net/browse/JW7-2835 and tested all the cases and didn't see any regressions.

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-1784

