### PR TITLE
Fix ESLint v5 errors

### DIFF
--- a/src/js/environment/environment.js
+++ b/src/js/environment/environment.js
@@ -28,9 +28,7 @@ function supportsPassive() {
 
     try {
         const opts = Object.defineProperty({}, 'passive', {
-            get: function() {
-                passiveOptionRead = true;
-            }
+            get: () => (passiveOptionRead = true)
         });
         window.addEventListener('testPassive', null, opts);
         window.removeEventListener('testPassive', null, opts);

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -497,7 +497,7 @@ class ProgramController extends Eventable {
     get audioTracks() {
         const { mediaController } = this;
         if (!mediaController) {
-            return;
+            return undefined;
         }
 
         return mediaController.audioTracks;

--- a/src/js/utils/helpers.js
+++ b/src/js/utils/helpers.js
@@ -45,7 +45,7 @@ function crossdomain(uri) {
     a.href = location.href;
     try {
         b.href = uri;
-        b.href = b.href; /* IE fix for relative urls */
+        b.href = b.href; /* IE fix for relative urls */ // eslint-disable-line no-self-assign
         return a.protocol + '//' + a.host !== b.protocol + '//' + b.host;
     } catch (e) {/* swallow */}
     return true;


### PR DESCRIPTION
### This PR will...
 Fix the following lint errors reported when running `eslint ./src` using the cli with eslint v5.5.0:
```
/dev/jwplayer/src/js/environment/environment.js
  31:18  error  Expected to return a value in method 'get'  getter-return

/dev/jwplayer/src/js/program/program-controller.js
  500:13  error  Expected to return a value in getter 'audioTracks'  getter-return

/dev/jwplayer/src/js/utils/helpers.js
  48:18  error  'b.href' is assigned to itself  no-self-assign
```

### Why is this Pull Request needed?
`"extends": "eslint:recommended"` adds [getter-return](https://eslint.org/docs/rules/getter-return) and [no-self-assign](https://eslint.org/docs/rules/no-self-assign) in the latest version of ESLint. Fixing these errors preps us for updating ESLint, and they are good rules to follow. 
