### PR TITLE
Return Promise.all result in Setup.start for compatibility with zone.js

### DIFF
--- a/src/js/api/Setup.js
+++ b/src/js/api/Setup.js
@@ -12,9 +12,10 @@ const Setup = function(_model) {
 
     this.start = function (api) {
 
-        const setup = startSetup(_model, api, [
+        const setup = Promise.all([
             loadCoreBundle(_model),
-            loadPlugins(_model, api)
+            loadPlugins(_model, api),
+            startSetup(_model, api, [])
         ]);
 
         const timeout = new Promise((resolve, reject) => {

--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -14,7 +14,8 @@ import MediaElementPool from 'program/media-element-pool';
 import SharedMediaPool from 'program/shared-media-pool';
 import UI, { getElementWindow } from 'utils/ui';
 import { PlayerError, composePlayerError, convertToPlayerError,
-    SETUP_ERROR_LOADING_PLAYLIST, SETUP_ERROR_UNKNOWN, MSG_TECHNICAL_ERROR } from 'api/errors';
+    SETUP_ERROR_LOADING_PLAYLIST, SETUP_ERROR_PROMISE_API_CONFLICT, SETUP_ERROR_UNKNOWN,
+    MSG_TECHNICAL_ERROR } from 'api/errors';
 
 const ModelShim = function() {};
 Object.assign(ModelShim.prototype, SimpleModel);
@@ -108,6 +109,9 @@ Object.assign(CoreShim.prototype, {
         model.on('change:errorEvent', logError);
 
         return this.setup.start(api).then(allPromises => {
+            if (!allPromises) {
+                throw composePlayerError(null, SETUP_ERROR_PROMISE_API_CONFLICT);
+            }
             const CoreMixin = allPromises[0];
             if (!this.setup) {
                 // Exit if `playerDestroy` was called on CoreLoader clearing the config

--- a/src/js/api/errors.js
+++ b/src/js/api/errors.js
@@ -10,6 +10,12 @@ export const SETUP_ERROR_UNKNOWN = 100000;
 export const SETUP_ERROR_TIMEOUT = 100001;
 
 /**
+ * @type {ErrorCode} Setup failed because the setup promise result was undefined.
+ * This could be caused by 3rd party JavaScript interfering with native promises or an incomplete promise polyfill.
+ */
+export const SETUP_ERROR_PROMISE_API_CONFLICT = 100002;
+
+/**
  * @enum {ErrorCode} Setup failed because no license key was found.
  */
 export const SETUP_ERROR_LICENSE_MISSING = 100011;
@@ -150,6 +156,6 @@ export function convertToPlayerError(key, code, error) {
 
 export function composePlayerError(error, superCode) {
     const playerError = convertToPlayerError(MSG_TECHNICAL_ERROR, superCode, error);
-    playerError.code = (error.code || 0) + superCode;
+    playerError.code = (error && error.code || 0) + superCode;
     return playerError;
 }


### PR DESCRIPTION
### This PR will...
- Return `Promise.all` result in `Setup.start` for compatibility with [zone.js](https://github.com/angular/zone.js)
- Add setup error code 100,002 for falsey `Setup.start` result 

### Why is this Pull Request needed?
In 8.5.0 we introduced this change https://github.com/jwplayer/jwplayer/commit/c1c9b77b70dbf52310005b7e2ed36b5a6c1705ca#diff-49ba114a4fff54f99f3a7f73e2c67df0L15 which works when the Promise implementation is consistent.

Adding zone.js to the page after our library results in a mix of native Promise and ZoneAwarePromise instances being used. In this case results in the call to Promise.race([setup, timeout]) thinking that the timeout resolved first and returning that result.

Any players on pages that add zone.js after our library would fail setup with error code 100,000.
"//unpkg.com/zone.js@0.8.26/dist/zone.js"

Adding zone.js to the page before jwplayer.js would work because then we would use reference to ZoneAwarePromise consistently. We specifically avoid that and try to only use the reference to window.Promise on embed to avoid conflicts with third party libraries.

Despite us keeping a reference to window.Promise, not all of the frameworks that we use do. Webpack's chunk loader for example which is used in our setup promise chain accesses it globally and as a result introduces zone.js Promises into the chain. 

#### Addresses Issue(s):
JW8-2185

