### PR TITLE
Revert "Revisit styles for display playback label for IE 11 compatability"

### DIFF
--- a/src/css/controls/imports/display.less
+++ b/src/css/controls/imports/display.less
@@ -55,6 +55,9 @@ display icons
     .jw-icon {
         .square(75px);
         cursor: pointer;
+        display: flex;
+        justify-content: center;
+        align-items: center;
 
         .jw-svg-icon {
             .square((@mobile-touch-target * 0.75));

--- a/src/css/controls/imports/playback-label.less
+++ b/src/css/controls/imports/playback-label.less
@@ -2,7 +2,6 @@
 
 .jw-idle-icon-text {
     display: none;
-    width: 100%;
     line-height: 1;
     position: absolute;
     text-align: center;


### PR DESCRIPTION
**Description**

Previous changes had broken responsive behavior (while resizing) for playback variants in Safari/Chrome -- these variants no longer centered.