### PR TITLE
Set aria label for all submenu elements 

### DIFF
--- a/src/js/view/utils/submenu-factory.js
+++ b/src/js/view/utils/submenu-factory.js
@@ -22,10 +22,7 @@ export const makeSubmenu = (settingsMenu, name, contentItems, icon, tooltipText)
         const categoryButtonElement = categoryButton.element();
         categoryButtonElement.setAttribute('role', 'menuitemradio');
         categoryButtonElement.setAttribute('aria-checked', 'false');
-
-        if (name === QUALITIES_SUBMENU) {
-            categoryButtonElement.setAttribute('aria-label', tooltipText);
-        }
+        categoryButtonElement.setAttribute('aria-label', tooltipText);
 
         // Qualities submenu is the default submenu
         submenu = SettingsSubmenu(name, categoryButton, name === DEFAULT_SUBMENU);


### PR DESCRIPTION
### This PR will...

Remove if statement from ```makeSubmenu``` to set aria-labels for all submenu elements

### Why is this Pull Request needed?

If statement from a previous PR was left there and it prevents the aria labels for the other items from being set.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-1354

