### PR TITLE
Backwards support for localization options

### DIFF
--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -63,37 +63,26 @@ function _adjustDefaultBwEstimate(estimate) {
 
 function _copyToLocalization(allOptions) {
     const { advertising, related, sharing } = allOptions;
-    const localization = Object.assign({}, Defaults.localization, allOptions.localization);
+    const localization = Object.assign({}, allOptions.localization);
 
     if (advertising) {
-        localization.advertising = Object.assign({}, localization.advertising, {
-            admessage: advertising.admessage,
-            cuetext: advertising.cuetext,
-            loadingAd: localization.loadingAd,
-            podmessage: advertising.podmessage,
-            skipmessage: advertising.skipmessage,
-            skiptext: advertising.skiptext
-        });
+        localization.advertising = Object.assign({}, localization.advertising, advertising);
     }
 
     if (related) {
+        localization.related = localization.related || {};
         if (typeof related === 'object') {
-            localization.related = Object.assign({}, localization.related, {
-                autoplaymessage: related.autoplaymessage,
-                heading: related.heading,
-            });
+            localization.related.heading = localization.related.heading || related.heading;
+            localization.related.autoplaymessage = localization.related.autoplaymessage || related.autoplaymessage;
         } else {
-            localization.related = Object.assign({}, Defaults.localization.related, {
-                heading: related.heading
-            });
+            localization.related.heading = localization.related.heading || localization.related;
         }
     }
 
     if (sharing) {
-        localization.sharing = Object.assign({}, localization.sharing, {
-            copied: localization.copied,
-            heading: sharing.heading
-        });
+        localization.sharing = localization.sharing || {};
+        localization.sharing.heading = localization.sharing.heading || sharing.heading;
+        localization.sharing.copied = localization.sharing.copied || localization.copied;
     }
 
     localization.abouttext = localization.abouttext || allOptions.abouttext;

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -80,11 +80,11 @@ function _copyToLocalization(allOptions) {
         if (typeof related === 'object') {
             localization.related = Object.assign({}, localization.related, {
                 autoplaymessage: related.autoplaymessage,
-                heading: localization.nextUp || related.heading,
+                heading: related.heading,
             });
         } else {
             localization.related = Object.assign({}, Defaults.localization.related, {
-                heading: localization.related
+                heading: related.heading
             });
         }
     }

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -77,10 +77,16 @@ function _copyToLocalization(allOptions) {
     }
 
     if (related) {
-        localization.related = Object.assign({}, localization.related, {
-            autoplaymessage: related.autoplaymessage,
-            heading: localization.nextUp || related.heading,
-        });
+        if (typeof localization.related === 'object') {
+            localization.related = Object.assign({}, localization.related, {
+                autoplaymessage: related.autoplaymessage,
+                heading: localization.nextUp || related.heading,
+            });
+        } else {
+            localization.related = Object.assign({}, Defaults.localization.related, {
+                heading: localization.related
+            });
+        }
     }
 
     if (sharing) {

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -86,8 +86,7 @@ function _copyToLocalization(allOptions) {
     if (sharing) {
         localization.sharing = Object.assign({}, localization.sharing, {
             copied: localization.copied,
-            heading: sharing.heading,
-            link: sharing.link,
+            heading: sharing.heading
         });
     }
 

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -77,7 +77,7 @@ function _copyToLocalization(allOptions) {
     }
 
     if (related) {
-        if (typeof localization.related === 'object') {
+        if (typeof related === 'object') {
             localization.related = Object.assign({}, localization.related, {
                 autoplaymessage: related.autoplaymessage,
                 heading: localization.nextUp || related.heading,

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -61,9 +61,45 @@ function _adjustDefaultBwEstimate(estimate) {
     return Defaults.bandwidthEstimate;
 }
 
+function _copyToLocalization(allOptions) {
+    const { advertising, related, sharing } = allOptions;
+    const localization = Object.assign({}, Defaults.localization, allOptions.localization);
+
+    if (advertising) {
+        localization.advertising = Object.assign({}, localization.advertising, {
+            admessage: advertising.admessage,
+            cuetext: advertising.cuetext,
+            loadingAd: localization.loadingAd,
+            podmessage: advertising.podmessage,
+            skipmessage: advertising.skipmessage,
+            skiptext: advertising.skiptext
+        });
+    }
+
+    if (related) {
+        localization.related = Object.assign({}, localization.related, {
+            autoplaymessage: related.autoplaymessage,
+            heading: localization.nextUp || related.heading,
+        });
+    }
+
+    if (sharing) {
+        localization.sharing = Object.assign({}, localization.sharing, {
+            copied: localization.copied,
+            heading: sharing.heading,
+            link: sharing.link,
+        });
+    }
+
+    localization.abouttext = localization.abouttext || allOptions.abouttext;
+
+    allOptions.localization = localization;
+}
+
 const Config = function(options, persisted) {
     let allOptions = Object.assign({}, (window.jwplayer || {}).defaults, persisted, options);
 
+    _copyToLocalization(allOptions);
     _deserialize(allOptions);
 
     const language = getLanguage();

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -83,14 +83,15 @@ function _copyToLocalization(allOptions) {
         _mergeProperty(localization.advertising, advertising, 'skiptext');
     }
 
+    if (typeof localization.related === 'string') {
+        localization.related = {
+            heading: localization.related
+        };
+    } else {
+        localization.related = localization.related || {};
+    }
+
     if (related) {
-        if (typeof localization.related === 'string') {
-            localization.related = {
-                heading: localization.related
-            };
-        } else {
-            localization.related = localization.related || {};
-        }
         _mergeProperty(localization.related, related, 'autoplaymessage');
     }
 

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -62,14 +62,10 @@ function _adjustDefaultBwEstimate(estimate) {
 }
 
 function _mergeProperty(localizationObj, allOptionsObj, prop) {
-    if (prop) {
-        const propToCopy = localizationObj[prop] || allOptionsObj[prop];
+    const propToCopy = localizationObj[prop] || allOptionsObj[prop];
 
-        if (propToCopy) {
-            localizationObj[prop] = propToCopy;
-        }
-    } else {
-        localizationObj = Object.assign({}, localizationObj, allOptionsObj);
+    if (propToCopy) {
+        localizationObj[prop] = propToCopy;
     }
 }
 
@@ -78,7 +74,12 @@ function _copyToLocalization(allOptions) {
     const localization = Object.assign({}, allOptions.localization);
 
     if (advertising) {
-        _mergeProperty(localization.advertising, advertising);
+        _mergeProperty(localization.advertising, advertising, 'admessage');
+        _mergeProperty(localization.advertising, advertising, 'cuetext');
+        _mergeProperty(localization.advertising, advertising, 'loadingAd');
+        _mergeProperty(localization.advertising, advertising, 'podmessage');
+        _mergeProperty(localization.advertising, advertising, 'skipmessage');
+        _mergeProperty(localization.advertising, advertising, 'skiptext');
     }
 
     if (related) {
@@ -86,9 +87,10 @@ function _copyToLocalization(allOptions) {
             localization.related = {
                 heading: localization.related
             };
-
-            _mergeProperty(localization.related, related, 'autoplaymessage');
+        } else {
+            localization.related = {};
         }
+        _mergeProperty(localization.related, related, 'autoplaymessage');
     }
 
     if (sharing) {

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -88,7 +88,7 @@ function _copyToLocalization(allOptions) {
                 heading: localization.related
             };
         } else {
-            localization.related = {};
+            localization.related = localization.related || {};
         }
         _mergeProperty(localization.related, related, 'autoplaymessage');
     }
@@ -103,12 +103,17 @@ function _copyToLocalization(allOptions) {
         _mergeProperty(localization, allOptions, 'abouttext');
     }
 
+    const localizationClose = localization.close || localization.nextUpClose;
+
+    if (localizationClose) {
+        localization.close = localizationClose;
+    }
+
     allOptions.localization = localization;
 }
 
 const Config = function(options, persisted) {
     let allOptions = Object.assign({}, (window.jwplayer || {}).defaults, persisted, options);
-
     _copyToLocalization(allOptions);
     _deserialize(allOptions);
 

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -74,6 +74,7 @@ function _copyToLocalization(allOptions) {
     const localization = Object.assign({}, allOptions.localization);
 
     if (advertising) {
+        localization.advertising = localization.advertising || {};
         _mergeProperty(localization.advertising, advertising, 'admessage');
         _mergeProperty(localization.advertising, advertising, 'cuetext');
         _mergeProperty(localization.advertising, advertising, 'loadingAd');

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -61,31 +61,45 @@ function _adjustDefaultBwEstimate(estimate) {
     return Defaults.bandwidthEstimate;
 }
 
+function _mergeProperty(localizationObj, allOptionsObj, prop) {
+    if (prop) {
+        const propToCopy = localizationObj[prop] || allOptionsObj[prop];
+
+        if (propToCopy) {
+            localizationObj[prop] = propToCopy;
+        }
+    } else {
+        localizationObj = Object.assign({}, localizationObj, allOptionsObj);
+    }
+}
+
 function _copyToLocalization(allOptions) {
-    const { advertising, related, sharing } = allOptions;
+    const { advertising, related, sharing, abouttext } = allOptions;
     const localization = Object.assign({}, allOptions.localization);
 
     if (advertising) {
-        localization.advertising = Object.assign({}, localization.advertising, advertising);
+        _mergeProperty(localization.advertising, advertising);
     }
 
     if (related) {
-        localization.related = localization.related || {};
-        if (typeof related === 'object') {
-            localization.related.heading = localization.related.heading || related.heading;
-            localization.related.autoplaymessage = localization.related.autoplaymessage || related.autoplaymessage;
-        } else {
-            localization.related.heading = localization.related.heading || localization.related;
+        if (typeof localization.related === 'string') {
+            localization.related = {
+                heading: localization.related
+            };
+
+            _mergeProperty(localization.related, related, 'autoplaymessage');
         }
     }
 
     if (sharing) {
         localization.sharing = localization.sharing || {};
-        localization.sharing.heading = localization.sharing.heading || sharing.heading;
-        localization.sharing.copied = localization.sharing.copied || localization.copied;
+        _mergeProperty(localization.sharing, sharing, 'heading');
+        _mergeProperty(localization.sharing, sharing, 'copied');
     }
 
-    localization.abouttext = localization.abouttext || allOptions.abouttext;
+    if (abouttext) {
+        _mergeProperty(localization, allOptions, 'abouttext');
+    }
 
     allOptions.localization = localization;
 }

--- a/test/unit/localization-backwards-compatibility-test.js
+++ b/test/unit/localization-backwards-compatibility-test.js
@@ -127,5 +127,32 @@ describe('Localization Backwards Support', function () {
             expect(config.localization.advertising.cuetext).to.equal(advertisingConfig.localization.advertising.cuetext);
         });
     });
+
+    describe('Sharing', function () {
+        it('should fallback to the appropriate properties when localization isnt set', function () {
+            const sharingConfig = {
+                sharing: {
+                    link: 'http://example.com/page/MEDIAID/',
+                    heading: 'Share Video',
+                    copied: 'Copied',
+                    sites: [
+                        'email',
+                        'twitter',
+                        'facebook',
+                        {
+                            icon: 'assets/smiley.png',
+                            src: 'http://www.google.com/sharer/sharer.php?u=',
+                            label: 'smileyshare'
+                        }
+                    ]
+                }
+            };
+
+
+            const config = new Config(Object.assign({}, defaultConfig, sharingConfig));
+            expect(config.localization.sharing.copied).to.equal(config.sharing.copied);
+            expect(config.localization.sharing.heading).to.equal(config.sharing.heading);
+        });
+    });
 });
 

--- a/test/unit/localization-backwards-compatibility-test.js
+++ b/test/unit/localization-backwards-compatibility-test.js
@@ -1,7 +1,7 @@
 import Config from 'api/config';
 import en from 'assets/translations/en.js';
 
-describe.only('Localization Backwards Support', function () {
+describe('Localization Backwards Support', function () {
 
     describe('Defaults', function () {
 

--- a/test/unit/localization-backwards-compatibility-test.js
+++ b/test/unit/localization-backwards-compatibility-test.js
@@ -125,6 +125,10 @@ describe('Localization Backwards Support', function () {
 
             const config = new Config(Object.assign({}, defaultConfig, advertisingConfig));
             expect(config.localization.advertising.cuetext).to.equal(advertisingConfig.localization.advertising.cuetext);
+            expect(config.localization.advertising.loadingad).to.equal(advertisingConfig.localization.advertising.loadingad);
+            expect(config.localization.advertising.podmessage).to.equal(advertisingConfig.localization.advertising.podmessage);
+            expect(config.localization.advertising.skipmessage).to.equal(advertisingConfig.localization.advertising.skipmessage);
+            expect(config.localization.advertising.skiptext).to.equal(advertisingConfig.localization.advertising.skiptext);
         });
     });
 
@@ -152,6 +156,39 @@ describe('Localization Backwards Support', function () {
             const config = new Config(Object.assign({}, defaultConfig, sharingConfig));
             expect(config.localization.sharing.copied).to.equal(config.sharing.copied);
             expect(config.localization.sharing.heading).to.equal(config.sharing.heading);
+        });
+
+        it('should always use properties in the localization block', function () {
+            const sharingConfig = {
+                sharing: {
+                    link: 'http://example.com/page/MEDIAID/',
+                    heading: 'Wrong Heading',
+                    copied: 'Wrong copied Text',
+                    sites: [
+                        'email',
+                        'twitter',
+                        'facebook',
+                        {
+                            icon: 'assets/smiley.png',
+                            src: 'http://www.google.com/sharer/sharer.php?u=',
+                            label: 'smileyshare'
+                        }
+                    ]
+                },
+                localization: {
+                    sharing: {
+                        heading: 'Right heading',
+                        link: 'http://example.com/page/CORRECTID/',
+                        copied: 'Right copied text'
+                    }
+                }
+            };
+
+            const config = new Config(Object.assign({}, defaultConfig, sharingConfig));
+            expect(config.localization.sharing.heading).to.equal(sharingConfig.localization.sharing.heading);
+            expect(config.localization.sharing.link).to.equal(sharingConfig.localization.sharing.link);
+            expect(config.localization.sharing.copied).to.equal(sharingConfig.localization.sharing.copied);
+
         });
     });
 });

--- a/test/unit/localization-backwards-compatibility-test.js
+++ b/test/unit/localization-backwards-compatibility-test.js
@@ -1,0 +1,60 @@
+import Config from 'api/config';
+import en from 'assets/translations/en.js';
+
+describe.only('Localization Backwards Support', function () {
+
+    describe('Defaults', function () {
+
+        it('should not override defaults if localization block isnt set', function () {
+            const config = new Config({
+                title: 'Agent 327',
+                description: 'Operation Barbershop'
+            });
+
+            expect(config.localization).to.deep.equal(en);
+        });
+    });
+
+    describe('Related', function () {
+
+        it('should fallback to the appropriate properties when localization isnt set', function () {
+            const config = new Config({
+                related: {
+                    client: 'related.js',
+                    displayMode: 'shelfWidget',
+                    autoplaymessage: 'Showing next video in xx'
+                }
+            });
+
+            expect(config.localization.related.autoplaymessage).to.equal(config.related.autoplaymessage);
+            expect(config.localization.related.heading).to.equal(en.related.heading);
+        }); 
+
+        it('should use properties from the localization block when set', function () {
+            const config = new Config({
+                localization: {
+                    related: {
+                        heading: 'Lots of Videos',
+                        autoplaymessage: 'Showing next video in xx'
+                    }
+                }
+            }); 
+
+            expect(config.localization.related.autoplaymessage).to.not.equal(en.related.heading);
+            expect(config.localization.related.heading).to.not.equal(en.related.heading);
+            expect(config.localization.related.autoplaymessage).to.equal('Showing next video in xx');
+            expect(config.localization.related.heading).to.equal('Lots of Videos');
+        });
+
+        it('should set the correct text if localization.related was originally a string', function () {
+            const config = new Config({
+                localization: {
+                    related: 'Even more videos'
+                }
+            });
+
+            expect(config.localization.related).to.be.an('object');
+        });
+    });
+});
+

--- a/test/unit/localization-backwards-compatibility-test.js
+++ b/test/unit/localization-backwards-compatibility-test.js
@@ -2,58 +2,121 @@ import Config from 'api/config';
 import en from 'assets/translations/en.js';
 
 describe('Localization Backwards Support', function () {
+    const defaultConfig = {
+        title: 'Agent 327',
+        description: 'Operation Barbershop'
+    };
 
     describe('Defaults', function () {
 
         it('should not override defaults if localization block isnt set', function () {
-            const config = new Config({
-                title: 'Agent 327',
-                description: 'Operation Barbershop'
-            });
+            const config = new Config(Object.assign({}, defaultConfig));
 
             expect(config.localization).to.deep.equal(en);
         });
     });
 
     describe('Related', function () {
-
         it('should fallback to the appropriate properties when localization isnt set', function () {
-            const config = new Config({
+            const relatedConfig = {
                 related: {
                     client: 'related.js',
                     displayMode: 'shelfWidget',
                     autoplaymessage: 'Showing next video in xx'
                 }
-            });
+            };
+
+            const config = new Config(Object.assign({}, defaultConfig, relatedConfig));
 
             expect(config.localization.related.autoplaymessage).to.equal(config.related.autoplaymessage);
             expect(config.localization.related.heading).to.equal(en.related.heading);
         }); 
 
-        it('should use properties from the localization block when set', function () {
-            const config = new Config({
-                localization: {
-                    related: {
-                        heading: 'Lots of Videos',
-                        autoplaymessage: 'Showing next video in xx'
-                    }
-                }
-            }); 
-
-            expect(config.localization.related.autoplaymessage).to.not.equal(en.related.heading);
-            expect(config.localization.related.heading).to.not.equal(en.related.heading);
-            expect(config.localization.related.autoplaymessage).to.equal('Showing next video in xx');
-            expect(config.localization.related.heading).to.equal('Lots of Videos');
-        });
-
         it('should set the correct text if localization.related was originally a string', function () {
-            const config = new Config({
+            const relatedConfig = {
+                related: {
+                    client: 'related.js',
+                    displayMode: 'shelfWidget',
+                    autoplaymessage: 'Showing next video in xx'
+                },
                 localization: {
                     related: 'Even more videos'
                 }
-            });
+            };
+
+            const config = new Config(Object.assign({}, defaultConfig, relatedConfig));
 
             expect(config.localization.related).to.be.an('object');
+            expect(config.localization.related.heading).to.equal(relatedConfig.localization.related);
+        });
+
+        it('should always use properties in the localization block', function() {
+            const relatedConfig = {
+                related: {
+                    client: 'related.js',
+                    displayMode: 'shelfWidget',
+                    autoplaymessage: 'This is the wrong message'
+                },
+                localization: {
+                    related: {
+                        heading: 'Lots of Videos',
+                        autoplaymessage: 'This is the right message'
+                    }
+                }
+            };
+
+            const config = new Config(Object.assign({}, defaultConfig, relatedConfig));
+            expect(config.localization.related.autoplaymessage).to.equal(relatedConfig.localization.related.autoplaymessage);
+            expect(config.localization.related.heading).to.equal(relatedConfig.localization.related.heading);
+        });
+    });
+
+    describe('Advertising', function () {
+        it('should fallback to the appropriate properties when localization isnt set', function () {
+            const advertisingConfig = {
+                advertising: {
+                    autoplayadsmuted: true,
+                    client: 'googima.js',
+                    admessage: 'Ending in xx',
+                    cuetext: 'Ad',
+                    loadingAd: 'Loading....',
+                    podmessage: 'xx of yy',
+                    skipmessage: 'Skiping in xx',
+                    skiptext: 'Next ad'
+                }
+            };
+
+
+            const config = new Config(Object.assign({}, defaultConfig, advertisingConfig));
+            expect(config.localization.advertising.admessage).to.equal(config.advertising.admessage);
+            expect(config.localization.advertising.cuetext).to.equal(config.advertising.cuetext);
+            expect(config.localization.advertising.loadingAd).to.equal(config.advertising.loadingAd);
+            expect(config.localization.advertising.podmessage).to.equal(config.advertising.podmessage);
+            expect(config.localization.advertising.skipmessage).to.equal(config.advertising.skipmessage);
+            expect(config.localization.advertising.skiptext).to.equal(config.advertising.skiptext);
+        });
+
+        it('should always use properties in the localization block', function () {
+            const advertisingConfig = {
+                advertising: {
+                    autoplayadsmuted: true,
+                    client: 'googima.js',
+                    admessage: 'Ending in xx',
+                    cuetext: 'wrong Message',
+                },
+                localization: {
+                    advertising: {
+                        cuetext: 'Right message',
+                        loadingAd: 'Loading....',
+                        podmessage: 'xx of yy',
+                        skipmessage: 'Skiping in xx',
+                        skiptext: 'Next ad'
+                    }
+                }
+            };
+
+            const config = new Config(Object.assign({}, defaultConfig, advertisingConfig));
+            expect(config.localization.advertising.cuetext).to.equal(advertisingConfig.localization.advertising.cuetext);
         });
     });
 });

--- a/test/unit/localization-backwards-compatibility-test.js
+++ b/test/unit/localization-backwards-compatibility-test.js
@@ -14,6 +14,14 @@ describe('Localization Backwards Support', function () {
 
             expect(config.localization).to.deep.equal(en);
         });
+
+        it('should not override defaults if plugin blocks dont have the appropriate properties', function() {
+            const config = new Config(Object.assign({}, defaultConfig, {
+                sharing: {}
+            }));
+
+            expect(config.localization).to.deep.equal(en);
+        });
     });
 
     describe('Related', function () {


### PR DESCRIPTION
### This PR will...

- Provide backwards support for options that were customizable outside of ```config.localization``` (```config.sharing```. ```config.advertising```, ```config.related```,  ```config.abouttext```)

### Why is this Pull Request needed?

We want to use the ```localization``` block for customizable fields in those plugin blocks moving forward without messing with the functionality of customers who still customize it the old way.

### Are there any points in the code the reviewer needs to double check?

Making the function DRYer

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-plugin-related/pull/351
https://github.com/jwplayer/jwplayer-commercial/pull/5771

#### Addresses Issue(s):

JW8-1349