### PR TITLE
Ensure playback label is centered in IE

### DIFF
--- a/src/css/controls/imports/playback-label.less
+++ b/src/css/controls/imports/playback-label.less
@@ -8,6 +8,8 @@
     text-indent: 0.35em;
     top: 100%;
     white-space: nowrap;
+    left: 50%;
+    transform: translateX(-50%);
 }
 
 .jw-idle-label {


### PR DESCRIPTION
### This PR will...

Add `left` and `transform` properties to the `.jw-idle-icon-text`class to center the text in Internet Explorer.

### Why is this Pull Request needed?

(Seemingly) a bug in IE was preventing Flexbox from working its magic.

### Are there any points in the code the reviewer needs to double check?

No.

### Are there any Pull Requests open in other repos which need to be merged with this?

No.

#### Addresses Issue(s):

JW8-2360

