### PR TITLE
Include codecs in canPlayType check

### DIFF
--- a/src/js/providers/providers-supported.js
+++ b/src/js/providers/providers-supported.js
@@ -47,11 +47,18 @@ export function supportsType(source) {
             return false;
         }
 
-        const mimeType = source.mimeType || MimeTypes[type];
+        let mimeType = source.mimeType || MimeTypes[type];
 
         // Not OK to use HTML5 with no extension
         if (!mimeType) {
             return false;
+        }
+
+        // source.mediaTypes is an Array of media types that MediaSource must support for the stream to play
+        // Ex: ['video/webm; codecs="vp9"', 'audio/webm; codecs="vorbis"']
+        const mediaTypes = source.mediaTypes;
+        if (mediaTypes && mediaTypes.length) {
+            mimeType = [mimeType].concat(mediaTypes.slice()).join('; ');
         }
 
         // Last, but not least, we ask the browser

--- a/test/index.js
+++ b/test/index.js
@@ -1,9 +1,9 @@
 // Bundle files chunked by webpack
 import ProvidersLoaded from 'providers/providers-loaded';
-import * as vttparser from 'parsers/captions/vttparser';
-import * as html5 from 'providers/html5';
-import * as controls from 'view/controls/controls';
-import * as controller from 'controller/controller';
+import html5 from 'providers/html5';
+import 'parsers/captions/vttparser';
+import 'view/controls/controls';
+import 'controller/controller';
 
 // For unknown reasons importing xo causes webpack to split the chunks we need bundled
 // This polyfill will be embeded on the page by karma for IE
@@ -14,15 +14,9 @@ if (!('intersectionRatio' in window.IntersectionObserverEntry.prototype)) {
     window.IntersectionObserverEntry.prototype.intersectionRatio = 1;
 }
 
-ProvidersLoaded.html5 = html5.default;
+ProvidersLoaded.html5 = html5;
 
 const testsContext = require.context('./unit', true);
 testsContext.keys().forEach(testsContext);
 
-export default [
-    vttparser,
-    html5,
-    controls,
-    controller,
-    testsContext
-];
+export default testsContext;

