### PR TITLE
Add 'forceLocalizationDefaults' config option

### DIFF
--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -119,7 +119,7 @@ const Config = function(options, persisted) {
     _copyToLocalization(allOptions);
     _deserialize(allOptions);
 
-    const language = getLanguage();
+    const language = allOptions.forceLocalizationDefaults ? Defaults.language : getLanguage();
     const { localization, intl } = allOptions;
     allOptions.localization = applyTranslation(en, getCustomLocalization(localization, intl || {}, language));
 

--- a/test/unit/language-test.js
+++ b/test/unit/language-test.js
@@ -1,4 +1,4 @@
-import * as Language from 'utils/language';
+import { getLabel, getCode, getLanguage, translatedLanguageCodes, isTranslationAvailable, loadJsonTranslation, getCustomLocalization, isLocalizationComplete } from 'utils/language';
 import * as Browser from 'utils/browser';
 import Config from 'api/config';
 import en from 'assets/translations/en';
@@ -6,16 +6,6 @@ import sinon from 'sinon';
 
 describe('languageUtils', function() {
     const sandbox = sinon.sandbox.create();
-    const {
-        getLabel,
-        getCode,
-        getLanguage,
-        translatedLanguageCodes,
-        isTranslationAvailable,
-        loadJsonTranslation,
-        getCustomLocalization,
-        isLocalizationComplete
-    } = Language;
 
     describe('getLabel from unsupported codes', function() {
 
@@ -353,18 +343,23 @@ describe('languageUtils', function() {
         });
 
         it('should only use custom localization block if "forceLocalizationDefaults" is true', function() {
-            sandbox.stub(Language, 'getLanguage').returns('fr');
             const config = new Config({
                 forceLocalizationDefaults: true,
                 localization,
                 intl
             });
             const configLocalization = config.localization;
-            expect(Language.getLanguage()).to.equal('fr');
             expect(config.language).to.equal('en');
             expect(configLocalization.play).to.equal(localizationPlay);
             expect(configLocalization.pause).to.equal(localizationPause);
             expect(configLocalization.stop).to.equal(localizationStop);
+
+            Object.keys(en).forEach(key => {
+                if (key === 'play' || key === 'pause' || key === 'stop') {
+                    return;
+                }
+                expect(configLocalization[key]).to.deep.equal(en[key]);
+            });
         });
     });
 

--- a/test/unit/language-test.js
+++ b/test/unit/language-test.js
@@ -1,4 +1,4 @@
-import { getLabel, getCode, getLanguage, translatedLanguageCodes, isTranslationAvailable, loadJsonTranslation, getCustomLocalization, isLocalizationComplete } from 'utils/language';
+import * as Language from 'utils/language';
 import * as Browser from 'utils/browser';
 import Config from 'api/config';
 import en from 'assets/translations/en';
@@ -6,6 +6,16 @@ import sinon from 'sinon';
 
 describe('languageUtils', function() {
     const sandbox = sinon.sandbox.create();
+    const {
+        getLabel,
+        getCode,
+        getLanguage,
+        translatedLanguageCodes,
+        isTranslationAvailable,
+        loadJsonTranslation,
+        getCustomLocalization,
+        isLocalizationComplete
+    } = Language;
 
     describe('getLabel from unsupported codes', function() {
 
@@ -343,6 +353,7 @@ describe('languageUtils', function() {
         });
 
         it('should only use custom localization block if "forceLocalizationDefaults" is true', function() {
+            sandbox.stub(Language, 'getLanguage').returns('fr');
             const config = new Config({
                 forceLocalizationDefaults: true,
                 localization,

--- a/test/unit/language-test.js
+++ b/test/unit/language-test.js
@@ -1,4 +1,4 @@
-import { getLabel, getCode, getLanguage, translatedLanguageCodes, isTranslationAvailable, loadJsonTranslation, getCustomLocalization, isLocalizationComplete } from 'utils/language';
+import * as Language from 'utils/language';
 import * as Browser from 'utils/browser';
 import Config from 'api/config';
 import en from 'assets/translations/en';
@@ -6,11 +6,16 @@ import sinon from 'sinon';
 
 describe('languageUtils', function() {
     const sandbox = sinon.sandbox.create();
-
-    function stubHtmlLanguage(doc, value) {
-        const htmlTag = doc.querySelector('html');
-        sandbox.stub(htmlTag, 'getAttribute').withArgs('lang').returns(value);
-    }
+    const {
+        getLabel,
+        getCode,
+        getLanguage,
+        translatedLanguageCodes,
+        isTranslationAvailable,
+        loadJsonTranslation,
+        getCustomLocalization,
+        isLocalizationComplete
+    } = Language;
 
     describe('getLabel from unsupported codes', function() {
 
@@ -186,6 +191,11 @@ describe('languageUtils', function() {
     });
 
     describe('getLanguage', function() {
+        function stubHtmlLanguage(doc, value) {
+            const htmlTag = doc.querySelector('html');
+            sandbox.stub(htmlTag, 'getAttribute').withArgs('lang').returns(value);
+        }
+
         before(function() {
             if (Browser.isIE()) {
                 this.skip();
@@ -343,28 +353,19 @@ describe('languageUtils', function() {
         });
 
         it('should only use custom localization block if "forceLocalizationDefaults" is true', function() {
-            stubHtmlLanguage(document, 'fr');
+            sandbox.stub(Language, 'getLanguage').returns('fr');
             const config = new Config({
                 forceLocalizationDefaults: true,
                 localization,
                 intl
             });
             const configLocalization = config.localization;
-            expect(getLanguage()).to.equal('fr');
+            expect(Language.getLanguage()).to.equal('fr');
+            expect(config.language).to.equal('en');
             expect(configLocalization.play).to.equal(localizationPlay);
             expect(configLocalization.pause).to.equal(localizationPause);
             expect(configLocalization.stop).to.equal(localizationStop);
-            
-            Object.keys(en).forEach(key => {
-                if (key === 'play' || key === 'pause' || key === 'stop') {
-                    return;
-                }
-
-                expect(configLocalization[key]).to.deep.equal(en[key]);
-            });
         });
-
-        
     });
 
     describe('Is Localization Complete check', function() {


### PR DESCRIPTION
### This PR will...

- Add new config option ```forceLocalizationDefaults```
- Add unit test for config option:
  -  Check that page language doesn't change.
  -  Check that we don't try to load translation files if config option is ```true```
  -  Check we don't use ```intl``` block if given.
  -  Check localization options in config block still work.

### Why is this Pull Request needed?

New a/b test

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/borg/pull/1056
https://github.com/jwplayer/jwplayer-commercial/pull/5859

#### Addresses Issue(s):

JW8-2260

