### PR TITLE
Wrap top language extraction in try block

### DIFF
--- a/src/js/utils/language.js
+++ b/src/js/utils/language.js
@@ -50,7 +50,10 @@ function extractLanguage(doc) {
 export function getLanguage() {
     let language = extractLanguage(document);
     if (!language && isIframe()) {
-        language = extractLanguage(window.top.document);
+        try {
+            // Exception is thrown if iFrame is on a different domain name.
+            language = extractLanguage(window.top.document);
+        } catch (e) {/* ignore */}
     }
     return language || navigator.language || navigator.browserLanguage || navigator.userLanguage || navigator.systemLanguage || 'en';
 }


### PR DESCRIPTION
### This PR will...
wrap `window.top.document` in a `try` block.
### Why is this Pull Request needed?
When we fail to extract the language from an iFrame, we try to extract it from `window.top.document`. If the origins are different, attempting to access `window.top.document` will result in an exception; by wrapping it in a try block we prevent the exception and fallback to the browser's api. 
### Are there any points in the code the reviewer needs to double check?
n/a
### Are there any Pull Requests open in other repos which need to be merged with this?
n/a
#### Addresses Issue(s):

JW8-2262

