### PR TITLE
Clear captionsrenderer display when resuming a live stream 

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -716,8 +716,15 @@ function View(_api, _model) {
             default:
                 if (_captionsRenderer) {
                     _captionsRenderer.show();
-                    if (state === STATE_PAUSED && _controls && !_controls.showing) {
-                        _captionsRenderer.renderCues(true);
+                    if (state === STATE_PLAYING) {
+                        if (_model.get('streamType') === 'LIVE') {
+                            _captionsRenderer.clear();
+                        }
+                    }
+                    if (state === STATE_PAUSED) {
+                        if (_controls && !_controls.showing) {
+                            _captionsRenderer.renderCues(true);
+                        }
                     }
                 }
                 break;


### PR DESCRIPTION
### Why is this Pull Request needed?

So that the currently displaying cues do not re-appear when resuming the stream at a future point. An indeterminate amount of time may pass between pauses - the segment at which the current set of cues should have appeared could be long past.

### Are there any points in the code the reviewer needs to double check?

Is it OK to always clear the renderer on live play? The `livePaused` flag is a bit more complicated in the providers.

This code could also use a bit of cleanup. I think it makes sense to take these states out of the `default` case.

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-commercial/pull/5875
#### Addresses Issue(s):

JW8-2313

