### PR TITLE
[JW8-2488] enableAdsMode: set initial state to loading.

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -1,5 +1,5 @@
-import { STATE_BUFFERING, STATE_COMPLETE, STATE_PLAYING, STATE_PAUSED,
-    PLAYER_STATE,
+import { STATE_BUFFERING, STATE_COMPLETE, STATE_LOADING, STATE_PLAYING,
+    STATE_PAUSED, PLAYER_STATE,
     MEDIA_META, MEDIA_PLAY_ATTEMPT_FAILED, MEDIA_TIME, MEDIA_COMPLETE,
     PLAYLIST_ITEM, PLAYLIST_COMPLETE,
     INSTREAM_CLICK,
@@ -137,7 +137,7 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
             }
         });
         _model.set('instream', _adProgram);
-        _adProgram.model.set('state', STATE_PLAYING);
+        _adProgram.model.set('state', STATE_LOADING);
         _addClickHandler(clickThroughUrl);
         return this;
     };


### PR DESCRIPTION
### This PR will...
Upon enabling ads mode, set the model state to `loading` rather than `playing`.

### Why is this Pull Request needed?
In #3169 `adPlay` events are only emitted if `oldstate !== newstate`. No `adPlay` event is emitted for DAI since the `oldstate` already is `playing`. Initializing the model state to `loading` instead will trigger an `adPlay`.

Note - currently, when resuming from ad pause, `oldstate` already yields `loading`. Therefore, it make sense to also use `loading` when starting an ad.

### Are there any points in the code the reviewer needs to double check?
N/A

### Are there any Pull Requests open in other repos which need to be merged with this?
N/A

#### Addresses Issue(s):
JW8-2488