### PR TITLE
Remove code to trigger meta events for activeCues before time update

### DIFF
--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -34,7 +34,6 @@ const Tracks = {
     addCaptionsCue,
     addVTTCue,
     addVTTCuesToTrack,
-    findCuesInRange,
     triggerActiveCues,
     renderNatively: false
 };
@@ -608,17 +607,6 @@ function _clearSideloadedTextTracks() {
 
 function _cueChangeHandler(e) {
     this.triggerActiveCues(e.currentTarget.activeCues);
-}
-
-function findCuesInRange(start, end) {
-    const tracksById = this._tracksById;
-    if (tracksById) {
-        const track = tracksById.nativemetadata;
-        if (track) {
-            return Array.prototype.filter.call(track.cues, cue => (end >= cue.startTime && start <= cue.endTime));
-        }
-    }
-    return null;
 }
 
 function triggerActiveCues(activeCues) {


### PR DESCRIPTION
### This PR will...
Remove code to trigger meta events for activeCues before time update

### Why is this Pull Request needed?
`findCuesInRange` was used to identify active cues before the `oncuechange` event but it could also return cues which are already active.

#### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/6052

#### Addresses Issue(s):
JW8-107

