### PR TITLE
Add focus ring to volume slider in Firefox

### DIFF
--- a/src/css/controls/imports/tooltip.less
+++ b/src/css/controls/imports/tooltip.less
@@ -4,6 +4,10 @@
     opacity: 1;
     transition-delay: 0s;
     visibility: visible;
+
+    &:focus:not(.jw-not-focus) {
+        outline: @ui-focus;
+    }
 }
 
 .jw-slider-time .jw-overlay:before {

--- a/src/css/controls/imports/tooltip.less
+++ b/src/css/controls/imports/tooltip.less
@@ -5,7 +5,7 @@
     transition-delay: 0s;
     visibility: visible;
 
-    &:focus:not(.jw-not-focus) {
+    &:focus {
         outline: @ui-focus;
     }
 }


### PR DESCRIPTION
JW8-2513

### This PR will...

Make sure the focus ring for the volume slider is the right decoration in Firefox.

### Why is this Pull Request needed?

In Firefox, the focus ring would just be the default browser style of a dotted outline. All other browsers were fine.

### Are there any points in the code the reviewer needs to double check?

n/a

### Are there any Pull Requests open in other repos which need to be merged with this?

n/a

#### Addresses Issue(s):

JW8-2513

