### PR TITLE
Extend setup timeout to 60 seconds

### DIFF
--- a/src/js/api/Setup.js
+++ b/src/js/api/Setup.js
@@ -3,7 +3,7 @@ import startSetup from 'api/setup-steps';
 import loadPlugins from 'plugins/plugins';
 import { PlayerError, SETUP_ERROR_TIMEOUT, MSG_CANT_LOAD_PLAYER } from 'api/errors';
 
-const SETUP_TIMEOUT_SECONDS = 30;
+const SETUP_TIMEOUT_SECONDS = 60;
 
 const Setup = function(_model) {
 

--- a/src/js/utils/scriptloader.js
+++ b/src/js/utils/scriptloader.js
@@ -3,7 +3,7 @@ import { ERROR, STATE_COMPLETE } from 'events/events';
 
 const ScriptPromises = {};
 
-const SCRIPT_LOAD_TIMEOUT = 15000;
+const SCRIPT_LOAD_TIMEOUT = 45000;
 
 export const SCRIPT_LOAD_STATUS_NEW = 0;
 export const SCRIPT_LOAD_STATUS_LOADING = 1;


### PR DESCRIPTION
### This PR will...

- Change setup timeout from 30 to 60 seconds
- Change script load timeout from 15 to 45 (plugins)

### Why is this Pull Request needed?

This will reduce the number of 30 second setup timeout errors, and allow us to extend the timeout for plugins, 3rd party scripts, and webpack modules.

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-commercial/pull/5730

#### Addresses Issue(s):

JW8-2223

