### PR TITLE
Use native font scaling when in iOS fullscreen

### DIFF
--- a/src/js/view/captionsrenderer.js
+++ b/src/js/view/captionsrenderer.js
@@ -206,26 +206,27 @@ const CaptionsRenderer = function (viewModel) {
 
     function _setFontSize() {
         const height = _model.get('containerHeight');
+
         if (!height) {
             return;
         }
 
+        let fontSize;
         if (_model.get('fullscreen') && OS.iOS) {
-            style(_display, {
-                fontSize: 'initial'
-            });
+            fontSize = 'inherit';
         } else {
-            const containerFontSize = height * _fontScale;
             // round to 1dp to match browser precision
-            const fontSize = Math.round(getScaledFontSize(containerFontSize) * 10) / 10;
+            const containerFontSize = height * _fontScale;
+            fontSize = Math.round(getScaledFontSize(containerFontSize) * 10) / 10;
+        }
 
-            if (_model.get('renderCaptionsNatively')) {
-                _setShadowDOMFontSize(_model.get('id'), fontSize);
-            } else {
-                style(_display, {
-                    fontSize: fontSize + 'px'
-                });
-            }
+        if (_model.get('renderCaptionsNatively')) {
+            _setShadowDOMFontSize(_model.get('id'), fontSize);
+        } else {
+            // 'px' will automatically be appended if fontSize is a number
+            style(_display, {
+                fontSize
+            });
         }
     }
 

--- a/src/js/view/captionsrenderer.js
+++ b/src/js/view/captionsrenderer.js
@@ -206,21 +206,26 @@ const CaptionsRenderer = function (viewModel) {
 
     function _setFontSize() {
         const height = _model.get('containerHeight');
-
         if (!height) {
             return;
         }
 
-        const containerFontSize = height * _fontScale;
-        // round to 1dp to match browser precision
-        const fontSize = Math.round(getScaledFontSize(containerFontSize) * 10) / 10;
-
-        if (_model.get('renderCaptionsNatively')) {
-            _setShadowDOMFontSize(_model.get('id'), fontSize);
-        } else {
+        if (_model.get('fullscreen') && OS.iOS) {
             style(_display, {
-                fontSize: fontSize + 'px'
+                fontSize: 'initial'
             });
+        } else {
+            const containerFontSize = height * _fontScale;
+            // round to 1dp to match browser precision
+            const fontSize = Math.round(getScaledFontSize(containerFontSize) * 10) / 10;
+
+            if (_model.get('renderCaptionsNatively')) {
+                _setShadowDOMFontSize(_model.get('id'), fontSize);
+            } else {
+                style(_display, {
+                    fontSize: fontSize + 'px'
+                });
+            }
         }
     }
 
@@ -241,14 +246,7 @@ const CaptionsRenderer = function (viewModel) {
                 if (screen.orientation) {
                     containerHeight = screen.availHeight;
                     containerWidth = screen.availWidth;
-                } else {
-                    // availHeight and availWidth don't change in iOS when the orientation changes
-                    // iOS device is in portrait mode when window.orientation = 0 || 180
-                    const portraitMode = !(window.orientation % 180);
-                    containerHeight = portraitMode ? screen.availHeight : screen.availWidth;
-                    containerWidth = portraitMode ? screen.availWidth : screen.availHeight;
                 }
-
             }
 
             if (containerWidth && containerHeight && videoWidth && videoHeight) {


### PR DESCRIPTION
### This PR will...
- Set the fontSize to initial when in iOS fullscreen instead of using the `getScaledFontSize` method

### Why is this Pull Request needed?
iOS uses extra magic to get the proper font scale that we haven't figured out. Instead of spending the effort to do it we can just remove our style and inherit iOS'

### Are there any points in the code the reviewer needs to double check?
- This means that viewers loose custom styling in iOS fullscreen. Is that OK?
- Removing `px` from the `setFontSize` method causes all font sizes to be rounded up. Is this OK? 

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-1814

