### PR TITLE
Add ability for metadata cues to be cleared when live streams restart

### DIFF
--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -19,6 +19,7 @@ const Tracks = {
     _initTextTracks,
     addTracksListener,
     clearTracks,
+    clearMetaCues,
     clearCueData,
     disableTextTrack,
     enableTextTrack,
@@ -349,6 +350,15 @@ function removeTracksListener(tracks, eventType, handler) {
         tracks.removeEventListener(eventType, handler);
     } else {
         tracks['on' + eventType] = null;
+    }
+}
+
+function clearMetaCues() {
+    const metadataTrack = this._tracksById && this._tracksById.nativemetadata;
+    if (metadataTrack) {
+        _removeCues(this.renderNatively, [metadataTrack]);
+        metadataTrack.mode = 'hidden';
+        metadataTrack.inuse = true;
     }
 }
 


### PR DESCRIPTION
### Why is this Pull Request needed?
`clearMetaCues` allows the hlsjs provider to remove metadata cues when restarting a live stream.

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/6101

#### Addresses Issue(s):
JW8-2495

