### PR TITLE
[JW8-2212] Fix BGL for autostart with ads.

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -838,7 +838,7 @@ Object.assign(Controller.prototype, {
         this.backgroundActiveMedia = () => _programController.backgroundActiveMedia();
         this.restoreBackgroundMedia = () => _programController.restoreBackgroundMedia();
         this.preloadNextItem = () => {
-            if (_programController.backgroundMedia) {
+            if (_programController.background.currentMedia) {
                 // Instruct the background media to preload if it's already been loaded
                 _programController.preloadVideo();
             }


### PR DESCRIPTION
### This PR will...
Rename `backgroundMedia` to `background.currentMedia`.

### Why is this Pull Request needed?
BGL for autostart with ads is currently not working. In e5085f5, `programController.backgroundMedia` was renamed to `programController.background`, with `BackgroundMedia()` assigned as value in the constructor. `BackgroundMedia` has a property `currentMedia`, pointing to the `backgroundMedia`.

### Are there any points in the code the reviewer needs to double check?
N/A

### Are there any Pull Requests open in other repos which need to be merged with this?
N/A

#### Addresses Issue(s):
JW8-2212