### PR TITLE
[JW8-2321] Absolutely position wrapper.

### DIFF
--- a/src/css/jwplayer/flags/floatingplayer.less
+++ b/src/css/jwplayer/flags/floatingplayer.less
@@ -3,16 +3,13 @@
     overflow: visible;
     background-color: #000;
 
-    &.jw-flag-aspect-mode .jw-aspect {
-        display: block;
-    }
-
     .jw-wrapper {
         overflow: visible;
         animation: jw-float 150ms cubic-bezier(0, 0.25, 0.25, 1) forwards 1;
-        bottom: 1rem;
+        top: auto;
         right: 1rem;
-        height: auto;
+        bottom: 1rem;
+        left: auto;
         margin-top: 2em;
         position: fixed;
         z-index: 1;

--- a/src/css/jwplayer/imports/jwplayerlayout.less
+++ b/src/css/jwplayer/imports/jwplayerlayout.less
@@ -24,7 +24,7 @@
         /* stylelint-disable-next-line declaration-no-important */
         height: auto !important;
 
-        & .jw-wrapper .jw-aspect {
+        .jw-aspect {
             display: block;
         }
     }
@@ -90,7 +90,10 @@
 }
 
 .jw-wrapper {
-    &:extend(.jwplayer);
     background-color: #000;
-    height: 100%;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
 }


### PR DESCRIPTION
### This PR will...
Absolutely position the `jw-wrapper`, so that we get a more reliable behavior when it comes to:
- fullscreen: the container has 100% width/height, so wrapper will be fullscreen too. 
- aspectratio: both `.jw-aspect`s are either both displayed, or both are not.
- height: does not need to be set to 100%, auto, or initial since it relies on the positioning instead. For floating players, height is set inline, or uses aspectratio if relative.

### Why is this Pull Request needed?
Make things easier, plus reduce our CSS.

### Are there any points in the code the reviewer needs to double check?
N/A

### Are there any Pull Requests open in other repos which need to be merged with this?
Alternative approach in #3116.

#### Addresses Issue(s):
JW8-2321