### PR TITLE
Wait for plugins to load before handling setup errors

### DIFF
--- a/src/js/api/Setup.js
+++ b/src/js/api/Setup.js
@@ -1,9 +1,14 @@
 import loadCoreBundle from 'api/core-loader';
-import startSetup from 'api/setup-steps';
 import loadPlugins from 'plugins/plugins';
+import {
+    loadProvider,
+    loadModules,
+    loadSkin,
+    loadTranslations
+} from 'api/setup-steps';
 import { PlayerError, SETUP_ERROR_TIMEOUT, MSG_CANT_LOAD_PLAYER } from 'api/errors';
 
-const SETUP_TIMEOUT_SECONDS = 60;
+const SETUP_TIMEOUT = 60 * 1000;
 
 const Setup = function(_model) {
 
@@ -11,24 +16,34 @@ const Setup = function(_model) {
 
     this.start = function (api) {
 
+        const pluginsPromise = loadPlugins(_model, api);
+
         const setup = Promise.all([
             loadCoreBundle(_model),
-            loadPlugins(_model, api),
-            startSetup(_model, api, [])
+            pluginsPromise,
+            loadProvider(_model),
+            loadModules(_model, api),
+            loadSkin(_model),
+            loadTranslations(_model)
         ]);
 
         const timeout = new Promise((resolve, reject) => {
             _setupFailureTimeout = setTimeout(() => {
-                const error = new PlayerError(MSG_CANT_LOAD_PLAYER, SETUP_ERROR_TIMEOUT);
-                reject(error);
-            }, SETUP_TIMEOUT_SECONDS * 1000);
+                reject(new PlayerError(MSG_CANT_LOAD_PLAYER, SETUP_ERROR_TIMEOUT));
+            }, SETUP_TIMEOUT);
             const timeoutCancelled = () => {
                 clearTimeout(_setupFailureTimeout);
+                setTimeout(resolve, SETUP_TIMEOUT);
             };
             setup.then(timeoutCancelled).catch(timeoutCancelled);
         });
 
-        return Promise.race([setup, timeout]);
+        return Promise.race([setup, timeout]).catch(error => {
+            const throwError = () => {
+                throw error;
+            };
+            return pluginsPromise.then(throwError).catch(throwError);
+        });
     };
 
     this.destroy = function() {

--- a/src/js/api/setup-steps.js
+++ b/src/js/api/setup-steps.js
@@ -36,7 +36,7 @@ function setPlaylistAttributes(model, playlist, feedData) {
     attributes.feedData = feedData;
 }
 
-function loadProvider(_model) {
+export function loadProvider(_model) {
     return loadPlaylist(_model).then(() => {
         if (destroyed(_model)) {
             return;
@@ -95,7 +95,7 @@ export function loadSkin(_model) {
     return Promise.resolve();
 }
 
-function loadTranslations(_model) {
+export function loadTranslations(_model) {
     const language = getLanguage();
     if (language && isTranslationAvailable(language)) {
         return new Promise((resolve, reject) => {
@@ -114,19 +114,10 @@ function loadTranslations(_model) {
     return Promise.resolve();
 }
 
+export function loadModules(/* model, api */) {
+    return Promise.resolve();
+}
+
 function destroyed(_model) {
     return _model.attributes._destroyed;
 }
-
-const startSetup = function(model, api, promises) {
-    if (destroyed(model)) {
-        return Promise.reject();
-    }
-    return Promise.all(promises.concat([
-        loadProvider(model),
-        loadSkin(model),
-        loadTranslations(model)
-    ]));
-};
-
-export default startSetup;


### PR DESCRIPTION
### This PR will...

- Wait for plugins to load before handling setup errors.
- Export each setup step so that each step can be extended.

### Why is this Pull Request needed?

This will allow plugins that listen to "setupError" to load before we trigger that event so that they can execute callbacks.

Exporting each step allows us to extend steps instead of blocking all promises with additional promises that only needs to block a single step.

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-commercial/pull/5724

#### Addresses Issue(s):

JW8-1830

