### PR TITLE
 Always use Promise global

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -25,10 +25,6 @@
         "no-restricted-globals": [
             "error",
             {
-                "name": "Promise",
-                "message": "import Promise from 'polyfills/promise'"
-            },
-            {
                 "name": "VTTCue",
                 "message": "import VTTCue from 'parsers/captions/vttcue'"
             }

--- a/src/js/api/Setup.js
+++ b/src/js/api/Setup.js
@@ -2,7 +2,6 @@ import loadCoreBundle from 'api/core-loader';
 import startSetup from 'api/setup-steps';
 import loadPlugins from 'plugins/plugins';
 import { PlayerError, SETUP_ERROR_TIMEOUT, MSG_CANT_LOAD_PLAYER } from 'api/errors';
-import Promise from 'polyfills/promise';
 
 const SETUP_TIMEOUT_SECONDS = 30;
 
@@ -25,7 +24,6 @@ const Setup = function(_model) {
             }, SETUP_TIMEOUT_SECONDS * 1000);
             const timeoutCancelled = () => {
                 clearTimeout(_setupFailureTimeout);
-                resolve();
             };
             setup.then(timeoutCancelled).catch(timeoutCancelled);
         });

--- a/src/js/api/core-loader.js
+++ b/src/js/api/core-loader.js
@@ -3,7 +3,6 @@ import { fixSources } from 'playlist/playlist';
 import ProvidersSupported from 'providers/providers-supported';
 import registerProvider from 'providers/providers-register';
 import { ControlsLoader } from 'controller/controls-loader';
-import { resolved } from 'polyfills/promise';
 import { PlayerError, SETUP_ERROR_LOADING_CORE_JS, MSG_CANT_LOAD_PLAYER } from 'api/errors';
 
 let bundlePromise = null;
@@ -144,5 +143,5 @@ function loadIntersectionObserverIfNeeded() {
             return require('intersection-observer');
         }, chunkLoadErrorHandler(SETUP_ERROR_LOADING_CORE_JS + 120), 'polyfills.intersection-observer');
     }
-    return resolved;
+    return Promise.resolve();
 }

--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -8,7 +8,6 @@ import SimpleModel from 'model/simplemodel';
 import { INITIAL_PLAYER_STATE, INITIAL_MEDIA_STATE } from 'model/player-model';
 import { SETUP_ERROR, STATE_ERROR } from 'events/events';
 import Events from 'utils/backbone.events';
-import { resolved } from 'polyfills/promise';
 import ErrorContainer from 'view/error-container';
 import MediaElementPool from 'program/media-element-pool';
 import SharedMediaPool from 'program/shared-media-pool';
