### PR TITLE
[JW8-2057 JW8-2292] Handle playOnViewable for ad pauseReason.

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -127,6 +127,17 @@ Object.assign(Controller.prototype, {
             });
         });
 
+        const changeReason = function(model, reason) {
+            // Stop autoplay behavior if the video is started by the user or an api call
+            if (reason === 'clickthrough' || reason === 'interaction' || reason === 'external') {
+                _model.set('playOnViewable', false);
+                _model.off('change:pauseReason', changeReason);
+                _model.off('change:playReason', changeReason);
+            }
+        };
+        _model.on('change:pauseReason', changeReason);
+        _model.on('change:playReason', changeReason);
+
         _model.on('change:scrubbing', function(model, state) {
             if (state) {
                 _pause();
@@ -415,10 +426,6 @@ Object.assign(Controller.prototype, {
 
             const playReason = _getReason(meta);
             _model.set('playReason', playReason);
-            // Stop autoplay behavior if the video is started by the user or an api call
-            if (playReason === 'interaction' || playReason === 'external') {
-                _model.set('playOnViewable', false);
-            }
 
             const adState = _getAdState();
             if (adState) {
@@ -563,12 +570,7 @@ Object.assign(Controller.prototype, {
             _actionOnAttach = null;
             checkAutoStartCancelable.cancel();
 
-            const pauseReason = _getReason(meta);
-            _model.set('pauseReason', pauseReason);
-            // Stop autoplay behavior if the video is paused by the user or an api call
-            if (pauseReason === 'interaction' || pauseReason === 'external') {
-                _model.set('playOnViewable', false);
-            }
+            _model.set('pauseReason', _getReason(meta));
 
             const adState = _getAdState();
             if (adState) {

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -21,6 +21,7 @@ import { isUndefined, isBoolean } from 'utils/underscore';
 import { INITIAL_MEDIA_STATE } from 'model/player-model';
 import { PLAYER_STATE, STATE_BUFFERING, STATE_IDLE, STATE_COMPLETE, STATE_PAUSED, STATE_PLAYING, STATE_ERROR, STATE_LOADING,
     STATE_STALLED, AUTOSTART_NOT_ALLOWED, MEDIA_BEFOREPLAY, PLAYLIST_LOADED, ERROR, PLAYLIST_COMPLETE, CAPTIONS_CHANGED, READY,
+    AD_PLAY, AD_PAUSE,
     MEDIA_ERROR, MEDIA_COMPLETE, CAST_SESSION, FULLSCREEN, PLAYLIST_ITEM, MEDIA_VOLUME, MEDIA_MUTE, PLAYBACK_RATE_CHANGED,
     CAPTIONS_LIST, RESIZE, MEDIA_VISUAL_QUALITY } from 'events/events';
 import ProgramController from 'program/program-controller';
@@ -131,12 +132,14 @@ Object.assign(Controller.prototype, {
             // Stop autoplay behavior if the video is started by the user or an api call
             if (reason === 'clickthrough' || reason === 'interaction' || reason === 'external') {
                 _model.set('playOnViewable', false);
-                _model.off('change:pauseReason', changeReason);
-                _model.off('change:playReason', changeReason);
+                _model.off('change:playReason change:pauseReason', changeReason);
             }
         };
-        _model.on('change:pauseReason', changeReason);
-        _model.on('change:playReason', changeReason);
+        _model.on('change:playReason change:pauseReason', changeReason);
+
+        // Listen for play and pause reasons from instream.
+        _this.on(AD_PLAY, event => changeReason(null, event.playReason));
+        _this.on(AD_PAUSE, event => changeReason(null, event.pauseReason));
 
         _model.on('change:scrubbing', function(model, state) {
             if (state) {

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -207,14 +207,8 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
         adModel.set('state', newstate);
 
         if (newstate === STATE_PLAYING) {
-            if (event.playReason) {
-                _model.set('playReason', event.playReason);
-            }
             _controller.trigger(AD_PLAY, event);
         } else if (newstate === STATE_PAUSED) {
-            if (event.pauseReason) {
-                _model.set('pauseReason', event.pauseReason);
-            }
             _controller.trigger(AD_PAUSE, event);
         }
     };

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -207,17 +207,14 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
         adModel.set('state', newstate);
 
         if (newstate === STATE_PLAYING) {
+            if (event.playReason) {
+                _model.set('playReason', event.playReason);
+            }
             _controller.trigger(AD_PLAY, event);
         } else if (newstate === STATE_PAUSED) {
-            const pauseReason = event.pauseReason;
-            _model.set('pauseReason', pauseReason);
-
-            // Stop autoplay behavior if the ad was paused by the user or an api call.
-            if (pauseReason === 'interaction' || pauseReason === 'external' ||
-                 pauseReason === 'clickthrough' || pauseReason === 'vpaid') {
-                _model.set('playOnViewable', false);
+            if (event.pauseReason) {
+                _model.set('pauseReason', event.pauseReason);
             }
-
             _controller.trigger(AD_PAUSE, event);
         }
     };

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -195,7 +195,7 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
     /**
      * Update instream player state. If `event.newstate` is 'playing' trigger an 'adPlay' event.
      * If `event.newstate` is 'paused' trigger and 'adPause' event.
-     * @param {AdPlayEvent|AdPauseEvent} event - An ad event object containing relavant ad data.
+     * @param {AdPlayEvent|AdPauseEvent} event - An ad event object containing relevant ad data.
      * @return {void}
      */
     this.setState = function(event) {
@@ -209,6 +209,15 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
         if (newstate === STATE_PLAYING) {
             _controller.trigger(AD_PLAY, event);
         } else if (newstate === STATE_PAUSED) {
+            const pauseReason = event.pauseReason;
+            _model.set('pauseReason', pauseReason);
+
+            // Stop autoplay behavior if the ad was paused by the user or an api call.
+            if (pauseReason === 'interaction' || pauseReason === 'external' ||
+                 pauseReason === 'clickthrough' || pauseReason === 'vpaid') {
+                _model.set('playOnViewable', false);
+            }
+
             _controller.trigger(AD_PAUSE, event);
         }
     };

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -201,6 +201,10 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
             oldstate: _adProgram.model.get('state')
         }, _data, event);
 
+        if (adEvent.oldstate === newstate) {
+            return;
+        }
+
         if (newstate === STATE_PLAYING) {
             _controller.trigger(AD_PLAY, adEvent);
             _data = { }; // Reset.

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -83,6 +83,7 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
             return;
         }
         _inited = true;
+        _data = { };
 
         // Keep track of the original player state
         _adProgram.setup();
@@ -197,20 +198,17 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
 
     function _triggerAdPlayPause(event) {
         const { newstate } = event;
-        const adEvent = Object.assign({
-            oldstate: _adProgram.model.get('state')
-        }, _data, event);
+        const oldstate = event.oldstate || _adProgram.model.get('state');
 
-        if (adEvent.oldstate === newstate) {
+        if (oldstate === newstate) {
             return;
         }
 
+        const adEvent = Object.assign({ oldstate }, _data, event);
         if (newstate === STATE_PLAYING) {
             _controller.trigger(AD_PLAY, adEvent);
-            _data = { }; // Reset.
         } else if (newstate === STATE_PAUSED) {
             _controller.trigger(AD_PAUSE, adEvent);
-            _data = { }; // Reset.
         }
     }
 
@@ -273,6 +271,7 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
     }
 
     function _instreamItemNext(e) {
+        _data = { };
         if (_array && _arrayIndex + 1 < _array.length) {
             _loadNextItem();
         } else {
@@ -294,6 +293,8 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
         if (_destroyed || !_inited) {
             return Promise.reject(new Error('Instream not setup'));
         }
+        _data = { };
+
         // Copy the playlist item passed in and make sure it's formatted as a proper playlist item
         let playlist = item;
         if (Array.isArray(item)) {
@@ -371,6 +372,7 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
      * @return {void}
      */
     this.play = function() {
+        _data = { };
         _adProgram.playVideo();
     };
 
@@ -379,6 +381,7 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
      * @return {void}
      */
     this.pause = function() {
+        _data = { };
         _adProgram.pause();
     };
 
@@ -454,6 +457,7 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
         _model.set('instream', null);
 
         _adProgram = null;
+        _data = { };
 
         if (!_inited || _model.attributes._destroyed) {
             return;

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -1,4 +1,5 @@
 import { STATE_BUFFERING, STATE_COMPLETE, STATE_PLAYING, STATE_PAUSED,
+    PLAYER_STATE,
     MEDIA_META, MEDIA_PLAY_ATTEMPT_FAILED, MEDIA_TIME, MEDIA_COMPLETE,
     PLAYLIST_ITEM, PLAYLIST_COMPLETE,
     INSTREAM_CLICK,
@@ -30,6 +31,7 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
     let _array;
     let _arrayOptions;
     let _arrayIndex = 0;
+    let _data = {};
     let _options = {};
     let _skipAd = _instreamItemNext;
     let _backgroundLoadTriggered = false;
@@ -90,6 +92,7 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
         _adProgram.on(MEDIA_TIME, _instreamTime, this);
         _adProgram.on(MEDIA_COMPLETE, _instreamItemComplete, this);
         _adProgram.on(MEDIA_META, _instreamMeta, this);
+        _adProgram.on(PLAYER_STATE, _this.setState, this);
 
         // Make sure the original player's provider stops broadcasting events (pseudo-lock...)
         _controller.detachMedia();
@@ -192,6 +195,10 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
         }
     }
 
+    this.setEventData = function(data) {
+        _data = data;
+    };
+
     /**
      * Update instream player state. If `event.newstate` is 'playing' trigger an 'adPlay' event.
      * If `event.newstate` is 'paused' trigger and 'adPause' event.
@@ -201,15 +208,14 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
     this.setState = function(event) {
         const { newstate } = event;
         const adModel = _adProgram.model;
-
-        event.oldstate = adModel.get('state');
+        const evt = Object.assign({ oldstate: adModel.get('state') }, _data, event);
 
         adModel.set('state', newstate);
 
         if (newstate === STATE_PLAYING) {
-            _controller.trigger(AD_PLAY, event);
+            _controller.trigger(AD_PLAY, evt);
         } else if (newstate === STATE_PAUSED) {
-            _controller.trigger(AD_PAUSE, event);
+            _controller.trigger(AD_PAUSE, evt);
         }
     };
 

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -203,8 +203,10 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
 
         if (newstate === STATE_PLAYING) {
             _controller.trigger(AD_PLAY, adEvent);
+            _data = { }; // Reset.
         } else if (newstate === STATE_PAUSED) {
             _controller.trigger(AD_PAUSE, adEvent);
+            _data = { }; // Reset.
         }
     }
 

--- a/src/js/program/ad-program-controller.js
+++ b/src/js/program/ad-program-controller.js
@@ -111,7 +111,7 @@ export default class AdProgramController extends ProgramController {
 
         const adMediaModelContext = model.mediaModel;
         provider.on(PLAYER_STATE, (event) => {
-            event.oldstate = adMediaModelContext.get('mediaState');
+            event.oldstate = model.get(PLAYER_STATE);
             adMediaModelContext.set('mediaState', event.newstate);
         });
         adMediaModelContext.on('change:mediaState', (changeAdModel, state) => {

--- a/src/js/program/ad-program-controller.js
+++ b/src/js/program/ad-program-controller.js
@@ -111,6 +111,7 @@ export default class AdProgramController extends ProgramController {
 
         const adMediaModelContext = model.mediaModel;
         provider.on(PLAYER_STATE, (event) => {
+            event.oldstate = adMediaModelContext.get('mediaState');
             adMediaModelContext.set('mediaState', event.newstate);
         });
         adMediaModelContext.on('change:mediaState', (changeAdModel, state) => {


### PR DESCRIPTION
### This PR will...
Update `playOnViewable` depending on the `pauseReason` passed by the ad plugins.

### Why is this Pull Request needed?
`autostart` depends on the `pauseReason` and `playOnViewable` properties, and currently does not work properly for VPAIDs.

### Are there any points in the code the reviewer needs to double check?
N/A

### Are there any Pull Requests open in other repos which need to be merged with this?
* jwplayer/jwplayer-ads-googima#440
* jwplayer/jwplayer-ads-freewheel#144
* jwplayer/jwplayer-ads-vast#466

#### Addresses Issue(s):
JW8-2057
JW8-2292