### PR TITLE
Set textContent on live button to localization value

### DIFF
--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -278,9 +278,11 @@ export default class Controlbar {
             const { liveBroadcast, notLive } = localization;
             const liveElement = this.elements.live.element();
             const dvrNotLive = dvrLive === false;
+            const liveButtonText = dvrNotLive ? notLive : liveBroadcast;
             // jw-dvr-live: Player is in DVR mode but not at the live edge.
             toggleClass(liveElement, 'jw-dvr-live', dvrNotLive);
-            setAttribute(liveElement, 'aria-label', dvrNotLive ? notLive : liveBroadcast);
+            setAttribute(liveElement, 'aria-label', liveButtonText);
+            liveButton.element().textContent = liveButtonText;
         }, this);
         _model.change('altText', this.setAltText, this);
         _model.change('customButtons', this.updateButtons, this);

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -282,7 +282,7 @@ export default class Controlbar {
             // jw-dvr-live: Player is in DVR mode but not at the live edge.
             toggleClass(liveElement, 'jw-dvr-live', dvrNotLive);
             setAttribute(liveElement, 'aria-label', liveButtonText);
-            liveButton.element().textContent = liveButtonText;
+            liveElement.textContent = liveButtonText;
         }, this);
         _model.change('altText', this.setAltText, this);
         _model.change('customButtons', this.updateButtons, this);


### PR DESCRIPTION
### This PR will...

Set ```textContent``` on live button to localization when ```dvrLive``` fires.

### Why is this Pull Request needed?

```textContent``` wasn't being set to the correct value.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-2302