@@ -256,7 +255,7 @@ Object.assign(CoreShim.prototype, {
 });
 
 function setupError(core, api, error) {
-    resolved.then(() => {
+    Promise.resolve().then(() => {
         const playerError = convertToPlayerError(MSG_TECHNICAL_ERROR, SETUP_ERROR_UNKNOWN, error);
         const model = core._model || core.modelShim;
 

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -16,7 +16,6 @@ import Events from 'utils/backbone.events';
 import { AUTOPLAY_DISABLED, AUTOPLAY_MUTED, canAutoplay, startPlayback } from 'utils/can-autoplay';
 import { OS } from 'environment/environment';
 import { streamType } from 'providers/utils/stream-type';
-import Promise, { resolved } from 'polyfills/promise';
 import cancelable from 'utils/cancelable';
 import { isUndefined, isBoolean } from 'utils/underscore';
 import { INITIAL_MEDIA_STATE } from 'model/player-model';
@@ -303,7 +302,7 @@ Object.assign(Controller.prototype, {
                 if (!mediaPool.primed() && OS.android) {
                     const video = mediaPool.getTestElement();
                     const muted = _this.getMute();
-                    resolved.then(() => startPlayback(video, { muted })).then(() => {
+                    Promise.resolve().then(() => startPlayback(video, { muted })).then(() => {
                         if (_model.get('state') === 'idle') {
                             _programController.preloadVideo();
                         }
@@ -404,7 +403,7 @@ Object.assign(Controller.prototype, {
             checkAutoStartCancelable.cancel();
 
             if (_model.get('state') === STATE_ERROR) {
-                return resolved;
+                return Promise.resolve();
             }
 
             const playReason = _getReason(meta);
@@ -418,7 +417,7 @@ Object.assign(Controller.prototype, {
             if (adState) {
                 // this will resume the ad. _api.playAd would load a new ad
                 _api.pauseAd(false, meta);
-                return resolved;
+                return Promise.resolve();
             }
 
             if (_model.get('state') === STATE_COMPLETE) {
@@ -446,7 +445,7 @@ Object.assign(Controller.prototype, {
                     }
                     _interruptPlay = false;
                     _actionOnAttach = null;
-                    return resolved;
+                    return Promise.resolve();
                 }
             }
 
@@ -767,7 +766,7 @@ Object.assign(Controller.prototype, {
                 }, _this)
                 .on(MEDIA_COMPLETE, () => {
                     // Insert a small delay here so that other complete handlers can execute
-                    resolved.then(_completeHandler);
+                    Promise.resolve().then(_completeHandler);
                 }, _this)
                 .on(MEDIA_ERROR, _this.triggerError, _this);
         }

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -4,7 +4,6 @@ import { STATE_BUFFERING, STATE_COMPLETE, STATE_PLAYING, STATE_PAUSED,
     INSTREAM_CLICK,
     AD_PLAY, AD_PAUSE, AD_TIME, AD_CLICK, AD_SKIPPED } from 'events/events';
 import { BACKGROUND_LOAD_OFFSET, BACKGROUND_LOAD_MIN_OFFSET } from '../program/program-constants';
-import Promise from 'polyfills/promise';
 import { offsetToSeconds } from 'utils/strings';
 import Events from 'utils/backbone.events';
 import AdProgramController from 'program/ad-program-controller';

--- a/src/js/jwplayer.js
+++ b/src/js/jwplayer.js
@@ -1,3 +1,4 @@
+import 'polyfills/promise';
 import { loadFrom } from './utils/playerutils';
 import instances from './api/players';
 import GlobalApi from 'api/global-api';

--- a/src/js/plugins/loader.js
+++ b/src/js/plugins/loader.js
@@ -1,11 +1,10 @@
-import Promise, { resolved } from 'polyfills/promise';
 import { configurePlugin } from 'plugins/plugin';
 
 const PluginLoader = function () {
     this.load = function (api, pluginsModel, pluginsConfig, model) {
         // Must be a hash map
         if (!pluginsConfig || typeof pluginsConfig !== 'object') {
-            return resolved;
+            return Promise.resolve();
         }
 
         return Promise.all(Object.keys(pluginsConfig).filter(pluginUrl => pluginUrl)

--- a/src/js/plugins/plugin.js
+++ b/src/js/plugins/plugin.js
@@ -1,4 +1,3 @@
-import Promise from 'polyfills/promise';
 import ScriptLoader from 'utils/scriptloader';
 import { getAbsolutePath } from 'utils/parser';
 import { extension } from 'utils/strings';

--- a/src/js/polyfills/promise.js
+++ b/src/js/polyfills/promise.js
@@ -1,7 +1,3 @@
 import PromiseModule from 'promise-polyfill/src/index';
 
-const Promise = window.Promise || (window.Promise = PromiseModule);
-
-export const resolved = Promise.resolve();
-
-export default Promise;
+(function() {}(window.Promise || (window.Promise = PromiseModule)));

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -1,6 +1,5 @@
 import Providers from 'providers/providers';
 import MediaController from 'program/media-controller';
-import Promise, { resolved } from 'polyfills/promise';
 import cancelable from 'utils/cancelable';
 import { MediaControllerListener } from 'program/program-listeners';
 import Eventable from 'utils/eventable';
@@ -26,7 +25,7 @@ class ProgramController extends Eventable {
         this.mediaControllerListener = MediaControllerListener(model, this);
         this.model = model;
         this.providers = new Providers(model.getConfiguration());
-        this.loadPromise = resolved;
+        this.loadPromise = Promise.resolve();
         this.backgroundLoading = model.get('backgroundLoading');
 
         if (!this.backgroundLoading) {

--- a/src/js/providers/providers.js
+++ b/src/js/providers/providers.js
@@ -2,7 +2,6 @@ import ProvidersSupported from 'providers/providers-supported';
 import registerProvider from 'providers/providers-register';
 import ProvidersLoaded from 'providers/providers-loaded';
 import { chunkLoadErrorHandler } from '../api/core-loader';
-import Promise from 'polyfills/promise';
 
 function Providers(config) {
     this.config = config || {};

--- a/src/js/providers/utils/play-promise.js
+++ b/src/js/providers/utils/play-promise.js
@@ -1,5 +1,3 @@
-import Promise from 'polyfills/promise';
-
 export default function createPlayPromise(video) {
     return new Promise(function(resolve, reject) {
         if (video.paused) {

--- a/src/js/utils/can-autoplay.js
+++ b/src/js/utils/can-autoplay.js
@@ -23,7 +23,6 @@
 // SOFTWARE.
 
 import createPlayPromise from '../providers/utils/play-promise';
-import Promise from '../polyfills/promise';
 
 // Use webkitURL or mozURL as a backup if URL was overwritten
 const URL = (global => global.URL && global.URL.createObjectURL ?

--- a/src/js/utils/cancelable.js
+++ b/src/js/utils/cancelable.js
@@ -1,12 +1,10 @@
-import { resolved } from 'polyfills/promise';
-
 export default function cancelable(callback) {
     let cancelled = false;
 
     return {
         async: function() {
             const args = arguments;
-            return resolved.then(() => {
+            return Promise.resolve().then(() => {
                 if (cancelled) {
                     return;
                 }

--- a/src/js/utils/scriptloader.js
+++ b/src/js/utils/scriptloader.js
@@ -1,6 +1,5 @@
 import Events from 'utils/backbone.events';
 import { ERROR, STATE_COMPLETE } from 'events/events';
-import Promise from 'polyfills/promise';
 
 const ScriptPromises = {};
 


### PR DESCRIPTION
### This PR will...
Remove `Promise` and `resolved` exports from "polyfills/promise".

### Why is this Pull Request needed?
Always get `Promise` and `Promise.resolved()` from the global scope for compatibility with libraries that modify `window.Promise` like zone.js.

Other tools we use like webpack, shaka and hlsjs access `Promise` from the global scope AFAIK so we should too.

For more see https://github.com/jwplayer/jwplayer/pull/3044

### Commercial PR
https://github.com/jwplayer/jwplayer-commercial/pull/5639

#### Addresses Issue(s):
JW8-2206


