### PR TITLE
[JW8-2234] Retrieve mediaController after setting the active item.

### DIFF
--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -42,7 +42,7 @@ class ProgramController extends Eventable {
      * @memberOf ProgramController
      */
     setActiveItem(index) {
-        const { background, mediaController, model } = this;
+        const { model } = this;
         const item = model.get('playlist')[index];
 
         model.attributes.itemReady = false;
@@ -51,6 +51,8 @@ class ProgramController extends Eventable {
         if (!source) {
             return Promise.reject(new PlayerError(MSG_CANT_PLAY_VIDEO, ERROR_PLAYLIST_ITEM_MISSING_SOURCE));
         }
+
+        const { background, mediaController } = this;
 
         // Activate the background media if it's loading the item we want to play
         if (background.isNext(item)) {


### PR DESCRIPTION
### This PR will...
Retrieve the `mediaController` only after the active item is set in `model.setActiveItem`. The latter updates the `playlistItem`, which cause the ad plugins to destroy the current ad break (if any) and re-attach the original media. Therefore, we should get the `mediaController` only after this completes, to ensure we got the latest one.

### Why is this Pull Request needed?
With ad breaks, upon updating the `playlistItem`, two video tags (one hidden which played, one visible which was idle) appeared on the page as the original video tag was never destroyed (because `mediaController` would be `null` as the ad was still playing).

### Are there any points in the code the reviewer needs to double check?
N/A

### Are there any Pull Requests open in other repos which need to be merged with this?
N/A

#### Addresses Issue(s):
JW8-2234