### PR TITLE
Only allow valid "buffer" event.reason values

### DIFF
--- a/src/js/events/change-state-event.js
+++ b/src/js/events/change-state-event.js
@@ -1,4 +1,4 @@
-import { STATE_IDLE, STATE_COMPLETE, STATE_ERROR } from 'events/events';
+import { STATE_IDLE, STATE_LOADING, STATE_STALLED, STATE_BUFFERING, STATE_COMPLETE, STATE_ERROR } from 'events/events';
 
 // The api should dispatch an idle event when the model's state changes to complete
 // This is to avoid conflicts with the complete event and to maintain legacy event flow
@@ -9,6 +9,13 @@ function normalizeApiState(newstate) {
     return newstate;
 }
 
+function normalizeReason(newstate, reason) {
+    if (newstate === STATE_BUFFERING) {
+        return reason === STATE_STALLED ? reason : STATE_LOADING;
+    }
+    return reason;
+}
+
 export default function ChangeStateEvent(model, newstate, oldstate) {
     newstate = normalizeApiState(newstate);
     oldstate = normalizeApiState(oldstate);
@@ -16,19 +23,21 @@ export default function ChangeStateEvent(model, newstate, oldstate) {
     if (newstate !== oldstate) {
         // buffering, playing and paused states become:
         // buffer, play and pause events
-        const eventType = newstate.replace(/(?:ing|d)$/, '');
+        const type = newstate.replace(/(?:ing|d)$/, '');
+        const reason = normalizeReason(newstate, model.mediaModel.get('mediaState'));
+
         const evt = {
-            type: eventType,
-            newstate: newstate,
-            oldstate: oldstate,
-            reason: model.mediaModel.get('mediaState')
+            type,
+            newstate,
+            oldstate,
+            reason
         };
         // add reason for play/pause events
-        if (eventType === 'play') {
+        if (type === 'play') {
             evt.playReason = model.get('playReason');
-        } else if (eventType === 'pause') {
+        } else if (type === 'pause') {
             evt.pauseReason = model.get('pauseReason');
         }
-        this.trigger(eventType, evt);
+        this.trigger(type, evt);
     }
 }


### PR DESCRIPTION
### Why is this Pull Request needed?
There are only two valid "buffer" event.reason values "loading" and "stalled". If the media state is not "stalled" then we're "loading".

#### Addresses Issue(s):
JW8-2483