--- a/test/unit/api-get-config-test.js
+++ b/test/unit/api-get-config-test.js
@@ -23,7 +23,7 @@ describe('Api.getConfig', function() {
         for (let i = instances.length; i--;) {
             instances[i].remove();
         }
-        console.error.restore();
+        sandbox.restore();
     });
 
     it('has expected model members', function() {

--- a/test/unit/api-get-config-test.js
+++ b/test/unit/api-get-config-test.js
@@ -5,11 +5,13 @@ import sinon from 'sinon';
 
 describe('Api.getConfig', function() {
 
+    const sandbox = sinon.sandbox.create();
+
     beforeEach(() => {
         const container = document.createElement('div');
         container.id = 'player';
         document.body.appendChild(container);
-        console.error = sinon.stub();
+        sandbox.spy(console, 'error');
     });
 
     afterEach(() => {
@@ -21,7 +23,7 @@ describe('Api.getConfig', function() {
         for (let i = instances.length; i--;) {
             instances[i].remove();
         }
-        console.error.reset();
+        console.error.restore();
     });
 
     it('has expected model members', function() {

--- a/test/unit/api-test.js
+++ b/test/unit/api-test.js
@@ -25,9 +25,12 @@ describe('Api', function() {
 
     this.timeout(6000);
 
+    const sandbox = sinon.sandbox.create();
+
     beforeEach(function() {
-        utils.log = sinon.stub();
-        console.error = sinon.stub();
+        sandbox.spy(utils, 'log');
+        sandbox.spy(console, 'log');
+        sandbox.spy(console, 'error');
     });
 
     afterEach(function() {
@@ -39,8 +42,9 @@ describe('Api', function() {
         for (let i = instances.length; i--;) {
             instances[i].remove();
         }
-        utils.log.reset();
-        console.error.reset();
+        utils.log.restore();
+        console.log.restore();
+        console.error.restore();
     });
 
     it('instances has a uniqueIds greater than 0', function() {
@@ -81,8 +85,6 @@ describe('Api', function() {
     it('bad events do not break player', function() {
         ApiSettings.debug = false;
 
-        console.log = sinon.stub();
-
         const api = createApi('player');
         const validEvent = sinon.stub();
         const invalidEvent = sinon.stub().throws('TypeError');
@@ -98,8 +100,6 @@ describe('Api', function() {
         expect(invalidEvent).to.have.callCount(2);
         expect(validEvent).to.have.callCount(1);
         expect(console.log).to.have.callCount(2);
-
-        console.log.reset();
     });
 
     it('throws exceptions when debug is true', function() {

--- a/test/unit/api-test.js
+++ b/test/unit/api-test.js
@@ -42,9 +42,7 @@ describe('Api', function() {
         for (let i = instances.length; i--;) {
             instances[i].remove();
         }
-        utils.log.restore();
-        console.log.restore();
-        console.error.restore();
+        sandbox.restore();
     });
 
     it('instances has a uniqueIds greater than 0', function() {

--- a/test/unit/captionsrenderer-test.js
+++ b/test/unit/captionsrenderer-test.js
@@ -2,8 +2,6 @@ import MockModel from 'mock/mock-model';
 import ViewModel from 'view/view-model';
 import CaptionsRenderer from 'view/captionsrenderer';
 import VTTCue from 'parsers/captions/vttcue';
-import { WARNING } from 'events/events';
-import { MSG_CANT_LOAD_PLAYER } from 'api/errors';
 
 describe('CaptionsRenderer.getCurrentCues', function() {
     let captionsRenderer;
@@ -31,25 +29,6 @@ describe('CaptionsRenderer.getCurrentCues', function() {
         for (let i = 0; i < currentNumCues.length; i += 1) {
             expect(captionsRenderer.getCurrentCues(allCues, i).length, 'Invalid number of cues at position ' + i).to.equal(currentNumCues[i]);
         }
-    });
-
-    it('triggers a standardized warning if the WebVTT polyfill fails to load', function () {
-        return new Promise((resolve, reject) => {
-            captionsRenderer.on(WARNING, e => {
-                const { code, key } = e.reason;
-                if (code !== 300121) {
-                    reject(`Expected code 300121, got ${code}`);
-                } else if (key !== MSG_CANT_LOAD_PLAYER) {
-                    reject(`Expected key cantLoadPlayer, got ${code}`);
-                }
-                resolve();
-            });
-
-            // The captionsRenderer will try to load the VTT polyfill in response to the captionsList change event; it
-            // will load with a 404 because unit tests don't chunk polyfills.webvtt.js
-            model.set('renderCaptionsNatively', false);
-            model.set('captionsList', [ {}, {} ]);
-        });
     });
 });
 

--- a/test/unit/core-shim-test.js
+++ b/test/unit/core-shim-test.js
@@ -4,15 +4,17 @@ import { PlayerError } from 'api/errors';
 import { SETUP_ERROR, READY } from 'events/events';
 
 describe('CoreShim', function() {
+    const sandbox = sinon.sandbox.create();
+
     let core;
-    let sandbox = sinon.sandbox.create();
+
     beforeEach(function() {
         core = new CoreShim(document.createElement('div'));
         sandbox.spy(console, 'error');
     });
 
     afterEach(function() {
-        console.error.restore();
+        sandbox.restore();
     });
 
     function expectError(expectedCode) {

--- a/test/unit/core-shim-test.js
+++ b/test/unit/core-shim-test.js
@@ -8,11 +8,11 @@ describe('CoreShim', function() {
     let sandbox = sinon.sandbox.create();
     beforeEach(function() {
         core = new CoreShim(document.createElement('div'));
-        console.error = sinon.stub();
+        sandbox.spy(console, 'error');
     });
 
     afterEach(function() {
-        console.error.reset();
+        console.error.restore();
     });
 
     function expectError(expectedCode) {

--- a/test/unit/setup-test.js
+++ b/test/unit/setup-test.js
@@ -11,6 +11,8 @@ describe('api.setup', function() {
 
     this.timeout(6000);
 
+    const sandbox = sinon.sandbox.create();
+
     const errorMessage = 'This video file cannot be played.';
 
     beforeEach(function () {
@@ -22,7 +24,7 @@ describe('api.setup', function() {
         container.id = 'player';
         fixture.appendChild(container);
         document.body.appendChild(fixture);
-        console.error = sinon.stub();
+        sandbox.spy(console, 'error');
     });
 
     afterEach(function() {
@@ -35,7 +37,7 @@ describe('api.setup', function() {
         for (let i = instances.length; i--;) {
             instances[i].remove();
         }
-        console.error.reset();
+        console.error.restore();
     });
 
     function expectReady(model) {

--- a/test/unit/setup-test.js
+++ b/test/unit/setup-test.js
@@ -37,7 +37,7 @@ describe('api.setup', function() {
         for (let i = instances.length; i--;) {
             instances[i].remove();
         }
-        console.error.restore();
+        sandbox.restore();
     });
 
     function expectReady(model) {


### PR DESCRIPTION
### This PR will...

Include `source.mediaTypes` codecs when present in `canPlayType` check.
 
### Why is this Pull Request needed?

So that the html5 provider does not attempt to handle DASH streams in Edge when the only video codec used is VP9.

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-commercial/pull/5778

#### Addresses Issue(s):

JW8-1405

