### PR TITLE
Assign error codes to "playAttemptFailed" events

### DIFF
--- a/src/js/api/errors.js
+++ b/src/js/api/errors.js
@@ -86,6 +86,36 @@ export const FLASH_ERROR = 210000;
 export const FLASH_MEDIA_ERROR = 214000;
 
 /**
+ * @enum {ErrorCode} The play attempt failed for unknown reasons.
+ */
+const PLAY_ATTEMPT_FAILED_MISC = 303200;
+
+/**
+ * @enum {ErrorCode} The play attempt was interrupted for unknown reasons.
+ */
+const PLAY_ATTEMPT_FAILED_ABORT = 303210;
+
+/**
+ * @enum {ErrorCode} The play attempt was interrupted by a new load request.
+ */
+const PLAY_ATTEMPT_FAILED_ABORT_LOAD = 303212;
+
+/**
+ * @enum {ErrorCode} The play attempt was interrupted by a call to pause().
+ */
+const PLAY_ATTEMPT_FAILED_ABORT_PAUSE = 303213;
+
+/**
+ * @enum {ErrorCode} The play attempt failed because the user didn't interact with the document first.
+ */
+const PLAY_ATTEMPT_FAILED_NOT_ALLOWED = 303220;
+
+/**
+ * @enum {ErrorCode} The play attempt failed because no supported source was found.
+ */
+const PLAY_ATTEMPT_FAILED_NOT_SUPPORTED = 303230;
+
+/**
  * @enum {ErrorKey}
  */
 export const MSG_CANT_PLAY_VIDEO = 'cantPlayVideo';
@@ -158,4 +188,23 @@ export function composePlayerError(error, superCode) {
     const playerError = convertToPlayerError(MSG_TECHNICAL_ERROR, superCode, error);
     playerError.code = (error && error.code || 0) + superCode;
     return playerError;
+}
+
+export function getPlayAttemptFailedErrorCode(error) {
+    const { name, message } = error;
+    switch (name) {
+        case 'AbortError':
+            if (/pause/.test(message)) {
+                return PLAY_ATTEMPT_FAILED_ABORT_PAUSE;
+            } else if (/load/.test(message)) {
+                return PLAY_ATTEMPT_FAILED_ABORT_LOAD;
+            }
+            return PLAY_ATTEMPT_FAILED_ABORT;
+        case 'NotAllowedError':
+            return PLAY_ATTEMPT_FAILED_NOT_ALLOWED;
+        case 'NotSupportedError':
+            return PLAY_ATTEMPT_FAILED_NOT_SUPPORTED;
+        default:
+            return PLAY_ATTEMPT_FAILED_MISC;
+    }
 }

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -26,7 +26,7 @@ import { PLAYER_STATE, STATE_BUFFERING, STATE_IDLE, STATE_COMPLETE, STATE_PAUSED
 import ProgramController from 'program/program-controller';
 import initQoe from 'controller/qoe';
 import { BACKGROUND_LOAD_OFFSET } from 'program/program-constants';
-import { composePlayerError, convertToPlayerError, MSG_CANT_PLAY_VIDEO, MSG_TECHNICAL_ERROR,
+import { composePlayerError, convertToPlayerError, getPlayAttemptFailedErrorCode, MSG_CANT_PLAY_VIDEO, MSG_TECHNICAL_ERROR,
     ERROR_COMPLETING_SETUP, ERROR_LOADING_PLAYLIST, ERROR_LOADING_PROVIDER, ERROR_LOADING_PLAYLIST_ITEM } from 'api/errors';
 
 // The model stores a different state than the provider
@@ -507,8 +507,10 @@ Object.assign(Controller.prototype, {
                 // Emit event unless test was explicitly canceled.
                 if (!checkAutoStartCancelable.cancelled()) {
                     const { reason } = error;
+                    const code = getPlayAttemptFailedErrorCode(error);
                     _this.trigger(AUTOSTART_NOT_ALLOWED, {
                         reason,
+                        code,
                         error
                     });
                 }

--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -1,6 +1,7 @@
 import cancelable from 'utils/cancelable';
 import Eventable from 'utils/eventable';
 import ApiQueueDecorator from 'api/api-queue';
+import { PlayerError, getPlayAttemptFailedErrorCode } from 'api/errors';
 import { ProviderListener } from 'program/program-listeners';
 import { MediaModel } from 'controller/model';
 import { seconds } from 'utils/strings';
@@ -154,11 +155,14 @@ export default class MediaController extends Eventable {
                     }
                     mediaModel.set('mediaState', STATE_PAUSED);
                 }
-                this.trigger(MEDIA_PLAY_ATTEMPT_FAILED, {
+
+                const playerError = Object.assign(new PlayerError(null, getPlayAttemptFailedErrorCode(error), error), {
                     error,
                     item,
                     playReason
                 });
+                delete playerError.key;
+                this.trigger(MEDIA_PLAY_ATTEMPT_FAILED, playerError);
                 throw error;
             }
         });

--- a/src/js/providers/utils/play-promise.js
+++ b/src/js/providers/utils/play-promise.js
@@ -1,7 +1,7 @@
 export default function createPlayPromise(video) {
     return new Promise(function(resolve, reject) {
         if (video.paused) {
-            return reject(new Error('Play refused.'));
+            return reject(playPromiseError('NotAllowedError', 0, 'play() failed.'));
         }
         const removeEventListeners = function() {
             video.removeEventListener('play', playListener);
@@ -21,9 +21,21 @@ export default function createPlayPromise(video) {
             if (e.type === 'playing') {
                 resolve();
             } else {
-                reject(new Error('The play() request was interrupted by a "' + e.type + '" event.'));
+                const message = `The play() request was interrupted by a "${e.type}" event.`;
+                if (e.type === 'error') {
+                    reject(playPromiseError('NotSupportedError', 9, message));
+                } else {
+                    reject(playPromiseError('AbortError', 20, message));
+                }
             }
         };
         video.addEventListener('play', playListener);
     });
+}
+
+function playPromiseError(name, code, message) {
+    const error = new Error(message);
+    error.name = name;
+    error.code = code;
+    return error;
 }


### PR DESCRIPTION
### This PR will...

Assign the following error codes to "playAttemptFailed" events:

- 303,200 The play attempt failed for unknown reasons.
- 303,210 The play attempt was interrupted for unknown reasons.
- 303,212 The play attempt was interrupted by a new load request.
- 303,213 The play attempt was interrupted by a call to pause().
- 303,220 The play attempt failed because the user didn't interact with the document first, or disabled auto-play completely.
- 303,230 The play attempt failed because no supported source was found.

Add `code` and `sourceError` properties to "playAttemptFailed" events:
```js
{
  type: "playAttemptFailed",
  playReason: "external",
  code: 303212,
  error: { DOMException: "The play() request was interrupted by a new load request. https://goo.gl/LdLk22" }
  sourceError: { DOMException: "The play() request was interrupted by a new load request. https://goo.gl/LdLk22" }
  item: { sources: Array(3), tracks: Array(1), … }
}
```

### Why is this Pull Request needed?

These error codes will allow troubleshooting and monitoring of "playAttemptFailed" events. The `code` and `sourceError` properties provide consistency with "error" and "warning" events. The `sourceError` property has the same value as `error`, which is left in place for backwards compatibility.

#### Addresses Issue(s):

JW8-820

