### PR TITLE
Fix resume DVR playback in html5 provider

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -247,6 +247,9 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
         },
         isLive() {
             return _videotag.duration === Infinity;
+        },
+        isDVR() {
+            return _this.isLive() && (_getSeekableEnd() - _getSeekableStart()) >= MIN_DVR_DURATION;
         }
     });
 
@@ -392,8 +395,8 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
     }
 
     function _play() {
-        const resumeLive = _videotag.duration === Infinity && _videotag.paused && _videotag.played && _videotag.played.length;
-        if (resumeLive) {
+        const resumingPlayback = _videotag.paused && _videotag.played && _videotag.played.length;
+        if (resumingPlayback && _this.isLive() && !_this.isDVR()) {
             _videotag.load();
         }
         return _videotag.play() || createPlayPromise(_videotag);


### PR DESCRIPTION
### This PR will...
Do not reload DVR streams when resuming from paused state with html5 provider

### Why is this Pull Request needed?
The check for live on resume that reload the stream to get us back to the live edge added a regression to DVR functionality. Normal pausing and resuming is fine for DVR streams. This also affected seeking while paused.

#### Addresses Issue(s):
JW8-2255

