### PR TITLE
Fix incorrect implementations of warnings

### DIFF
--- a/src/js/api/core-loader.js
+++ b/src/js/api/core-loader.js
@@ -23,6 +23,12 @@ export function chunkLoadErrorHandler(code, error) {
     };
 }
 
+export function chunkLoadWarningHandler(code, error) {
+    return () => {
+        throw new PlayerError(null, code, error);
+    };
+}
+
 export function selectBundle(model) {
     const controls = model.get('controls');
     const polyfills = requiresPolyfills();

--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -120,7 +120,6 @@ Object.assign(CoreShim.prototype, {
 
             this.on(WARNING, logWarning);
             setupResult.warnings.forEach(w => {
-                delete w.key;
                 this.trigger(WARNING, w);
             });
 

--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -2,7 +2,6 @@ import { loadFile } from 'controller/tracks-loader';
 import { createId, createLabel } from 'controller/tracks-helper';
 import Events from 'utils/backbone.events';
 import { WARNING } from 'events/events';
-import { PlayerError, ERROR_LOADING_CAPTIONS } from 'api/errors';
 
 /* Displays closed captions or subtitles on top of the video */
 const Captions = function(_model) {
@@ -38,8 +37,8 @@ const Captions = function(_model) {
                     _addTrack(track);
                     loadFile(track, (vttCues) => {
                         _addVTTCuesToTrack(track, vttCues);
-                    }, (key, url, xhr, error) => {
-                        this.trigger(WARNING, new PlayerError(null, ERROR_LOADING_CAPTIONS + error.code, error));
+                    }, error => {
+                        this.trigger(WARNING, error);
                     });
                 }
             }

--- a/src/js/controller/controls-loader.js
+++ b/src/js/controller/controls-loader.js
@@ -12,7 +12,7 @@ export function loadControls() {
             return ControlsModule;
         }, function() {
             controlsPromise = null;
-            chunkLoadWarningHandler(300130)();
+            chunkLoadWarningHandler(301130)();
         }, 'jwplayer.controls');
     }
     return controlsPromise;

--- a/src/js/controller/controls-loader.js
+++ b/src/js/controller/controls-loader.js
@@ -1,4 +1,4 @@
-import { chunkLoadErrorHandler } from '../api/core-loader';
+import { chunkLoadWarningHandler } from '../api/core-loader';
 
 let controlsPromise = null;
 
@@ -12,7 +12,7 @@ export function loadControls() {
             return ControlsModule;
         }, function() {
             controlsPromise = null;
-            chunkLoadErrorHandler(300130)();
+            chunkLoadWarningHandler(300130)();
         }, 'jwplayer.controls');
     }
     return controlsPromise;

