### PR TITLE
Clear VTTCue cache for metadata track when clearing cues

### DIFF
--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -359,6 +359,7 @@ function clearMetaCues() {
         _removeCues(this.renderNatively, [metadataTrack]);
         metadataTrack.mode = 'hidden';
         metadataTrack.inuse = true;
+        this._cachedVTTCues[metadataTrack._id] = {};
     }
 }
 


### PR DESCRIPTION
### Why is this Pull Request needed?
The cue cache must be deleted with cues so reloaded metadata is added to the track.

#### Addresses Issue(s):
JW8-2510

