### PR TITLE
RTL menu support

### DIFF
--- a/src/css/controls/imports/settings-menu.less
+++ b/src/css/controls/imports/settings-menu.less
@@ -100,6 +100,7 @@
     line-height: 1;
     padding: 7px 0 7px 15px;
     width: 100%;
+    text-align: left;
 
     &:hover {
         color: @hover-color;

--- a/src/js/view/controls/templates/settings/content-item.js
+++ b/src/js/view/controls/templates/settings/content-item.js
@@ -1,6 +1,6 @@
 export default (content) => {
     return (
-        `<button type="button" class="jw-reset jw-settings-content-item" role="menuitemradio" aria-checked="false">` +
+        `<button type="button" class="jw-reset-text jw-settings-content-item" role="menuitemradio" aria-checked="false" dir="auto">` +
             `${content}` +
         `</button>`
     );

--- a/src/js/view/utils/submenu-factory.js
+++ b/src/js/view/utils/submenu-factory.js
@@ -3,6 +3,7 @@ import SettingsSubmenu from 'view/controls/components/settings/submenu';
 import SettingsContentItem from 'view/controls/components/settings/content-item';
 import button from 'view/controls/components/button';
 import { SimpleTooltip } from 'view/controls/components/simple-tooltip';
+import { isRtl } from 'utils/language';
 
 const AUDIO_TRACKS_SUBMENU = 'audioTracks';
 const CAPTIONS_SUBMENU = 'captions';
@@ -98,7 +99,7 @@ export function removeQualitiesSubmenu(settingsMenu) {
 
 export function addPlaybackRatesSubmenu(settingsMenu, rateList, action, initialSelectionIndex, tooltipText) {
     const rateItems = rateList.map((playbackRate) => {
-        return SettingsContentItem(playbackRate, playbackRate + 'x', (evt) => {
+        return SettingsContentItem(playbackRate, isRtl(tooltipText) ? 'x' + playbackRate : playbackRate + 'x', (evt) => {
             action(playbackRate);
             settingsMenu.close(evt);
         });


### PR DESCRIPTION
### This PR will...
- prefix the playback rate with the `'x'` if the 'playbackRate' localization field is RTL 
-- i.e. x1 vs 1x.
- fix a bug where the RTL localization of auto quality would be placed in between the rate and the 'p' (i.e. `420<rtl auto>p` instead of `420p <rtl auto>` )
### Why is this Pull Request needed?
- RTL playback rate display should be prefixed by the x
- the rtl `auto quality` localization should not be place in between the number and the `p`
### Are there any points in the code the reviewer needs to double check?
n/a
### Are there any Pull Requests open in other repos which need to be merged with this?
n/a
#### Addresses Issue(s):

JW8-2432

