### PR TITLE
Revert "Fix initial 'buffer' event.reason"

### DIFF
--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -7,7 +7,7 @@ import { MediaModel } from 'controller/model';
 import { seconds } from 'utils/strings';
 import {
     MEDIA_PLAY_ATTEMPT, MEDIA_PLAY_ATTEMPT_FAILED, MEDIA_COMPLETE,
-    PLAYER_STATE, STATE_PAUSED, STATE_PLAYING, STATE_LOADING, STATE_COMPLETE
+    PLAYER_STATE, STATE_PAUSED, STATE_PLAYING, STATE_BUFFERING, STATE_COMPLETE
 } from 'events/events';
 
 export default class MediaController extends Eventable {
@@ -119,9 +119,9 @@ export default class MediaController extends Eventable {
             item,
             playReason
         });
-        // Set the media model state to loading which propigates to a player model state of buffering
+        // Immediately set player state to buffering if these conditions are met
         if (video ? !video.paused : model.get(PLAYER_STATE) === STATE_PLAYING) {
-            mediaModel.set('mediaState', STATE_LOADING);
+            model.set(PLAYER_STATE, STATE_BUFFERING);
         }
 
         return playPromise.then(() => {


### PR DESCRIPTION
Reverts jwplayer/jwplayer#3197

This change caused two regressions.
1. Providers that do not asynchronously provide a state update after play() will leave the player in a loading/buffering state (timer provider)
2. Subsequent ad pods in an ad break do not emit adImpression events from the vast plugin