### PR TITLE
Improve focus border on keyboard tab

### DIFF
--- a/src/css/controls/imports/display.less
+++ b/src/css/controls/imports/display.less
@@ -52,6 +52,10 @@ display icons
     padding: (@mobile-touch-target * 0.125);
     margin: 0 (@mobile-touch-target * 0.5);
 
+    &.jw-no-focus .jw-icon svg {
+        outline: none;
+    }
+
     .jw-icon {
         .square(75px);
         cursor: pointer;
@@ -67,10 +71,6 @@ display icons
 
         .jw-svg-icon-rewind {
             padding: 0.2em 0.05em;
-        }
-
-        &&.jw-no-focus svg {
-            outline: none;
         }
     }
 }

--- a/src/css/controls/imports/skipad.less
+++ b/src/css/controls/imports/skipad.less
@@ -13,7 +13,7 @@
     align-items: center;
     height: 2em;
 
-    &:focus {
+    &:focus&:not(.jw-no-focus) {
         outline: @ui-focus;
     }
 

--- a/src/css/controls/imports/tooltip.less
+++ b/src/css/controls/imports/tooltip.less
@@ -1,6 +1,6 @@
 @import "../../shared-imports/vars.less";
 
-.jw-icon-tooltip.jw-open:not(.jw-no-focus) .jw-overlay {
+.jw-icon-tooltip.jw-open .jw-overlay {
     opacity: 1;
     transition-delay: 0s;
     visibility: visible;

--- a/src/css/shared-imports/mixins.less
+++ b/src/css/shared-imports/mixins.less
@@ -190,7 +190,7 @@
                 --disconnected-color: @inactive-color;
 
                 &:focus {
-                    outline: @ui-focus;
+                    outline: none;
                 }
 
                 &.jw-off {
@@ -201,12 +201,21 @@
             &:focus google-cast-launcher {
                 --connected-color: @active-color;
                 --disconnected-color: @hover-color;
-                outline: @ui-focus;
             }
 
             &:hover google-cast-launcher {
                 --connected-color: @hover-color;
                 --disconnected-color: @hover-color;
+            }
+        }
+
+        .jw-icon-cast:not(.jw-no-focus) {
+            &:focus google-cast-launcher {
+                outline: @ui-focus;
+            }
+
+            google-cast-launcher:focus {
+                outline: @ui-focus;
             }
         }
 

--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -52,20 +52,6 @@ export function addClass(element, classes) {
     setClassName(element, originalClasses.join(' '));
 }
 
-export function addFocusHandler(element) {
-    element.addEventListener('mousedown', () => {
-        addClass(element, 'jw-no-focus');
-    });
-
-    element.addEventListener('touchstart', () => {
-        addClass(element, 'jw-no-focus');
-    });
-
-    element.addEventListener('blur', () => {
-        removeClass(element, 'jw-no-focus');
-    });
-}
-
 export function removeClass(element, c) {
     const originalClasses = classNameArray(element);
     const removeClasses = Array.isArray(c) ? c : c.split(' ');

--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -1,8 +1,8 @@
 import { OS, Features } from 'environment/environment';
 import { DRAG, DRAG_START, DRAG_END, CLICK, DOUBLE_CLICK, MOVE, OUT, TAP, DOUBLE_TAP, OVER, ENTER } from 'events/events';
 import Eventable from 'utils/eventable';
+import flagNoFocus from 'view/utils/flag-no-focus';
 import { now } from 'utils/date';
-import { addClass, removeClass } from 'utils/dom';
 
 const TOUCH_SUPPORT = ('ontouchstart' in window);
 const USE_POINTER_EVENTS = ('PointerEvent' in window) && !OS.android;
@@ -38,6 +38,7 @@ export default class UI extends Eventable {
         this.pointerId = null;
         this.startX = 0;
         this.startY = 0;
+        this.noFocusHelper = flagNoFocus(element);
     }
 
     on(name, callback, context) {
@@ -65,6 +66,10 @@ export default class UI extends Eventable {
         this.off();
         if (USE_POINTER_EVENTS) {
             releasePointerCapture(this);
+        }
+        if (this.noFocusHelper) {
+            this.noFocusHelper.destroy();
+            this.noFocusHelper = null;
         }
         this.el = null;
     }
@@ -102,7 +107,6 @@ function initInteractionListeners(ui) {
         ui.startY = pageY;
 
         removeHandlers(ui, WINDOW_GROUP);
-        addClass(ui.el, 'jw-no-focus');
         if (!ui.handlers.blur || !ui.handlers.blur.blur) {
             eventRegisters.blur(ui);
         }
@@ -260,7 +264,6 @@ const eventRegisters = {
         const blur = 'blur';
         addEventListener(ui, blur, blur, (e) => {
             triggerSimpleEvent(ui, blur, e);
-            removeClass(ui.el, 'jw-no-focus');
         });
     },
     over(ui) {

--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -58,6 +58,10 @@ export default class UI extends Eventable {
             Object.keys(handlers).forEach(triggerName => {
                 removeHandlers(this, triggerName);
             });
+            if (this.noFocusHelper) {
+                this.noFocusHelper.destroy();
+                this.noFocusHelper = null;
+            }
         }
         return super.off(name, callback, context);
     }
@@ -66,10 +70,6 @@ export default class UI extends Eventable {
         this.off();
         if (USE_POINTER_EVENTS) {
             releasePointerCapture(this);
-        }
-        if (this.noFocusHelper) {
-            this.noFocusHelper.destroy();
-            this.noFocusHelper = null;
         }
         this.el = null;
     }

--- a/src/js/view/controls/components/button.js
+++ b/src/js/view/controls/components/button.js
@@ -1,6 +1,6 @@
 import UI from 'utils/ui';
 import svgParse from 'utils/svgParser';
-import { addFocusHandler } from 'utils/dom';
+import flagNoFocus from 'view/utils/flag-no-focus';
 
 export default function (icon, apiAction, ariaText, svgIcons) {
     const element = document.createElement('div');
@@ -21,7 +21,7 @@ export default function (icon, apiAction, ariaText, svgIcons) {
     }
 
     // prevent button from having a border when focused through click
-    addFocusHandler(element);
+    flagNoFocus(element);
 
     if (svgIcons) {
         Array.prototype.forEach.call(svgIcons, svgIcon => {

--- a/src/js/view/controls/components/settings/menu.js
+++ b/src/js/view/controls/components/settings/menu.js
@@ -1,7 +1,7 @@
 import { cloneIcon } from 'view/controls/icons';
 import button from 'view/controls/components/button';
 import SettingsMenuTemplate from 'view/controls/templates/settings/menu';
-import { createElement, emptyElement, prependChild, nextSibling, previousSibling } from 'utils/dom';
+import { addClass, createElement, emptyElement, prependChild, nextSibling, previousSibling } from 'utils/dom';
 
 function focusSettingsElement(direction) {
     const settingsIcon = document.getElementsByClassName('jw-icon-settings')[0];
@@ -104,8 +104,9 @@ export function SettingsMenu(onVisibility, onSubmenuAdded, onMenuEmpty, localiza
                 active.categoryButtonElement.focus();
                 return;
             }
-
-            active.element().firstChild.focus();
+            const child = active.element().firstChild;
+            child.focus();
+            addClass(child, 'jw-no-focus');
         },
         close(event) {
             visible = false;

--- a/test/unit/ui-test.js
+++ b/test/unit/ui-test.js
@@ -651,18 +651,18 @@ describe('UI', function() {
 
         spyOnDomEventListenerMethods([ button ]);
         ui = new UI(button);
-        expect(button.addEventListener, 'button without options').to.have.callCount(0);
+        expect(button.addEventListener, 'button without options').to.have.callCount(3);
         ui.destroy();
 
         spyOnDomEventListenerMethods([ button ]);
         ui = new UI(button)
             .on('click tap doubleClick doubleTap dragStart drag dragEnd enter over out focus blur move', () => {});
         if (USE_POINTER_EVENTS) {
-            expect(button.addEventListener, 'button with all listeners').to.have.callCount(7);
+            expect(button.addEventListener, 'button with all listeners').to.have.callCount(10);
         } else if (!USE_MOUSE_EVENTS) {
-            expect(button.addEventListener, 'button with all listeners').to.have.callCount(4);
+            expect(button.addEventListener, 'button with all listeners').to.have.callCount(7);
         } else {
-            expect(button.addEventListener, 'button with all listeners').to.have.callCount(8);
+            expect(button.addEventListener, 'button with all listeners').to.have.callCount(11);
         }
         ui.destroy();
     });
@@ -673,14 +673,14 @@ describe('UI', function() {
             .on('click tap doubleClick doubleTap dragStart drag dragEnd enter over out focus blur move', () => {})
             .off();
         if (USE_POINTER_EVENTS) {
+            expect(button.addEventListener, 'button with all listeners').to.have.callCount(10);
+            expect(button.removeEventListener, 'button with all listeners').to.have.callCount(10);
+        } else if (!USE_MOUSE_EVENTS) {
             expect(button.addEventListener, 'button with all listeners').to.have.callCount(7);
             expect(button.removeEventListener, 'button with all listeners').to.have.callCount(7);
-        } else if (!USE_MOUSE_EVENTS) {
-            expect(button.addEventListener, 'button with all listeners').to.have.callCount(4);
-            expect(button.removeEventListener, 'button with all listeners').to.have.callCount(4);
         } else {
-            expect(button.addEventListener, 'button with all listeners').to.have.callCount(8);
-            expect(button.removeEventListener, 'button with all listeners').to.have.callCount(8);
+            expect(button.addEventListener, 'button with all listeners').to.have.callCount(11);
+            expect(button.removeEventListener, 'button with all listeners').to.have.callCount(11);
         }
         ui.destroy();
     });
@@ -691,14 +691,14 @@ describe('UI', function() {
         const ui = new UI(button).on('click tap doubleClick doubleTap dragStart drag dragEnd enter over out focus blur move', () => {});
         ui.destroy();
         if (USE_POINTER_EVENTS) {
+            expect(button.addEventListener, 'button with all listeners').to.have.callCount(10);
+            expect(button.removeEventListener, 'button with all listeners').to.have.callCount(10);
+        } else if (!USE_MOUSE_EVENTS) {
             expect(button.addEventListener, 'button with all listeners').to.have.callCount(7);
             expect(button.removeEventListener, 'button with all listeners').to.have.callCount(7);
-        } else if (!USE_MOUSE_EVENTS) {
-            expect(button.addEventListener, 'button with all listeners').to.have.callCount(4);
-            expect(button.removeEventListener, 'button with all listeners').to.have.callCount(4);
         } else {
-            expect(button.addEventListener, 'button with all listeners').to.have.callCount(8);
-            expect(button.removeEventListener, 'button with all listeners').to.have.callCount(8);
+            expect(button.addEventListener, 'button with all listeners').to.have.callCount(11);
+            expect(button.removeEventListener, 'button with all listeners').to.have.callCount(11);
         }
     });
 


### PR DESCRIPTION
### This PR will...
- Remove `addFocusHandler` method added in previous commit, and use `flagNoFocus`
- Fix bugs with removing focus border on clicked elements
- Fix a bug with volume tooltip not appearing on hover after clicking on the volume icon

### Why is this Pull Request needed?
Improvements to the previous work

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):
JW8-2477 JW8-2476

