### PR TITLE
Do not rely on compute visibility if detect that in an iFrame

### DIFF
--- a/src/js/view/utils/visibility.js
+++ b/src/js/view/utils/visibility.js
@@ -27,7 +27,7 @@ export default function getVisibility(model, element) {
     }
     return intersectionRatio;
 }
- 
+
 function computeVisibility(target) {
     const html = document.documentElement;
     const body = document.body;

--- a/src/js/view/utils/visibility.js
+++ b/src/js/view/utils/visibility.js
@@ -17,7 +17,8 @@ export default function getVisibility(model, element) {
     // Otherwise, set it to the intersection ratio reported from the intersection observer
     let intersectionRatio = model.get('intersectionRatio');
 
-    if (intersectionRatio === undefined) {
+    // Compute visibility does not return accurate value for iFrame player
+    if (intersectionRatio === undefined && !(window.top !== window.self)) {
         // Get intersectionRatio through brute force
         intersectionRatio = computeVisibility(element);
     }
@@ -25,10 +26,8 @@ export default function getVisibility(model, element) {
     return intersectionRatio;
 }
 
+ 
 function computeVisibility(target) {
-    if (window.top !== window.self) {
-        return 0;
-    }
     const html = document.documentElement;
     const body = document.body;
     const rootRect = {

--- a/src/js/view/utils/visibility.js
+++ b/src/js/view/utils/visibility.js
@@ -26,6 +26,9 @@ export default function getVisibility(model, element) {
 }
 
 function computeVisibility(target) {
+    if (window.top !== window.self) {
+        return 0;
+    }
     const html = document.documentElement;
     const body = document.body;
     const rootRect = {

--- a/src/js/view/utils/visibility.js
+++ b/src/js/view/utils/visibility.js
@@ -25,7 +25,6 @@ export default function getVisibility(model, element) {
             return 0;
         }
     }
-
     return intersectionRatio;
 }
  

--- a/src/js/view/utils/visibility.js
+++ b/src/js/view/utils/visibility.js
@@ -25,7 +25,6 @@ export default function getVisibility(model, element) {
 
     return intersectionRatio;
 }
-
  
 function computeVisibility(target) {
     const html = document.documentElement;

--- a/src/js/view/utils/visibility.js
+++ b/src/js/view/utils/visibility.js
@@ -17,10 +17,13 @@ export default function getVisibility(model, element) {
     // Otherwise, set it to the intersection ratio reported from the intersection observer
     let intersectionRatio = model.get('intersectionRatio');
 
-    // Compute visibility does not return accurate value for iFrame player
-    if (intersectionRatio === undefined && !(window.top !== window.self)) {
+    if (intersectionRatio === undefined) {
         // Get intersectionRatio through brute force
         intersectionRatio = computeVisibility(element);
+        // Disregard intersectionRatio if it returns that the player is viewable in iFrame
+        if ((window.top !== window.self) && intersectionRatio) {
+            return 0;
+        }
     }
 
     return intersectionRatio;


### PR DESCRIPTION
### This PR will...

Does not rely on compute visibility if we detect we are within an iFrame.

### Why is this Pull Request needed?

Regardless of viewability, we are returning that the player is in view when it is in an iFrame. This is due to the method for viewability detection within computeVisibility. The method using the IntersectionObserver is reliable.

### Are there any points in the code the reviewer needs to double check?

N/A

### Are there any Pull Requests open in other repos which need to be merged with this?

No

#### Addresses Issue(s):

JW8-2248

