### PR TITLE
RTL truncation support

### DIFF
--- a/src/css/controls/imports/nextup.less
+++ b/src/css/controls/imports/nextup.less
@@ -95,6 +95,7 @@
 .jw-nextup-title {
     overflow: hidden;
     text-overflow: ellipsis;
+    direction: unset;
     white-space: nowrap;
     width: 100%;
 }

--- a/src/css/controls/imports/nextup.less
+++ b/src/css/controls/imports/nextup.less
@@ -95,7 +95,6 @@
 .jw-nextup-title {
     overflow: hidden;
     text-overflow: ellipsis;
-    direction: unset;
     white-space: nowrap;
     width: 100%;
 }

--- a/src/css/controls/imports/tooltip.less
+++ b/src/css/controls/imports/tooltip.less
@@ -155,6 +155,7 @@
         height: 100%;
         white-space: nowrap;
         text-overflow: ellipsis;
+        direction: unset;
         max-width: 246px;
         overflow: hidden;
     }

--- a/src/css/jwplayer/imports/reset.less
+++ b/src/css/jwplayer/imports/reset.less
@@ -1,22 +1,7 @@
 .jw-reset {
-    color: inherit;
-    background-color: transparent;
-    padding: 0;
-    margin: 0;
-    float: none;
-    font-family: Arial, Helvetica, sans-serif;
-    font-size: 1em;
-    line-height: 1em;
-    list-style: none;
+    &:extend(.jw-reset-text);
     text-align: left;
-    text-transform: none;
-    vertical-align: baseline;
-    border: 0;
     direction: ltr;
-    font-variant: inherit;
-    font-stretch: inherit;
-    /* non-standard prefixed style used in Chrome, Safari, and some MS browsers.  Not Autoprefixed */
-    -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
 }
 
 .jw-reset-text {

--- a/src/css/jwplayer/imports/reset.less
+++ b/src/css/jwplayer/imports/reset.less
@@ -18,3 +18,22 @@
     /* non-standard prefixed style used in Chrome, Safari, and some MS browsers.  Not Autoprefixed */
     -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
 }
+
+.jw-reset-text {
+    color: inherit;
+    background-color: transparent;
+    padding: 0;
+    margin: 0;
+    float: none;
+    font-family: Arial, Helvetica, sans-serif;
+    font-size: 1em;
+    line-height: 1em;
+    list-style: none;
+    text-transform: none;
+    vertical-align: baseline;
+    border: 0;
+    font-variant: inherit;
+    font-stretch: inherit;
+    /* non-standard prefixed style used in Chrome, Safari, and some MS browsers.  Not Autoprefixed */
+    -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+}

--- a/src/css/jwplayer/imports/title.less
+++ b/src/css/jwplayer/imports/title.less
@@ -16,6 +16,7 @@
     padding-bottom: 0.5em;
     overflow: hidden;
     text-overflow: ellipsis;
+    direction: unset;
     white-space: nowrap;
     width: 100%;
 }

--- a/src/js/view/controls/components/simple-tooltip.js
+++ b/src/js/view/controls/components/simple-tooltip.js
@@ -2,10 +2,12 @@ import { addClass, removeClass } from 'utils/dom';
 
 export function SimpleTooltip(attachToElement, name, text, openCallback, closeCallback) {
     const tooltipElement = document.createElement('div');
-    tooltipElement.className = `jw-reset jw-tooltip jw-tooltip-${name}`;
+    tooltipElement.className = `jw-reset-text jw-tooltip jw-tooltip-${name}`;
+    tooltipElement.setAttribute('dir', 'auto');
 
     const textElement = document.createElement('div');
     textElement.className = 'jw-text';
+
     textElement.textContent = text;
 
     tooltipElement.appendChild(textElement);

--- a/src/js/view/controls/components/simple-tooltip.js
+++ b/src/js/view/controls/components/simple-tooltip.js
@@ -7,7 +7,6 @@ export function SimpleTooltip(attachToElement, name, text, openCallback, closeCa
 
     const textElement = document.createElement('div');
     textElement.className = 'jw-text';
-
     textElement.textContent = text;
 
     tooltipElement.appendChild(textElement);

--- a/src/js/view/controls/templates/nextup.js
+++ b/src/js/view/controls/templates/nextup.js
@@ -5,7 +5,7 @@ export default (header = '', title = '', duration = '', closeAriaLabel = '') => 
                 `<div class="jw-nextup-thumbnail jw-reset"></div>` +
                 `<div class="jw-nextup-body jw-reset">` +
                     `<div class="jw-nextup-header jw-reset">${header}</div>` +
-                    `<div class="jw-nextup-title jw-reset">${title}</div>` +
+                    `<div class="jw-nextup-title jw-reset-text" dir="auto">${title}</div>` +
                     `<div class="jw-nextup-duration jw-reset">${duration}</div>` +
                 `</div>` +
             `</div>` +

--- a/src/templates/error.js
+++ b/src/templates/error.js
@@ -6,11 +6,11 @@ export default (id, message, errorCode, code) => {
                 `<style>` +
                 `[id="${id}"].jw-error{background:#000;overflow:hidden;position:relative}` +
                 `[id="${id}"] .jw-error-msg{top:50%;left:50%;position:absolute;transform:translate(-50%,-50%)}` +
-                `[id="${id}"] .jw-error-text{color:#FFF;font:14px/1.35 Arial,Helvetica,sans-serif}` +
+                `[id="${id}"] .jw-error-text{text-align:start;color:#FFF;font:14px/1.35 Arial,Helvetica,sans-serif}` +
                 `</style>` +
                 `<div class="jw-icon jw-reset"></div>` +
                 `<div class="jw-info-container jw-reset">` +
-                    `<div class="jw-error-text jw-reset">${(message || '')}<span class="jw-break jw-reset"></span>${detail}</div>` +
+                    `<div class="jw-error-text jw-reset-text" dir="auto">${(message || '')}<span class="jw-break jw-reset"></span>${detail}</div>` +
                 `</div>` +
             `</div>` +
         `</div>`

--- a/src/templates/player.js
+++ b/src/templates/player.js
@@ -7,9 +7,9 @@ export default (id, ariaLabel = '') => {
                 `<div class="jw-aspect jw-reset"></div>` +
                 `<div class="jw-media jw-reset"></div>` +
                 `<div class="jw-preview jw-reset"></div>` +
-                `<div class="jw-title jw-reset">` +
-                    `<div class="jw-title-primary jw-reset"></div>` +
-                    `<div class="jw-title-secondary jw-reset"></div>` +
+                `<div class="jw-title jw-reset-text" dir="auto">` +
+                    `<div class="jw-title-primary jw-reset-text"></div>` +
+                    `<div class="jw-title-secondary jw-reset-text"></div>` +
                 `</div>` +
                 `<div class="jw-overlays jw-reset"></div>` +
             `</div>` +


### PR DESCRIPTION
### This PR will...
- add `jw-reset-text` css class which excludes `direction: ltr` and `text-align: left`
- `jw-reset` extends `jw-reset-text`
- add `dir='auto'` and the `jw-reset-text` class on element which are generally truncated
### Why is this Pull Request needed?
`direction: ltr` and `text-align: left` prevent dir='auto' from properly aligning rtl text
### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-plugin-related/pull/364
#### Addresses Issue(s):
JW8-2407

