### PR TITLE
[JW8-2285] Restrict dimensions of floating player.

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -40,6 +40,9 @@ require('css/jwplayer.less');
 
 let ControlsModule;
 
+const MAX_FLOATING_WIDTH = 320;
+const MAX_FLOATING_HEIGHT = 320;
+
 const _isMobile = OS.mobile;
 const _isIE = Browser.ie;
 
@@ -864,7 +867,11 @@ function View(_api, _model) {
             _model.set('floating', true);
 
             _resizeOnFloat = true;
-            _this.resize(320, 320 * rect.height / rect.width, true);
+
+            // Resize within MAX_FLOATING_WIDTH×MAX_FLOATING_HEIGHT bounds, never enlarge.
+            const ratio = Math.min(1, MAX_FLOATING_WIDTH / rect.width, MAX_FLOATING_HEIGHT / rect.height);
+            _this.resize(rect.width * ratio, rect.height * ratio, true);
+
             _resizeOnFloat = false;
         } else if (isVisible) {
             _stopFloating();


### PR DESCRIPTION
### This PR will...
Ensure floating players are resized properly (retaining aspect ratio), and will never exceed:
- 320px width,
- 320px height,
- their original dimension (don't up-scale players with < 320px width / height).

### Why is this Pull Request needed?
Currently, there is no upper limit for heights on floating players, making them potentially take up the entire viewport. 

### Are there any points in the code the reviewer needs to double check?
Boundaries are set to 320x320 - this is arbitrary and we can refine as needed. I'd argue this PR should be in 8.6.0, and refinements in 8.6.1+.

### Are there any Pull Requests open in other repos which need to be merged with this?
N/A

#### Addresses Issue(s):
JW8-2285