### PR TITLE
Fallback to model's state when video element is absent

### DIFF
--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -121,7 +121,7 @@ export default class MediaController extends Eventable {
             playReason
         });
         // Immediately set player state to buffering if these conditions are met
-        if (video && !video.paused) {
+        if (video ? !video.paused : model.get(PLAYER_STATE) !== STATE_PAUSED) {
             model.set(PLAYER_STATE, STATE_BUFFERING);
         }
 

--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -7,7 +7,7 @@ import { MediaModel } from 'controller/model';
 import { seconds } from 'utils/strings';
 import {
     MEDIA_PLAY_ATTEMPT, MEDIA_PLAY_ATTEMPT_FAILED, MEDIA_COMPLETE,
-    PLAYER_STATE, STATE_PAUSED, STATE_BUFFERING, STATE_COMPLETE,
+    PLAYER_STATE, STATE_PAUSED, STATE_PLAYING, STATE_BUFFERING, STATE_COMPLETE,
     MEDIA_VISUAL_QUALITY
 } from 'events/events';
 
@@ -121,7 +121,7 @@ export default class MediaController extends Eventable {
             playReason
         });
         // Immediately set player state to buffering if these conditions are met
-        if (video ? !video.paused : model.get(PLAYER_STATE) !== STATE_PAUSED) {
+        if (video ? !video.paused : model.get(PLAYER_STATE) === STATE_PLAYING) {
             model.set(PLAYER_STATE, STATE_BUFFERING);
         }
 


### PR DESCRIPTION
### This PR will...
- check the model's state when the video element is absent.
### Why is this Pull Request needed?
- The Mobile SDKs render video natively, therefore the webView in which jwplayer.js runs does not have a video tag. Since the video tag is absent, the buffer state is never set on the model; as a result, the state stays at `playing`, so the change required to activate the `playHandler` in adPlayer.js never gets triggered, preventing adImpressions from firing in adPods. 
By falling back to the model's state, we can ensure a consistent experience across all platforms.
### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?
#### Addresses Issue(s):

SDK Channel 5

