### PR TITLE
Clear tracks when resuming live playback in html5

### DIFF
--- a/src/js/providers/utils/stream-type.js
+++ b/src/js/providers/utils/stream-type.js
@@ -1,22 +1,34 @@
+/** @module */
 
-// It's DVR if the duration is above the minDvrWindow, Live otherwise
+/**
+ * It's DVR if the duration is not Infinity and above the minDvrWindow, Live otherwise.
+ * @param {Number} duration - The duration or seekable range of a stream in seconds.
+ * @param {Number} minDvrWindow - The duration threshold beyond which a stream should be treated as DVR instead of Live.
+ * @returns {boolean} DVR or not.
+ */
 export function isDvr(duration, minDvrWindow) {
-    return Math.abs(duration) >= Math.max(minDvrWindow, 0);
+    return duration !== Infinity && Math.abs(duration) >= Math.max(validMinDvrWindow(minDvrWindow), 0);
 }
 
-// Determine the adaptive type - Live, DVR, or VOD
-// Duration can be positive or negative, but minDvrWindow should always be positive
+/**
+ * Determine the adaptive type.
+ * @param {Number} duration - The duration or seekable range of a stream in seconds. Can be positive or negative.
+ * Positive or non-infinite values will result in a return value of 'VOD'. Infinite values always return 'LIVE'.
+ * @param {Number} minDvrWindow - The duration threshold beyond which a stream should be treated as DVR instead of Live.
+ * minDvrWindow should always be positive.
+ * @returns {('VOD'|'LIVE'|'DVR')} The stream typeR.
+ */
 export function streamType(duration, minDvrWindow) {
-    const _minDvrWindow = (minDvrWindow === undefined) ? 120 : minDvrWindow;
     let type = 'VOD';
 
     if (duration === Infinity) {
-        // Live streams are always Infinity duration
         type = 'LIVE';
     } else if (duration < 0) {
-        type = isDvr(duration, _minDvrWindow) ? 'DVR' : 'LIVE';
+        type = isDvr(duration, validMinDvrWindow(minDvrWindow)) ? 'DVR' : 'LIVE';
     }
-
-    // Default option is VOD (i.e. positive or non-infinite)
     return type;
+}
+
+function validMinDvrWindow(minDvrWindow) {
+    return (minDvrWindow === undefined) ? 120 : Math.max(minDvrWindow, 0);
 }

--- a/test/unit/stream-type-util-test.js
+++ b/test/unit/stream-type-util-test.js
@@ -1,46 +1,78 @@
-import * as streamTypeUtil from 'providers/utils/stream-type';
+import { streamType, isDvr } from 'providers/utils/stream-type';
 
 describe('stream-type', function() {
 
-    it('stream-type.streamType', function() {
+    it('determines streamType', function() {
         const minDvrWindow = 120;
-        let type = streamTypeUtil.streamType(0, minDvrWindow);
+        let type = streamType(0, minDvrWindow);
         expect(type, 'streamType with 0 and 120').to.equal('VOD');
 
-        type = streamTypeUtil.streamType(0, 0);
+        type = streamType(0, 0);
         expect(type, 'streamType with 0 and 0').to.equal('VOD');
 
-        type = streamTypeUtil.streamType(10, minDvrWindow);
+        type = streamType(10, minDvrWindow);
         expect(type, 'streamType with 10 and 120').to.equal('VOD');
 
-        type = streamTypeUtil.streamType(10, undefined);
+        type = streamType(10, undefined);
         expect(type, 'streamType with 10 and undefined').to.equal('VOD');
 
-        type = streamTypeUtil.streamType(-120, minDvrWindow);
+        type = streamType(-120, minDvrWindow);
         expect(type, 'streamType with -120 and 120').to.equal('DVR');
 
-        type = streamTypeUtil.streamType(-120, -10);
+        type = streamType(-120, -10);
         expect(type, 'streamType with 120 and -10').to.equal('DVR');
 
-        type = streamTypeUtil.streamType(-120, 0);
+        type = streamType(-120, 0);
         expect(type, 'streamType with 120 and 0').to.equal('DVR');
 
-        type = streamTypeUtil.streamType(-120, 0);
+        type = streamType(-120, 0);
         expect(type, 'streamType with -120 and 0').to.equal('DVR');
 
-        type = streamTypeUtil.streamType(-120, undefined);
+        type = streamType(-120, undefined);
         expect(type, 'streamType with 120 and undefined').to.equal('DVR');
 
-        type = streamTypeUtil.streamType(-20, minDvrWindow);
+        type = streamType(-20, minDvrWindow);
         expect(type, 'streamType with -20 and 120').to.equal('LIVE');
 
-        type = streamTypeUtil.streamType(-1, minDvrWindow);
+        type = streamType(-1, minDvrWindow);
         expect(type, 'streamType with -1 and 120').to.equal('LIVE');
 
-        type = streamTypeUtil.streamType(Infinity, minDvrWindow);
+        type = streamType(Infinity, minDvrWindow);
         expect(type, 'streamType with Infinity').to.equal('LIVE');
 
-        type = streamTypeUtil.streamType(-20, undefined);
+        type = streamType(-20, undefined);
         expect(type, 'streamType with -20 and undefined').to.equal('LIVE');
+    });
+
+    it('determines isDvr', function() {
+        const minDvrWindow = 120;
+        let dvrMode;
+
+        dvrMode = isDvr(0, minDvrWindow);
+        expect(dvrMode, 'expect false when duration is less than minDvrWindow').to.equal(false);
+
+        dvrMode = isDvr(Infinity, minDvrWindow);
+        expect(dvrMode, 'expect false when duration is Infinity').to.equal(false);
+
+        dvrMode = isDvr(-110, minDvrWindow);
+        expect(dvrMode, 'expect false when absolute duration is less than minDvrWindow').to.equal(false);
+
+        dvrMode = isDvr(10, undefined);
+        expect(dvrMode, 'expect false when duration is greater than 0 and minDvrWindow is undefined').to.equal(false);
+
+        dvrMode = isDvr(-10, undefined);
+        expect(dvrMode, 'expect false when duration is less than 0 and minDvrWindow is undefined').to.equal(false);
+
+        dvrMode = isDvr(0, 0);
+        expect(dvrMode, 'expect true when duration is equal to minDvrWindow').to.equal(true);
+
+        dvrMode = isDvr(-120, minDvrWindow);
+        expect(dvrMode, 'expect true when absolute duration equals minDvrWindow').to.equal(true);
+
+        dvrMode = isDvr(-60, -10);
+        expect(dvrMode, 'expect true when absolute duration is greater than negative minDvrWindow').to.equal(true);
+
+        dvrMode = isDvr(-60, 0);
+        expect(dvrMode, 'expect true when absolute duration is greater than minDvrWindow').to.equal(true);
     });
 });


### PR DESCRIPTION
### This PR will...
- Clear tracks when resuming live playback in html5
- Use model and item's `minDvrWindow`

### Why is this Pull Request needed?
Live streams reload when playback is resumed. With native text track rendering, tracks need to be cleared, otherwise they will be duplicated.

We should not be using the old `MIN_DVR_DURATION = 120` constant in html5 because it conflicts with the logic in the rest of the player. `minDvrWindow` can be set in the config per playlist item. 

#### Addresses Issue(s):
JW8-2289

