### PR TITLE
Clear iOS longpress on touchend

### DIFF
--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -236,6 +236,7 @@ const eventRegisters = {
             });
             addEventListener(ui, longPress, 'touchmove', cancel);
             addEventListener(ui, longPress, 'touchcancel', cancel);
+            addEventListener(ui, longPress, 'touchend', cancel);
         } else {
             ui.el.oncontextmenu = (e) => {
                 triggerEvent(ui, longPress, e);


### PR DESCRIPTION
### Why is this Pull Request needed?
When there are no UI instances to cancel longpress on "touchend", the rightclick menu is displayed on iOS, even when the screen was only tapped for less than half a second. This can be seen when tapping on an IMA ad in 8.5.0.

#### Addresses Issue(s):
JW8-2177

