### PR TITLE
Trigger "visualQuality" after "firstFrame"

### DIFF
--- a/src/js/controller/qoe.js
+++ b/src/js/controller/qoe.js
@@ -1,4 +1,11 @@
-import { PLAYLIST_ITEM, MEDIA_PLAY_ATTEMPT, PROVIDER_FIRST_FRAME, MEDIA_TIME, MEDIA_FIRST_FRAME } from 'events/events';
+import {
+    PLAYLIST_ITEM,
+    MEDIA_PLAY_ATTEMPT,
+    PROVIDER_FIRST_FRAME,
+    MEDIA_TIME,
+    MEDIA_FIRST_FRAME,
+    MEDIA_VISUAL_QUALITY
+} from 'events/events';
 import Timer from 'api/timer';
 
 const TAB_HIDDEN = 'tabHidden';
@@ -43,6 +50,18 @@ function trackFirstFrame(model, programController) {
 
         const time = qoeItem.getFirstFrame();
         programController.trigger(MEDIA_FIRST_FRAME, { loadTime: time });
+
+        // Start firing visualQuality once playback has started
+        if (programController.mediaController) {
+            const mediaModel = programController.mediaController.mediaModel;
+            mediaModel.off(`change:${MEDIA_VISUAL_QUALITY}`, null, mediaModel);
+            mediaModel.change(MEDIA_VISUAL_QUALITY, (changedMediaModel, eventData) => {
+                if (eventData) {
+                    programController.trigger(MEDIA_VISUAL_QUALITY, eventData);
+                }
+            }, mediaModel);
+        }
+
         unbindFirstFrameEvents(model, programController);
     };
 

--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -7,8 +7,7 @@ import { MediaModel } from 'controller/model';
 import { seconds } from 'utils/strings';
 import {
     MEDIA_PLAY_ATTEMPT, MEDIA_PLAY_ATTEMPT_FAILED, MEDIA_COMPLETE,
-    PLAYER_STATE, STATE_PAUSED, STATE_PLAYING, STATE_BUFFERING, STATE_COMPLETE,
-    MEDIA_VISUAL_QUALITY
+    PLAYER_STATE, STATE_PAUSED, STATE_PLAYING, STATE_BUFFERING, STATE_COMPLETE
 } from 'events/events';
 
 export default class MediaController extends Eventable {
@@ -132,14 +131,6 @@ export default class MediaController extends Eventable {
             }
             mediaModel.set('started', true);
             if (mediaModel === model.mediaModel) {
-                // Start firing visualQuality once playback has started
-                mediaModel.off(MEDIA_VISUAL_QUALITY, null, this);
-                mediaModel.change(MEDIA_VISUAL_QUALITY, (changedMediaModel, eventData) => {
-                    if (!eventData) {
-                        return;
-                    }
-                    this.trigger(MEDIA_VISUAL_QUALITY, eventData);
-                }, this);
                 syncPlayerWithMediaModel(mediaModel);
             }
         }).catch(error => {

--- a/src/js/providers/video-listener-mixin.js
+++ b/src/js/providers/video-listener-mixin.js
@@ -51,6 +51,7 @@ const VideoListenerMixin = {
             this.stallTime !== currentTime) {
             this.stallTime = -1;
             this.setState(STATE_PLAYING);
+            this.trigger(PROVIDER_FIRST_FRAME);
         }
 
         const timeEventObject = {


### PR DESCRIPTION
### This PR will...
- Trigger "visualQuality" after "firstFrame"
- Fire "providerFirstFrame" when playback starts after seek

### Why is this Pull Request needed?
"visualQuality" events should always follow the "play" event and precede "time" events. Triggering "visualQuality" from the qoe module after "firstFrame" helps ensure this. Doing it after play promises resolved resulted in inconsistent event order because browsers do run video event handlers and play promise handlers synchronously in an order we can rely on.

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/6091

#### Addresses Issue(s):
JW8-2478
