### PR TITLE
Revisit styles for display playback label for IE 11 compatability

### DIFF
--- a/src/css/controls/imports/display.less
+++ b/src/css/controls/imports/display.less
@@ -55,9 +55,6 @@ display icons
     .jw-icon {
         .square(75px);
         cursor: pointer;
-        display: flex;
-        justify-content: center;
-        align-items: center;
 
         .jw-svg-icon {
             .square((@mobile-touch-target * 0.75));

--- a/src/css/controls/imports/playback-label.less
+++ b/src/css/controls/imports/playback-label.less
@@ -2,6 +2,7 @@
 
 .jw-idle-icon-text {
     display: none;
+    width: 100%;
     line-height: 1;
     position: absolute;
     text-align: center;


### PR DESCRIPTION
### This PR will...

Enforce consistency for the positioning of the playback label across browsers. This PR removes Flexbox for the labels' parent container, which was the cause of incorrect positioning in Internet Explorer.

As an alternative, setting the width of the ```.jw-idle-icon-text``` class to 100% achieves the desired result. In conjunction with the previously defined ```text-align: center``` rule, forcing the label to occupy width of the parent container, the label is centered across all browsers.

### Why is this Pull Request needed?

In IE, the "Play" playback label is not centered under the play icon; instead, it is aligned to the right.

### Are there any points in the code the reviewer needs to double check?

N/A

### Are there any Pull Requests open in other repos which need to be merged with this?

No

#### Addresses Issue(s):

JW8-2360

