### PR TITLE
Add metadata type to "meta" events

### DIFF
--- a/src/js/program/program-listeners.js
+++ b/src/js/program/program-listeners.js
@@ -59,6 +59,9 @@ export function ProviderListener(mediaController) {
                 }
                 break;
             case MEDIA_META: {
+                if (!data.metadataType) {
+                    data.metadataType = 'unknown';
+                }
                 const duration = data.duration;
                 if (isValidNumber(duration)) {
                     mediaModel.set('seekRange', data.seekRange);

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -105,9 +105,11 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
                 duration = 0;
             }
             const metadata = {
+                metadataType: 'media',
                 duration: duration,
                 height: _videotag.videoHeight,
-                width: _videotag.videoWidth
+                width: _videotag.videoWidth,
+                seekRange: _this.getSeekRange()
             };
             _this.trigger(MEDIA_META, metadata);
             checkVisualQuality();

--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -636,6 +636,10 @@ function triggerActiveCues(activeCues) {
             if (metadata.programDateTime) {
                 event.programDateTime = metadata.programDateTime;
             }
+            if (metadata.metadataType) {
+                event.metadataType = metadata.metadataType;
+                delete metadata.metadataType;
+            }
             this.trigger(MEDIA_META, event);
         }
         return false;
@@ -644,6 +648,7 @@ function triggerActiveCues(activeCues) {
     if (dataCues.length) {
         const metadata = parseID3(dataCues);
         this.trigger(MEDIA_META, {
+            metadataType: 'id3',
             metadataTime,
             metadata
         });

--- a/src/js/providers/video-listener-mixin.js
+++ b/src/js/providers/video-listener-mixin.js
@@ -25,6 +25,7 @@ const VideoListenerMixin = {
 
     loadedmetadata() {
         const metadata = {
+            metadataType: 'media',
             duration: this.getDuration(),
             height: this.video.videoHeight,
             width: this.video.videoWidth,

--- a/test/unit/program-controller-test.js
+++ b/test/unit/program-controller-test.js
@@ -37,7 +37,8 @@ const providerEvents = [
         type: 'levels'
     },
     {
-        type: 'meta'
+        type: 'meta',
+        metadataType: 'unknown'
     },
     {
         type: 'subtitlesTracks'


### PR DESCRIPTION
### This PR will...
- Add `metadataType` property to "meta" events
- `metadataType` is defined by providers triggering the "meta" event
- For providers using the tracks-mixin for timed metadata, `metadataType` is copied from JSON in VTT cue text
- "meta" events triggered on the video tag's "loadedmetadata" event is assigned a `metadataType` of "media"
- When undefined, `metadataType` is assigned a value of "unknown" 
- Added missing `seekRange` property to html5 media "meta" event

### Why is this Pull Request needed?
`metadataType` provides information about what to expect in the "meta" event object.

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/6053

#### Addresses Issue(s):
JW8-2448

