### PR TITLE
Fix float close button not clickable

### DIFF
--- a/src/css/jwplayer/flags/floatingplayer.less
+++ b/src/css/jwplayer/flags/floatingplayer.less
@@ -35,14 +35,10 @@
     position: absolute;
     text-align: right;
     top: -2em;
-    width: 100%;
-
-    .jw-reset {
-        float: right;
-        cursor: pointer;
-        pointer-events: all;
-        opacity: 0.8;
-    }
+    right: 0;
+    cursor: pointer;
+    pointer-events: all;
+    opacity: 0.8;
 }
 
 @keyframes jw-float {

--- a/src/css/jwplayer/flags/floatingplayer.less
+++ b/src/css/jwplayer/flags/floatingplayer.less
@@ -37,7 +37,8 @@
     top: -2em;
     width: 100%;
 
-    .jw-icon {
+    .jw-reset {
+        float: right;
         cursor: pointer;
         pointer-events: all;
         opacity: 0.8;

--- a/src/js/view/floating-close-button.js
+++ b/src/js/view/floating-close-button.js
@@ -9,8 +9,8 @@ const FloatingCloseButton = function(wrapperElement) {
 };
 
 Object.assign(FloatingCloseButton.prototype, {
-    setup: function(callback) {
-        this.element = createElement(floatingCloseButton());
+    setup: function(callback, ariaLabel) {
+        this.element = createElement(floatingCloseButton(ariaLabel));
 
         this.element.appendChild(cloneIcon('close'));
         this.ui = new UI(this.element).on('click tap enter', callback, this);

--- a/src/js/view/floating-close-button.js
+++ b/src/js/view/floating-close-button.js
@@ -12,9 +12,8 @@ Object.assign(FloatingCloseButton.prototype, {
     setup: function(callback) {
         this.element = createElement(floatingCloseButton());
 
-        const icon = this.element.querySelector('.jw-reset');
-        icon.appendChild(cloneIcon('close'));
-        this.ui = new UI(icon).on('click tap enter', callback, this);
+        this.element.appendChild(cloneIcon('close'));
+        this.ui = new UI(this.element).on('click tap enter', callback, this);
 
         this.wrapperElement.appendChild(this.element);
     },

--- a/src/js/view/floating-close-button.js
+++ b/src/js/view/floating-close-button.js
@@ -12,7 +12,7 @@ Object.assign(FloatingCloseButton.prototype, {
     setup: function(callback) {
         this.element = createElement(floatingCloseButton());
 
-        const icon = this.element.querySelector('.jw-icon');
+        const icon = this.element.querySelector('.jw-reset');
         icon.appendChild(cloneIcon('close'));
         this.ui = new UI(icon).on('click tap enter', callback, this);
 

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -52,8 +52,9 @@ function View(_api, _model) {
         model: _model
     });
 
+    const _localization = _model.get('localization');
     const _floatOnScroll = _model.get('floatOnScroll');
-    const _playerElement = createElement(playerTemplate(_model.get('id'), _model.get('localization').player));
+    const _playerElement = createElement(playerTemplate(_model.get('id'), _localization.player));
     const _wrapperElement = _playerElement.querySelector('.jw-wrapper');
     const _videoLayer = _playerElement.querySelector('.jw-media');
 
@@ -275,7 +276,7 @@ function View(_api, _model) {
             viewsManager.observe(_playerElement);
             if (_floatOnScroll) {
                 const floatCloseButton = new FloatingCloseButton(_wrapperElement);
-                floatCloseButton.setup(_stopFloating);
+                floatCloseButton.setup(_stopFloating, _localization.close);
             }
         }
         _model.set('inDom', inDOM);

--- a/src/templates/floating-close-button.js
+++ b/src/templates/floating-close-button.js
@@ -1,7 +1,6 @@
 export default () => {
     return (
-        `<div class="jw-float-close jw-reset">` +
-        `<div class="jw-reset" aria-label="Unfloat" tabindex="0"></div>` +
+        `<div class="jw-float-close jw-reset" aria-label="Unfloat" tabindex="0">` +
         `</div>`
     );
 };

--- a/src/templates/floating-close-button.js
+++ b/src/templates/floating-close-button.js
@@ -1,6 +1,6 @@
-export default () => {
+export default (ariaLabel) => {
     return (
-        `<div class="jw-float-close jw-reset" aria-label="Unfloat" tabindex="0">` +
+        `<div class="jw-float-close jw-reset" aria-label=${ariaLabel} tabindex="0">` +
         `</div>`
     );
 };

--- a/src/templates/floating-close-button.js
+++ b/src/templates/floating-close-button.js
@@ -1,7 +1,7 @@
 export default () => {
     return (
         `<div class="jw-float-close jw-reset">` +
-        `<span class="jw-icon jw-reset" aria-label="Unfloat" tabindex="0"></span>` +
+        `<div class="jw-reset" aria-label="Unfloat" tabindex="0"></div>` +
         `</div>`
     );
 };


### PR DESCRIPTION
### This PR will...
Change from using `<span>` to `<div>` for float close icon container

### Why is this Pull Request needed?
Having `<span>` causes the icon to be half not clickable.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/5815

#### Addresses Issue(s):
JW8-1842

