### PR TITLE
Make volume focus and hover behavior consistent

### DIFF
--- a/src/css/controls/imports/tooltip.less
+++ b/src/css/controls/imports/tooltip.less
@@ -70,15 +70,6 @@
         }
     }
 
-    .jw-icon-volume .jw-overlay {
-        visibility: visible;
-        transition: none;
-
-        &:hover {
-            outline: none;
-        }
-    }
-
     .jw-option {
         position: relative;
         white-space: nowrap;

--- a/src/js/view/controls/components/tooltip.js
+++ b/src/js/view/controls/components/tooltip.js
@@ -57,15 +57,19 @@ export default class Tooltip {
     }
 
     openTooltip(evt) {
-        this.trigger('open-' + this.componentType, evt, { isOpen: true });
-        this.isOpen = true;
-        toggleClass(this.el, this.openClass, this.isOpen);
+        if (!this.isOpen) {
+            this.trigger('open-' + this.componentType, evt, { isOpen: true });
+            this.isOpen = true;
+            toggleClass(this.el, this.openClass, this.isOpen);
+        }
     }
 
     closeTooltip(evt) {
-        this.trigger('close-' + this.componentType, evt, { isOpen: false });
-        this.isOpen = false;
-        toggleClass(this.el, this.openClass, this.isOpen);
+        if (this.isOpen) {
+            this.trigger('close-' + this.componentType, evt, { isOpen: false });
+            this.isOpen = false;
+            toggleClass(this.el, this.openClass, this.isOpen);
+        }
     }
 
     toggleOpenState(evt) {

--- a/src/js/view/controls/components/volumetooltip.js
+++ b/src/js/view/controls/components/volumetooltip.js
@@ -15,9 +15,10 @@ export default class VolumeTooltip extends Tooltip {
 
         const volumeSliderElement = this.volumeSlider.element();
         volumeSliderElement.classList.remove('jw-background-color');
-
         setAttribute(volumeSliderElement, 'aria-label', localization.volumeSlider);
-        setAttribute(this.container, 'tabindex', '0');
+
+        const overlay = this.container;
+        setAttribute(overlay, 'tabindex', '0');
 
         this.addContent(volumeSliderElement);
 
@@ -26,16 +27,19 @@ export default class VolumeTooltip extends Tooltip {
         }, this);
 
         // Apply a click interaction listener to help with focus styling
-        this.uiOver = new UI(this.container)
+        const { openTooltip, closeTooltip } = this;
+        this.uiOver = new UI(overlay)
             .on('click', function() {}, this)
-            .on('focus', this.openTooltip, this)
-            .on('blur', this.closeTooltip, this);
+            .on('focus', openTooltip, this)
+            .on('blur', closeTooltip, this);
 
         this.ui = new UI(this.el, { directSelect: true })
             .on('click enter', this.toggleValue, this)
             .on('tap', this.toggleOpenState, this)
-            .on('over', this.openTooltip, this)
-            .on('out', this.closeTooltip, this);
+            .on('over', openTooltip, this)
+            .on('out', closeTooltip, this)
+            .on('focus', openTooltip, this)
+            .on('blur', closeTooltip, this);
 
         this._model.on('change:volume', this.onVolume, this);
     }

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -119,9 +119,8 @@ export default class Controlbar {
         const localization = _model.get('localization');
         const timeSlider = new TimeSlider(_model, _api, _accessibilityContainer.querySelector('.jw-time-update'));
         const menus = this.menus = [];
-        this.ui= [];
+        this.ui = [];
         let volumeTooltip;
-        let muteTip;
         let muteButton;
         let feedShownId = '';
 
@@ -147,11 +146,8 @@ export default class Controlbar {
             setAttribute(volumeTooltipEl, 'aria-valuemax', 100);
             setAttribute(volumeTooltipEl, 'aria-orientation', 'vertical');
             setAttribute(volumeTooltipEl, 'role', 'slider');
-            muteTip = SimpleTooltip(volumeTooltipEl, 'mutetooltip', localization.mute);
-            volumeTooltipEl.removeEventListener('mouseover', muteTip.open);
             _model.change('mute', (model, muted) => {
                 const muteText = muted ? localization.unmute : localization.mute;
-                muteTip.setText(muteText);
                 setAttribute(volumeTooltipEl, 'aria-label', muteText);
             }, this);
         }


### PR DESCRIPTION
### This PR will...
Make volume focus and hover behavior consistent. Focus and hover show the slider and no mute tip.

### Why is this Pull Request needed?
In order to tab into the volume slider it needs to be visible. The simplest way to do this is to open the slider when the volume/mute button has focus - same as when it's hovered over.

The alternative would be to change the volume-icon, overlay and open classes to never set the visibility of the slider to none and instead hide it with transforms or maybe clipping. That could however interfere with animations and other elements sharing some of these classes. This seems like the simplest fix.

#### Addresses Issue(s):
JW8-2343

