### PR TITLE
Prevent updating the aria text while seeking

### DIFF
--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -290,15 +290,18 @@ class TimeSlider extends Slider {
     }
 
     updateAriaText() {
-        const position = this._model.get('position');
-        const duration = this._model.get('duration');
-        let ariaText;
-
-        if (this.streamType === 'DVR') {
-            ariaText = timeFormat(position);
-        } else {
-            ariaText = `${timeFormat(position)} of ${timeFormat(duration)}`;
+        const model = this._model;
+        if (model.get('seeking')) {
+            return;
         }
+        const position = model.get('position');
+        const duration = model.get('duration');
+
+        let ariaText = timeFormat(position);
+        if (this.streamType !== 'DVR') {
+            ariaText += ` of ${timeFormat(duration)}`;
+        }
+
         const sliderElement = this.el;
         if (document.activeElement !== sliderElement) {
             this.timeUpdateKeeper.textContent = ariaText;


### PR DESCRIPTION
### This PR will...
prevent time announcements while seeking.
### Why is this Pull Request needed?
`updateAriaText` is fired when a seek occurs, and when the time slider is focused. Since the time slider is focused on when the user clicks it, a click to seek was triggering an update before the seeking was completed, resulting in the announcement of the wrong time (the time before seek). This fix ensures that when the user clicks to seek, the only time update is made when seeking is complete.

SkillSoft had reported a bug where the time was being announced twice. We were not able to reproduce on our end, but assuming a long enough lag in between the click and the seek completion, it would make sense for 2 time announcements to fire. Hopefully this also fixes that issue. 
### Are there any points in the code the reviewer needs to double check?
n/a
### Are there any Pull Requests open in other repos which need to be merged with this?
n/a
#### Addresses Issue(s):

JW8-2512

