### PR TITLE
Implement standardized warnings

### DIFF
--- a/src/js/api/Setup.js
+++ b/src/js/api/Setup.js
@@ -43,7 +43,7 @@ const Setup = function(_model) {
                 throw error;
             };
             return pluginsPromise.then(throwError).catch(throwError);
-        });
+        }).then(allPromises => setupResult(allPromises));
     };
 
     this.destroy = function() {
@@ -51,7 +51,35 @@ const Setup = function(_model) {
         _model.set('_destroyed', true);
         _model = null;
     };
-
 };
+
+/**
+ * @typedef { object } SetupResult
+ * @property { object } core
+ * @property {Array<PlayerError>} warnings
+ */
+
+/**
+ *
+ * @param {Array<Promise>} allPromises - An array of promise resolutions or rejections
+ * @returns {SetupResult} setupResult
+ */
+export function setupResult(allPromises) {
+    if (!allPromises || !allPromises.length) {
+        return {
+            core: null,
+            warnings: []
+        };
+    }
+
+    const warnings = allPromises
+        .reduce((acc, val) => acc.concat(val), []) // Flattens the sub-arrays of allPromises into a single array
+        .filter(p => p && p.code);
+
+    return {
+        core: allPromises[0],
+        warnings
+    };
+}
 
 export default Setup;

