### PR TITLE
Remove/Update hard coded aria labels

### DIFF
--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -64,10 +64,11 @@ const Defaults = {
         settings: 'Settings',
         stop: 'Stop',
         sharing: {
+            copied: 'Copied',
             email: 'Email',
             embed: 'Embed',
-            link: 'Link',
-            share: 'Share'
+            heading: 'Share',
+            link: 'Link'
         },
         videoInfo: 'About This Video',
         volume: 'Volume',

--- a/src/js/view/controls/templates/rightclick.js
+++ b/src/js/view/controls/templates/rightclick.js
@@ -18,7 +18,7 @@ const rightClickItem = (item, localization) => {
 const itemContentTypes = {
     link: ({ link, title, logo }) => `<a href="${link || ''}" class="jw-rightclick-link jw-reset" target="_blank">${logo}${title || ''}</a>`,
     info: (item, localization) => `<button type="button" class="jw-reset jw-rightclick-link jw-info-overlay-item">${localization.videoInfo}</button>`,
-    share: (item, localization) => `<button type="button" class="jw-reset jw-rightclick-link jw-share-item">${localization.sharing.share}</button>`
+    share: (item, localization) => `<button type="button" class="jw-reset jw-rightclick-link jw-share-item">${localization.sharing.heading}</button>`
 };
 
 

--- a/src/js/view/logo.js
+++ b/src/js/view/logo.js
@@ -85,7 +85,7 @@ export default function Logo(_model) {
 
         if (_settings.link) {
             _logo.setAttribute('tabindex', '0');
-            _logo.setAttribute('aria-label', 'Logo');
+            _logo.setAttribute('aria-label', _model.get('localization').logo);
         }
 
         this.ui = new UI(_logo).on('click tap enter', function (evt) {


### PR DESCRIPTION
### This PR will...

- Use ```localization.logo``` instead of the hard coded text in ```logo.js```.
- Use ```localization.sharing.heading``` in ```rightclick.js```.

### Why is this Pull Request needed?

- All hard coded options should use localization instead (missed ```logo``` in previous PRs`
- ```rightclick.js``` should be updated to use the new localization option (```localization.sharing.heading```)

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-1354

