### PR TITLE
Feature/hls manifest metadata daterange cues

### DIFF
--- a/src/js/events/events.js
+++ b/src/js/events/events.js
@@ -308,6 +308,11 @@ export const MEDIA_MUTE = 'mute';
 
 /**
  * Fired when metadata embedded in the media file is obtained.
+ */
+export const MEDIA_META_CUE_PARSED = 'metadataCueParsed';
+
+/**
+ * Fired when metadata embedded in the media file is obtained.
 */
 export const MEDIA_META = 'meta';
 


### PR DESCRIPTION
### This PR will...
- Add "metadataCueParsed" event constant
- Expose methods for triggering metadata text track events before on "cuechange"

### Why is this Pull Request needed?
This allows media providers to implement "metadataCueParsed" events, and trigger "meta" events for text track metadata with more accuracy (before a "timeupdate" event past the metadata start time is fired).

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/6010

#### Addresses Issue(s):
JW8-107

