### PR TITLE
[JW8-2301] Round intersectionRatio to two decimals.

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -838,9 +838,9 @@ function View(_api, _model) {
         return _model.get('floating') ? _wrapperElement : _playerElement;
     }
 
-    function _updateFloating() {
+    function _updateFloating(model, intersectionRatio) {
         // Entirely invisible and no floating player already in the DOM.
-        const isVisible = _model.get('intersectionRatio') === 1;
+        const isVisible = intersectionRatio === 1;
         if (!isVisible && _model.get('state') !== STATE_IDLE && floatingPlayer === null) {
             floatingPlayer = _playerElement;
 

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -302,10 +302,6 @@ function View(_api, _model) {
             }
         });
 
-        if (_floatOnScroll) {
-            _model.on('change:intersectionRatio', _updateFloating);
-        }
-
         updateVisibility();
 
         // Always draw first player for icons to load
@@ -832,13 +828,17 @@ function View(_api, _model) {
         // Round as the IntersectionObserver polyfill sometimes returns ±0.00XXX.
         const intersectionRatio = Math.round(entry.intersectionRatio * 100) / 100;
         _model.set('intersectionRatio', intersectionRatio);
+
+        if (_floatOnScroll) {
+            _updateFloating(intersectionRatio);
+        }
     };
 
     function _getCurrentElement() {
         return _model.get('floating') ? _wrapperElement : _playerElement;
     }
 
-    function _updateFloating(model, intersectionRatio) {
+    function _updateFloating(intersectionRatio) {
         // Entirely invisible and no floating player already in the DOM.
         const isVisible = intersectionRatio === 1;
         if (!isVisible && _model.get('state') !== STATE_IDLE && floatingPlayer === null) {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -837,8 +837,11 @@ function View(_api, _model) {
     }
 
     function _setFloatingIntersection(entry) {
-        // Entirely invisible and no floating player already in the DOM
-        const isVisible = entry.intersectionRatio === 1;
+        // Round as the IntersectionObserver polyfill sometimes returns ±0.00XXX.
+        const intersectionRatio = Math.round(entry.intersectionRatio * 100) / 100;
+
+        // Entirely invisible and no floating player already in the DOM.
+        const isVisible = intersectionRatio === 1;
         if (!isVisible && _model.get('state') !== STATE_IDLE && floatingPlayer === null) {
             floatingPlayer = _playerElement;
 


### PR DESCRIPTION
### This PR will...
Round the `intersectionRatio` to two decimals.

### Why is this Pull Request needed?
The `IntersectionObserver` polyfill (used in IE11) uses math to return the intersection ratio, which sometimes results in 1.000000123456 or 0.9999999123456 rather than 1.

### Are there any points in the code the reviewer needs to double check?
N/A

### Are there any Pull Requests open in other repos which need to be merged with this?
N/A

#### Addresses Issue(s):
JW8-2301