### PR TITLE
[JW8-2368] Fix double call to _autoStart on viewable

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -283,7 +283,7 @@ Object.assign(Controller.prototype, {
             }
 
             // Autostart immediately if we're not waiting for the player to become viewable first.
-            if (_model.get('autostart') === true) {
+            if (_model.get('autostart') === true && !_model.get('playOnViewable')) {
                 _autoStart();
             }
             apiQueue.flush();

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -501,6 +501,11 @@ Object.assign(Controller.prototype, {
                     });
                 }
 
+                // Enable autoPause behavior.
+                if (_model.get('autoPause') && _model.get('autoPause').viewability) {
+                    _model.set('playOnViewable', true);
+                }
+
                 return _play({ reason: 'autostart' }).catch(() => {
                     if (!_this._instreamAdapter) {
                         _model.set('autostartFailed', true);

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -502,7 +502,8 @@ Object.assign(Controller.prototype, {
                 }
 
                 // Enable autoPause behavior.
-                if (_model.get('autoPause') && _model.get('autoPause').viewability) {
+                const autoPause = _model.get('autoPause');
+                if (autoPause && autoPause.viewability) {
                     _model.set('playOnViewable', true);
                 }
 

--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -1,3 +1,4 @@
+import { OS } from 'environment/environment';
 import SimpleModel from 'model/simplemodel';
 import { INITIAL_PLAYER_STATE, INITIAL_MEDIA_STATE } from 'model/player-model';
 import { STATE_IDLE } from 'events/events';
@@ -185,7 +186,9 @@ const Model = function() {
         if (autoStart !== undefined) {
             this.set('autostart', autoStart);
         }
-        this.set('playOnViewable', this.get('autostart'));
+
+        const autoStartOnMobile = OS.mobile && this.get('autostart');
+        this.set('playOnViewable', autoStartOnMobile || this.get('autostart') === 'viewable');
     };
 
     this.resetItem = function (item) {


### PR DESCRIPTION
### This PR will...
Fix a bug introduced with autoPause (3c1ff92) where `_autoStart` was called twice with `autostart: true` and viewable when setting up. Instead, autoPause is set-up only after calling `_autoStart`. This works fine since autoPause only works when autostarting (viewable or otherwise).

### Why is this Pull Request needed?
There is no need to call `_autoStart` twice, plus this was leading to duplicate events (e.g. `beforePlay`).

### Are there any points in the code the reviewer needs to double check?
N/A

### Are there any Pull Requests open in other repos which need to be merged with this?
N/A

#### Addresses Issue(s):
JW8-2368