### PR TITLE
Use fastSeek when scrubbing

### DIFF
--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -304,9 +304,11 @@ export default class MediaController extends Eventable {
 
     set position(pos) {
         const { provider } = this;
-        const { fastSeek } = provider;
-        const seek = this.model.get('scrubbing') && fastSeek ? fastSeek : provider.seek;
-        seek(pos);
+        if (this.model.get('scrubbing') && provider.fastSeek) {
+            provider.fastSeek(pos);
+        } else {
+            provider.seek(pos);
+        }
     }
 
     set quality(index) {

--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -303,7 +303,10 @@ export default class MediaController extends Eventable {
     }
 
     set position(pos) {
-        this.provider.seek(pos);
+        const { provider } = this;
+        const { fastSeek } = provider;
+        const seek = this.model.get('scrubbing') && fastSeek ? fastSeek : provider.seek;
+        seek(pos);
     }
 
     set quality(index) {


### PR DESCRIPTION
### This PR will...
- call `fastSeek` when seek is called while scrubbing and fastSeek is available.
### Why is this Pull Request needed?
- certain providers support an imprecise seek (a.k.a fastSeek) which allows a frame to appear sooner. We want to use `fastSeek` while scrubbing because we prefer a quicker frame rendition over frame precision.
### Are there any points in the code the reviewer needs to double check?
In my opinion an if statement would read better, but the ternary operator minifies better so i chose the latter. Any thoughts ?
### Are there any Pull Requests open in other repos which need to be merged with this?
n/a
#### Addresses Issue(s):

JW8-2379

