### PR TITLE
Safari 12 workaround: array.reverse is cached

### DIFF
--- a/src/js/polyfills/webvtt.js
+++ b/src/js/polyfills/webvtt.js
@@ -764,7 +764,7 @@ function moveBoxToLinePosition(window, styleBox, containerBox, boxPositions, num
             // We call reverse on a copy of the 'axis' array, instead of calling it directly on the original var because
             // Safari 12 introduced a bug where the reverse order of an array is cached after calling
             // array.prototype.reverse (https://bugs.webkit.org/show_bug.cgi?id=188794).
-            axis = axis.slice(0).reverse();
+            axis = axis.slice().reverse();
         }
 
         // Shift the position of the captions up to prevent minor overlaps as the text is laid out in IE11

--- a/src/js/polyfills/webvtt.js
+++ b/src/js/polyfills/webvtt.js
@@ -760,10 +760,11 @@ function moveBoxToLinePosition(window, styleBox, containerBox, boxPositions, num
             // Account for lines of text when determining position based on a negative line value
             const textHeight = numLinesOfText * step;
             position -= textHeight;
-            // We call reverse on a copy of the 'axis' array, instead of calling it on the original array because
+            // Modified on 10/23/2018 by Karim Mourra: karim@jwplayer.com
+            // We call reverse on a copy of the 'axis' array, instead of calling it directly on the original var because
             // Safari 12 introduced a bug where the reverse order of an array is cached after calling
             // array.prototype.reverse (https://bugs.webkit.org/show_bug.cgi?id=188794).
-            axis = array1.slice(0).reverse();
+            axis = axis.slice(0).reverse();
         }
 
         // Shift the position of the captions up to prevent minor overlaps as the text is laid out in IE11