--- a/src/js/api/Setup.js
+++ b/src/js/api/Setup.js
@@ -74,7 +74,7 @@ export function setupResult(allPromises) {
 
     const warnings = allPromises
         .reduce((acc, val) => acc.concat(val), []) // Flattens the sub-arrays of allPromises into a single array
-        .filter(p => p && p.code);
+        .filter(result => result && result.code);
 
     return {
         core: allPromises[0],

--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -108,11 +108,12 @@ Object.assign(CoreShim.prototype, {
         model.on('change:errorEvent', logError);
 
         return this.setup.start(api).then(setupResult => {
-            if (!setupResult) {
+            if (!setupResult.core) {
                 throw composePlayerError(null, SETUP_ERROR_PROMISE_API_CONFLICT);
             }
 
             setupResult.warnings.forEach(w => {
+                console.warn(PlayerError.logMessage(w.code));
                 this.trigger(WARNING, w);
             });
 

--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -112,16 +112,17 @@ Object.assign(CoreShim.prototype, {
                 throw composePlayerError(null, SETUP_ERROR_PROMISE_API_CONFLICT);
             }
 
-            setupResult.warnings.forEach(w => {
-                console.warn(PlayerError.logMessage(w.code));
-                this.trigger(WARNING, w);
-            });
-
             const CoreMixin = setupResult.core;
             if (!this.setup) {
                 // Exit if `playerDestroy` was called on CoreLoader clearing the config
                 return;
             }
+
+            setupResult.warnings.forEach(w => {
+                console.warn(PlayerError.logMessage(w.code));
+                this.trigger(WARNING, w);
+            });
+
             const config = this.modelShim.clone();
             // Exit if embed config encountered an error
             if (config.error) {

--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -108,11 +108,11 @@ Object.assign(CoreShim.prototype, {
         model.on('change:errorEvent', logError);
 
         return this.setup.start(api).then(setupResult => {
-            if (!setupResult.core) {
+            const CoreMixin = setupResult.core;
+            if (!CoreMixin) {
                 throw composePlayerError(null, SETUP_ERROR_PROMISE_API_CONFLICT);
             }
 
-            const CoreMixin = setupResult.core;
             if (!this.setup) {
                 // Exit if `playerDestroy` was called on CoreLoader clearing the config
                 return;

--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -118,7 +118,7 @@ Object.assign(CoreShim.prototype, {
                 return;
             }
 
-            setupResult.warnings.forEach(w => emitWarning(w));
+            setupResult.warnings.forEach(w => logWarning(w));
 
             const config = this.modelShim.clone();
             // Exit if embed config encountered an error
@@ -137,7 +137,7 @@ Object.assign(CoreShim.prototype, {
             // Switch the error log handlers after the real model has been set
             model.off('change:errorEvent', logError);
             coreModel.on('change:errorEvent', logError);
-            this.on(WARNING, emitWarning);
+            this.on(WARNING, logWarning);
             storage.track(coreModel);
 
             // Set the active playlist item after plugins are loaded and the view is setup
@@ -300,7 +300,7 @@ function logError(model, error) {
     console.error(PlayerError.logMessage(error.code));
 }
 
-function emitWarning(warning) {
+function logWarning(warning) {
     if (!warning || !warning.code) {
         return;
     }

--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -118,7 +118,10 @@ Object.assign(CoreShim.prototype, {
                 return;
             }
 
-            setupResult.warnings.forEach(w => logWarning(w));
+            this.on(WARNING, logWarning);
+            setupResult.warnings.forEach(w => {
+                this.trigger(WARNING, w);
+            });
 
             const config = this.modelShim.clone();
             // Exit if embed config encountered an error
@@ -137,7 +140,6 @@ Object.assign(CoreShim.prototype, {
             // Switch the error log handlers after the real model has been set
             model.off('change:errorEvent', logError);
             coreModel.on('change:errorEvent', logError);
-            this.on(WARNING, logWarning);
             storage.track(coreModel);
 
             // Set the active playlist item after plugins are loaded and the view is setup

--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -137,7 +137,7 @@ Object.assign(CoreShim.prototype, {
             // Switch the error log handlers after the real model has been set
             model.off('change:errorEvent', logError);
             coreModel.on('change:errorEvent', logError);
-            this.on('warning', emitWarning);
+            this.on(WARNING, emitWarning);
             storage.track(coreModel);
 
             // Set the active playlist item after plugins are loaded and the view is setup

--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -118,10 +118,7 @@ Object.assign(CoreShim.prototype, {
                 return;
             }
 
-            setupResult.warnings.forEach(w => {
-                console.warn(PlayerError.logMessage(w.code));
-                this.trigger(WARNING, w);
-            });
+            setupResult.warnings.forEach(w => emitWarning(w));
 
             const config = this.modelShim.clone();
             // Exit if embed config encountered an error
@@ -140,6 +137,7 @@ Object.assign(CoreShim.prototype, {
             // Switch the error log handlers after the real model has been set
             model.off('change:errorEvent', logError);
             coreModel.on('change:errorEvent', logError);
+            this.on('warning', emitWarning);
             storage.track(coreModel);
 
             // Set the active playlist item after plugins are loaded and the view is setup
@@ -300,6 +298,13 @@ function logError(model, error) {
         console.error(error.sourceError);
     }
     console.error(PlayerError.logMessage(error.code));
+}
+
+function emitWarning(warning) {
+    if (!warning || !warning.code) {
+        return;
+    }
+    console.warn(PlayerError.logMessage(warning.code));
 }
 
 export function showView(core, viewElement) {

--- a/src/js/api/errors.js
+++ b/src/js/api/errors.js
@@ -153,18 +153,17 @@ export const MSG_TECHNICAL_ERROR = 'technicalError';
 /**
  * @enum {ErrorKey}
  */
-export const MSG_PLUGIN_LOAD_FAILED = 'pluginLoadFailed';
+export const MSG_PLUGIN_ERROR = 'pluginError';
 
 /**
  * @enum {ErrorKey}
  */
-export const MSG_PLUGIN_NOT_REGISTERED = 'pluginNotRegistered';
+export const MSG_CAPTIONS_ERROR = 'captionsError';
 
 /**
  * @enum {ErrorKey}
  */
-
-export const MSG_CAPTIONS_LOAD_FAILED = 'captionsLoadFailed';
+export const MSG_NETWORK_ERROR = 'networkError';
 
 
 /**

--- a/src/js/api/errors.js
+++ b/src/js/api/errors.js
@@ -156,22 +156,6 @@ export const MSG_PROTECTED_CONTENT = 'protectedContent';
 export const MSG_TECHNICAL_ERROR = 'technicalError';
 
 /**
- * @enum {ErrorKey}
- */
-export const MSG_PLUGIN_ERROR = 'pluginError';
-
-/**
- * @enum {ErrorKey}
- */
-export const MSG_CAPTIONS_ERROR = 'captionsError';
-
-/**
- * @enum {ErrorKey}
- */
-export const MSG_NETWORK_ERROR = 'networkError';
-
-
-/**
  * Class used to create "setupError" and "error" event instances.
  * @class PlayerError
  * @param {message} string - The error message.

--- a/src/js/api/errors.js
+++ b/src/js/api/errors.js
@@ -118,6 +118,11 @@ const PLAY_ATTEMPT_FAILED_NOT_SUPPORTED = 303230;
 /**
  * @enum {ErrorKey}
  */
+export const ERROR_LOADING_CAPTIONS = 306000;
+
+/**
+ * @enum {ErrorKey}
+ */
 export const MSG_CANT_PLAY_VIDEO = 'cantPlayVideo';
 
 /**

--- a/src/js/api/errors.js
+++ b/src/js/api/errors.js
@@ -156,6 +156,18 @@ export const MSG_TECHNICAL_ERROR = 'technicalError';
 export const MSG_PLUGIN_LOAD_FAILED = 'pluginLoadFailed';
 
 /**
+ * @enum {ErrorKey}
+ */
+export const MSG_PLUGIN_NOT_REGISTERED = 'pluginNotRegistered';
+
+/**
+ * @enum {ErrorKey}
+ */
+
+export const MSG_CAPTIONS_LOAD_FAILED = 'captionsLoadFailed';
+
+
+/**
  * Class used to create "setupError" and "error" event instances.
  * @class PlayerError
  * @param {message} string - The error message.

--- a/src/js/api/errors.js
+++ b/src/js/api/errors.js
@@ -193,7 +193,10 @@ export class PlayerError {
         if (suffix >= 400 && suffix < 600) {
             codeStr = `${prefix}400-${prefix}599`;
         }
-        return `JW Player Error ${code}. For more information see https://developer.jwplayer.com/jw-player/docs/developer-guide/api/errors-reference#${codeStr}`;
+
+        // Warnings are in the 3xx,xxx range
+        const isWarning = code > 299999 && code < 400000;
+        return `JW Player ${isWarning ? 'Warning' : 'Error'} ${code}. For more information see https://developer.jwplayer.com/jw-player/docs/developer-guide/api/errors-reference#${codeStr}`;
     }
 }
 

--- a/src/js/api/errors.js
+++ b/src/js/api/errors.js
@@ -181,8 +181,10 @@ export const MSG_NETWORK_ERROR = 'networkError';
 export class PlayerError {
     constructor(key, code, sourceError = null) {
         this.code = isValidNumber(code) ? code : 0;
-        this.key = key;
         this.sourceError = sourceError;
+        if (key) {
+            this.key = key;
+        }
     }
 
     static logMessage(code) {

--- a/src/js/api/errors.js
+++ b/src/js/api/errors.js
@@ -151,6 +151,11 @@ export const MSG_PROTECTED_CONTENT = 'protectedContent';
 export const MSG_TECHNICAL_ERROR = 'technicalError';
 
 /**
+ * @enum {ErrorKey}
+ */
+export const MSG_PLUGIN_LOAD_FAILED = 'pluginLoadFailed';
+
+/**
  * Class used to create "setupError" and "error" event instances.
  * @class PlayerError
  * @param {message} string - The error message.

--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -1,7 +1,7 @@
 import { loadFile } from 'controller/tracks-loader';
 import { createId, createLabel } from 'controller/tracks-helper';
 import Events from 'utils/backbone.events';
-import { ERROR } from 'events/events';
+import { WARNING } from 'events/events';
 
 /* Displays closed captions or subtitles on top of the video */
 const Captions = function(_model) {
@@ -38,7 +38,7 @@ const Captions = function(_model) {
                     loadFile(track, (vttCues) => {
                         _addVTTCuesToTrack(track, vttCues);
                     }, (key, url, xhr, error) => {
-                        this.trigger(ERROR, {
+                        this.trigger(WARNING, {
                             message: 'Captions failed to load',
                             sourceError: error
                         });

--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -2,6 +2,7 @@ import { loadFile } from 'controller/tracks-loader';
 import { createId, createLabel } from 'controller/tracks-helper';
 import Events from 'utils/backbone.events';
 import { WARNING } from 'events/events';
+import { PlayerError, MSG_CAPTIONS_LOAD_FAILED } from 'api/errors';
 
 /* Displays closed captions or subtitles on top of the video */
 const Captions = function(_model) {
@@ -38,10 +39,7 @@ const Captions = function(_model) {
                     loadFile(track, (vttCues) => {
                         _addVTTCuesToTrack(track, vttCues);
                     }, (key, url, xhr, error) => {
-                        this.trigger(WARNING, {
-                            message: 'Captions failed to load',
-                            sourceError: error
-                        });
+                        this.trigger(WARNING, new PlayerError(MSG_CAPTIONS_LOAD_FAILED, 306000 + error.code, error));
                     });
                 }
             }

--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -2,7 +2,7 @@ import { loadFile } from 'controller/tracks-loader';
 import { createId, createLabel } from 'controller/tracks-helper';
 import Events from 'utils/backbone.events';
 import { WARNING } from 'events/events';
-import { PlayerError, MSG_CAPTIONS_LOAD_FAILED } from 'api/errors';
+import { PlayerError, MSG_NETWORK_ERROR } from 'api/errors';
 
 /* Displays closed captions or subtitles on top of the video */
 const Captions = function(_model) {
@@ -39,7 +39,7 @@ const Captions = function(_model) {
                     loadFile(track, (vttCues) => {
                         _addVTTCuesToTrack(track, vttCues);
                     }, (key, url, xhr, error) => {
-                        this.trigger(WARNING, new PlayerError(MSG_CAPTIONS_LOAD_FAILED, 306000 + error.code, error));
+                        this.trigger(WARNING, new PlayerError(MSG_NETWORK_ERROR, 306000 + error.code, error));
                     });
                 }
             }

--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -2,7 +2,7 @@ import { loadFile } from 'controller/tracks-loader';
 import { createId, createLabel } from 'controller/tracks-helper';
 import Events from 'utils/backbone.events';
 import { WARNING } from 'events/events';
-import { PlayerError, MSG_NETWORK_ERROR } from 'api/errors';
+import { PlayerError, MSG_NETWORK_ERROR, ERROR_LOADING_CAPTIONS } from 'api/errors';
 
 /* Displays closed captions or subtitles on top of the video */
 const Captions = function(_model) {
@@ -39,7 +39,7 @@ const Captions = function(_model) {
                     loadFile(track, (vttCues) => {
                         _addVTTCuesToTrack(track, vttCues);
                     }, (key, url, xhr, error) => {
-                        this.trigger(WARNING, new PlayerError(MSG_NETWORK_ERROR, 306000 + error.code, error));
+                        this.trigger(WARNING, new PlayerError(MSG_NETWORK_ERROR, ERROR_LOADING_CAPTIONS + error.code, error));
                     });
                 }
             }

--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -2,7 +2,7 @@ import { loadFile } from 'controller/tracks-loader';
 import { createId, createLabel } from 'controller/tracks-helper';
 import Events from 'utils/backbone.events';
 import { WARNING } from 'events/events';
-import { PlayerError, MSG_NETWORK_ERROR, ERROR_LOADING_CAPTIONS } from 'api/errors';
+import { PlayerError, ERROR_LOADING_CAPTIONS } from 'api/errors';
 
 /* Displays closed captions or subtitles on top of the video */
 const Captions = function(_model) {
@@ -39,7 +39,7 @@ const Captions = function(_model) {
                     loadFile(track, (vttCues) => {
                         _addVTTCuesToTrack(track, vttCues);
                     }, (key, url, xhr, error) => {
-                        this.trigger(WARNING, new PlayerError(MSG_NETWORK_ERROR, ERROR_LOADING_CAPTIONS + error.code, error));
+                        this.trigger(WARNING, new PlayerError(null, ERROR_LOADING_CAPTIONS + error.code, error));
                     });
                 }
             }

--- a/src/js/controller/controls-loader.js
+++ b/src/js/controller/controls-loader.js
@@ -12,7 +12,7 @@ export function loadControls() {
             return ControlsModule;
         }, function() {
             controlsPromise = null;
-            chunkLoadErrorHandler(130)();
+            chunkLoadErrorHandler(300130)();
         }, 'jwplayer.controls');
     }
     return controlsPromise;

--- a/src/js/controller/tracks-loader.js
+++ b/src/js/controller/tracks-loader.js
@@ -96,5 +96,5 @@ function xhrSuccess(xhr, track, successHandler, errorHandler) {
 function loadVttParser() {
     return require.ensure(['parsers/captions/vttparser'], function (require) {
         return require('parsers/captions/vttparser').default;
-    }, chunkLoadErrorHandler(131), 'vttparser');
+    }, chunkLoadErrorHandler(300131), 'vttparser');
 }

--- a/src/js/events/events.js
+++ b/src/js/events/events.js
@@ -107,6 +107,11 @@ export const OUT = 'out';
 */
 export const ERROR = STATE_ERROR;
 
+/**
+ * Event triggered when a non-fatal error is encountered
+ */
+export const WARNING = 'warning';
+
 // Ad events
 
 /**

--- a/src/js/parsers/captions/dfxp.js
+++ b/src/js/parsers/captions/dfxp.js
@@ -5,7 +5,7 @@ import { PlayerError, MSG_CAPTIONS_LOAD_FAILED } from 'api/errors';
 
 export default function Dfxp(xmlDoc) {
     if (!xmlDoc) {
-        parseError(306103);
+        parseError(306007);
     }
 
     const _captions = [];
@@ -21,7 +21,7 @@ export default function Dfxp(xmlDoc) {
     }
 
     if (!paragraphs) {
-        parseError(306101);
+        parseError(306005);
     }
     if (!paragraphs.length) {
         paragraphs = xmlDoc.getElementsByTagName('tt:p');
@@ -59,7 +59,7 @@ export default function Dfxp(xmlDoc) {
         }
     }
     if (!_captions.length) {
-        parseError(306101);
+        parseError(306005);
     }
     return _captions;
 }

--- a/src/js/parsers/captions/dfxp.js
+++ b/src/js/parsers/captions/dfxp.js
@@ -1,5 +1,5 @@
 import { seconds, trim } from 'utils/strings';
-import { PlayerError, MSG_CAPTIONS_LOAD_FAILED } from 'api/errors';
+import { PlayerError, MSG_CAPTIONS_ERROR } from 'api/errors';
 
 // Component that loads and parses an DFXP file
 
@@ -65,5 +65,5 @@ export default function Dfxp(xmlDoc) {
 }
 
 function parseError(code) {
-    throw new PlayerError(MSG_CAPTIONS_LOAD_FAILED, code);
+    throw new PlayerError(MSG_CAPTIONS_ERROR, code);
 }

--- a/src/js/parsers/captions/dfxp.js
+++ b/src/js/parsers/captions/dfxp.js
@@ -1,9 +1,13 @@
 import { seconds, trim } from 'utils/strings';
+import { PlayerError, MSG_CAPTIONS_LOAD_FAILED } from 'api/errors';
 
 // Component that loads and parses an DFXP file
 
 export default function Dfxp(xmlDoc) {
-    validate(xmlDoc);
+    if (!xmlDoc) {
+        parseError(306103);
+    }
+
     const _captions = [];
     let paragraphs = xmlDoc.getElementsByTagName('p');
     // Default frameRate is 30
@@ -15,7 +19,10 @@ export default function Dfxp(xmlDoc) {
             frameRate = parsedFrameRate;
         }
     }
-    validate(paragraphs);
+
+    if (!paragraphs) {
+        parseError(306101);
+    }
     if (!paragraphs.length) {
         paragraphs = xmlDoc.getElementsByTagName('tt:p');
         if (!paragraphs.length) {
@@ -52,17 +59,11 @@ export default function Dfxp(xmlDoc) {
         }
     }
     if (!_captions.length) {
-        parseError();
+        parseError(306101);
     }
     return _captions;
 }
 
-function validate(object) {
-    if (!object) {
-        parseError();
-    }
-}
-
-function parseError() {
-    throw new Error('Invalid DFXP file');
+function parseError(code) {
+    throw new PlayerError(MSG_CAPTIONS_LOAD_FAILED, code);
 }

--- a/src/js/parsers/captions/dfxp.js
+++ b/src/js/parsers/captions/dfxp.js
@@ -1,5 +1,5 @@
 import { seconds, trim } from 'utils/strings';
-import { PlayerError, MSG_CAPTIONS_ERROR } from 'api/errors';
+import { PlayerError } from 'api/errors';
 
 // Component that loads and parses an DFXP file
 
@@ -65,5 +65,5 @@ export default function Dfxp(xmlDoc) {
 }
 
 function parseError(code) {
-    throw new PlayerError(MSG_CAPTIONS_ERROR, code);
+    throw new PlayerError(null, code);
 }

--- a/src/js/plugins/loader.js
+++ b/src/js/plugins/loader.js
@@ -1,4 +1,5 @@
-import { configurePlugin } from 'plugins/plugin';
+import { PlayerError, MSG_PLUGIN_LOAD_FAILED } from 'api/errors';
+import { configurePlugin, mapPluginToCode } from 'plugins/utils';
 
 const PluginLoader = function () {
     this.load = function (api, pluginsModel, pluginsConfig, model) {
@@ -17,10 +18,7 @@ const PluginLoader = function () {
                     return configurePlugin(plugin, pluginConfig, api);
                 }).catch(error => {
                     pluginsModel.removePlugin(pluginUrl);
-                    if (!(error instanceof Error)) {
-                        return new Error(`Error in ${pluginUrl} "${error}"`);
-                    }
-                    return error;
+                    return new PlayerError(MSG_PLUGIN_LOAD_FAILED, mapPluginToCode(pluginUrl), error);
                 });
             }));
     };

--- a/src/js/plugins/loader.js
+++ b/src/js/plugins/loader.js
@@ -18,7 +18,10 @@ const PluginLoader = function () {
                     return configurePlugin(plugin, pluginConfig, api);
                 }).catch(error => {
                     pluginsModel.removePlugin(pluginUrl);
-                    return new PlayerError(MSG_PLUGIN_LOAD_FAILED, mapPluginToCode(pluginUrl), error);
+                    if (!error.code) {
+                        return new PlayerError(MSG_PLUGIN_LOAD_FAILED, mapPluginToCode(pluginUrl), error);
+                    }
+                    return error;
                 });
             }));
     };

--- a/src/js/plugins/loader.js
+++ b/src/js/plugins/loader.js
@@ -1,4 +1,4 @@
-import { PlayerError, MSG_PLUGIN_LOAD_FAILED } from 'api/errors';
+import { PlayerError, MSG_NETWORK_ERROR } from 'api/errors';
 import { configurePlugin, mapPluginToCode } from 'plugins/utils';
 
 const PluginLoader = function () {
@@ -19,7 +19,7 @@ const PluginLoader = function () {
                 }).catch(error => {
                     pluginsModel.removePlugin(pluginUrl);
                     if (!error.code) {
-                        return new PlayerError(MSG_PLUGIN_LOAD_FAILED, mapPluginToCode(pluginUrl), error);
+                        return new PlayerError(MSG_NETWORK_ERROR, mapPluginToCode(pluginUrl), error);
                     }
                     return error;
                 });

--- a/src/js/plugins/loader.js
+++ b/src/js/plugins/loader.js
@@ -1,4 +1,4 @@
-import { PlayerError, MSG_NETWORK_ERROR } from 'api/errors';
+import { PlayerError } from 'api/errors';
 import { configurePlugin, mapPluginToCode } from 'plugins/utils';
 
 const PluginLoader = function () {
@@ -19,7 +19,7 @@ const PluginLoader = function () {
                 }).catch(error => {
                     pluginsModel.removePlugin(pluginUrl);
                     if (!error.code) {
-                        return new PlayerError(MSG_NETWORK_ERROR, mapPluginToCode(pluginUrl), error);
+                        return new PlayerError(null, mapPluginToCode(pluginUrl), error);
                     }
                     return error;
                 });

--- a/src/js/plugins/model.js
+++ b/src/js/plugins/model.js
@@ -1,14 +1,8 @@
 import Plugin from 'plugins/plugin';
 import { log } from 'utils/log';
+import { getPluginName } from 'plugins/utils';
 
 const pluginsRegistered = {};
-
-// Extract a plugin name from a string
-const getPluginName = function(url) {
-    // Regex locates the characters after the last slash, until it encounters a dash.
-    return url.replace(/^(.*\/)?([^-]*)-?.*\.(js)$/, '$2');
-};
-
 const PluginModel = function() {};
 const prototype = PluginModel.prototype;
 

--- a/src/js/plugins/plugin.js
+++ b/src/js/plugins/plugin.js
@@ -101,18 +101,4 @@ Object.assign(Plugin.prototype, {
     }
 });
 
-export function configurePlugin(pluginObj, pluginConfig, api) {
-    const pluginName = pluginObj.name;
-
-    const div = document.createElement('div');
-    div.id = api.id + '_' + pluginName;
-    div.className = 'jw-plugin jw-reset';
-
-    const pluginOptions = Object.assign({}, pluginConfig);
-    const pluginInstance = pluginObj.getNewInstance(api, pluginOptions, div);
-
-    api.addPlugin(pluginName, pluginInstance);
-    return pluginInstance;
-}
-
 export default Plugin;

--- a/src/js/plugins/plugin.js
+++ b/src/js/plugins/plugin.js
@@ -1,7 +1,7 @@
 import ScriptLoader from 'utils/scriptloader';
 import { getAbsolutePath } from 'utils/parser';
 import { extension } from 'utils/strings';
-import { PlayerError, MSG_PLUGIN_NOT_REGISTERED } from 'api/errors';
+import { PlayerError, MSG_PLUGIN_ERROR } from 'api/errors';
 import { mapPluginToCode } from 'plugins/utils';
 
 const PLUGIN_PATH_TYPE_ABSOLUTE = 0;
@@ -77,7 +77,7 @@ Object.assign(Plugin.prototype, {
     getNewInstance(api, config, div) {
         const PluginClass = this.js;
         if (typeof PluginClass !== 'function') {
-            throw new PlayerError(MSG_PLUGIN_NOT_REGISTERED, mapPluginToCode(this.url) + 100);
+            throw new PlayerError(MSG_PLUGIN_ERROR, mapPluginToCode(this.url) + 100);
         }
         const pluginInstance = new PluginClass(api, config, div);
 

--- a/src/js/plugins/plugin.js
+++ b/src/js/plugins/plugin.js
@@ -1,6 +1,8 @@
 import ScriptLoader from 'utils/scriptloader';
 import { getAbsolutePath } from 'utils/parser';
 import { extension } from 'utils/strings';
+import { PlayerError, MSG_PLUGIN_NOT_REGISTERED } from 'api/errors';
+import { mapPluginToCode } from 'plugins/utils';
 
 const PLUGIN_PATH_TYPE_ABSOLUTE = 0;
 const PLUGIN_PATH_TYPE_RELATIVE = 1;
@@ -75,7 +77,7 @@ Object.assign(Plugin.prototype, {
     getNewInstance(api, config, div) {
         const PluginClass = this.js;
         if (typeof PluginClass !== 'function') {
-            throw new Error(`"${this.url}" did not call registerPlugin`);
+            throw new PlayerError(MSG_PLUGIN_NOT_REGISTERED, mapPluginToCode(this.url) + 100);
         }
         const pluginInstance = new PluginClass(api, config, div);
 

--- a/src/js/plugins/plugin.js
+++ b/src/js/plugins/plugin.js
@@ -1,7 +1,7 @@
 import ScriptLoader from 'utils/scriptloader';
 import { getAbsolutePath } from 'utils/parser';
 import { extension } from 'utils/strings';
-import { PlayerError, MSG_PLUGIN_ERROR } from 'api/errors';
+import { PlayerError } from 'api/errors';
 import { mapPluginToCode } from 'plugins/utils';
 
 const PLUGIN_PATH_TYPE_ABSOLUTE = 0;
@@ -77,7 +77,7 @@ Object.assign(Plugin.prototype, {
     getNewInstance(api, config, div) {
         const PluginClass = this.js;
         if (typeof PluginClass !== 'function') {
-            throw new PlayerError(MSG_PLUGIN_ERROR, mapPluginToCode(this.url) + 100);
+            throw new PlayerError(null, mapPluginToCode(this.url) + 100);
         }
         const pluginInstance = new PluginClass(api, config, div);
 

--- a/src/js/plugins/plugins.js
+++ b/src/js/plugins/plugins.js
@@ -1,6 +1,5 @@
 import PluginsLoader from 'plugins/loader';
 import PluginsModel from 'plugins/model';
-import { log } from 'utils/log';
 
 const pluginsModel = new PluginsModel();
 
@@ -23,13 +22,6 @@ export default function loadPlugins(model, api) {
         if (model.attributes._destroyed) {
             // Player and plugin loader was replaced
             return;
-        }
-        if (results) {
-            results.forEach(object => {
-                if (object instanceof Error) {
-                    log(object.message);
-                }
-            });
         }
         delete window.jwplayerPluginJsonp;
         return results;

--- a/src/js/plugins/utils.js
+++ b/src/js/plugins/utils.js
@@ -1,0 +1,52 @@
+// Extract a plugin name from a string
+export const getPluginName = function(url) {
+    // Regex locates the characters after the last slash, until it encounters a dash.
+    return url.replace(/^(.*\/)?([^-]*)-?.*\.(js)$/, '$2');
+};
+
+export function mapPluginToCode(pluginUrl) {
+    let code = 305000;
+    if (!pluginUrl) {
+        return code;
+    }
+
+    switch (getPluginName(pluginUrl)) {
+        case 'jwpsrv':
+            code = 305001;
+            break;
+        case 'googima':
+            code = 305002;
+            break;
+        case 'vast':
+            code = 305003;
+            break;
+        case 'freewheel':
+            code = 305004;
+            break;
+        case 'dai':
+            code = 305005;
+            break;
+        case 'gapro':
+            code = 305006;
+            break;
+        default:
+            break;
+    }
+
+    return code;
+}
+
+export function configurePlugin(pluginObj, pluginConfig, api) {
+    const pluginName = pluginObj.name;
+
+    const div = document.createElement('div');
+    div.id = api.id + '_' + pluginName;
+    div.className = 'jw-plugin jw-reset';
+
+    const pluginOptions = Object.assign({}, pluginConfig);
+    const pluginInstance = pluginObj.getNewInstance(api, pluginOptions, div);
+
+    api.addPlugin(pluginName, pluginInstance);
+    return pluginInstance;
+}
+

--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -69,7 +69,7 @@ export default class MediaController extends Eventable {
             return;
         }
         // The provider has a video tag, but has not started nor preloaded
-        if (this.attached && !this.setup && !this.preloaded) {998
+        if (this.attached && !this.setup && !this.preloaded) {
             mediaModel.set('preloaded', true);
             provider.preload(item);
         }

--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -69,7 +69,7 @@ export default class MediaController extends Eventable {
             return;
         }
         // The provider has a video tag, but has not started nor preloaded
-        if (this.attached && !this.setup && !this.preloaded) {
+        if (this.attached && !this.setup && !this.preloaded) {998
             mediaModel.set('preloaded', true);
             provider.preload(item);
         }

--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -2,7 +2,7 @@ import { loadFile, cancelXhr, convertToVTTCues } from 'controller/tracks-loader'
 import { createId, createLabel } from 'controller/tracks-helper';
 import { parseID3 } from 'providers/utils/id3Parser';
 import { Browser } from 'environment/environment';
-import { ERROR } from 'events/events';
+import { WARNING } from 'events/events';
 import { findWhere, each, filter } from 'utils/underscore';
 
 // Used across all providers for loading tracks and handling browser track-related events
@@ -460,7 +460,7 @@ function addTextTracks(tracksArray) {
                     this.addVTTCuesToTrack(textTrackAny, vttCues);
                 },
                 (key, url, xhr, error) => {
-                    this.trigger(ERROR, {
+                    this.trigger(WARNING, {
                         message: 'Captions failed to load',
                         sourceError: error
                     });

--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -4,7 +4,7 @@ import { parseID3 } from 'providers/utils/id3Parser';
 import { Browser } from 'environment/environment';
 import { WARNING } from 'events/events';
 import { findWhere, each, filter } from 'utils/underscore';
-import { PlayerError, MSG_NETWORK_ERROR } from 'api/errors';
+import { PlayerError, MSG_NETWORK_ERROR, ERROR_LOADING_CAPTIONS } from 'api/errors';
 
 // Used across all providers for loading tracks and handling browser track-related events
 const Tracks = {
@@ -461,7 +461,7 @@ function addTextTracks(tracksArray) {
                     this.addVTTCuesToTrack(textTrackAny, vttCues);
                 },
                 (key, url, xhr, error) => {
-                    this.trigger(WARNING, new PlayerError(MSG_NETWORK_ERROR, 306000 + error.code, error));
+                    this.trigger(WARNING, new PlayerError(MSG_NETWORK_ERROR, ERROR_LOADING_CAPTIONS + error.code, error));
                 });
         }
     });

--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -4,7 +4,7 @@ import { parseID3 } from 'providers/utils/id3Parser';
 import { Browser } from 'environment/environment';
 import { WARNING } from 'events/events';
 import { findWhere, each, filter } from 'utils/underscore';
-import { PlayerError, MSG_CAPTIONS_LOAD_FAILED } from 'api/errors';
+import { PlayerError, MSG_NETWORK_ERROR } from 'api/errors';
 
 // Used across all providers for loading tracks and handling browser track-related events
 const Tracks = {
@@ -461,7 +461,7 @@ function addTextTracks(tracksArray) {
                     this.addVTTCuesToTrack(textTrackAny, vttCues);
                 },
                 (key, url, xhr, error) => {
-                    this.trigger(WARNING, new PlayerError(MSG_CAPTIONS_LOAD_FAILED, 306000 + error.code, error));
+                    this.trigger(WARNING, new PlayerError(MSG_NETWORK_ERROR, 306000 + error.code, error));
                 });
         }
     });

--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -4,6 +4,7 @@ import { parseID3 } from 'providers/utils/id3Parser';
 import { Browser } from 'environment/environment';
 import { WARNING } from 'events/events';
 import { findWhere, each, filter } from 'utils/underscore';
+import { PlayerError, MSG_CAPTIONS_LOAD_FAILED } from 'api/errors';
 
 // Used across all providers for loading tracks and handling browser track-related events
 const Tracks = {
@@ -460,10 +461,7 @@ function addTextTracks(tracksArray) {
                     this.addVTTCuesToTrack(textTrackAny, vttCues);
                 },
                 (key, url, xhr, error) => {
-                    this.trigger(WARNING, {
-                        message: 'Captions failed to load',
-                        sourceError: error
-                    });
+                    this.trigger(WARNING, new PlayerError(MSG_CAPTIONS_LOAD_FAILED, 306000 + error.code, error));
                 });
         }
     });

--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -4,7 +4,7 @@ import { parseID3 } from 'providers/utils/id3Parser';
 import { Browser } from 'environment/environment';
 import { WARNING } from 'events/events';
 import { findWhere, each, filter } from 'utils/underscore';
-import { PlayerError, MSG_NETWORK_ERROR, ERROR_LOADING_CAPTIONS } from 'api/errors';
+import { PlayerError, ERROR_LOADING_CAPTIONS } from 'api/errors';
 
 // Used across all providers for loading tracks and handling browser track-related events
 const Tracks = {
@@ -461,7 +461,7 @@ function addTextTracks(tracksArray) {
                     this.addVTTCuesToTrack(textTrackAny, vttCues);
                 },
                 (key, url, xhr, error) => {
-                    this.trigger(WARNING, new PlayerError(MSG_NETWORK_ERROR, ERROR_LOADING_CAPTIONS + error.code, error));
+                    this.trigger(WARNING, new PlayerError(null, ERROR_LOADING_CAPTIONS + error.code, error));
                 });
         }
     });

--- a/src/js/view/captionsrenderer.js
+++ b/src/js/view/captionsrenderer.js
@@ -1,7 +1,7 @@
 import { Browser, OS } from 'environment/environment';
 import { chunkLoadErrorHandler } from '../api/core-loader';
 import Events from 'utils/backbone.events';
-import { ERROR } from 'events/events';
+import { WARNING } from 'events/events';
 import { css, style, getRgba } from 'utils/css';
 import { addClass, removeClass, empty } from 'utils/dom';
 import { identity, isNumber, isFinite, filter } from 'utils/underscore';
@@ -339,8 +339,8 @@ const CaptionsRenderer = function (viewModel) {
 
         // don't load the polyfill or do unnecessary work if rendering natively
         if (!model.get('renderCaptionsNatively') && !_WebVTT) {
-            loadWebVttPolyfill().catch((error) => {
-                this.trigger(ERROR, {
+            loadWebVttPolyfill().catch(error => {
+                this.trigger(WARNING, {
                     message: 'Captions renderer failed to load',
                     reason: error
                 });

--- a/src/js/view/captionsrenderer.js
+++ b/src/js/view/captionsrenderer.js
@@ -352,7 +352,7 @@ const CaptionsRenderer = function (viewModel) {
     function loadWebVttPolyfill() {
         return require.ensure(['polyfills/webvtt'], function (require) {
             _WebVTT = require('polyfills/webvtt').default;
-        }, chunkLoadErrorHandler(121), 'polyfills.webvtt');
+        }, chunkLoadErrorHandler(300121), 'polyfills.webvtt');
     }
 
     _model.on('change:playlistItem', function () {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -11,7 +11,7 @@ import { Browser, OS, Features } from 'environment/environment';
 import { ControlsLoader, loadControls } from 'controller/controls-loader';
 import {
     STATE_BUFFERING, STATE_IDLE, STATE_COMPLETE, STATE_PAUSED, STATE_PLAYING, STATE_ERROR,
-    RESIZE, BREAKPOINT, DISPLAY_CLICK, LOGO_CLICK, ERROR, NATIVE_FULLSCREEN, MEDIA_VISUAL_QUALITY, CONTROLS } from 'events/events';
+    RESIZE, BREAKPOINT, DISPLAY_CLICK, LOGO_CLICK, WARNING, NATIVE_FULLSCREEN, MEDIA_VISUAL_QUALITY, CONTROLS } from 'events/events';
 import Events from 'utils/backbone.events';
 import {
     addClass,
@@ -325,7 +325,7 @@ function View(_api, _model) {
                     return enabledState;
                 });
                 controlsEvent.loadPromise.catch(function (reason) {
-                    _this.trigger(ERROR, {
+                    _this.trigger(WARNING, {
                         message: 'Controls failed to load',
                         reason: reason
                     });

--- a/test/unit/captionsrenderer-test.js
+++ b/test/unit/captionsrenderer-test.js
@@ -1,14 +1,19 @@
-import Model from 'controller/model';
+import MockModel from 'mock/mock-model';
 import ViewModel from 'view/view-model';
 import CaptionsRenderer from 'view/captionsrenderer';
 import VTTCue from 'parsers/captions/vttcue';
-
-const model = new Model({});
-const viewModel = new ViewModel(model);
-const captionsRenderer = new CaptionsRenderer(viewModel, model);
-captionsRenderer.setup('player', {});
+import { ERROR } from 'events/events';
+import { MSG_CANT_LOAD_PLAYER } from 'api/errors';
 
 describe('CaptionsRenderer.getCurrentCues', function() {
+    let captionsRenderer;
+    let model;
+    beforeEach(function () {
+        model = new MockModel();
+        model.setup({});
+        captionsRenderer = new CaptionsRenderer(new ViewModel(model));
+        captionsRenderer.setup('player', {});
+    });
 
     it('should show the correct number of cues at any given position in time', function() {
         const allCues = [
@@ -26,6 +31,25 @@ describe('CaptionsRenderer.getCurrentCues', function() {
         for (let i = 0; i < currentNumCues.length; i += 1) {
             expect(captionsRenderer.getCurrentCues(allCues, i).length, 'Invalid number of cues at position ' + i).to.equal(currentNumCues[i]);
         }
+    });
+
+    it('triggers a standardized warning if the WebVTT polyfill fails to load', function () {
+        return new Promise((resolve, reject) => {
+            captionsRenderer.on(ERROR, e => {
+                const { code, key } = e.reason;
+                if (code !== 300121) {
+                    reject(`Expected code 300121, got ${code}`);
+                } else if (key !== MSG_CANT_LOAD_PLAYER) {
+                    reject(`Expected key cantLoadPlayer, got ${code}`);
+                }
+                resolve();
+            });
+
+            // The captionsRenderer will try to load the VTT polyfill in response to the captionsList change event; it
+            // will load with a 404 because unit tests don't chunk polyfills.webvtt.js
+            model.set('renderCaptionsNatively', false);
+            model.set('captionsList', [ {}, {} ]);
+        });
     });
 });
 

--- a/test/unit/captionsrenderer-test.js
+++ b/test/unit/captionsrenderer-test.js
@@ -2,7 +2,7 @@ import MockModel from 'mock/mock-model';
 import ViewModel from 'view/view-model';
 import CaptionsRenderer from 'view/captionsrenderer';
 import VTTCue from 'parsers/captions/vttcue';
-import { ERROR } from 'events/events';
+import { WARNING } from 'events/events';
 import { MSG_CANT_LOAD_PLAYER } from 'api/errors';
 
 describe('CaptionsRenderer.getCurrentCues', function() {
@@ -35,7 +35,7 @@ describe('CaptionsRenderer.getCurrentCues', function() {
 
     it('triggers a standardized warning if the WebVTT polyfill fails to load', function () {
         return new Promise((resolve, reject) => {
-            captionsRenderer.on(ERROR, e => {
+            captionsRenderer.on(WARNING, e => {
                 const { code, key } = e.reason;
                 if (code !== 300121) {
                     reject(`Expected code 300121, got ${code}`);

--- a/test/unit/dfxp-test.js
+++ b/test/unit/dfxp-test.js
@@ -1,14 +1,40 @@
 import dfxp from 'parsers/captions/dfxp';
+import { MSG_CAPTIONS_LOAD_FAILED } from 'api/errors';
 
 describe('dfxp', function() {
 
-    it('exceptions', function() {
+    it('is a function', function () {
         expect(typeof dfxp, 'dfxp is a function').to.equal('function');
+    });
 
-        expect(function() {
+    it('throws an error if the xml document is null', function () {
+        try {
             dfxp(null);
-        }).to.throw(Error, 'Invalid DFXP file');
+        } catch (e) {
+            expect(e.code).to.equal(306103);
+            expect(e.key).to.equal(MSG_CAPTIONS_LOAD_FAILED);
+        }
+    });
 
+    it('throws an error if the xml doc has no paragraphs', function () {
+        try {
+            parseDFXP('<?xml version="1.0" encoding="UTF-8"?><tt xmlns="http://www.w3.org/2006/10/ttaf1"><head></head><body><div></div></body></tt>');
+        } catch (e) {
+            expect(e.code).to.equal(306101);
+            expect(e.key).to.equal(MSG_CAPTIONS_LOAD_FAILED);
+        }
+    });
+
+    it('throws an error if the xml doc has no valid cues', function () {
+        try {
+            parseDFXP('<?xml version="1.0" encoding="UTF-8"?><tt xmlns="http://www.w3.org/2006/10/ttaf1"><head></head><body><div><p begin="00:00:31" end="00:00:33"></p></div></body></tt>');
+        } catch (e) {
+            expect(e.code).to.equal(306101);
+            expect(e.key).to.equal(MSG_CAPTIONS_LOAD_FAILED);
+        }
+    });
+
+    it('parses a valid xml doc', function() {
         const DFXP = '<?xml version="1.0" encoding="UTF-8"?><tt xmlns="http://www.w3.org/2006/10/ttaf1"><head></head><body><div><p begin="00:00:00.5" end="00:00:04">The Peach Open Movie Project presents</p><p begin="00:00:06.5" end="00:00:09">One big rabbit</p><p begin="00:00:11" end="00:00:13">Three rodents</p><p begin="00:00:16.5" end="00:00:19">And one giant payback</p><p begin="00:00:23" end="00:00:25">Get ready</p><p begin="00:00:27" end="00:00:30">Big Buck Bunny</p><p begin="00:00:30" end="00:00:31">Coming soon</p><p begin="00:00:31" end="00:00:33">www.bigbuckbunny.org<br/>Licensed as Creative Commons 3.0 attribution</p></div></body></tt>';
 
         // Do not run the test if inner HTML does not exist, as it will fail in phantomjs

--- a/test/unit/dfxp-test.js
+++ b/test/unit/dfxp-test.js
@@ -1,5 +1,5 @@
 import dfxp from 'parsers/captions/dfxp';
-import { MSG_CAPTIONS_LOAD_FAILED } from 'api/errors';
+import { MSG_CAPTIONS_ERROR } from 'api/errors';
 
 describe('dfxp', function() {
 
@@ -12,7 +12,7 @@ describe('dfxp', function() {
             dfxp(null);
         } catch (e) {
             expect(e.code).to.equal(306007);
-            expect(e.key).to.equal(MSG_CAPTIONS_LOAD_FAILED);
+            expect(e.key).to.equal(MSG_CAPTIONS_ERROR);
         }
     });
 
@@ -21,7 +21,7 @@ describe('dfxp', function() {
             parseDFXP('<?xml version="1.0" encoding="UTF-8"?><tt xmlns="http://www.w3.org/2006/10/ttaf1"><head></head><body><div></div></body></tt>');
         } catch (e) {
             expect(e.code).to.equal(306005);
-            expect(e.key).to.equal(MSG_CAPTIONS_LOAD_FAILED);
+            expect(e.key).to.equal(MSG_CAPTIONS_ERROR);
         }
     });
 
@@ -30,7 +30,7 @@ describe('dfxp', function() {
             parseDFXP('<?xml version="1.0" encoding="UTF-8"?><tt xmlns="http://www.w3.org/2006/10/ttaf1"><head></head><body><div><p begin="00:00:31" end="00:00:33"></p></div></body></tt>');
         } catch (e) {
             expect(e.code).to.equal(306005);
-            expect(e.key).to.equal(MSG_CAPTIONS_LOAD_FAILED);
+            expect(e.key).to.equal(MSG_CAPTIONS_ERROR);
         }
     });
 

--- a/test/unit/dfxp-test.js
+++ b/test/unit/dfxp-test.js
@@ -11,7 +11,7 @@ describe('dfxp', function() {
         try {
             dfxp(null);
         } catch (e) {
-            expect(e.code).to.equal(306103);
+            expect(e.code).to.equal(306007);
             expect(e.key).to.equal(MSG_CAPTIONS_LOAD_FAILED);
         }
     });
@@ -20,7 +20,7 @@ describe('dfxp', function() {
         try {
             parseDFXP('<?xml version="1.0" encoding="UTF-8"?><tt xmlns="http://www.w3.org/2006/10/ttaf1"><head></head><body><div></div></body></tt>');
         } catch (e) {
-            expect(e.code).to.equal(306101);
+            expect(e.code).to.equal(306005);
             expect(e.key).to.equal(MSG_CAPTIONS_LOAD_FAILED);
         }
     });
@@ -29,7 +29,7 @@ describe('dfxp', function() {
         try {
             parseDFXP('<?xml version="1.0" encoding="UTF-8"?><tt xmlns="http://www.w3.org/2006/10/ttaf1"><head></head><body><div><p begin="00:00:31" end="00:00:33"></p></div></body></tt>');
         } catch (e) {
-            expect(e.code).to.equal(306101);
+            expect(e.code).to.equal(306005);
             expect(e.key).to.equal(MSG_CAPTIONS_LOAD_FAILED);
         }
     });

--- a/test/unit/dfxp-test.js
+++ b/test/unit/dfxp-test.js
@@ -1,5 +1,4 @@
 import dfxp from 'parsers/captions/dfxp';
-import { MSG_CAPTIONS_ERROR } from 'api/errors';
 
 describe('dfxp', function() {
 
@@ -12,7 +11,6 @@ describe('dfxp', function() {
             dfxp(null);
         } catch (e) {
             expect(e.code).to.equal(306007);
-            expect(e.key).to.equal(MSG_CAPTIONS_ERROR);
         }
     });
 
@@ -21,7 +19,6 @@ describe('dfxp', function() {
             parseDFXP('<?xml version="1.0" encoding="UTF-8"?><tt xmlns="http://www.w3.org/2006/10/ttaf1"><head></head><body><div></div></body></tt>');
         } catch (e) {
             expect(e.code).to.equal(306005);
-            expect(e.key).to.equal(MSG_CAPTIONS_ERROR);
         }
     });
 
@@ -30,7 +27,6 @@ describe('dfxp', function() {
             parseDFXP('<?xml version="1.0" encoding="UTF-8"?><tt xmlns="http://www.w3.org/2006/10/ttaf1"><head></head><body><div><p begin="00:00:31" end="00:00:33"></p></div></body></tt>');
         } catch (e) {
             expect(e.code).to.equal(306005);
-            expect(e.key).to.equal(MSG_CAPTIONS_ERROR);
         }
     });
 

--- a/test/unit/errors/player-error-test.js
+++ b/test/unit/errors/player-error-test.js
@@ -18,6 +18,14 @@ describe('PlayerError', function () {
             expect(PlayerError.logMessage(312345)).to.equal(generateCopy(312345, 312345, true));
         });
     });
+
+    it('sets the key property if the key argument exists', function () {
+        expect(new PlayerError('foo')).to.have.property('key').which.equals('foo');
+    });
+
+    it('does not set the key property if the key argument does not exist', function () {
+        expect(new PlayerError(null)).to.not.have.property('key');
+    });
 });
 
 function generateCopy(code, hash, isWarning = false) {

--- a/test/unit/errors/player-error-test.js
+++ b/test/unit/errors/player-error-test.js
@@ -11,9 +11,15 @@ describe('PlayerError', function () {
             const error = new PlayerError('', 123404);
             expect(PlayerError.logMessage(error.code)).to.equal(generateCopy(123404, '123400-123599'));
         });
+
+        it('logs warning if the code is in the 300,000 range', function () {
+            expect(PlayerError.logMessage(300000)).to.equal(generateCopy(300000, 300000, true));
+            expect(PlayerError.logMessage(399999)).to.equal(generateCopy(399999, 399999, true));
+            expect(PlayerError.logMessage(312345)).to.equal(generateCopy(312345, 312345, true));
+        });
     });
 });
 
-function generateCopy(code, hash) {
-    return `JW Player Error ${code}. For more information see https://developer.jwplayer.com/jw-player/docs/developer-guide/api/errors-reference#${hash}`;
+function generateCopy(code, hash, isWarning = false) {
+    return `JW Player ${isWarning ? 'Warning' : 'Error'} ${code}. For more information see https://developer.jwplayer.com/jw-player/docs/developer-guide/api/errors-reference#${hash}`;
 }

--- a/test/unit/plugin-utils-tests.js
+++ b/test/unit/plugin-utils-tests.js
@@ -1,0 +1,42 @@
+import { mapPluginToCode } from 'plugins/utils';
+
+describe('mapPluginToCode', function () {
+    it('assigns 305000 to unknown plugins', function () {
+        expect(mapPluginToCode('foo')).to.equal(305000);
+    });
+
+    it('assigns 305001 to jwpsrv.js', function () {
+        expect(mapPluginToCode('http://foo.com/jwpsrv.js')).to.equal(305001);
+    });
+
+    it('assigns 305002 to googima.js', function () {
+        expect(mapPluginToCode('http://foo.com/googima.js')).to.equal(305002);
+    });
+
+    it('assigns 305003 to vast.js', function () {
+        expect(mapPluginToCode('http://foo.com/vast.js')).to.equal(305003);
+    });
+
+    it('assigns 305004 to freewheel.js', function () {
+        expect(mapPluginToCode('http://foo.com/freewheel.js')).to.equal(305004);
+    });
+
+    it('assigns 305005 to dai.js', function () {
+        expect(mapPluginToCode('http://foo.com/dai.js')).to.equal(305005);
+    });
+
+    it('assigns 305006 to gapro.js', function () {
+        expect(mapPluginToCode('http://foo.com/gapro.js')).to.equal(305006);
+    });
+
+    // Our (JW's) plugins do not use query parameters, so it's safe to assume that any which do are not ours
+    it('assigns 305000 when the URL contains query parameters', function () {
+        expect(mapPluginToCode('http://foo.com/jwpsrv.js?foo=bar')).to.equal(305000);
+    });
+
+    it('assigns 305000 when the URL is empty or does not exist', function () {
+        expect(mapPluginToCode('')).to.equal(305000);
+        expect(mapPluginToCode(null)).to.equal(305000);
+        expect(mapPluginToCode(undefined)).to.equal(305000);
+    });
+});

--- a/test/unit/plugins-test.js
+++ b/test/unit/plugins-test.js
@@ -2,6 +2,7 @@ import loadPlugins, { registerPlugin } from 'plugins/plugins';
 import PluginsModel from 'plugins/model';
 import Plugin from 'plugins/plugin';
 import SimpleModel from 'model/simplemodel';
+import { PlayerError } from 'api/errors';
 import sinon from 'sinon';
 
 // Any instance of PluginsModel provides access to registered plugins
@@ -262,7 +263,7 @@ describe('plugins', function() {
                 expect(Object.keys(registeredPlugins), 'registeredPlugins').to.have.lengthOf(0);
                 expect(api.addPlugin).to.have.callCount(0);
 
-                expect(results[0]).to.be.an('error');
+                expect(results[0].code).to.equal(305000);
             });
         });
 
@@ -357,8 +358,8 @@ describe('plugins', function() {
                 const registeredPlugins = globalPluginsModel.getPlugins();
                 expect(Object.keys(registeredPlugins), 'The JavaScript did not call registerPlugin()').to.have.lengthOf(0);
                 expect(api.addPlugin, 'No instance was added').to.have.callCount(0);
-                expect(results[0]).to.be.an('error').which.has.property('message')
-                    .which.contains('did not call registerPlugin');
+                expect(results[0].code).to.equal(305000);
+                expect(results[0].sourceError.message).to.contain('did not call registerPlugin');
             });
         });
 
@@ -373,7 +374,7 @@ describe('plugins', function() {
                 const registeredPlugins = globalPluginsModel.getPlugins();
                 expect(Object.keys(registeredPlugins), 'registry is empty').to.have.lengthOf(0);
                 expect(api.addPlugin, 'no instance was added').to.have.callCount(0);
-                expect(results[0]).to.be.an('error');
+                expect(results[0].code).to.equal(305000);
             });
         });
 

--- a/test/unit/plugins-test.js
+++ b/test/unit/plugins-test.js
@@ -2,7 +2,7 @@ import loadPlugins, { registerPlugin } from 'plugins/plugins';
 import PluginsModel from 'plugins/model';
 import Plugin from 'plugins/plugin';
 import SimpleModel from 'model/simplemodel';
-import { PlayerError } from 'api/errors';
+import { MSG_PLUGIN_NOT_REGISTERED, MSG_PLUGIN_LOAD_FAILED } from 'api/errors';
 import sinon from 'sinon';
 
 // Any instance of PluginsModel provides access to registered plugins
@@ -264,6 +264,7 @@ describe('plugins', function() {
                 expect(api.addPlugin).to.have.callCount(0);
 
                 expect(results[0].code).to.equal(305000);
+                expect(results[0].key).to.equal(MSG_PLUGIN_LOAD_FAILED);
             });
         });
 
@@ -358,8 +359,8 @@ describe('plugins', function() {
                 const registeredPlugins = globalPluginsModel.getPlugins();
                 expect(Object.keys(registeredPlugins), 'The JavaScript did not call registerPlugin()').to.have.lengthOf(0);
                 expect(api.addPlugin, 'No instance was added').to.have.callCount(0);
-                expect(results[0].code).to.equal(305000);
-                expect(results[0].sourceError.message).to.contain('did not call registerPlugin');
+                expect(results[0].code).to.equal(305100);
+                expect(results[0].key).to.equal(MSG_PLUGIN_NOT_REGISTERED);
             });
         });
 
@@ -374,7 +375,8 @@ describe('plugins', function() {
                 const registeredPlugins = globalPluginsModel.getPlugins();
                 expect(Object.keys(registeredPlugins), 'registry is empty').to.have.lengthOf(0);
                 expect(api.addPlugin, 'no instance was added').to.have.callCount(0);
-                expect(results[0].code).to.equal(305000);
+                expect(results[0].code).to.equal(305100);
+                expect(results[0].key).to.equal(MSG_PLUGIN_NOT_REGISTERED);
             });
         });
 

--- a/test/unit/plugins-test.js
+++ b/test/unit/plugins-test.js
@@ -2,7 +2,7 @@ import loadPlugins, { registerPlugin } from 'plugins/plugins';
 import PluginsModel from 'plugins/model';
 import Plugin from 'plugins/plugin';
 import SimpleModel from 'model/simplemodel';
-import { MSG_PLUGIN_NOT_REGISTERED, MSG_PLUGIN_LOAD_FAILED } from 'api/errors';
+import { MSG_PLUGIN_ERROR, MSG_NETWORK_ERROR } from 'api/errors';
 import sinon from 'sinon';
 
 // Any instance of PluginsModel provides access to registered plugins
@@ -264,7 +264,7 @@ describe('plugins', function() {
                 expect(api.addPlugin).to.have.callCount(0);
 
                 expect(results[0].code).to.equal(305000);
-                expect(results[0].key).to.equal(MSG_PLUGIN_LOAD_FAILED);
+                expect(results[0].key).to.equal(MSG_NETWORK_ERROR);
             });
         });
 
@@ -360,7 +360,7 @@ describe('plugins', function() {
                 expect(Object.keys(registeredPlugins), 'The JavaScript did not call registerPlugin()').to.have.lengthOf(0);
                 expect(api.addPlugin, 'No instance was added').to.have.callCount(0);
                 expect(results[0].code).to.equal(305100);
-                expect(results[0].key).to.equal(MSG_PLUGIN_NOT_REGISTERED);
+                expect(results[0].key).to.equal(MSG_PLUGIN_ERROR);
             });
         });
 
@@ -376,7 +376,7 @@ describe('plugins', function() {
                 expect(Object.keys(registeredPlugins), 'registry is empty').to.have.lengthOf(0);
                 expect(api.addPlugin, 'no instance was added').to.have.callCount(0);
                 expect(results[0].code).to.equal(305100);
-                expect(results[0].key).to.equal(MSG_PLUGIN_NOT_REGISTERED);
+                expect(results[0].key).to.equal(MSG_PLUGIN_ERROR);
             });
         });
 

--- a/test/unit/plugins-test.js
+++ b/test/unit/plugins-test.js
@@ -2,7 +2,6 @@ import loadPlugins, { registerPlugin } from 'plugins/plugins';
 import PluginsModel from 'plugins/model';
 import Plugin from 'plugins/plugin';
 import SimpleModel from 'model/simplemodel';
-import { MSG_PLUGIN_ERROR, MSG_NETWORK_ERROR } from 'api/errors';
 import sinon from 'sinon';
 
 // Any instance of PluginsModel provides access to registered plugins
@@ -264,7 +263,6 @@ describe('plugins', function() {
                 expect(api.addPlugin).to.have.callCount(0);
 
                 expect(results[0].code).to.equal(305000);
-                expect(results[0].key).to.equal(MSG_NETWORK_ERROR);
             });
         });
 
@@ -360,7 +358,6 @@ describe('plugins', function() {
                 expect(Object.keys(registeredPlugins), 'The JavaScript did not call registerPlugin()').to.have.lengthOf(0);
                 expect(api.addPlugin, 'No instance was added').to.have.callCount(0);
                 expect(results[0].code).to.equal(305100);
-                expect(results[0].key).to.equal(MSG_PLUGIN_ERROR);
             });
         });
 
@@ -376,7 +373,6 @@ describe('plugins', function() {
                 expect(Object.keys(registeredPlugins), 'registry is empty').to.have.lengthOf(0);
                 expect(api.addPlugin, 'no instance was added').to.have.callCount(0);
                 expect(results[0].code).to.equal(305100);
-                expect(results[0].key).to.equal(MSG_PLUGIN_ERROR);
             });
         });
 

--- a/test/unit/setup-result-tests.js
+++ b/test/unit/setup-result-tests.js
@@ -1,0 +1,38 @@
+import { setupResult } from 'api/Setup';
+import { PlayerError } from 'api/errors';
+
+describe('Setup result tests', function () {
+    let allPromises;
+    beforeEach(function () {
+        allPromises = [() => {}];
+    });
+
+    it('sets core to the first item in the promises array', function () {
+        allPromises.push(() => {});
+        const actual = setupResult(allPromises);
+        expect(actual.core).to.equal(allPromises[0]);
+        expect(actual.warnings.length).to.equal(0);
+    });
+
+    it('sets core to null if the promise array is empty', function () {
+        allPromises.pop();
+        const actual = setupResult(allPromises);
+        expect(actual.core).to.be.null;
+        expect(actual.warnings.length).to.equal(0);
+    });
+
+    it('adds PlayerErrors found in the promises array as warnings', function () {
+        allPromises.push({},
+            new PlayerError('foo', 1),
+            [new PlayerError('bar', 2), {}],
+            [new PlayerError('baz', 3), new PlayerError('qux', 4)]
+        );
+
+        const actual = setupResult(allPromises).warnings;
+        expect(actual.length).to.equal(4);
+        expect(actual[0]).to.equal(allPromises[2]);
+        expect(actual[1]).to.equal(allPromises[3][0]);
+        expect(actual[2]).to.equal(allPromises[4][0]);
+        expect(actual[3]).to.equal(allPromises[4][1]);
+    });
+});


### PR DESCRIPTION
### This PR will...
- Convert non-fatal plugin load errors to warnings
- Convert non-fatal webpack component load errors to warnings
- Convert captions errors to warnings (no caption error is fatal)
- Refactor Setup to return a `setupResult` object, which contains warnings thrown during setup
- Emit and `console.warn` warnings found in `setupResult` *before* ready

### Why is this Pull Request needed?

So that errors can be tracked; and be consumed by developers via the new `WARNING` event

### Are there any points in the code the reviewer needs to double check?
Do the codes & keys make sense? Did I miss any existing logs or errors which could be warnings? Do I need to localize the warnings messages?

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/5709

#### Addresses Issue(s):

JW8-1504

