### PR TITLE
Only close menus if there is no event

### DIFF
--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -441,7 +441,7 @@ export default class Controlbar {
 
     // Close menus if it has no event.
     closeMenus(evt) {
-        if (!this.menus) {
+        if (!evt || !this.menus) {
             return;
         }
 

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -439,9 +439,9 @@ export default class Controlbar {
         this.elements.alt.textContent = altText;
     }
 
-    // Close menus if it has no event.  Otherwise close all but the event's target.
+    // Close menus if it has no event.
     closeMenus(evt) {
-        if (evt) {
+        if (!this.menus) {
             return;
         }
 

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -441,7 +441,7 @@ export default class Controlbar {
 
     // Close menus if it has no event.
     closeMenus(evt) {
-        if (!evt || !this.menus) {
+        if (evt || !this.menus) {
             return;
         }
 

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -441,15 +441,15 @@ export default class Controlbar {
 
     // Close menus if it has no event.  Otherwise close all but the event's target.
     closeMenus(evt) {
-        if (!evt) {
-            this.menus.forEach(ele => {
-                if (evt.target !== ele.el) {
-                    ele.closeTooltip(evt);
-                } else {
-                    return;
-                }
-            });
+        if (evt) {
+            return;
         }
+
+        this.menus.forEach(ele => {
+            if (evt.target !== ele.el) {
+                ele.closeTooltip(evt);
+            }
+        });
     }
 
     rewind() {

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -441,12 +441,12 @@ export default class Controlbar {
 
     // Close menus if it has no event.
     closeMenus(evt) {
-        if (evt || !this.menus) {
+        if (!this.menus) {
             return;
         }
 
         this.menus.forEach(ele => {
-            if (evt.target !== ele.el) {
+            if (!evt || evt.target !== ele.el) {
                 ele.closeTooltip(evt);
             }
         });

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -441,11 +441,15 @@ export default class Controlbar {
 
     // Close menus if it has no event.  Otherwise close all but the event's target.
     closeMenus(evt) {
-        this.menus.forEach(ele => {
-            if (!evt || evt.target !== ele.el) {
-                ele.closeTooltip(evt);
-            }
-        });
+        if (!evt) {
+            this.menus.forEach(ele => {
+                if (evt.target !== ele.el) {
+                    ele.closeTooltip(evt);
+                } else {
+                    return;
+                }
+            });
+        }
     }
 
     rewind() {

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -597,7 +597,8 @@ export default class Controlbar {
 
     destroy() {
         Object.keys(this.elements).forEach((elementName) => {
-            if (typeof this.elements[elementName].destroy === 'function') {
+            const el = this.elements[elementName];
+            if (el && typeof el.destroy === 'function') {
                 this.elements[elementName].destroy();
             }
         });


### PR DESCRIPTION
JW8-2343

### This PR will...

Only close menus when in the controlbar if there is no event

### Why is this Pull Request needed?

Before, the `!evt` check was inside of the `this.menus.forEach` loop which would cause an exception when tabbing through the controlbar if there are no existing menus.

### Are there any points in the code the reviewer needs to double check?

Tested in Chrome 71, iPad/iPhone on iOS 12.1.1, IE 11 on Windows 7 & 10, Edge on Windows 10

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-###

