### PR TITLE
Prevent focus on play button on fullscreen

### DIFF
--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -406,8 +406,6 @@ export default class Controlbar {
 
     onFullscreen(model, val) {
         toggleClass(this.elements.fullscreen.element(), 'jw-off', val);
-        this.elements.fullscreen.element().focus();
-        console.log('active element', document.activeElement);
     }
 
     onAudioMode(model, val) {

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -406,7 +406,8 @@ export default class Controlbar {
 
     onFullscreen(model, val) {
         toggleClass(this.elements.fullscreen.element(), 'jw-off', val);
-        this.elements.play.element().focus();
+        this.elements.fullscreen.element().focus();
+        console.log('active element', document.activeElement);
     }
 
     onAudioMode(model, val) {


### PR DESCRIPTION
### This PR will...

- Remove code to focus on play button element.
- Prevent fullscreen tooltip from being shown when fullscreen is clicked

### Why is this Pull Request needed?

The active element should still be the fullscreen element once fullscreen is triggered.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-2340

