### PR TITLE
Fix issues with freewheel display click play event

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -51,7 +51,9 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
         // toggle playback after click event
         if (_adProgram.model.get('state') === STATE_PAUSED) {
             if (evt.hasControls) {
-                _adProgram.playVideo();
+                _adProgram.playVideo().catch(() => {
+                    _controller.play();
+                });
             }
         } else {
             _adProgram.pause();


### PR DESCRIPTION
### This PR will...
Call `play` function on controller if `adProgram.playVideo` fails after display click.

### Why is this Pull Request needed?
1. On freewheel, `adProgram.playVideo` throws exception due to no playlistItem. We want to catch the uncaught exception
2. When `adProgram.playVideo` fails, the ad does not trigger `play` event, although the ad resumes. Clicking on the play/pause icon is fine, as it calls `controller.play`. Do the same for display click.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):
JW8-2357

