### PR TITLE
Emit the playerError as the payload of the controls load warning event

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -11,7 +11,7 @@ import { Browser, OS, Features } from 'environment/environment';
 import { ControlsLoader, loadControls } from 'controller/controls-loader';
 import {
     STATE_BUFFERING, STATE_IDLE, STATE_COMPLETE, STATE_PAUSED, STATE_PLAYING, STATE_ERROR,
-    RESIZE, BREAKPOINT, DISPLAY_CLICK, LOGO_CLICK, WARNING, NATIVE_FULLSCREEN, MEDIA_VISUAL_QUALITY, CONTROLS } from 'events/events';
+    RESIZE, BREAKPOINT, DISPLAY_CLICK, LOGO_CLICK, NATIVE_FULLSCREEN, MEDIA_VISUAL_QUALITY, CONTROLS, WARNING } from 'events/events';
 import Events from 'utils/backbone.events';
 import {
     addClass,
@@ -324,11 +324,8 @@ function View(_api, _model) {
                     }
                     return enabledState;
                 });
-                controlsEvent.loadPromise.catch(function (reason) {
-                    _this.trigger(WARNING, {
-                        message: 'Controls failed to load',
-                        reason: reason
-                    });
+                controlsEvent.loadPromise.catch(function (error) {
+                    _this.trigger(WARNING, error);
                 });
             } else {
                 addControls();


### PR DESCRIPTION
### Why is this Pull Request needed?
So that the PlayerError can be easily consumed from the WARNING event

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-1504