--- a/src/js/controller/events-middleware.js
+++ b/src/js/controller/events-middleware.js
@@ -1,23 +1,18 @@
-import { MEDIA_TIME, MEDIA_BEFOREPLAY, READY, WARNING } from 'events/events';
 export default function middleware(model, type, currentState) {
     let newState = currentState;
 
     switch (type) {
-        case MEDIA_TIME:
-        case MEDIA_BEFOREPLAY:
+        case 'time':
+        case 'beforePlay':
         case 'pause':
         case 'play':
-        case READY: {
+        case 'ready': {
             const viewable = model.get('viewable');
             // Don't add viewable to events if we don't know we're viewable
             if (viewable !== undefined) {
                 // Emit viewable as 0 or 1
                 newState = Object.assign({}, currentState, { viewable: viewable });
             }
-            break;
-        }
-        case WARNING: {
-            delete newState.key;
             break;
         }
         default: {

--- a/src/js/controller/events-middleware.js
+++ b/src/js/controller/events-middleware.js
@@ -1,18 +1,23 @@
+import { MEDIA_TIME, MEDIA_BEFOREPLAY, READY, WARNING } from 'events/events';
 export default function middleware(model, type, currentState) {
     let newState = currentState;
 
     switch (type) {
-        case 'time':
-        case 'beforePlay':
+        case MEDIA_TIME:
+        case MEDIA_BEFOREPLAY:
         case 'pause':
         case 'play':
-        case 'ready': {
+        case READY: {
             const viewable = model.get('viewable');
             // Don't add viewable to events if we don't know we're viewable
             if (viewable !== undefined) {
                 // Emit viewable as 0 or 1
                 newState = Object.assign({}, currentState, { viewable: viewable });
             }
+            break;
+        }
+        case WARNING: {
+            delete newState.key;
             break;
         }
         default: {

--- a/src/js/controller/tracks-loader.js
+++ b/src/js/controller/tracks-loader.js
@@ -10,7 +10,7 @@ export function loadFile(track, successHandler, errorHandler) {
     track.xhr = ajax(track.file, function(xhr) {
         xhrSuccess(xhr, track, successHandler, errorHandler);
     }, (key, url, xhr, error) => {
-      errorHandler(composePlayerError(error, ERROR_LOADING_CAPTIONS));
+        errorHandler(composePlayerError(error, ERROR_LOADING_CAPTIONS));
     });
 }
 

--- a/src/js/controller/tracks-loader.js
+++ b/src/js/controller/tracks-loader.js
@@ -4,7 +4,7 @@ import { ajax } from 'utils/ajax';
 import { localName } from 'parsers/parsers';
 import srt from 'parsers/captions/srt';
 import dfxp from 'parsers/captions/dfxp';
-import { composePlayerError, convertToPlayerError, ERROR_LOADING_CAPTIONS } from 'api/errors'
+import { composePlayerError, convertToPlayerError, ERROR_LOADING_CAPTIONS } from 'api/errors';
 
 export function loadFile(track, successHandler, errorHandler) {
     track.xhr = ajax(track.file, function(xhr) {

--- a/src/js/controller/tracks-loader.js
+++ b/src/js/controller/tracks-loader.js
@@ -1,5 +1,5 @@
 import VTTCue from 'parsers/captions/vttcue';
-import { chunkLoadErrorHandler } from '../api/core-loader';
+import { chunkLoadWarningHandler } from '../api/core-loader';
 import { ajax } from 'utils/ajax';
 import { localName } from 'parsers/parsers';
 import srt from 'parsers/captions/srt';
@@ -96,5 +96,5 @@ function xhrSuccess(xhr, track, successHandler, errorHandler) {
 function loadVttParser() {
     return require.ensure(['parsers/captions/vttparser'], function (require) {
         return require('parsers/captions/vttparser').default;
-    }, chunkLoadErrorHandler(300131), 'vttparser');
+    }, chunkLoadWarningHandler(300131), 'vttparser');
 }

--- a/src/js/controller/tracks-loader.js
+++ b/src/js/controller/tracks-loader.js
@@ -4,11 +4,14 @@ import { ajax } from 'utils/ajax';
 import { localName } from 'parsers/parsers';
 import srt from 'parsers/captions/srt';
 import dfxp from 'parsers/captions/dfxp';
+import { composePlayerError, convertToPlayerError, ERROR_LOADING_CAPTIONS } from 'api/errors'
 
 export function loadFile(track, successHandler, errorHandler) {
     track.xhr = ajax(track.file, function(xhr) {
         xhrSuccess(xhr, track, successHandler, errorHandler);
-    }, errorHandler);
+    }, (key, url, xhr, error) => {
+      errorHandler(composePlayerError(error, ERROR_LOADING_CAPTIONS));
+    });
 }
 
 export function cancelXhr(tracks) {
@@ -77,7 +80,7 @@ function xhrSuccess(xhr, track, successHandler, errorHandler) {
                     parser.parse(responseText);
                 }).catch(error => {
                     delete track.xhr;
-                    errorHandler(error);
+                    errorHandler(convertToPlayerError(null, ERROR_LOADING_CAPTIONS, error));
                 });
             } else {
                 // make VTTCues from SRT track
@@ -89,12 +92,12 @@ function xhrSuccess(xhr, track, successHandler, errorHandler) {
         }
     } catch (error) {
         delete track.xhr;
-        errorHandler(error);
+        errorHandler(convertToPlayerError(null, ERROR_LOADING_CAPTIONS, error));
     }
 }
 
 function loadVttParser() {
     return require.ensure(['parsers/captions/vttparser'], function (require) {
         return require('parsers/captions/vttparser').default;
-    }, chunkLoadWarningHandler(300131), 'vttparser');
+    }, chunkLoadWarningHandler(301131), 'vttparser');
 }

--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -4,7 +4,6 @@ import { parseID3 } from 'providers/utils/id3Parser';
 import { Browser } from 'environment/environment';
 import { WARNING } from 'events/events';
 import { findWhere, each, filter } from 'utils/underscore';
-import { PlayerError, ERROR_LOADING_CAPTIONS } from 'api/errors';
 
 // Used across all providers for loading tracks and handling browser track-related events
 const Tracks = {
@@ -460,8 +459,8 @@ function addTextTracks(tracksArray) {
                 (vttCues) => {
                     this.addVTTCuesToTrack(textTrackAny, vttCues);
                 },
-                (key, url, xhr, error) => {
-                    this.trigger(WARNING, new PlayerError(null, ERROR_LOADING_CAPTIONS + error.code, error));
+                error => {
+                    this.trigger(WARNING, error);
                 });
         }
     });

--- a/src/js/view/captionsrenderer.js
+++ b/src/js/view/captionsrenderer.js
@@ -340,10 +340,7 @@ const CaptionsRenderer = function (viewModel) {
         // don't load the polyfill or do unnecessary work if rendering natively
         if (!model.get('renderCaptionsNatively') && !_WebVTT) {
             loadWebVttPolyfill().catch(error => {
-                this.trigger(WARNING, {
-                    message: 'Captions renderer failed to load',
-                    reason: error
-                });
+                this.trigger(WARNING, error);
             });
             model.off('change:captionsList', _captionsListHandler, this);
         }
@@ -352,7 +349,7 @@ const CaptionsRenderer = function (viewModel) {
     function loadWebVttPolyfill() {
         return require.ensure(['polyfills/webvtt'], function (require) {
             _WebVTT = require('polyfills/webvtt').default;
-        }, chunkLoadWarningHandler(300121), 'polyfills.webvtt');
+        }, chunkLoadWarningHandler(301121), 'polyfills.webvtt');
     }
 
     _model.on('change:playlistItem', function () {

--- a/src/js/view/captionsrenderer.js
+++ b/src/js/view/captionsrenderer.js
@@ -1,5 +1,5 @@
 import { Browser, OS } from 'environment/environment';
-import { chunkLoadErrorHandler } from '../api/core-loader';
+import { chunkLoadWarningHandler } from '../api/core-loader';
 import Events from 'utils/backbone.events';
 import { WARNING } from 'events/events';
 import { css, style, getRgba } from 'utils/css';
@@ -352,7 +352,7 @@ const CaptionsRenderer = function (viewModel) {
     function loadWebVttPolyfill() {
         return require.ensure(['polyfills/webvtt'], function (require) {
             _WebVTT = require('polyfills/webvtt').default;
-        }, chunkLoadErrorHandler(300121), 'polyfills.webvtt');
+        }, chunkLoadWarningHandler(300121), 'polyfills.webvtt');
     }
 
     _model.on('change:playlistItem', function () {

--- a/test/unit/captionsrenderer-test.js
+++ b/test/unit/captionsrenderer-test.js
@@ -2,6 +2,7 @@ import MockModel from 'mock/mock-model';
 import ViewModel from 'view/view-model';
 import CaptionsRenderer from 'view/captionsrenderer';
 import VTTCue from 'parsers/captions/vttcue';
+import { WARNING } from 'events/events';
 
 describe('CaptionsRenderer.getCurrentCues', function() {
     let captionsRenderer;

--- a/test/unit/captionsrenderer-test.js
+++ b/test/unit/captionsrenderer-test.js
@@ -30,5 +30,22 @@ describe('CaptionsRenderer.getCurrentCues', function() {
             expect(captionsRenderer.getCurrentCues(allCues, i).length, 'Invalid number of cues at position ' + i).to.equal(currentNumCues[i]);
         }
     });
+
+    it('triggers a standardized warning if the WebVTT polyfill fails to load', function () {
+        return new Promise((resolve, reject) => {
+            captionsRenderer.on(WARNING, e => {
+                const { code } = e.reason;
+                if (code !== 300121) {
+                    reject(new Error(`Expected code 300121, got ${code}`));
+                }
+                resolve();
+            });
+
+            // The captionsRenderer will try to load the VTT polyfill in response to the captionsList change event; it
+            // will load with a 404 because unit tests don't chunk polyfills.webvtt.js
+            model.set('renderCaptionsNatively', false);
+            model.set('captionsList', [ {}, {} ]);
+        });
+    });
 });
 

--- a/test/unit/captionsrenderer-test.js
+++ b/test/unit/captionsrenderer-test.js
@@ -34,9 +34,8 @@ describe('CaptionsRenderer.getCurrentCues', function() {
     it('triggers a standardized warning if the WebVTT polyfill fails to load', function () {
         return new Promise((resolve, reject) => {
             captionsRenderer.on(WARNING, e => {
-                const { code } = e.reason;
-                if (code !== 300121) {
-                    reject(new Error(`Expected code 300121, got ${code}`));
+                if (e.code !== 301121) {
+                    reject(new Error(`Expected code 301121, got ${e.code}`));
                 }
                 resolve();
             });

--- a/test/unit/errors/core-loader-error-tests.js
+++ b/test/unit/errors/core-loader-error-tests.js
@@ -1,4 +1,5 @@
-import { chunkLoadErrorHandler } from 'api/core-loader';
+import { chunkLoadErrorHandler, chunkLoadWarningHandler } from 'api/core-loader';
+import { MSG_CANT_LOAD_PLAYER } from 'api/errors';
 
 describe('core-loader errors', function () {
     it('exports a chunkLoadErrorHandler function which throws a JWError', function () {
@@ -6,6 +7,14 @@ describe('core-loader errors', function () {
         expect(handler).to.be.a('function');
         // The handler itself is a function, which returns a function which throws
         expect(chunkLoadErrorHandler).to.not.throw();
-        expect(handler).to.throw();
+        expect(handler).to.throw().with.property('key', MSG_CANT_LOAD_PLAYER);
+    });
+
+    it('exports a chunkLoadWarningHandler function which throws a JWError', function () {
+        const handler = chunkLoadWarningHandler(105);
+        expect(handler).to.be.a('function');
+        // The handler itself is a function, which returns a function which throws
+        expect(chunkLoadErrorHandler).to.not.throw();
+        expect(handler).to.throw().but.not.with.property('key');
     });
 });


### PR DESCRIPTION
### This PR will...
- Use the new `chunkLoadWarningHandler` to dispatch chunk warnings without keys
- Unify the error response from `tracks-loader` to return a `playerError` as the first argument in all cases

### Why is this Pull Request needed?
So that warnings are dispatched without keys at the source of error creation. This is preferable to deleting the keys as a last step before emitting publicly. 

So that we don't throw an `undefined exception` when parsing errors. Unifying the response is the preferred solution because it results in less code duplication.

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/5780

#### Addresses Issue(s):

JW8-1504

