### PR TITLE
Use flagNoFocus On Volume Slider Overlay

### DIFF
--- a/src/css/controls/imports/tooltip.less
+++ b/src/css/controls/imports/tooltip.less
@@ -72,11 +72,10 @@
 
     .jw-icon-volume .jw-overlay {
         visibility: visible;
-        outline: none;
         transition: none;
 
-        &:focus:not(:hover) {
-            outline: @ui-focus;
+        &:hover {
+            outline: none;
         }
     }
 

--- a/src/js/view/controls/components/tooltip.js
+++ b/src/js/view/controls/components/tooltip.js
@@ -2,6 +2,7 @@ import Events from 'utils/backbone.events';
 import ariaLabel from 'utils/aria';
 import { toggleClass } from 'utils/dom';
 import svgParse from 'utils/svgParser';
+import flagNoFocus from 'view/utils/flag-no-focus';
 
 export default class Tooltip {
     constructor(name, ariaText, elementShown, svgIcons) {
@@ -19,6 +20,7 @@ export default class Tooltip {
         this.container.className = 'jw-overlay jw-reset';
         this.openClass = 'jw-open';
         this.componentType = 'tooltip';
+        flagNoFocus(this.container);
 
         this.el.appendChild(this.container);
         if (svgIcons && svgIcons.length > 0) {


### PR DESCRIPTION
JW8-2343

### This PR will...

* Add @pajong 's `flagNoFocus` on to the volume slider's overlay to simplify and improve when the focus ring appears.

### Why is this Pull Request needed?

* Before, the focus ring would still appear if you mouse out of the volume slider while still dragging the knob.

### Are there any points in the code the reviewer needs to double check?

n/a

### Are there any Pull Requests open in other repos which need to be merged with this?

n/a

#### Addresses Issue(s):

JW8-2343

