### PR TITLE
Prevent duplicate volume and seek slider updates

### DIFF
--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -110,6 +110,7 @@ class TimeSlider extends Slider {
         setAttribute(this.el, 'tabindex', '0');
         setAttribute(this.el, 'role', 'slider');
         setAttribute(this.el, 'aria-label', this._model.get('localization').slider);
+        setAttribute(this.el, 'aria-live', 'off');
         this.el.removeAttribute('aria-hidden');
         this.elementRail.appendChild(this.timeTip.element());
 

--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -106,21 +106,20 @@ class TimeSlider extends Slider {
             .change('buffer', this.onBuffer, this)
             .change('streamType', this.onStreamType, this);
 
-
-        setAttribute(this.el, 'tabindex', '0');
-        setAttribute(this.el, 'role', 'slider');
-        setAttribute(this.el, 'aria-label', this._model.get('localization').slider);
-        setAttribute(this.el, 'aria-live', 'off');
-        this.el.removeAttribute('aria-hidden');
+        const sliderElement = this.el;
+        setAttribute(sliderElement, 'tabindex', '0');
+        setAttribute(sliderElement, 'role', 'slider');
+        setAttribute(sliderElement, 'aria-label', this._model.get('localization').slider);
+        sliderElement.removeAttribute('aria-hidden');
         this.elementRail.appendChild(this.timeTip.element());
 
         // Show the tooltip on while dragging (touch) moving(mouse), or moving over(mouse)
-        this.ui = (this.ui || new UI(this.el))
+        this.ui = (this.ui || new UI(sliderElement))
             .on('move', this.showTimeTooltip, this)
             .on('dragEnd out', this.hideTimeTooltip, this)
-            .on('click', () => this.el.focus());
+            .on('click', () => sliderElement.focus());
 
-        this.el.addEventListener('focus', () => this.updateAriaText());
+        sliderElement.addEventListener('focus', () => this.updateAriaText());
     }
 
     update(percent) {
@@ -301,8 +300,12 @@ class TimeSlider extends Slider {
         } else {
             ariaText = `${timeFormat(position)} of ${timeFormat(duration)}`;
         }
-        this.timeUpdateKeeper.textContent = ariaText;
-        setAttribute(this.el, 'aria-valuetext', ariaText);
+        const sliderElement = this.el;
+        if (document.activeElement !== sliderElement) {
+            this.timeUpdateKeeper.textContent = ariaText;
+        }
+        setAttribute(sliderElement, 'aria-valuenow', position);
+        setAttribute(sliderElement, 'aria-valuetext', ariaText);
     }
 
     reset() {

--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -117,9 +117,8 @@ class TimeSlider extends Slider {
         this.ui = (this.ui || new UI(sliderElement))
             .on('move', this.showTimeTooltip, this)
             .on('dragEnd out', this.hideTimeTooltip, this)
-            .on('click', () => sliderElement.focus());
-
-        sliderElement.addEventListener('focus', () => this.updateAriaText());
+            .on('click', () => sliderElement.focus())
+            .on('focus', this.updateAriaText, this);
     }
 
     update(percent) {

--- a/src/js/view/controls/components/volumetooltip.js
+++ b/src/js/view/controls/components/volumetooltip.js
@@ -17,6 +17,7 @@ export default class VolumeTooltip extends Tooltip {
         volumeSliderElement.classList.remove('jw-background-color');
 
         setAttribute(volumeSliderElement, 'aria-label', localization.volumeSlider);
+        setAttribute(volumeSliderElement, 'aria-live', 'off');
         setAttribute(this.container, 'tabindex', '0');
 
         this.addContent(volumeSliderElement);

--- a/src/js/view/controls/components/volumetooltip.js
+++ b/src/js/view/controls/components/volumetooltip.js
@@ -17,7 +17,6 @@ export default class VolumeTooltip extends Tooltip {
         volumeSliderElement.classList.remove('jw-background-color');
 
         setAttribute(volumeSliderElement, 'aria-label', localization.volumeSlider);
-        setAttribute(volumeSliderElement, 'aria-live', 'off');
         setAttribute(this.container, 'tabindex', '0');
 
         this.addContent(volumeSliderElement);

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -382,7 +382,9 @@ export default class Controlbar {
             setAttribute(volumeTooltipEl, 'aria-valuenow', volume);
             const ariaText = `Volume ${volume}%`;
             setAttribute(volumeTooltipEl, 'aria-valuetext', ariaText);
-            this._volumeAnnouncer.textContent = ariaText;
+            if (document.activeElement !== volumeTooltipEl) {
+                this._volumeAnnouncer.textContent = ariaText;
+            }
         }
     }
 


### PR DESCRIPTION
### This PR will...
Update the hidden announcements only when the slider is not in focus. 
update the time slider's `aria-valuenow` to work around a JAWS bug where the time is announced twice if the `aria-valuetext` is updated without an update to `aria-valuenow`.

### Why is this Pull Request needed?
We introduced the `jw-hidden-annoucements` element to announce volume and seek changes executed with the arrow keys when the sliders are not in focus. This resulted in the JAWS screen reader making duplicate announcements when the sliders are in focus.
I chose only trigger the hidden announcements when the slider is not in focus  instead of removing the `aria-valuenow` and `aria-valuetext` from the sliders, because per [MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuenow_attribute) , `"aria-valuenow is a required attribute of role slider, scrollbar and spinbutton."`, therefore removing the aria values would negatively affect our score in an accessibility audit.
### Are there any points in the code the reviewer needs to double check?
i noticed we never use document.activeElement to check if the element is in focus; any known issues with this api ?
### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-2507

