### PR TITLE
Do not show focus decoration on mouse interaction

### DIFF
--- a/src/css/controls/imports/tooltip.less
+++ b/src/css/controls/imports/tooltip.less
@@ -4,10 +4,6 @@
     opacity: 1;
     transition-delay: 0s;
     visibility: visible;
-
-    &:hover {
-        outline: 0;
-    }
 }
 
 .jw-slider-time .jw-overlay:before {
@@ -76,6 +72,12 @@
 
     .jw-icon-volume .jw-overlay {
         visibility: visible;
+        outline: none;
+        transition: none;
+
+        &:focus:not(:hover) {
+            outline: @ui-focus;
+        }
     }
 
     .jw-option {


### PR DESCRIPTION
JW8-2343

### This PR will...

* Make sure the focus decoration (blue outline) does not appear unless the volume slider is focused via a keyboard interaction.
* Make sure the focus decoration does not appear when the CSS opacity transition for the volume slider takes place.

### Why is this Pull Request needed?

* After https://github.com/jwplayer/jwplayer/pull/3208, the focus decoration for the volume slider will still appear if the volume slider is hovered on after it has been focused on.
* The opacity transition for the volume slider was causing the focus decoration to briefly appear when mousing over or out of the slider.

### Are there any points in the code the reviewer needs to double check?

n/a

### Are there any Pull Requests open in other repos which need to be merged with this?

n/a

#### Addresses Issue(s):

JW8-2343

