### PR TITLE
Prevent settings menu from appear on the top corner of the player

### DIFF
--- a/src/css/controls/states.less
+++ b/src/css/controls/states.less
@@ -218,7 +218,6 @@ body .jwplayer.jw-state-error,
 
     .jw-settings-menu {
         height: 100%;
-        top: 0;
         bottom: 0;
     }
 


### PR DESCRIPTION
### This PR will...
remove a line of css setting the top to 0
### Why is this Pull Request needed?
On idle we can open the share menu when sharing is enabled in right click. Therefore the share menu can be opened when the player is in the idle state. In order to prevent the menu from appearing on the top of the player, we remove a line explicitly setting top to 0. bottom is still 0 therefore the menu appears at the bottom.
### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-2256

