### PR TITLE
Include buffered TimeRange in html5 seekable range

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -334,14 +334,14 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
     _this.getSeekRange = function() {
         const seekRange = {
             start: 0,
-            end: _this.getDuration()
+            end: _videotag.duration
         };
 
-        const seekable = this.video.seekable;
+        const seekable = _videotag.seekable;
 
         if (seekable.length) {
-            seekRange.end = Math.max(seekable.end(0), seekable.end(seekable.length - 1));
-            seekRange.start = Math.min(seekable.start(0), seekable.start(seekable.length - 1));
+            seekRange.end = _getSeekableEnd();
+            seekRange.start = _getSeekableStart();
         }
 
         return seekRange;
@@ -477,22 +477,28 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
     }
 
     function _getSeekableStart() {
-        let index = _videotag.seekable ? _videotag.seekable.length : 0;
         let start = Infinity;
+        ['buffered', 'seekable'].forEach(range => {
+            const timeRange = _videotag[range];
+            let index = timeRange ? timeRange.length : 0;
 
-        while (index--) {
-            start = Math.min(start, _videotag.seekable.start(index));
-        }
+            while (index--) {
+                start = Math.min(start, timeRange.start(index));
+            }
+        });
         return start;
     }
 
     function _getSeekableEnd() {
-        let index = _videotag.seekable ? _videotag.seekable.length : 0;
         let end = 0;
+        ['buffered', 'seekable'].forEach(range => {
+            const timeRange = _videotag[range];
+            let index = timeRange ? timeRange.length : 0;
 
-        while (index--) {
-            end = Math.max(end, _videotag.seekable.end(index));
-        }
+            while (index--) {
+                end = Math.max(end, timeRange.end(index));
+            }
+        });
         return end;
     }
 

--- a/src/js/providers/video-listener-mixin.js
+++ b/src/js/providers/video-listener-mixin.js
@@ -38,6 +38,7 @@ const VideoListenerMixin = {
     },
 
     timeupdate() {
+        const currentTime = this.video.currentTime;
         const position = this.getCurrentTime();
         const duration = this.getDuration();
         if (isNaN(duration)) {
@@ -54,10 +55,10 @@ const VideoListenerMixin = {
         const timeEventObject = {
             position,
             duration,
-            currentTime: this.video.currentTime,
+            currentTime: currentTime,
             seekRange: this.getSeekRange(),
             metadata: {
-                currentTime: this.video.currentTime
+                currentTime: currentTime
             }
         };
         if (this.getPtsOffset) {


### PR DESCRIPTION
### This PR will...
Include buffered TimeRanges in html5 seekable range. Prevent time from bouncing in html5.

### Why is this Pull Request needed?
Safari does not initially report seekable ranges correctly for some live HLS streams. This is an archived live stream with five 10s segments, but the seekable range is reported from 0 to 20. The buffered range is from 20 to 49. Combining these provides the complete range that can be accessed.

It should be safe to seek within buffered ranges, and this fixes behavior with some DVR use cases, this seems like an.

In Safari 12 the seekable range is only representing a small percentage of the addressable video. The buffered range addresses all segments in the manifest (the back buffer is cleared in live streams) which represents what we report with hls.js.

The time bouncing code is borrowed from hlsjs.

### How was this tested?
Testing `minDvrWindow` of `0` with short live streams:
http://player-develop-test-jenkins.longtailvideo.com/builds/lastSuccessfulBuild/archive/test/public/events/?config=hlsjs/hls-dvr-min-window-less

DVR tests
http://player-develop-test-jenkins.longtailvideo.com/builds/lastSuccessfulBuild/archive/test/squash/bootstrap.html?primary=html5&edition=ads&feature=hlsjs/dvr_hls_streams_using_hlsjs_provider&suite=HLSjs%20Provider

Live tests
http://player-develop-test-jenkins.longtailvideo.com/builds/lastSuccessfulBuild/archive/test/squash/bootstrap.html?primary=html5&edition=ads&feature=hlsjs/live_streams_using_hlsjs_provider&suite=HLSjs%20Provider

### Are there any Pull Requests open in other repos which need to be merged with this?

This issue was uncovered while performing additional spot checks on https://github.com/jwplayer/jwplayer/pull/3157 to verify consistency in behavior between HLS playback in Chrome (hls.js provider) and Safari (html5 provider).

#### Addresses Issue(s):
JW8-2289