### PR TITLE
Restore the original container when destroying in the core-shim

### DIFF
--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -167,6 +167,12 @@ Object.assign(CoreShim.prototype, {
         if (this.setup) {
             this.setup.destroy();
         }
+
+        // Removes the ErrorContainer if it has been shown
+        if (this.currentContainer !== this.originalContainer) {
+            showView(this, this.originalContainer);
+        }
+
         this.off();
         this._events =
             this._model =

--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -177,7 +177,6 @@ Object.assign(CoreShim.prototype, {
         this._events =
             this._model =
             this.modelShim =
-            this.originalContainer =
             this.apiQueue =
             this.setup = null;
     },


### PR DESCRIPTION
### This PR will...
 - Restore the original container when destroying in the core-shim, effectively removing any `errorContainer` set.

### Why is this Pull Request needed?
So that calling `jwplayer().remove()` for a setup error which failed *before* core loaded can actually be removed. In this case the `playerDestroy` in `core-shim` is called, which previously did not remove the `errorContainer`.

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-2413

