### PR TITLE
Format duration on nextup

### DIFF
--- a/src/js/view/controls/nextuptooltip.js
+++ b/src/js/view/controls/nextuptooltip.js
@@ -6,6 +6,7 @@ import Events from 'utils/backbone.events';
 import { cloneIcon } from 'view/controls/icons';
 import { seconds } from 'utils/strings';
 import { genId, FEED_SHOWN_ID_LENGTH } from 'utils/random-id-generator';
+import { timeFormat } from 'utils/parser';
 
 export default class NextUpTooltip {
     constructor(_model, _api, playerElement) {
@@ -127,12 +128,11 @@ export default class NextUpTooltip {
             this.title.innerText = title ? createElement(title).textContent : '';
 
             // Set duration
-            if (nextUpItem.duration) {
+            const duration = nextUpItem.duration;
+            if (duration) {
                 this.duration = this.content.querySelector('.jw-nextup-duration');
-                const duration = nextUpItem.duration;
-                this.duration.innerText = duration ? createElement(duration).textContent : '';
+                this.duration.innerText = createElement(typeof duration === 'number' ? timeFormat(duration) : duration).textContent;
             }
-
         }, 500);
     }
 

--- a/src/js/view/controls/nextuptooltip.js
+++ b/src/js/view/controls/nextuptooltip.js
@@ -125,7 +125,8 @@ export default class NextUpTooltip {
             // Set title
             this.title = this.content.querySelector('.jw-nextup-title');
             const title = nextUpItem.title;
-            this.title.innerText = title || '';
+            // createElement is used to leverage 'textContent', to protect against developers passing a title with html styling.
+            this.title.innerText = title ? createElement(title).textContent : '';
 
             // Set duration
             const duration = nextUpItem.duration;

--- a/src/js/view/controls/nextuptooltip.js
+++ b/src/js/view/controls/nextuptooltip.js
@@ -125,13 +125,13 @@ export default class NextUpTooltip {
             // Set title
             this.title = this.content.querySelector('.jw-nextup-title');
             const title = nextUpItem.title;
-            this.title.innerText = title ? createElement(title).textContent : '';
+            this.title.innerText = title || '';
 
             // Set duration
             const duration = nextUpItem.duration;
             if (duration) {
                 this.duration = this.content.querySelector('.jw-nextup-duration');
-                this.duration.innerText = createElement(typeof duration === 'number' ? timeFormat(duration) : duration).textContent;
+                this.duration.innerText = typeof duration === 'number' ? timeFormat(duration) : duration;
             }
         }, 500);
     }


### PR DESCRIPTION
### This PR will...
- remove unnecessary conversion of strings to elements 
- convert duration to hh:mm:ss format when a number
### Why is this Pull Request needed?
duration should be displayed as hh:mm:ss
### Are there any points in the code the reviewer needs to double check?
- anything wrong with removing `createElement` ? 
- It would be beneficial to normalize duration on playlist items, see https://github.com/jwplayer/jwplayer/issues/3126
### Are there any Pull Requests open in other repos which need to be merged with this?
n/a
#### Addresses Issue(s):

JW8-2345

