### PR TITLE
Deprecate unused localization options

### DIFF
--- a/src/assets/translations/en.js
+++ b/src/assets/translations/en.js
@@ -31,7 +31,6 @@ export default {
     more: 'More',
     next: 'Next',
     nextUp: 'Next Up',
-    nextUpClose: 'Next Up Close',
     notLive: 'Not Live',
     off: 'Off',
     pause: 'Pause',

--- a/src/assets/translations/en.js
+++ b/src/assets/translations/en.js
@@ -28,7 +28,6 @@ export default {
     hd: 'Quality',
     liveBroadcast: 'Live',
     logo: 'Logo',
-    more: 'More',
     next: 'Next',
     nextUp: 'Next Up',
     notLive: 'Not Live',


### PR DESCRIPTION
### This PR will...

- Remove ```nextUpClose``` from localization options.
- Remove ```more``` from localization options.

### Why is this Pull Request needed?

Deprecate options that no longer needed for localization 

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-2218

