### PR TITLE
Remove video element after ad playback on mobile SDK

### DIFF
--- a/src/js/program/ad-program-controller.js
+++ b/src/js/program/ad-program-controller.js
@@ -11,6 +11,7 @@ export default class AdProgramController extends ProgramController {
         this.playerModel = model;
         this.provider = null;
         this.backgroundLoading = model.get('backgroundLoading');
+        this.isSDK = model.get('sdkplatform');
 
         adModel.mediaModel.attributes.mediaType = 'video';
 
@@ -145,7 +146,7 @@ export default class AdProgramController extends ProgramController {
 
         // We only use one media element from ads; getPrimedElement will return it
         const mediaElement = mediaPool.getPrimedElement();
-        if (!this.backgroundLoading) {
+        if (!this.backgroundLoading && !this.isSDK) {
             if (mediaElement) {
                 mediaElement.removeEventListener('emptied', this.srcResetListener);
                 // Reset the player media model if the src was changed externally


### PR DESCRIPTION
### This PR will...
Remove video element after ad playback on mobile SDK

### Why is this Pull Request needed?
Mobile SDK uses the video element on our player ONLY for VPAID ads.
The content player (called "ExoPlayer") is behind our player.
Not removing the video tag after the VPAID ads result the content to be hidden at the back of the video tag.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-2241
