### PR TITLE
[JW8-1840] Use getState to determine player state.

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -473,7 +473,7 @@ Object.assign(Controller.prototype, {
         }
 
         function _autoStart() {
-            const state = _model.get('state');
+            const state = _getState();
             if (state !== STATE_IDLE && state !== STATE_PAUSED) {
                 return;
             }


### PR DESCRIPTION
### This PR will...
Use `_getState()` to determine the players' state, which returns the ad state when there is an instream.

### Why is this Pull Request needed?
Fixes a bug with autoPause in postrolls.

### Are there any points in the code the reviewer needs to double check?
N/A

### Are there any Pull Requests open in other repos which need to be merged with this?
N/A

#### Addresses Issue(s):
JW8-1840