### PR TITLE
[JW8-1840] Add autoPause.viewability.

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -277,7 +277,7 @@ Object.assign(Controller.prototype, {
             }
 
             // Autostart immediately if we're not waiting for the player to become viewable first.
-            if (_model.get('autostart') === true && !_model.get('playOnViewable')) {
+            if (_model.get('autostart') === true) {
                 _autoStart();
             }
             apiQueue.flush();

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -317,7 +317,7 @@ Object.assign(Controller.prototype, {
             if (model.get('playOnViewable')) {
                 if (viewable) {
                     _autoStart();
-                } else if (OS.mobile) {
+                } else if (OS.mobile || (model.get('autoPause') && model.get('autoPause').viewability)) {
                     _this.pause({ reason: 'autostart' });
                 }
             }

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -1,4 +1,3 @@
-import { OS } from 'environment/environment';
 import SimpleModel from 'model/simplemodel';
 import { INITIAL_PLAYER_STATE, INITIAL_MEDIA_STATE } from 'model/player-model';
 import { STATE_IDLE } from 'events/events';
@@ -186,9 +185,7 @@ const Model = function() {
         if (autoStart !== undefined) {
             this.set('autostart', autoStart);
         }
-
-        const autoStartOnMobile = OS.mobile && this.get('autostart');
-        this.set('playOnViewable', autoStartOnMobile || this.get('autostart') === 'viewable');
+        this.set('playOnViewable', this.get('autostart'));
     };
 
     this.resetItem = function (item) {


### PR DESCRIPTION
### This PR will...
Add `autoPause` for autostarting videos, so they pause when transitioning from viewable to not viewable, and resume when viewable again. Config: `autoPause: { viewability: true }`.

### Why is this Pull Request needed?
Mainly for outstream, but applicable to all autostarting players.

### Are there any points in the code the reviewer needs to double check?
* Feature only applicable to autostarting videos.
* User gestures (i.e. manual pause) cancel out `autoPause`.
* The above means if the video cannot autostart (i.e. browser restrictions), setting does not apply since a user gesture is needed before playback starts.
* `pauseReason` is `autostart`.

### Are there any Pull Requests open in other repos which need to be merged with this?
N/A

#### Addresses Issue(s):
JW8-1840