### PR TITLE
Include sourceError in html5 provider errors

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -176,7 +176,8 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
 
         error() {
             const { video } = _this;
-            const errorCode = (video.error && video.error.code) || -1;
+            const error = video.error;
+            const errorCode = (error && error.code) || -1;
             // Error code 2 from the video element is a network error
             let code = HTML5_BASE_MEDIA_ERROR;
             let key = MSG_CANT_PLAY_VIDEO;
@@ -198,7 +199,7 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
             _clearVideotagSource();
             _this.trigger(
                 MEDIA_ERROR,
-                new PlayerError(key, code, video.error)
+                new PlayerError(key, code, error)
             );
         }
     };


### PR DESCRIPTION
### This PR will...
Add the media element's `MediaError` to the "error" event's `sourceError` property.

## Why is this Pull Request needed?
`video.error` and thus `sourceError` is being set to `null` when `_clearVideotagSource()` is called.

These changes capture the error in a const before that so that it is passed to the `PlayerError` constructor.  

It's important that we provide the original `MediaError` so that it's `message` property can be examined for more information about decode errors in the browser.