### PR TITLE
[DNM] [Experiment] Add wrapper div around contents of the player

### DIFF
--- a/src/css/jwplayer/imports/jwplayerlayout.less
+++ b/src/css/jwplayer/imports/jwplayerlayout.less
@@ -89,3 +89,8 @@
 .jw-logo {
     pointer-events: all;
 }
+
+.jw-wrapper {
+    &:extend(.jwplayer);
+    height: 100%;
+}

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -344,11 +344,16 @@ export default class Controls {
         // Show controls when enabled
         this.userActive();
 
-        this.playerContainer.appendChild(this.div);
-
+        this.addControls();
         this.addBackdrop();
 
         model.set('controlsEnabled', true);
+    }
+
+    addControls() {
+        // Put the controls element inside the wrapper
+        const element = this.playerContainer.querySelector('.jw-wrapper');
+        element.appendChild(this.div);
     }
 
     disable(model) {
@@ -366,7 +371,7 @@ export default class Controls {
 
         if (this.div.parentNode) {
             removeClass(this.playerContainer, 'jw-flag-touch');
-            this.playerContainer.removeChild(this.div);
+            this.div.parentNode.removeChild(this.div);
         }
         if (this.rightClickMenu) {
             this.rightClickMenu.destroy();
@@ -488,7 +493,7 @@ export default class Controls {
         // Put the backdrop element on top of overlays during instream mode
         // otherwise keep it behind captions and on top of preview poster
         const element = this.instreamState ? this.div : this.playerContainer.querySelector('.jw-captions');
-        this.playerContainer.insertBefore(this.backdrop, element);
+        element.parentNode.insertBefore(this.backdrop, element);
     }
 
     removeBackdrop() {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -194,7 +194,7 @@ function View(_api, _model) {
         _captionsRenderer.setup(_playerElement.id, _model.get('captions'));
 
         // captions should be placed behind controls, and not hidden when controls are hidden
-        _playerElement.insertBefore(_captionsRenderer.element(), _title.element());
+        _title.element().parentNode.insertBefore(_captionsRenderer.element(), _title.element());
 
         // Display Click and Double Click Handling
         displayClickHandler = clickHandlerHelper(_api, _model, _videoLayer);
@@ -637,7 +637,7 @@ function View(_api, _model) {
         const element = (isAudioFile && !isFlash) ? _videoLayer : _videoLayer.nextSibling;
         // Put the preview element before the media element in order to display browser captions
         // otherwise keep it on top of the media element to display captions with the captions renderer
-        _playerElement.insertBefore(_preview.el, element);
+        _preview.el.parentNode.insertBefore(_preview.el, element);
     }
 
     function _errorHandler(model, errorEvent) {

--- a/src/templates/player.js
+++ b/src/templates/player.js
@@ -1,15 +1,16 @@
 export default (id, ariaLabel = '') => {
     return (
         `<div id="${id}" class="jwplayer jw-reset jw-state-setup" tabindex="0" aria-label="${ariaLabel}" role="application">` +
-            `<div class="jw-aspect jw-reset"></div>` +
-            `<div class="jw-media jw-reset"></div>` +
-            `<div class="jw-preview jw-reset"></div>` +
-            `<div class="jw-title jw-reset">` +
-                `<div class="jw-title-primary jw-reset"></div>` +
-                `<div class="jw-title-secondary jw-reset"></div>` +
+            `<div class="jw-wrapper jw-reset">` +
+                `<div class="jw-aspect jw-reset"></div>` +
+                `<div class="jw-media jw-reset"></div>` +
+                `<div class="jw-preview jw-reset"></div>` +
+                `<div class="jw-title jw-reset">` +
+                    `<div class="jw-title-primary jw-reset"></div>` +
+                    `<div class="jw-title-secondary jw-reset"></div>` +
+                `</div>` +
+                `<div class="jw-overlays jw-reset"></div>` +
             `</div>` +
-            `<div class="jw-overlays jw-reset"></div>` +
         `</div>`
     );
 };
-


### PR DESCRIPTION
### This PR will...
Add a div called `.jw-wrapper` that acts as an intermediate parent for manipulating the contents of the player without affecting the player container itself.

### Why is this Pull Request needed?
I keep running into similar issues while building experiments. Adding a wrapping div works in multiple cases.

### Are there any points in the code the reviewer needs to double check?
There are likely some other elements that I'm not aware of which should be aware of this new div.

#### Related Issue:
JW8-1863
