### PR TITLE
Fix initial "buffer" event.reason

### DIFF
--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -7,7 +7,7 @@ import { MediaModel } from 'controller/model';
 import { seconds } from 'utils/strings';
 import {
     MEDIA_PLAY_ATTEMPT, MEDIA_PLAY_ATTEMPT_FAILED, MEDIA_COMPLETE,
-    PLAYER_STATE, STATE_PAUSED, STATE_PLAYING, STATE_BUFFERING, STATE_COMPLETE
+    PLAYER_STATE, STATE_PAUSED, STATE_PLAYING, STATE_LOADING, STATE_COMPLETE
 } from 'events/events';
 
 export default class MediaController extends Eventable {
@@ -121,7 +121,7 @@ export default class MediaController extends Eventable {
         });
         // Immediately set player state to buffering if these conditions are met
         if (video ? !video.paused : model.get(PLAYER_STATE) === STATE_PLAYING) {
-            model.set(PLAYER_STATE, STATE_BUFFERING);
+            mediaModel.set('mediaState', STATE_LOADING);
         }
 
         return playPromise.then(() => {

--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -119,7 +119,7 @@ export default class MediaController extends Eventable {
             item,
             playReason
         });
-        // Immediately set player state to buffering if these conditions are met
+        // Set the media model state to loading which propigates to a player model state of buffering
         if (video ? !video.paused : model.get(PLAYER_STATE) === STATE_PLAYING) {
             mediaModel.set('mediaState', STATE_LOADING);
         }


### PR DESCRIPTION
### Why is this Pull Request needed?
Initial "buffer" `event.reason` should equal "loading" not "idle". Setting the mediaModel's `mediaState` immediately updates the player model state and results in the correct reason being set in `ChangeStateEvent` https://github.com/jwplayer/jwplayer/blob/0ac0e36ae281cc50ec8d7e32c5832ead1e194832/src/js/events/change-state-event.js#L12-L24

### Are there any points in the code the reviewer needs to double check?
Why would we need `mediaModel.mediaState` to remain "idle" in `_playAttempt()`? If there is no reason for it to remain unchanged, then these changes are fine.

#### Addresses Issue(s):
JW8-2483