--- a/src/js/polyfills/webvtt.js
+++ b/src/js/polyfills/webvtt.js
@@ -709,25 +709,27 @@ function moveBoxToLinePosition(window, styleBox, containerBox, boxPositions, num
     const cue = styleBox.cue;
     let linePos = computeLinePos(cue);
     let axis = [];
-    const positiveY = '+y';
-    const negativeY = '-y';
-    const positiveX = '+x';
-    const negativeX = '-x';
+    // We use variables instead of strings because Safari 12 introduced a bug where the reverse order of an array
+    // is cached after array.prototype.reverse is called on the array (https://bugs.webkit.org/show_bug.cgi?id=188794).
+    const posY = '+y';
+    const negY = '-y';
+    const posX = '+x';
+    const negX = '-x';
 
     // If we have a line number to align the cue to.
     if (cue.snapToLines) {
         let size;
         switch (cue.vertical) {
             case '':
-                axis = [positiveY, negativeY];
+                axis = [posY, negY];
                 size = 'height';
                 break;
             case 'rl':
-                axis = [positiveX, negativeX];
+                axis = [posX, negX];
                 size = 'width';
                 break;
             case 'lr':
-                axis = [negativeX, positiveX];
+                axis = [negX, posX];
                 size = 'width';
                 break;
             default:
@@ -809,7 +811,7 @@ function moveBoxToLinePosition(window, styleBox, containerBox, boxPositions, num
                 break;
         }
 
-        axis = [positiveY, negativeX, positiveX, negativeY];
+        axis = [posY, negX, posX, negY];
 
         // Get the box position again after we've applied the specified positioning
         // to it.

--- a/src/js/polyfills/webvtt.js
+++ b/src/js/polyfills/webvtt.js
@@ -709,27 +709,21 @@ function moveBoxToLinePosition(window, styleBox, containerBox, boxPositions, num
     const cue = styleBox.cue;
     let linePos = computeLinePos(cue);
     let axis = [];
-    // We use variables instead of strings because Safari 12 introduced a bug where the reverse order of an array
-    // is cached after array.prototype.reverse is called on the array (https://bugs.webkit.org/show_bug.cgi?id=188794).
-    const posY = '+y';
-    const negY = '-y';
-    const posX = '+x';
-    const negX = '-x';
 
     // If we have a line number to align the cue to.
     if (cue.snapToLines) {
         let size;
         switch (cue.vertical) {
             case '':
-                axis = [posY, negY];
+                axis = ['+y', '-y'];
                 size = 'height';
                 break;
             case 'rl':
-                axis = [posX, negX];
+                axis = ['+x', '-x'];
                 size = 'width';
                 break;
             case 'lr':
-                axis = [negX, posX];
+                axis = ['-x', '+x'];
                 size = 'width';
                 break;
             default:
@@ -766,7 +760,10 @@ function moveBoxToLinePosition(window, styleBox, containerBox, boxPositions, num
             // Account for lines of text when determining position based on a negative line value
             const textHeight = numLinesOfText * step;
             position -= textHeight;
-            axis = axis.reverse();
+            // We call reverse on a copy of the 'axis' array, instead of calling it on the original array because
+            // Safari 12 introduced a bug where the reverse order of an array is cached after calling
+            // array.prototype.reverse (https://bugs.webkit.org/show_bug.cgi?id=188794).
+            axis = array1.slice(0).reverse();
         }
 
         // Shift the position of the captions up to prevent minor overlaps as the text is laid out in IE11
@@ -811,7 +808,7 @@ function moveBoxToLinePosition(window, styleBox, containerBox, boxPositions, num
                 break;
         }
 
-        axis = [posY, negX, posX, negY];
+        axis = ['+y', '-x', '+x', '-y'];
 
         // Get the box position again after we've applied the specified positioning
         // to it.

--- a/src/js/polyfills/webvtt.js
+++ b/src/js/polyfills/webvtt.js
@@ -709,13 +709,15 @@ function moveBoxToLinePosition(window, styleBox, containerBox, boxPositions, num
     const cue = styleBox.cue;
     let linePos = computeLinePos(cue);
     let axis = [];
+    const positiveY = '+y';
+    const negativeY = '-y';
 
     // If we have a line number to align the cue to.
     if (cue.snapToLines) {
         let size;
         switch (cue.vertical) {
             case '':
-                axis = ['+y', '-y'];
+                axis = [positiveY, negativeY];
                 size = 'height';
                 break;
             case 'rl':

--- a/src/js/polyfills/webvtt.js
+++ b/src/js/polyfills/webvtt.js
@@ -711,6 +711,8 @@ function moveBoxToLinePosition(window, styleBox, containerBox, boxPositions, num
     let axis = [];
     const positiveY = '+y';
     const negativeY = '-y';
+    const positiveX = '+x';
+    const negativeX = '-x';
 
     // If we have a line number to align the cue to.
     if (cue.snapToLines) {
@@ -721,11 +723,11 @@ function moveBoxToLinePosition(window, styleBox, containerBox, boxPositions, num
                 size = 'height';
                 break;
             case 'rl':
-                axis = ['+x', '-x'];
+                axis = [positiveX, negativeX];
                 size = 'width';
                 break;
             case 'lr':
-                axis = ['-x', '+x'];
+                axis = [negativeX, positiveX];
                 size = 'width';
                 break;
             default:
@@ -807,7 +809,7 @@ function moveBoxToLinePosition(window, styleBox, containerBox, boxPositions, num
                 break;
         }
 
-        axis = ['+y', '-x', '+x', '-y'];
+        axis = [positiveY, negativeX, positiveX, negativeY];
 
         // Get the box position again after we've applied the specified positioning
         // to it.


### PR DESCRIPTION
### This PR will...
Call `slice` on the axis array to make a copy before calling `reverse`.
### Why is this Pull Request needed?
Safari 12 introduced a bug where calling reverse on an array would then cache the reverse value (https://bugs.webkit.org/show_bug.cgi?id=188794). This went undetected in our testing because webVTT is not used in safari, since on safari we render captions natively. The iOS SDK however uses the webVTT polyfill because media is rendered in the native AVPlayer instead of the webView, therefore we cannot render captions natively in the webView.
To reproduce the bug run the following:
```
for (var i = 0; i <= 10; i ++) {
	var array1 = ['one', 'two'];
	console.log('array1: ', array1);
	var reversed = array1.reverse(); 
}
```
notice that even though the array is being instantiated, the value is reversed before `reverse` is even called.
The following screenshot shows the bug in action:
![wtf](https://user-images.githubusercontent.com/12138319/47315232-f94a8a00-d611-11e8-9978-ac2bf997101b.png)
By reversing a copy of the array, we can work around the bug 
Upstream fix: https://github.com/mozilla/vtt.js/pull/377

### Are there any points in the code the reviewer needs to double check?
`array.prototype.reverse` is not used anywhere else.
### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

iOS

