### PR TITLE
Add border when focused with keyboard

### DIFF
--- a/src/css/jwplayer/imports/jwplayerlayout.less
+++ b/src/css/jwplayer/imports/jwplayerlayout.less
@@ -33,7 +33,6 @@
         display: none;
     }
 
-    &.jw-no-focus:focus,
     .jw-swf {
         outline: none;
     }
@@ -41,6 +40,10 @@
     &.jw-ie:focus {
         outline: #585858 dotted 1px;
     }
+}
+
+.jw-no-focus:focus {
+    outline: none;
 }
 
 .jw-media,

--- a/src/css/shared-imports/mixins.less
+++ b/src/css/shared-imports/mixins.less
@@ -115,7 +115,6 @@
         &:not(.jw-flag-touch) .jw-button-color:not(.jw-logo-button) {
             &:focus,
             &:hover {
-                outline: none;
                 color: @hover-color;
             }
         }
@@ -165,7 +164,6 @@
 
         .jw-skip {
             padding: @ui-padding;
-            outline: none;
 
             .jw-skiptext,
             .jw-skip-icon {

--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -52,6 +52,32 @@ export function addClass(element, classes) {
     setClassName(element, originalClasses.join(' '));
 }
 
+function addNoFocusClass(element, focusElements) {
+    addClass(element, 'jw-no-focus');
+    focusElements.forEach((el) => {
+        addClass(el, 'jw-no-focus');
+    });
+}
+
+
+export function addFocusHandler(element, focusElements) {
+    focusElements = focusElements || [];
+    element.addEventListener('mousedown', () => {
+        addNoFocusClass(element, focusElements);
+    });
+
+    element.addEventListener('touchstart', () => {
+        addNoFocusClass(element, focusElements);
+    });
+
+    element.addEventListener('blur', () => {
+        removeClass(element, 'jw-no-focus');
+        focusElements.forEach((el) => {
+            removeClass(el, 'jw-no-focus');
+        });
+    });
+}
+
 export function removeClass(element, c) {
     const originalClasses = classNameArray(element);
     const removeClasses = Array.isArray(c) ? c : c.split(' ');

--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -2,6 +2,7 @@ import { OS, Features } from 'environment/environment';
 import { DRAG, DRAG_START, DRAG_END, CLICK, DOUBLE_CLICK, MOVE, OUT, TAP, DOUBLE_TAP, OVER, ENTER } from 'events/events';
 import Eventable from 'utils/eventable';
 import { now } from 'utils/date';
+import { addFocusHandler } from 'utils/dom';
 
 const TOUCH_SUPPORT = ('ontouchstart' in window);
 const USE_POINTER_EVENTS = ('PointerEvent' in window) && !OS.android;
@@ -37,6 +38,8 @@ export default class UI extends Eventable {
         this.pointerId = null;
         this.startX = 0;
         this.startY = 0;
+
+        addFocusHandler(element, options.focusElements);
     }
 
     on(name, callback, context) {

--- a/src/js/view/controls/components/button.js
+++ b/src/js/view/controls/components/button.js
@@ -1,5 +1,6 @@
 import UI from 'utils/ui';
 import svgParse from 'utils/svgParser';
+import { addFocusHandler } from 'utils/dom';
 
 export default function (icon, apiAction, ariaText, svgIcons) {
     const element = document.createElement('div');
@@ -21,9 +22,7 @@ export default function (icon, apiAction, ariaText, svgIcons) {
 
     // Prevent button from being focused on mousedown so that the tooltips don't remain visible until
     // the user interacts with another element on the page
-    element.addEventListener('mousedown', (e) => {
-        e.preventDefault();
-    });
+    addFocusHandler(element);
 
     if (svgIcons) {
         Array.prototype.forEach.call(svgIcons, svgIcon => {

--- a/src/js/view/controls/play-display-icon.js
+++ b/src/js/view/controls/play-display-icon.js
@@ -12,7 +12,7 @@ export default class PlayDisplayIcon {
         this.icon = iconDisplay;
         this.el = element;
 
-        new UI(this.el).on('click tap enter', (evt) => {
+        new UI(this.el, { focusElements: [ iconDisplay ] }).on('click tap enter', (evt) => {
             this.trigger(evt.type);
         });
 


### PR DESCRIPTION
### This PR will...
Add border when focused with keyboard

### Why is this Pull Request needed?
It is not apparent which element is focused. We want the viewer to know what element is focused when using keyboard.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-2330
