### PR TITLE
[REVIEW] Let keyboard shortcut seek be announced by accessibility

### DIFF
--- a/src/css/jwplayer/imports/jwplayerlayout.less
+++ b/src/css/jwplayer/imports/jwplayerlayout.less
@@ -97,3 +97,15 @@
     right: 0;
     bottom: 0;
 }
+
+/* Visually hidden element that is recognized by accessibility */
+.jw-hidden-accessibility {
+    border: 0;
+    clip: rect(0 0 0 0);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    width: 1px;
+}

--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -69,13 +69,14 @@ function reasonInteraction() {
 }
 
 class TimeSlider extends Slider {
-    constructor(_model, _api, _playerContainer) {
+    constructor(_model, _api, _accessibilityContainer) {
         super('jw-slider-time', 'horizontal');
 
         this._model = _model;
         this._api = _api;
 
-        this.accessibilityContainer = _playerContainer.querySelector('.jw-hidden-accessibility');
+        this.accessibilityContainer = _accessibilityContainer;
+        this.timeUpdateKeeper = _accessibilityContainer.querySelector('.jw-time-update');
 
         this.timeTip = new TimeTip('jw-tooltip-time', null, true);
         this.timeTip.setup();
@@ -112,11 +113,6 @@ class TimeSlider extends Slider {
         setAttribute(this.el, 'aria-label', this._model.get('localization').slider);
         this.el.removeAttribute('aria-hidden');
         this.elementRail.appendChild(this.timeTip.element());
-
-        this.timeUpdateKeeper = document.createElement('p');
-        setAttribute(this.timeUpdateKeeper, 'aria-live', 'assertive');
-
-        this.accessibilityContainer.appendChild(this.timeUpdateKeeper);
 
         // Show the tooltip on while dragging (touch) moving(mouse), or moving over(mouse)
         this.ui = (this.ui || new UI(this.el))
@@ -305,7 +301,7 @@ class TimeSlider extends Slider {
         } else {
             ariaText = `${timeFormat(position)} of ${timeFormat(duration)}`;
         }
-        this.timeUpdateKeeper.innerHTML = ariaText;
+        this.timeUpdateKeeper.textContent = ariaText;
         setAttribute(this.el, 'aria-valuetext', ariaText);
     }
 

--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -69,13 +69,13 @@ function reasonInteraction() {
 }
 
 class TimeSlider extends Slider {
-    constructor(_model, _api) {
+    constructor(_model, _api, _playerContainer) {
         super('jw-slider-time', 'horizontal');
 
         this._model = _model;
         this._api = _api;
 
-        this.accessibilityContainer = _api.getContainer().querySelector('.jw-hidden-accessibility');
+        this.accessibilityContainer = _playerContainer.querySelector('.jw-hidden-accessibility');
 
         this.timeTip = new TimeTip('jw-tooltip-time', null, true);
         this.timeTip.setup();

--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -75,6 +75,8 @@ class TimeSlider extends Slider {
         this._model = _model;
         this._api = _api;
 
+        this.accessibilityContainer = _api.getContainer().querySelector('.jw-hidden-accessibility');
+
         this.timeTip = new TimeTip('jw-tooltip-time', null, true);
         this.timeTip.setup();
 
@@ -110,6 +112,11 @@ class TimeSlider extends Slider {
         setAttribute(this.el, 'aria-label', this._model.get('localization').slider);
         this.el.removeAttribute('aria-hidden');
         this.elementRail.appendChild(this.timeTip.element());
+
+        this.timeUpdateKeeper = document.createElement('p');
+        setAttribute(this.timeUpdateKeeper, 'aria-live', 'assertive');
+
+        this.accessibilityContainer.appendChild(this.timeUpdateKeeper);
 
         // Show the tooltip on while dragging (touch) moving(mouse), or moving over(mouse)
         this.ui = (this.ui || new UI(this.el))
@@ -298,6 +305,7 @@ class TimeSlider extends Slider {
         } else {
             ariaText = `${timeFormat(position)} of ${timeFormat(duration)}`;
         }
+        this.timeUpdateKeeper.innerHTML = ariaText;
         setAttribute(this.el, 'aria-valuetext', ariaText);
     }
 

--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -75,7 +75,6 @@ class TimeSlider extends Slider {
         this._model = _model;
         this._api = _api;
 
-        this.accessibilityContainer = _accessibilityContainer;
         this.timeUpdateKeeper = _accessibilityContainer.querySelector('.jw-time-update');
 
         this.timeTip = new TimeTip('jw-tooltip-time', null, true);

--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -69,13 +69,13 @@ function reasonInteraction() {
 }
 
 class TimeSlider extends Slider {
-    constructor(_model, _api, _accessibilityContainer) {
+    constructor(_model, _api, _timeUpdateKeeper) {
         super('jw-slider-time', 'horizontal');
 
         this._model = _model;
         this._api = _api;
 
-        this.timeUpdateKeeper = _accessibilityContainer.querySelector('.jw-time-update');
+        this.timeUpdateKeeper = _timeUpdateKeeper;
 
         this.timeTip = new TimeTip('jw-tooltip-time', null, true);
         this.timeTip.setup();

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -111,13 +111,13 @@ const appendChildren = (container, elements) => {
 };
 
 export default class Controlbar {
-    constructor(_api, _model, _playerContainer) {
+    constructor(_api, _model, _accessibilityContainer) {
         Object.assign(this, Events);
         this._api = _api;
         this._model = _model;
         this._isMobile = OS.mobile;
         const localization = _model.get('localization');
-        const timeSlider = new TimeSlider(_model, _api, _playerContainer);
+        const timeSlider = new TimeSlider(_model, _api, _accessibilityContainer);
         let volumeTooltip;
         let muteButton;
         let feedShownId = '';

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -111,13 +111,13 @@ const appendChildren = (container, elements) => {
 };
 
 export default class Controlbar {
-    constructor(_api, _model) {
+    constructor(_api, _model, _playerContainer) {
         Object.assign(this, Events);
         this._api = _api;
         this._model = _model;
         this._isMobile = OS.mobile;
         const localization = _model.get('localization');
-        const timeSlider = new TimeSlider(_model, _api);
+        const timeSlider = new TimeSlider(_model, _api, _playerContainer);
         let volumeTooltip;
         let muteButton;
         let feedShownId = '';

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -117,7 +117,7 @@ export default class Controlbar {
         this._model = _model;
         this._isMobile = OS.mobile;
         const localization = _model.get('localization');
-        const timeSlider = new TimeSlider(_model, _api, _accessibilityContainer);
+        const timeSlider = new TimeSlider(_model, _api, _accessibilityContainer.querySelector('.jw-time-update'));
         let volumeTooltip;
         let muteButton;
         let feedShownId = '';

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -55,7 +55,6 @@ export default class Controls {
         this.nextUpToolTip = null;
         this.playerContainer = playerContainer;
         this.wrapperElement = playerContainer.querySelector('.jw-wrapper');
-        this.accessibilityContainer = playerContainer.querySelector('.jw-hidden-accessibility');
         this.rightClickMenu = null;
         this.settingsMenu = null;
         this.showing = false;
@@ -122,7 +121,8 @@ export default class Controls {
         }
 
         // Controlbar
-        const controlbar = this.controlbar = new Controlbar(api, model, this.accessibilityContainer);
+        const controlbar = this.controlbar = new Controlbar(api, model,
+            this.playerContainer.querySelector('.jw-hidden-accessibility'));
         controlbar.on(USER_ACTION, () => this.userActive());
         controlbar.on('nextShown', function (data) {
             this.trigger('nextShown', data);

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -55,6 +55,7 @@ export default class Controls {
         this.nextUpToolTip = null;
         this.playerContainer = playerContainer;
         this.wrapperElement = playerContainer.querySelector('.jw-wrapper');
+        this.accessibilityContainer = playerContainer.querySelector('.jw-hidden-accessibility');
         this.rightClickMenu = null;
         this.settingsMenu = null;
         this.showing = false;
@@ -121,7 +122,7 @@ export default class Controls {
         }
 
         // Controlbar
-        const controlbar = this.controlbar = new Controlbar(api, model, this.playerContainer);
+        const controlbar = this.controlbar = new Controlbar(api, model, this.accessibilityContainer);
         controlbar.on(USER_ACTION, () => this.userActive());
         controlbar.on('nextShown', function (data) {
             this.trigger('nextShown', data);

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -121,7 +121,7 @@ export default class Controls {
         }
 
         // Controlbar
-        const controlbar = this.controlbar = new Controlbar(api, model);
+        const controlbar = this.controlbar = new Controlbar(api, model, this.playerContainer);
         controlbar.on(USER_ACTION, () => this.userActive());
         controlbar.on('nextShown', function (data) {
             this.trigger('nextShown', data);

--- a/src/templates/player.js
+++ b/src/templates/player.js
@@ -12,6 +12,7 @@ export default (id, ariaLabel = '') => {
                     `<div class="jw-title-secondary jw-reset-text"></div>` +
                 `</div>` +
                 `<div class="jw-overlays jw-reset"></div>` +
+                `<div class="jw-hidden-accessibility"></div>` +
             `</div>` +
         `</div>`
     );

--- a/src/templates/player.js
+++ b/src/templates/player.js
@@ -12,7 +12,9 @@ export default (id, ariaLabel = '') => {
                     `<div class="jw-title-secondary jw-reset-text"></div>` +
                 `</div>` +
                 `<div class="jw-overlays jw-reset"></div>` +
-                `<div class="jw-hidden-accessibility"></div>` +
+                `<div class="jw-hidden-accessibility">` +
+                    `<p class="jw-time-update" aria-live="assertive"></p>` +
+                `</div>` +
             `</div>` +
         `</div>`
     );

--- a/test/unit/controlbar-test.js
+++ b/test/unit/controlbar-test.js
@@ -15,6 +15,7 @@ model.mediaController.on.returnsThis();
 
 describe('Control Bar', function() {
 
+    let playerContainer;
     let controlBar;
     let container;
     let children;
@@ -24,11 +25,16 @@ describe('Control Bar', function() {
         spacer.className += 'jw-spacer';
         const settingsButton = document.createElement('div');
 
+        const accessible = document.createElement('div');
+        accessible.className = 'jw-hidden-accessibility';
+        playerContainer = document.createElement('div');
+        playerContainer.appendChild(accessible);
+
         container = document.createElement('div');
         container.appendChild(settingsButton);
         container.appendChild(spacer);
 
-        controlBar = new ControlBar({}, model);
+        controlBar = new ControlBar({}, model, playerContainer);
         controlBar.elements.spacer = spacer;
         controlBar.elements.settingsButton = settingsButton;
         controlBar.elements.buttonContainer = container;

--- a/test/unit/controlbar-test.js
+++ b/test/unit/controlbar-test.js
@@ -15,7 +15,7 @@ model.mediaController.on.returnsThis();
 
 describe('Control Bar', function() {
 
-    let playerContainer;
+    let accessibilityContainer;
     let controlBar;
     let container;
     let children;
@@ -27,14 +27,14 @@ describe('Control Bar', function() {
 
         const accessible = document.createElement('div');
         accessible.className = 'jw-hidden-accessibility';
-        playerContainer = document.createElement('div');
-        playerContainer.appendChild(accessible);
+        accessibilityContainer = document.createElement('div');
+        accessibilityContainer.appendChild(accessible);
 
         container = document.createElement('div');
         container.appendChild(settingsButton);
         container.appendChild(spacer);
 
-        controlBar = new ControlBar({}, model, playerContainer);
+        controlBar = new ControlBar({}, model, accessibilityContainer);
         controlBar.elements.spacer = spacer;
         controlBar.elements.settingsButton = settingsButton;
         controlBar.elements.buttonContainer = container;


### PR DESCRIPTION
### This PR will...
- Add visually hidden div to the player
- Add seek time update to the visually hidden div
- Make the seek time update `aria-live="assertive"` to have assistive technology announce every change

### Why is this Pull Request needed?
- We want assistive technologies to announce time change from user interactive.
- Assistive technologies does not announce changes to hidden elements, so we are adding a "fake" hidden element (from: https://www.w3.org/WAI/tutorials/forms/labels/)

### Are there any points in the code the reviewer needs to double check?
This may not be an ideal solution. If you have suggestions on how to do this better, please let me know.

We are adding `jw-hidden-accessibility` to `jw-wrapper`, because the user can seek with keyboard without having focus on the controlbar. If we add the div to the controlbar instead of `jw-wrapper`, the changes are not announced when controlbar is not showing.

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):
JW8-2467

