### PR TITLE
[JW8-2321] Set height on wrapper.

### DIFF
--- a/src/css/jwplayer/flags/fullscreen.less
+++ b/src/css/jwplayer/flags/fullscreen.less
@@ -1,8 +1,4 @@
 .jwplayer.jw-flag-fullscreen {
-    /* !important required to ensure that fullscreen state is respected */
-    /* stylelint-disable declaration-no-important */
-    width: 100% !important;
-    height: 100% !important;
     /* stylelint-enable declaration-no-important */
     top: 0;
     right: 0;
@@ -11,4 +7,11 @@
     z-index: 1000;
     margin: 0;
     position: fixed;
+
+    .jw-wrapper {
+        /* !important required to ensure that fullscreen state is respected */
+        /* stylelint-disable declaration-no-important */
+        width: 100% !important;
+        height: 100% !important;
+    }
 }

--- a/src/css/jwplayer/flags/fullscreen.less
+++ b/src/css/jwplayer/flags/fullscreen.less
@@ -1,5 +1,4 @@
 .jwplayer.jw-flag-fullscreen {
-    /* stylelint-enable declaration-no-important */
     top: 0;
     right: 0;
     bottom: 0;
@@ -13,5 +12,6 @@
         /* stylelint-disable declaration-no-important */
         width: 100% !important;
         height: 100% !important;
+        /* stylelint-enable declaration-no-important */
     }
 }

--- a/src/css/jwplayer/imports/jwplayerlayout.less
+++ b/src/css/jwplayer/imports/jwplayerlayout.less
@@ -19,12 +19,12 @@
     }
 
     // Aspect Ratio styles
-    &.jw-flag-aspect-mode {
+    &.jw-flag-aspect-mode .jw-wrapper {
         /* Height auto required for displaying aspect ratio correctly */
         /* stylelint-disable-next-line declaration-no-important */
         height: auto !important;
 
-        & .jw-wrapper .jw-aspect {
+        .jw-aspect {
             display: block;
         }
     }


### PR DESCRIPTION
### This PR will...
Set height on the wrapper:
- 100% if absolute (px) height.
- auto if relative (%) height.
- 100% if fullscreen.

### Why is this Pull Request needed?
Previously, height on the wrapper was always 100%, causing incorrect player sizing.

### Are there any points in the code the reviewer needs to double check?
N/A

### Are there any Pull Requests open in other repos which need to be merged with this?
Alternative approach in #3122.

#### Addresses Issue(s):
JW8-2321