### PR TITLE
Scope all logic for volume tooltip to desktop-only

### DIFF
--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -601,6 +601,7 @@ export default class Controlbar {
                 this.elements[elementName].destroy();
             }
         });
+        this._model.off(null, null, this);
     }
 }
 

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -11,7 +11,6 @@ import Events from 'utils/backbone.events';
 import { prependChild, setAttribute, toggleClass } from 'utils/dom';
 import { timeFormat } from 'utils/parser';
 import UI from 'utils/ui';
-import { each } from 'utils/underscore';
 import { genId, FEED_SHOWN_ID_LENGTH } from 'utils/random-id-generator';
 
 function text(name, role) {
@@ -119,8 +118,8 @@ export default class Controlbar {
         this._volumeAnnouncer = _accessibilityContainer.querySelector('.jw-volume-update');
         const localization = _model.get('localization');
         const timeSlider = new TimeSlider(_model, _api, _accessibilityContainer.querySelector('.jw-time-update'));
+        const menus = [];
         let volumeTooltip;
-        let volumeTooltipEl;
         let muteTip;
         let muteButton;
         let feedShownId = '';
@@ -141,7 +140,8 @@ export default class Controlbar {
             volumeTooltip = new VolumeTooltip(_model, 'jw-icon-volume', vol,
                 cloneIcons('volume-0,volume-50,volume-100'));
 
-            volumeTooltipEl = volumeTooltip.element();
+            const volumeTooltipEl = volumeTooltip.element();
+            menus.push(volumeTooltip);
             setAttribute(volumeTooltipEl, 'aria-valuemin', 0);
             setAttribute(volumeTooltipEl, 'aria-valuemax', 100);
             setAttribute(volumeTooltipEl, 'aria-orientation', 'vertical');
@@ -257,10 +257,6 @@ export default class Controlbar {
             elements.buttonContainer
         ].filter(e => e);
 
-        const menus = this.menus = [
-            elements.volumetooltip
-        ].filter(e => e);
-
         this.el = document.createElement('div');
         this.el.className = 'jw-controlbar jw-reset';
 
@@ -360,9 +356,9 @@ export default class Controlbar {
         new UI(this.el).on('click tap drag', function () {
             this.trigger(USER_ACTION);
         }, this);
-        each(menus, function (ele) {
+        menus.forEach(ele => {
             ele.on('open-tooltip', this.closeMenus, this);
-        }, this);
+        });
     }
 
     onVolume(model, pct) {
@@ -445,7 +441,7 @@ export default class Controlbar {
 
     // Close menus if it has no event.  Otherwise close all but the event's target.
     closeMenus(evt) {
-        each(this.menus, function (ele) {
+        this.menus.forEach(ele => {
             if (!evt || evt.target !== ele.el) {
                 ele.closeTooltip(evt);
             }
@@ -597,6 +593,14 @@ export default class Controlbar {
         }
 
         toggleClass(captionsButton.element(), 'jw-off', !active);
+    }
+
+    destroy() {
+        Object.keys(this.elements).forEach((elementName) => {
+            if (typeof this.elements[elementName].destroy === 'function') {
+                this.elements[elementName].destroy();
+            }
+        });
     }
 }
 

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -313,7 +313,7 @@ export default class Controlbar {
             }
             nextUpTip.setText(tipText);
             elements.next.toggle(!!nextUp);
-        });
+        }, this);
         _model.change('audioMode', this.onAudioMode, this);
         if (elements.cast) {
             _model.change('castAvailable', this.onCastAvailable, this);

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -120,6 +120,8 @@ export default class Controlbar {
         const localization = _model.get('localization');
         const timeSlider = new TimeSlider(_model, _api, _accessibilityContainer.querySelector('.jw-time-update'));
         let volumeTooltip;
+        let volumeTooltipEl;
+        let muteTip;
         let muteButton;
         let feedShownId = '';
 
@@ -139,11 +141,18 @@ export default class Controlbar {
             volumeTooltip = new VolumeTooltip(_model, 'jw-icon-volume', vol,
                 cloneIcons('volume-0,volume-50,volume-100'));
 
-            const volumeTooltipEl = volumeTooltip.element();
+            volumeTooltipEl = volumeTooltip.element();
             setAttribute(volumeTooltipEl, 'aria-valuemin', 0);
             setAttribute(volumeTooltipEl, 'aria-valuemax', 100);
             setAttribute(volumeTooltipEl, 'aria-orientation', 'vertical');
             setAttribute(volumeTooltipEl, 'role', 'slider');
+            muteTip = SimpleTooltip(volumeTooltipEl, 'mutetooltip', localization.mute);
+            volumeTooltipEl.removeEventListener('mouseover', muteTip.open);
+            _model.change('mute', (model, muted) => {
+                const muteText = muted ? localization.unmute : localization.mute;
+                muteTip.setText(muteText);
+                setAttribute(volumeTooltipEl, 'aria-label', muteText);
+            }, this);
         }
 
         const nextButton = button('jw-icon-next', () => {
@@ -224,11 +233,6 @@ export default class Controlbar {
         SimpleTooltip(elements.settingsButton.element(), 'settings', localization.settings);
         const fullscreenTip = SimpleTooltip(elements.fullscreen.element(), 'fullscreen', localization.fullscreen);
 
-        const volumeTooltipEl = elements.volumetooltip.element();
-        const muteTip = SimpleTooltip(volumeTooltipEl, 'mutetooltip', localization.mute);
-        // We want the tooltip to show when tabbed over, but not when moused over; when moused over, the volume slider shows
-        volumeTooltipEl.removeEventListener('mouseover', muteTip.open);
-
         // Filter out undefined elements
         const buttonLayout = [
             elements.play,
@@ -279,9 +283,6 @@ export default class Controlbar {
         _model.change('volume', this.onVolume, this);
         _model.change('mute', (model, muted) => {
             this.renderVolume(muted, model.get('volume'));
-            const muteText = muted ? localization.unmute : localization.mute;
-            muteTip.setText(muteText);
-            setAttribute(volumeTooltipEl, 'aria-label', muteText);
         }, this);
         _model.change('state', this.onState, this);
         _model.change('duration', this.onDuration, this);

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -597,7 +597,8 @@ export default class Controlbar {
 
     destroy() {
         Object.keys(this.elements).forEach((elementName) => {
-            if (typeof this.elements[elementName].destroy === 'function') {
+            const el = this.elements[elementName];
+            if (el && typeof el.destroy === 'function') {
                 this.elements[elementName].destroy();
             }
         });

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -361,13 +361,7 @@ export default class Controls {
     }
 
     disable(model) {
-        const { nextUpToolTip, settingsMenu, infoOverlay } = this;
-        const volumeTooltip = this.controlbar.elements.volumetooltip;
-
-        
-        if (volumeTooltip) {
-            volumeTooltip.destroy();
-        }
+        const { nextUpToolTip, settingsMenu, infoOverlay, controlbar } = this;
 
         this.off();
 
@@ -384,6 +378,11 @@ export default class Controls {
             removeClass(this.playerContainer, 'jw-flag-touch');
             this.div.parentNode.removeChild(this.div);
         }
+        
+        if (controlbar) {
+            controlbar.destroy();
+        }
+
         if (this.rightClickMenu) {
             this.rightClickMenu.destroy();
         }

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -362,6 +362,13 @@ export default class Controls {
 
     disable(model) {
         const { nextUpToolTip, settingsMenu, infoOverlay } = this;
+        const volumeTooltip = this.controlbar.elements.volumetooltip;
+
+        
+        if (volumeTooltip) {
+            volumeTooltip.destroy();
+        }
+
         this.off();
 
         if (model) {
@@ -404,11 +411,6 @@ export default class Controls {
 
         if (infoOverlay) {
             infoOverlay.destroy();
-        }
-
-        const volumeTooltip = this.controlbar.elements.volumetooltip;
-        if (volumeTooltip) {
-            volumeTooltip.destroy();
         }
 
         this.removeBackdrop();


### PR DESCRIPTION
### This PR will...

Scope all logic pertaining to the volume tooltip to desktop devices, to prevent exceptions being thrown in mobile environments. In mobile environments, the volume tooltip is not instantiated, however is later referenced. 

Also ensures the volumeTooltip is referenced prior to to the controls being disabled within the disable() method, required as the previous implementation was causing the following error: `null is not an object (evaluating 'this.controlbar.elements')`. 

### Why is this Pull Request needed?

In mobile environments, player was throwing a 100000 error, as volumeTooltip was not defined in this environment. 

### Are there any points in the code the reviewer needs to double check?

N/A

### Are there any Pull Requests open in other repos which need to be merged with this?

No

#### Addresses Issue(s):

JW8-2343

