### PR TITLE
Fire a warning on Translation load failures

### DIFF
--- a/src/js/api/errors.js
+++ b/src/js/api/errors.js
@@ -123,6 +123,16 @@ export const ERROR_LOADING_CAPTIONS = 306000;
 /**
  * @enum {ErrorKey}
  */
+export const ERROR_LOADING_TRANSLATIONS = 308000;
+
+/**
+ * @enum {ErrorKey}
+ */
+export const ERROR_LOADING_TRANSLATIONS_EMPTY_RESPONSE = 308640;
+
+/**
+ * @enum {ErrorKey}
+ */
 export const MSG_CANT_PLAY_VIDEO = 'cantPlayVideo';
 
 /**

--- a/src/js/api/setup-steps.js
+++ b/src/js/api/setup-steps.js
@@ -3,8 +3,9 @@ import PlaylistLoader from 'playlist/loader';
 import Playlist, { filterPlaylist, validatePlaylist } from 'playlist/playlist';
 import ScriptLoader from 'utils/scriptloader';
 import { bundleContainsProviders } from 'api/core-loader';
-import { composePlayerError,
-    SETUP_ERROR_LOADING_PLAYLIST, SETUP_ERROR_LOADING_PROVIDER } from 'api/errors';
+import { composePlayerError, PlayerError,
+    SETUP_ERROR_LOADING_PLAYLIST, SETUP_ERROR_LOADING_PROVIDER,
+    ERROR_LOADING_TRANSLATIONS, ERROR_LOADING_TRANSLATIONS_EMPTY_RESPONSE } from 'api/errors';
 import { getCustomLocalization, isLocalizationComplete, loadJsonTranslation, isTranslationAvailable, applyTranslation } from 'utils/language';
 
 export function loadPlaylist(_model) {
@@ -109,15 +110,14 @@ export function loadTranslations(_model) {
                     return;
                 }
                 if (!response) {
-                    // TODO: throw a standardized player warning with a different code than catch-block to highlight empty response (JW8-2244)
-                    throw new Error();
+                    throw new PlayerError(null, ERROR_LOADING_TRANSLATIONS_EMPTY_RESPONSE);
                 }
                 attributes.localization = applyTranslation(response, customLocalization);
                 resolve();
             })
-            .catch(() => {
-                // TODO: trigger warning (JW8-2244). Calling resolve(PlayerError(warning, warningCode,...)) might handle this.
-                resolve();
+            .catch((error) => {
+                resolve(error.code === ERROR_LOADING_TRANSLATIONS_EMPTY_RESPONSE ? error :
+                    composePlayerError(error, ERROR_LOADING_TRANSLATIONS));
             });
     });
 }

--- a/src/js/utils/language.js
+++ b/src/js/utils/language.js
@@ -99,7 +99,8 @@ export function loadJsonTranslation(base, languageCode) {
     if (!translationLoad) {
         const url = `${base}translations/${normalizeLanguageCode(languageCode)}.json`;
         translationPromises[languageCode] = translationLoad = new Promise((oncomplete, reject) => {
-            ajax({ url, oncomplete, onerror: (message, file, _url, error) => reject(error), responseType: 'json' });
+            const onerror = (message, file, _url, error) => reject(error);
+            ajax({ url, oncomplete, onerror, responseType: 'json' });
         });
     }
     return translationLoad;

--- a/src/js/utils/language.js
+++ b/src/js/utils/language.js
@@ -98,8 +98,8 @@ export function loadJsonTranslation(base, languageCode) {
     let translationLoad = translationPromises[languageCode];
     if (!translationLoad) {
         const url = `${base}translations/${normalizeLanguageCode(languageCode)}.json`;
-        translationPromises[languageCode] = translationLoad = new Promise((oncomplete, onerror) => {
-            ajax({ url, oncomplete, onerror, responseType: 'json' });
+        translationPromises[languageCode] = translationLoad = new Promise((oncomplete, reject) => {
+            ajax({ url, oncomplete, onerror: (message, file, _url, error) => reject(error), responseType: 'json' });
         });
     }
     return translationLoad;

--- a/src/js/utils/language.js
+++ b/src/js/utils/language.js
@@ -99,7 +99,10 @@ export function loadJsonTranslation(base, languageCode) {
     if (!translationLoad) {
         const url = `${base}translations/${normalizeLanguageCode(languageCode)}.json`;
         translationPromises[languageCode] = translationLoad = new Promise((oncomplete, reject) => {
-            const onerror = (message, file, _url, error) => reject(error);
+            const onerror = (message, file, _url, error) => {
+                translationPromises[languageCode] = null;
+                reject(error);
+            };
             ajax({ url, oncomplete, onerror, responseType: 'json' });
         });
     }

--- a/test/unit/setup-steps-test.js
+++ b/test/unit/setup-steps-test.js
@@ -1,21 +1,19 @@
 import { loadTranslations } from 'api/setup-steps';
-import SimpleModel from 'model/simplemodel';
 import * as Language from 'utils/language';
 import { ERROR_LOADING_TRANSLATIONS, ERROR_LOADING_TRANSLATIONS_EMPTY_RESPONSE } from 'api/errors';
 import sinon from 'sinon';
 
-describe.only('Load Translations', function () {
+describe('Load Translations', function () {
     const sandbox = sinon.sandbox.create();
-    function MockModel() {}
-    Object.assign(MockModel.prototype, SimpleModel);
-    const model = new MockModel();
-    model.attributes = {
-        language: 'es-CL',
-        base: 'base',
-        setupConfig: {
-            localization: {}
-        },
-        intl: {}
+    const model = {
+        attributes: {
+            language: 'es-CL',
+            base: 'base',
+            setupConfig: {
+                localization: {}
+            },
+            intl: {}
+        }
     };
 
     beforeEach(function() {
@@ -27,19 +25,22 @@ describe.only('Load Translations', function () {
         sandbox.restore();
     });
 
+    function testLoadTranslations(expectedCode) {
+        loadTranslations(model).then(error => {
+            expect(error.code).to.equal(expectedCode);
+        }).catch(() => {
+            assert.isNotOk(true, 'loadTranslations should never be rejected')
+        });
+    }
+
     it('Triggers the translation load empty response warning when the response is empty', function() {
         sandbox.stub(Language, 'loadJsonTranslation').resolves({ response: null });
-        loadTranslations(model).then(error => {
-            expect(error.code).to.equal(ERROR_LOADING_TRANSLATIONS_EMPTY_RESPONSE);
-        });
+        testLoadTranslations(ERROR_LOADING_TRANSLATIONS_EMPTY_RESPONSE);
     });
 
     it('Triggers a warning composed of the translation loading base code and the ajax error code when ajax fails', function() {
-        const ajaxErrorCode = 999;
-        sandbox.stub(Language, 'loadJsonTranslation').rejects({ code: ajaxErrorCode });
-        loadTranslations(model).then(error => {
-            expect(error.code).to.equal(ERROR_LOADING_TRANSLATIONS + ajaxErrorCode);
-        });
-
+        const ERROR_AJAX = 999;
+        sandbox.stub(Language, 'loadJsonTranslation').rejects({ code: ERROR_AJAX });
+        testLoadTranslations(ERROR_LOADING_TRANSLATIONS + ERROR_AJAX);
     });
 });

--- a/test/unit/setup-steps-test.js
+++ b/test/unit/setup-steps-test.js
@@ -1,0 +1,45 @@
+import { loadTranslations } from 'api/setup-steps';
+import SimpleModel from 'model/simplemodel';
+import * as Language from 'utils/language';
+import { ERROR_LOADING_TRANSLATIONS, ERROR_LOADING_TRANSLATIONS_EMPTY_RESPONSE } from 'api/errors';
+import sinon from 'sinon';
+
+describe.only('Load Translations', function () {
+    const sandbox = sinon.sandbox.create();
+    function MockModel() {}
+    Object.assign(MockModel.prototype, SimpleModel);
+    const model = new MockModel();
+    model.attributes = {
+        language: 'es-CL',
+        base: 'base',
+        setupConfig: {
+            localization: {}
+        },
+        intl: {}
+    };
+
+    beforeEach(function() {
+        sandbox.stub(Language, 'isTranslationAvailable').returns(true);
+        sandbox.stub(Language, 'isLocalizationComplete').returns(false);
+    });
+
+    afterEach(function() {
+        sandbox.restore();
+    });
+
+    it('Triggers the translation load empty response warning when the response is empty', function() {
+        sandbox.stub(Language, 'loadJsonTranslation').resolves({ response: null });
+        loadTranslations(model).then(error => {
+            expect(error.code).to.equal(ERROR_LOADING_TRANSLATIONS_EMPTY_RESPONSE);
+        });
+    });
+
+    it('Triggers a warning composed of the translation loading base code and the ajax error code when ajax fails', function() {
+        const ajaxErrorCode = 999;
+        sandbox.stub(Language, 'loadJsonTranslation').rejects({ code: ajaxErrorCode });
+        loadTranslations(model).then(error => {
+            expect(error.code).to.equal(ERROR_LOADING_TRANSLATIONS + ajaxErrorCode);
+        });
+
+    });
+});


### PR DESCRIPTION
### This PR will...
- add warning codes for Translation load failures
### Why is this Pull Request needed?
To warn developers when translations fail to load. We do not need individual codes for each language, since the language code is in the model and will be pinged in PP-40
### Are there any points in the code the reviewer needs to double check?
- I updated [the confluence list of errors ](https://jwplayer.atlassian.net/wiki/spaces/ES/pages/231637123/Documented+Errors+list), do I have to open a documentation PR as well ?
- Ajax's `onerror` gets called with arguments that we no longer use (url, message, xhr) can we get rid of these ? We are only using the error (4th argument). 
In fact, Shaka might be erroneously using Ajax, at https://github.com/jwplayer/jwplayer-commercial/blob/master/src/js/providers/shaka.js#L507 
```
ajax(..., (error) => reject(error));
```
where the error returned by Ajax is the key, not the Ajax error
### Are there any Pull Requests open in other repos which need to be merged with this?
n/a
#### Addresses Issue(s):
JW8-2244

