### PR TITLE
8.6.0 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jwplayer",
-  "version": "8.6.0-rc.2",
+  "version": "8.6.0",
   "description": "The JW Player is free for non-commerical use. To buy a license for commercial use, please visit \r http://www.jwplayer.com/pricing/",
   "repository": "git@github.com:jwplayer/jwplayer.git",
   "homepage": "https://github.com/jwplayer/jwplayer",

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -278,11 +278,10 @@ export default class Controlbar {
             const { liveBroadcast, notLive } = localization;
             const liveElement = this.elements.live.element();
             const dvrNotLive = dvrLive === false;
-            const liveButtonText = dvrNotLive ? notLive : liveBroadcast;
             // jw-dvr-live: Player is in DVR mode but not at the live edge.
             toggleClass(liveElement, 'jw-dvr-live', dvrNotLive);
-            setAttribute(liveElement, 'aria-label', liveButtonText);
-            liveElement.textContent = liveButtonText;
+            setAttribute(liveElement, 'aria-label', dvrNotLive ? notLive : liveBroadcast);
+            liveElement.textContent = liveBroadcast;
         }, this);
         _model.change('altText', this.setAltText, this);
         _model.change('customButtons', this.updateButtons, this);


### PR DESCRIPTION
Release branch for 8.6.0 AND fix for DVR live button. The DVR live button should always say 'Live' even when not live. When not live, the box is hollow indicating the 'not live' state, so the text should still say 'live' but the aria label should say 'Not live'