### PR TITLE
Fix starttime regression

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -613,7 +613,7 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
             seekPos += seekRange.start + seekRange.end;
         }
         if (!_canSeek) {
-            _canSeek = !!seekRange.end;
+            _canSeek = !!_getSeekableEnd();
         }
         if (_canSeek) {
             _delayedSeek = 0;


### PR DESCRIPTION
### This PR will...
Fix iOS regression with seek before the start of the content using `starttime` from the following commit: https://github.com/jwplayer/jwplayer/commit/9e40fccb989592939dd7aa32858615b3a9b26c9b

### Why is this Pull Request needed?
`getSeekRange` returns `end: _videotag.duration` when `_videotag.seekable` does not have a length.
This results `end` of `seekRange` to be defined as the duration of the video when there should be no `seekable` range, and therefore tries to seek instead of delaying the seek attempt until the video is ready.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-2423

