### PR TITLE
Feature/html5 video src emptied error

### DIFF
--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -42,7 +42,7 @@ export default class MediaController extends Eventable {
             mediaModel.set('setup', true);
             playPromise = this._loadAndPlay(item, provider);
             if (!mediaModel.get('started')) {
-                this._playAttempt(playPromise, playReason);
+                playPromise = this._playAttempt(playPromise, playReason);
             }
         }
         return playPromise;
@@ -110,17 +110,18 @@ export default class MediaController extends Eventable {
     // Executes the playPromise
     _playAttempt(playPromise, playReason) {
         const { item, mediaModel, model, provider } = this;
+        const video = provider ? provider.video : null;
 
         this.trigger(MEDIA_PLAY_ATTEMPT, {
             item,
             playReason
         });
         // Immediately set player state to buffering if these conditions are met
-        if (provider && provider.video && !provider.video.paused) {
+        if (video && !video.paused) {
             model.set(PLAYER_STATE, STATE_BUFFERING);
         }
 
-        playPromise.then(() => {
+        return playPromise.then(() => {
             if (!mediaModel.get('setup')) {
                 // Exit if model state was reset
                 return;
@@ -140,8 +141,14 @@ export default class MediaController extends Eventable {
         }).catch(error => {
             if (this.item && mediaModel === model.mediaModel) {
                 model.set('playRejected', true);
-                const videoTagPaused = provider && provider.video && provider.video.paused;
+                const videoTagPaused = video && video.paused;
                 if (videoTagPaused) {
+                    // Check if the video.src was set to empty, resolving to location.href and loaded.
+                    // This can be caused by 3rd party ads libraries after an ad break.
+                    if (video.src === location.href) {
+                        // Attempt to reload the video once within the play promise chain.
+                        return this._loadAndPlay(item, provider);
+                    }
                     mediaModel.set('mediaState', STATE_PAUSED);
                 }
                 this.trigger(MEDIA_PLAY_ATTEMPT_FAILED, {
@@ -149,6 +156,7 @@ export default class MediaController extends Eventable {
                     item,
                     playReason
                 });
+                throw error;
             }
         });
     }

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -7,7 +7,6 @@ import VideoEvents from 'providers/video-listener-mixin';
 import VideoAction from 'providers/video-actions-mixin';
 import VideoAttached from 'providers/video-attached-mixin';
 import { style } from 'utils/css';
-import { tryCatch, JwError } from 'utils/trycatch';
 import { emptyElement } from 'utils/dom';
 import DefaultProvider from 'providers/default';
 import Events from 'utils/backbone.events';
@@ -499,7 +498,7 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
 
     this.load = function(item) {
         _setLevels(item.sources);
-        _completeLoad(item.starttime, item.duration || 0);
+        _completeLoad(item.starttime);
         this.setupSideloadedTracks(item.tracks);
     };
 
@@ -601,7 +600,7 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
         // This implementation is for iOS and Android WebKit only
         // This won't get called if the player container can go fullscreen
         if (state) {
-            const status = tryCatch(function() {
+            try {
                 const enterFullscreen =
                     _videotag.webkitEnterFullscreen ||
                     _videotag.webkitEnterFullScreen;
@@ -609,9 +608,7 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
                     enterFullscreen.apply(_videotag);
                 }
 
-            });
-
-            if (status instanceof JwError) {
+            } catch (error) {
                 // object can't go fullscreen
                 return false;
             }
@@ -650,9 +647,7 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
                 // from when the provider was first initialized
                 _playerConfig.qualityLabel = _levels[quality].label;
 
-                const time = _videotag.currentTime || 0;
-                const duration = _this.getDuration();
-                _completeLoad(time, duration);
+                _completeLoad(_videotag.currentTime || 0);
                 _play();
             }
         }

--- a/src/js/providers/video-listener-mixin.js
+++ b/src/js/providers/video-listener-mixin.js
@@ -20,6 +20,12 @@ const HTML5_BASE_MEDIA_ERROR = 224000;
 
 /**
  *
+ @enum {ErrorCode} - The HTML5 media element's src was emptied or set to the page's location.
+ */
+const HTML5_SRC_RESET = 224005;
+
+/**
+ *
  @enum {ErrorCode} - The HTML5 media element encountered a network error.
  */
 const HTML5_NETWORK_ERROR = 221000;
@@ -169,14 +175,17 @@ const VideoListenerMixin = {
             this.trigger(MEDIA_COMPLETE);
         }
     },
+
     loadeddata () {
         // If we're not rendering natively text tracks will be provided from another source - don't duplicate them here
         if (this.renderNatively) {
             this.setTextTracks(this.video.textTracks);
         }
     },
+
     error() {
-        const errorCode = (this.video.error && this.video.error.code) || -1;
+        const { video } = this;
+        const errorCode = (video.error && video.error.code) || -1;
         // Error code 2 from the video element is a network error
         let code = HTML5_BASE_MEDIA_ERROR;
         let key = MSG_CANT_PLAY_VIDEO;
@@ -188,6 +197,9 @@ const VideoListenerMixin = {
             code = HTML5_NETWORK_ERROR;
         } else if (errorCode === 3 || errorCode === 4) {
             code += errorCode - 1;
+            if (errorCode === 4 && video.src === location.href) {
+                code = HTML5_SRC_RESET;
+            }
         } else {
             key = MSG_TECHNICAL_ERROR;
         }


### PR DESCRIPTION
### This PR will...
Handle issues caused by 3rd party ads libraries clearing the video.src after an ad break or error.

If the src is cleared during a play attempt, the player will attempt to recover within the play promise chain.

If the src is cleared after playback has started a new error code - 224005 - will be included in errors to differentiate this type of failure from ones that result from MediaElement media not supported errors - 224003 (video.error.code 4).

### Why is this Pull Request needed?
This will add some resilience and tracking for errors we've identified on iPhone with IMA.

Changes to the media controller's play promise chain adds support for retries

### Are there any points in the code the reviewer needs to double check?
Returning the promise chain from `mediaController._playAttempt` rather than just the provider's play promise from `mediaController._loadAndPlay` may impact the order of events for things that use it > `programController.playVideo()` > `controller _play` > `controller _autostart` | `controller|api.play()`.

We may want to consider just implementing the new error code and tracking the impact of this issue before extending the media controller's play promise to support retries.

#### Addresses Issue(s):
JW8-2158
