### PR TITLE
Delete captions submenu & button on playlistItem change

### DIFF
--- a/src/js/view/controls/settings-menu.js
+++ b/src/js/view/controls/settings-menu.js
@@ -163,6 +163,12 @@ export function setupSubmenuListeners(settingsMenu, controlbar, viewModel, api) 
     }, settingsMenu);
 
     // Captions
+    model.on('change:playlistItem', () => {
+        // captions.js silently clears captions when the playlist item changes. The reason it silently clear captions
+        // instead of dispatching an event is because we don't want to emit 'captionsList' if the new list is empty.
+        removeCaptionsSubmenu(settingsMenu);
+        controlbar.elements.captionsButton.hide();
+    });
     model.change('captionsList', onCaptionsChanged, settingsMenu);
     model.change('captionsIndex', (changedModel, index) => {
         const captionsSubmenu = settingsMenu.getSubmenu('captions');
@@ -171,12 +177,6 @@ export function setupSubmenuListeners(settingsMenu, controlbar, viewModel, api) 
             controlbar.toggleCaptionsButtonState(!!index);
         }
     }, settingsMenu);
-    model.on('change:playlistItem', () => {
-        // captions.js silently clears captions when the playlist item changes. The reason it silently clear captions
-        // instead of dispatching an event is because we don't want to emit 'captionsList' if the new list is empty.
-        removeCaptionsSubmenu(settingsMenu);
-        controlbar.elements.captionsButton.hide();
-    });
 
     // Playback Rates
     model.change('playbackRates', setupPlaybackRatesMenu, settingsMenu);

--- a/src/js/view/controls/settings-menu.js
+++ b/src/js/view/controls/settings-menu.js
@@ -171,8 +171,14 @@ export function setupSubmenuListeners(settingsMenu, controlbar, viewModel, api) 
             controlbar.toggleCaptionsButtonState(!!index);
         }
     }, settingsMenu);
+    model.on('change:playlistItem', () => {
+        // captions.js silently clears captions when the playlist item changes. The reason it silently clear captions
+        // instead of dispatching an event is because we don't want to emit 'captionsList' if the new list is empty.
+        removeCaptionsSubmenu(settingsMenu);
+        controlbar.elements.captionsButton.hide();
+    });
 
-    // Playback Rates
+        // Playback Rates
     model.change('playbackRates', setupPlaybackRatesMenu, settingsMenu);
     model.change('playbackRate', (changedModel, playbackRate) => {
         const rates = model.get('playbackRates');

--- a/src/js/view/controls/settings-menu.js
+++ b/src/js/view/controls/settings-menu.js
@@ -178,7 +178,7 @@ export function setupSubmenuListeners(settingsMenu, controlbar, viewModel, api) 
         controlbar.elements.captionsButton.hide();
     });
 
-        // Playback Rates
+    // Playback Rates
     model.change('playbackRates', setupPlaybackRatesMenu, settingsMenu);
     model.change('playbackRate', (changedModel, playbackRate) => {
         const rates = model.get('playbackRates');


### PR DESCRIPTION
### Why is this Pull Request needed?
To mirror the silent captions list clearing on the `playlistItem` event done here:
https://github.com/jwplayer/jwplayer/blob/master/src/js/controller/captions.js#L19

We don't dispatch an empty `captionsList` event (because captions may be received later in a stream so we cannot definitively say captions are empty); however, our own internal events rely on an empty list to clear the submenu. This method clears out the menu on the same event which clears the captions.

### Are there any points in the code the reviewer needs to double check?
Is there a better way to do this? Ideally we'd let the events propagate through the player but not out of it; however, this seemed pretty uncertain because I'm not 100% sure that we should never dispatch a captions list consisting of just `off`.

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-1174

