### PR TITLE
[JW8-2366] Use api rather than rect.

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -859,7 +859,8 @@ function View(_api, _model) {
         if (!isVisible && _model.get('state') !== STATE_IDLE && floatingPlayer === null) {
             floatingPlayer = _playerElement;
 
-            const rect = bounds(_playerElement);
+            const width = _this.api.getWidth();
+            const height = _this.api.getHeight();
 
             // Copy background from preview element, fallback to image config.
             style(_playerElement, {
@@ -873,8 +874,8 @@ function View(_api, _model) {
             _resizeOnFloat = true;
 
             // Resize within MAX_FLOATING_WIDTH×MAX_FLOATING_HEIGHT bounds, never enlarge.
-            const ratio = Math.min(1, MAX_FLOATING_WIDTH / rect.width, MAX_FLOATING_HEIGHT / rect.height);
-            _this.resize(rect.width * ratio, rect.height * ratio, true);
+            const ratio = Math.min(1, MAX_FLOATING_WIDTH / width, MAX_FLOATING_HEIGHT / height);
+            _this.resize(width * ratio, height * ratio, true);
 
             _resizeOnFloat = false;
         } else if (isVisible) {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -859,9 +859,6 @@ function View(_api, _model) {
         if (!isVisible && _model.get('state') !== STATE_IDLE && floatingPlayer === null) {
             floatingPlayer = _playerElement;
 
-            const width = _this.api.getWidth();
-            const height = _this.api.getHeight();
-
             // Copy background from preview element, fallback to image config.
             style(_playerElement, {
                 backgroundImage: _preview.el.style.backgroundImage || _model.get('image')
@@ -874,6 +871,7 @@ function View(_api, _model) {
             _resizeOnFloat = true;
 
             // Resize within MAX_FLOATING_WIDTH×MAX_FLOATING_HEIGHT bounds, never enlarge.
+            const { width, height } = _this.getSafeRegion(false);
             const ratio = Math.min(1, MAX_FLOATING_WIDTH / width, MAX_FLOATING_HEIGHT / height);
             _this.resize(width * ratio, height * ratio, true);
 


### PR DESCRIPTION
### This PR will...
Rely on the API `getWidth` and `getHeight` methods to return the player dimensions. Since these will only get called when the player is *not* floating, the container dimensions will be returned.

### Why is this Pull Request needed?
For outstream, using `rect` will return a height of `1`, causing a tiny floating player. Instead, we should use the expected height to calculate the floating player size.

### Are there any points in the code the reviewer needs to double check?
N/A

### Are there any Pull Requests open in other repos which need to be merged with this?
jwplayer/jwplayer-commercial#5893

#### Addresses Issue(s):
JW8-2366