### PR TITLE
Remove share click logic

### DIFF
--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -106,24 +106,15 @@ export default class Controls {
             toggleClass(this.div, 'jw-info-open', visible);
         });
         this.rightClickMenu = new RightClick(this.infoOverlay);
-
-        const sharing = model.get('sharing');
-        let openShareMenu;
-        if (sharing && sharing.shareOnRightClick) {
-            openShareMenu = () => {
-                api.getPlugin('sharing').open();
-            };
-        }
-
         if (touchMode) {
             addClass(this.playerContainer, 'jw-flag-touch');
-            this.rightClickMenu.setup(model, this.playerContainer, this.playerContainer, openShareMenu);
+            this.rightClickMenu.setup(model, this.playerContainer, this.playerContainer);
         } else {
             model.change('flashBlocked', (modelChanged, isBlocked) => {
                 if (isBlocked) {
                     this.rightClickMenu.destroy();
                 } else {
-                    this.rightClickMenu.setup(modelChanged, this.playerContainer, this.playerContainer, openShareMenu);
+                    this.rightClickMenu.setup(modelChanged, this.playerContainer, this.playerContainer);
                 }
             }, this);
         }

--- a/src/js/view/controls/rightclick.js
+++ b/src/js/view/controls/rightclick.js
@@ -37,12 +37,6 @@ export default class RightClick {
             }]
         };
 
-        if (this.shareHandler) {
-            menu.items.unshift({
-                type: 'share'
-            });
-        }
-
         const provider = this.model.get('provider');
         if (provider && provider.name.indexOf('flash') >= 0) {
             const text = 'Flash Version ' + flashVersion();
@@ -144,20 +138,11 @@ export default class RightClick {
         };
     }
 
-    setup(_model, _playerElement, layer, openShareMenu) {
+    setup(_model, _playerElement, layer) {
         this.playerElement = _playerElement;
         this.model = _model;
         this.mouseOverContext = false;
         this.layer = layer;
-
-        if (openShareMenu) {
-            this.shareHandler = () => {
-                this.mouseOverContext = false;
-                this.hideMenu();
-                openShareMenu();
-            };
-        }
-
         this.ui = new UI(_playerElement).on('longPress', this.rightClick, this);
     }
 
@@ -175,10 +160,6 @@ export default class RightClick {
             this.el.addEventListener('mouseout', this.outHandler);
         }
         this.el.querySelector('.jw-info-overlay-item').addEventListener('click', this.infoOverlayHandler);
-        const shareItemElement = this.el.querySelector('.jw-share-item');
-        if (shareItemElement) {
-            shareItemElement.addEventListener('click', this.shareHandler);
-        }
     }
 
     removeHideMenuHandlers() {
@@ -189,11 +170,6 @@ export default class RightClick {
             this.el.querySelector('.jw-info-overlay-item').removeEventListener('click', this.infoOverlayHandler);
             this.el.removeEventListener('mouseover', this.overHandler);
             this.el.removeEventListener('mouseout', this.outHandler);
-            
-            const shareItemElement = this.el.querySelector('.jw-share-item');
-            if (shareItemElement) {
-                shareItemElement.addEventListener('click', this.shareHandler);
-            }
         }
         document.removeEventListener('click', this.hideMenuHandler);
         document.removeEventListener('touchstart', this.hideMenuHandler);


### PR DESCRIPTION
### This PR will...
remove the share on click logic from OS
undoes part of the work done in https://github.com/jwplayer/jwplayer/pull/3038
### Why is this Pull Request needed?
Sharing should be handled in Commercial, where the sharing plugin lives. Moving the logic to commercial allows us to simplify the way we alter the right click menu to accommodate for the share option.
### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/5838
#### Addresses Issue(s):

JW8-2257

