### PR TITLE
Add focus to button on mousedown for firefox

### DIFF
--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -38,7 +38,7 @@ export default class UI extends Eventable {
         this.pointerId = null;
         this.startX = 0;
         this.startY = 0;
-        this.noFocusHelper = flagNoFocus(element);
+        this.noFocusHelper = flagNoFocus(element, options.focusOnMouseDown);
     }
 
     on(name, callback, context) {

--- a/src/js/view/controls/components/settings/content-item.js
+++ b/src/js/view/controls/components/settings/content-item.js
@@ -5,7 +5,7 @@ import UI from 'utils/ui';
 export default function SettingsContentItem(name, content, action) {
     let active;
     const contentItemElement = createElement(ContentItemTemplate(content));
-    const contentItemUI = new UI(contentItemElement).on('click tap enter', (evt) => {
+    const contentItemUI = new UI(contentItemElement, { focusOnMouseDown: true }).on('click tap enter', (evt) => {
         action(evt);
     });
 

--- a/src/js/view/utils/flag-no-focus.js
+++ b/src/js/view/utils/flag-no-focus.js
@@ -1,7 +1,7 @@
 import { addClass, removeClass } from 'utils/dom';
 
 
-export default function (elementContext) {
+export default function (elementContext, focusOnMouseDown) {
     let _focusFromClick = false;
 
     const onBlur = function () {
@@ -12,6 +12,9 @@ export default function (elementContext) {
     const onMouseDown = function () {
         _focusFromClick = true;
         addClass(elementContext, 'jw-no-focus');
+        if (focusOnMouseDown) {
+            elementContext.focus();
+        }
     };
 
     const onFocus = function () {


### PR DESCRIPTION
### This PR will...
- Add focus to settings button on mousedown 
- This is a workaround for Firefox not having correct focus
- Other browsers work fine, and are not affected by this change

### Why is this Pull Request needed?
- On Firefox, there is an issue with the settings buttons not being focused on click.
- Since we removed the calls to `preventDefault` on button clicks, we should get focus on buttons.
- Having no focus results the buttons to not remove the `jw-no-focus` class added on mousedown, resulting no focus outline when they are back in focus with keyboard for the first time after clicking.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-2501
