### PR TITLE
Do not add focus outline on rightclick

### DIFF
--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -86,16 +86,14 @@ function initInteractionListeners(ui) {
     const listenerOptions = passiveEvents ? { passive } : false;
 
     const interactStartHandler = (e) => {
+        addClass(el, 'jw-no-focus');
+        ui.clickFocus = true;
+        if (isRightClick(e)) {
+            return;
+        }
         const { target, type } = e;
         if (ui.directSelect && target !== el) {
             // The 'directSelect' parameter only allows interactions on the element and not children
-            return;
-        }
-
-        addClass(el, 'jw-no-focus');
-        ui.clickFocus = true;
-
-        if (isRightClick(e)) {
             return;
         }
 

--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -86,12 +86,16 @@ function initInteractionListeners(ui) {
     const listenerOptions = passiveEvents ? { passive } : false;
 
     const interactStartHandler = (e) => {
-        if (isRightClick(e)) {
-            return;
-        }
         const { target, type } = e;
         if (ui.directSelect && target !== el) {
             // The 'directSelect' parameter only allows interactions on the element and not children
+            return;
+        }
+
+        addClass(el, 'jw-no-focus');
+        ui.clickFocus = true;
+
+        if (isRightClick(e)) {
             return;
         }
 
@@ -130,9 +134,6 @@ function initInteractionListeners(ui) {
                 preventDefault(e);
             }
         }
-
-        addClass(el, 'jw-no-focus');
-        ui.clickFocus = true;
     };
 
     const interactDragHandler = (e) => {

--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -86,8 +86,6 @@ function initInteractionListeners(ui) {
     const listenerOptions = passiveEvents ? { passive } : false;
 
     const interactStartHandler = (e) => {
-        addClass(el, 'jw-no-focus');
-        ui.clickFocus = true;
         if (isRightClick(e)) {
             return;
         }
@@ -132,6 +130,8 @@ function initInteractionListeners(ui) {
                 preventDefault(e);
             }
         }
+        addClass(el, 'jw-no-focus');
+        ui.clickFocus = true;
     };
 
     const interactDragHandler = (e) => {

--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -130,6 +130,7 @@ function initInteractionListeners(ui) {
                 preventDefault(e);
             }
         }
+
         addClass(el, 'jw-no-focus');
         ui.clickFocus = true;
     };

--- a/src/js/view/controls/rightclick.js
+++ b/src/js/view/controls/rightclick.js
@@ -56,7 +56,6 @@ export default class RightClick {
 
     rightClick(evt) {
         this.lazySetup();
-        addClass(this.playerElement, 'jw-no-focus');
 
         if (this.mouseOverContext) {
             // right click on menu item should execute it

--- a/src/js/view/controls/rightclick.js
+++ b/src/js/view/controls/rightclick.js
@@ -91,6 +91,7 @@ export default class RightClick {
 
         addClass(this.playerElement, 'jw-flag-rightclick-open');
         addClass(this.el, 'jw-open');
+        this.el.focus();
         clearTimeout(this._menuTimeout);
         this._menuTimeout = setTimeout(() => this.hideMenu(), 3000);
         return false;

--- a/src/js/view/controls/rightclick.js
+++ b/src/js/view/controls/rightclick.js
@@ -56,6 +56,7 @@ export default class RightClick {
 
     rightClick(evt) {
         this.lazySetup();
+        addClass(this.playerElement, 'jw-no-focus');
 
         if (this.mouseOverContext) {
             // right click on menu item should execute it

--- a/src/js/view/controls/templates/rightclick.js
+++ b/src/js/view/controls/templates/rightclick.js
@@ -3,7 +3,7 @@ export default (menu, localization) => {
     const menuItems = items.map(item => rightClickItem(item, localization));
 
     return (
-        `<div class="jw-rightclick jw-reset">` +
+        `<div class="jw-rightclick jw-reset jw-no-focus" tabindex="0">` +
             `<ul class="jw-rightclick-list jw-reset">${menuItems.join('')}</ul>` +
         `</div>`
     );


### PR DESCRIPTION
### This PR will...
Add focus to the rightclick menu when it is showing up.

### Why is this Pull Request needed?
Not allowing rightclick menu to focus causes the player element to be focused when we try to right click.
Since we have focus outline now, we are focusing on the menu instead of the player element to prevent unwanted outline.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-2515
