### PR TITLE
Fix display and skip icon focus issues

### DIFF
--- a/src/css/controls/flags/ads.less
+++ b/src/css/controls/flags/ads.less
@@ -87,15 +87,6 @@
             }
         }
     }
-
-    .jw-nextup-container {
-        bottom: @mobile-touch-target;
-    }
-
-    .jw-icon,
-    .jw-slider-horizontal {
-        pointer-events: all;
-    }
 }
 
 .jwplayer.jw-flag-ads-vpaid,

--- a/src/css/controls/imports/display.less
+++ b/src/css/controls/imports/display.less
@@ -52,10 +52,6 @@ display icons
     padding: (@mobile-touch-target * 0.125);
     margin: 0 (@mobile-touch-target * 0.5);
 
-    &:not(.jw-no-focus)&:focus {
-        outline: @ui-focus;
-    }
-
     .jw-icon {
         .square(75px);
         cursor: pointer;

--- a/src/css/controls/imports/icons.less
+++ b/src/css/controls/imports/icons.less
@@ -11,9 +11,7 @@
 }
 
 .jw-icon.jw-tab-focus:focus {
-    svg {
-        outline: @ui-focus;
-    }
+    border: @ui-focus;
 }
 
 .jw-icon-airplay {

--- a/src/css/controls/imports/icons.less
+++ b/src/css/controls/imports/icons.less
@@ -7,9 +7,10 @@
 .jw-icon {
     .square(44px);
     background-color: transparent;
+    outline: none;
 }
 
-.jw-icon:not(.jw-no-focus):focus svg {
+.jw-icon.jw-tab-focus:focus {
     outline: @ui-focus;
 }
 

--- a/src/css/controls/imports/icons.less
+++ b/src/css/controls/imports/icons.less
@@ -11,7 +11,9 @@
 }
 
 .jw-icon.jw-tab-focus:focus {
-    outline: @ui-focus;
+    svg {
+        outline: @ui-focus;
+    }
 }
 
 .jw-icon-airplay {

--- a/src/css/controls/imports/jwplayerlayout.less
+++ b/src/css/controls/imports/jwplayerlayout.less
@@ -42,7 +42,6 @@
 /* These items can intercept pointer-events */
 .jw-controlbar,
 .jw-skip,
-.jw-display-icon-container,
 .jw-display-icon-container .jw-icon,
 .jw-nextup-container,
 .jw-autostart-mute,

--- a/src/css/controls/imports/settings-menu.less
+++ b/src/css/controls/imports/settings-menu.less
@@ -117,7 +117,7 @@
 }
 
 .jw-settings-content-item.jw-tab-focus:focus {
-    outline: @ui-focus;
+    border: @ui-focus;
 }
 
 .jw-settings-item-active {

--- a/src/css/controls/imports/settings-menu.less
+++ b/src/css/controls/imports/settings-menu.less
@@ -101,6 +101,7 @@
     padding: 7px 0 7px 15px;
     width: 100%;
     text-align: left;
+    outline: none;
 
     &:hover {
         color: @hover-color;
@@ -115,7 +116,7 @@
     }
 }
 
-.jw-settings-content-item:focus:not(.jw-no-focus) {
+.jw-settings-content-item.jw-tab-focus:focus {
     outline: @ui-focus;
 }
 

--- a/src/css/controls/imports/skipad.less
+++ b/src/css/controls/imports/skipad.less
@@ -38,6 +38,7 @@
         display: none;
         margin-left: -0.75em;
         padding: 0 0.5em;
+        pointer-events: none;
 
         .jw-svg-icon-next {
             display: block;

--- a/src/css/controls/imports/skipad.less
+++ b/src/css/controls/imports/skipad.less
@@ -13,7 +13,7 @@
     align-items: center;
     height: 2em;
 
-    &:focus&:not(.jw-no-focus) {
+    &.jw-tab-focus:focus {
         outline: @ui-focus;
     }
 

--- a/src/css/controls/imports/slider.less
+++ b/src/css/controls/imports/slider.less
@@ -110,7 +110,7 @@
     }
 }
 
-.jw-slider-time:focus:not(.jw-no-focus) .jw-slider-container .jw-rail {
+.jw-slider-time.jw-tab-focus:focus .jw-rail {
     outline: @ui-focus;
 }
 

--- a/src/css/controls/imports/tooltip.less
+++ b/src/css/controls/imports/tooltip.less
@@ -110,7 +110,7 @@
         width: auto;
         z-index: 1;
 
-        &.jw-open.jw-tab-focus {
+        &.jw-open {
             opacity: 1;
             transform: translate(-50%, (-@tooltip-font-size));
             transition-duration: 150ms;

--- a/src/css/controls/imports/tooltip.less
+++ b/src/css/controls/imports/tooltip.less
@@ -106,7 +106,7 @@
         width: auto;
         z-index: 1;
 
-        &.jw-open:not(.jw-no-focus) {
+        &.jw-open.jw-tab-focus {
             opacity: 1;
             transform: translate(-50%, (-@tooltip-font-size));
             transition-duration: 150ms;

--- a/src/css/controls/imports/tooltip.less
+++ b/src/css/controls/imports/tooltip.less
@@ -6,7 +6,11 @@
     visibility: visible;
 
     &:focus {
-        outline: @ui-focus;
+        outline: none;
+
+        &.jw-tab-focus {
+            outline: @ui-focus;
+        }
     }
 }
 

--- a/src/css/controls/states.less
+++ b/src/css/controls/states.less
@@ -31,8 +31,8 @@
     .jw-display-icon-display .jw-icon {
         animation: spin 2s linear infinite;
 
-        &:focus svg {
-            outline: none;
+        &:focus {
+            border: none;
         }
 
         .jw-svg-icon-buffer {

--- a/src/css/controls/states.less
+++ b/src/css/controls/states.less
@@ -31,7 +31,7 @@
     .jw-display-icon-display .jw-icon {
         animation: spin 2s linear infinite;
 
-        &:focus svg {
+        &:focus {
             outline: none;
         }
 

--- a/src/css/controls/states.less
+++ b/src/css/controls/states.less
@@ -31,7 +31,7 @@
     .jw-display-icon-display .jw-icon {
         animation: spin 2s linear infinite;
 
-        &:focus {
+        &:focus svg {
             outline: none;
         }
 

--- a/src/css/jwplayer/imports/jwplayerlayout.less
+++ b/src/css/jwplayer/imports/jwplayerlayout.less
@@ -18,6 +18,12 @@
         box-sizing: inherit;
     }
 
+    outline: none;
+
+    &.jw-tab-focus:focus {
+        outline: @ui-focus;
+    }
+
     // Aspect Ratio styles
     &.jw-flag-aspect-mode {
         /* Height auto required for displaying aspect ratio correctly */
@@ -35,14 +41,6 @@
 
     .jw-swf {
         outline: none;
-    }
-
-    &:not(.jw-tab-focus) {
-        outline: none;
-    }
-
-    &.jw-ie.jw-tab-focus:focus {
-        outline: @ui-focus;
     }
 }
 

--- a/src/css/jwplayer/imports/jwplayerlayout.less
+++ b/src/css/jwplayer/imports/jwplayerlayout.less
@@ -37,13 +37,13 @@
         outline: none;
     }
 
-    &.jw-ie:focus {
-        outline: #585858 dotted 1px;
+    &:not(.jw-tab-focus) {
+        outline: none;
     }
-}
 
-.jw-no-focus:focus {
-    outline: none;
+    &.jw-ie.jw-tab-focus:focus {
+        outline: @ui-focus;
+    }
 }
 
 .jw-media,

--- a/src/css/jwplayer/imports/logo.less
+++ b/src/css/jwplayer/imports/logo.less
@@ -13,6 +13,12 @@
     right: auto;
     left: auto;
     bottom: auto;
+
+    outline: none;
+
+    &.jw-tab-focus:focus {
+        outline: @ui-focus;
+    }
 }
 
 .jw-flag-audio-player .jw-logo {

--- a/src/css/shared-imports/mixins.less
+++ b/src/css/shared-imports/mixins.less
@@ -115,7 +115,6 @@
         &:not(.jw-flag-touch) .jw-button-color:not(.jw-logo-button) {
             &:focus,
             &:hover {
-                outline: none;
                 color: @hover-color;
             }
         }
@@ -209,12 +208,8 @@
             }
         }
 
-        .jw-icon-cast:not(.jw-no-focus) {
-            &:focus google-cast-launcher {
-                outline: @ui-focus;
-            }
-
-            google-cast-launcher:focus {
+        .jw-icon-cast.jw-tab-focus {
+            &:focus {
                 outline: @ui-focus;
             }
         }

--- a/src/css/shared-imports/mixins.less
+++ b/src/css/shared-imports/mixins.less
@@ -208,12 +208,6 @@
             }
         }
 
-        .jw-icon-cast.jw-tab-focus {
-            &:focus {
-                outline: @ui-focus;
-            }
-        }
-
         /* Next up display */
         .jw-nextup-container {
             bottom: @controlbar-height;

--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -9,6 +9,7 @@ const USE_POINTER_EVENTS = ('PointerEvent' in window) && !OS.android;
 const USE_MOUSE_EVENTS = !USE_POINTER_EVENTS && !(TOUCH_SUPPORT && OS.mobile);
 
 const WINDOW_GROUP = 'window';
+const keydown = 'keydown';
 
 const { passiveEvents } = Features;
 const DEFAULT_LISTENER_OPTIONS = passiveEvents ? { passive: true } : false;
@@ -199,7 +200,7 @@ function initInteractionListeners(ui) {
         removeClass(el, 'jw-tab-focus');
     });
     addEventListener(ui, initGroup, 'focus', () => {
-        if (lastInteractionListener.event && lastInteractionListener.event.type === 'keydown') {
+        if (lastInteractionListener.event && lastInteractionListener.event.type === keydown) {
             addClass(el, 'jw-tab-focus');
         }
     });
@@ -318,7 +319,7 @@ const eventRegisters = {
         }
     },
     enter(ui) {
-        addEventListener(ui, ENTER, 'keydown', (e) => {
+        addEventListener(ui, ENTER, keydown, (e) => {
             if (e.key === 'Enter' || e.keyCode === 13) {
                 e.stopPropagation();
                 triggerSimpleEvent(ui, ENTER, e);
@@ -326,8 +327,7 @@ const eventRegisters = {
         });
     },
     keydown(ui) {
-        const keydown = 'keydown';
-        addEventListener(ui, keydown, 'keydown', (e) => {
+        addEventListener(ui, keydown, keydown, (e) => {
             triggerSimpleEvent(ui, keydown, e);
         }, false);
     },
@@ -335,7 +335,7 @@ const eventRegisters = {
         const gesture = 'gesture';
         const triggerGesture = (e) => triggerEvent(ui, gesture, e);
         addEventListener(ui, gesture, 'click', triggerGesture);
-        addEventListener(ui, gesture, 'keydown', triggerGesture);
+        addEventListener(ui, gesture, keydown, triggerGesture);
     },
     interaction(ui) {
         const interaction = 'interaction';
@@ -343,7 +343,7 @@ const eventRegisters = {
             ui.event = e;
         };
         addEventListener(ui, interaction, 'mousedown', triggerGesture, true);
-        addEventListener(ui, interaction, 'keydown', triggerGesture, true);
+        addEventListener(ui, interaction, keydown, triggerGesture, true);
     }
 };
 

--- a/src/js/view/controls/components/button.js
+++ b/src/js/view/controls/components/button.js
@@ -13,7 +13,7 @@ export default function (icon, apiAction, ariaText, svgIcons) {
 
     element.style.display = 'none';
 
-    new UI(element).on('click tap enter', apiAction || function() {});
+    const ui = new UI(element).on('click tap enter', apiAction || function() {});
 
     if (svgIcons) {
         Array.prototype.forEach.call(svgIcons, svgIcon => {
@@ -26,6 +26,7 @@ export default function (icon, apiAction, ariaText, svgIcons) {
     }
 
     return {
+        ui,
         element: function() {
             return element;
         },

--- a/src/js/view/controls/next-display-icon.js
+++ b/src/js/view/controls/next-display-icon.js
@@ -2,8 +2,9 @@ import UI from 'utils/ui';
 
 export default class NextDisplayIcon {
     constructor(model, api, element) {
+        const iconDisplay = element.querySelector('.jw-icon');
 
-        this.ui = new UI(element).on('click tap enter', function() {
+        this.ui = new UI(iconDisplay).on('click tap enter', function() {
             api.next({ reason: 'interaction' });
         });
 

--- a/src/js/view/controls/play-display-icon.js
+++ b/src/js/view/controls/play-display-icon.js
@@ -1,18 +1,16 @@
-import Events from 'utils/backbone.events';
+import Eventable from 'utils/eventable';
 import UI from 'utils/ui';
 import { addClass, createElement } from 'utils/dom';
 
-export default class PlayDisplayIcon {
+export default class PlayDisplayIcon extends Eventable {
     constructor(_model, api, element) {
-        Object.assign(this, Events);
-
+        super();
         const localization = _model.get('localization');
-        const iconDisplay = element.getElementsByClassName('jw-icon-display')[0];
-        element.style.cursor = 'pointer';
+        const iconDisplay = element.querySelector('.jw-icon');
+
         this.icon = iconDisplay;
         this.el = element;
-
-        this.ui = new UI(this.el).on('click tap enter', (evt) => {
+        this.ui = new UI(iconDisplay).on('click tap enter', (evt) => {
             this.trigger(evt.type);
         });
 
@@ -37,9 +35,9 @@ export default class PlayDisplayIcon {
                     break;
             }
             if (newStateLabel !== '') {
-                element.setAttribute('aria-label', newStateLabel);
+                iconDisplay.setAttribute('aria-label', newStateLabel);
             } else {
-                element.removeAttribute('aria-label');
+                iconDisplay.removeAttribute('aria-label');
             }
         });
 

--- a/src/js/view/controls/rewind-display-icon.js
+++ b/src/js/view/controls/rewind-display-icon.js
@@ -2,9 +2,10 @@ import UI from 'utils/ui';
 
 export default class RewindDisplayIcon {
     constructor(model, api, element) {
-        this.el = element;
+        const iconDisplay = element.querySelector('.jw-icon');
 
-        this.ui = new UI(this.el).on('click tap enter', function() {
+        this.el = element;
+        this.ui = new UI(iconDisplay).on('click tap enter', function() {
             const currentPosition = model.get('position');
             const duration = model.get('duration');
             const rewindPosition = currentPosition - 10;

--- a/src/js/view/controls/templates/display-icon.js
+++ b/src/js/view/controls/templates/display-icon.js
@@ -1,7 +1,7 @@
 export default (iconName = '', ariaLabel = '') => {
     return (
-        `<div class="jw-display-icon-container jw-display-icon-${iconName} jw-reset" role="button" tabindex="0" aria-label="${ariaLabel}">` +
-            `<div class="jw-icon jw-icon-${iconName} jw-button-color jw-reset"></div>` +
+        `<div class="jw-display-icon-container jw-display-icon-${iconName} jw-reset">` +
+            `<div class="jw-icon jw-icon-${iconName} jw-button-color jw-reset" role="button" tabindex="0" aria-label="${ariaLabel}"></div>` +
         `</div>`
     );
 };

--- a/src/js/view/utils/submenu-factory.js
+++ b/src/js/view/utils/submenu-factory.js
@@ -3,7 +3,6 @@ import SettingsSubmenu from 'view/controls/components/settings/submenu';
 import SettingsContentItem from 'view/controls/components/settings/content-item';
 import button from 'view/controls/components/button';
 import { SimpleTooltip } from 'view/controls/components/simple-tooltip';
-import { addClass } from 'utils/dom';
 import { isRtl } from 'utils/language';
 
 const AUDIO_TRACKS_SUBMENU = 'audioTracks';
@@ -20,9 +19,6 @@ export const makeSubmenu = (settingsMenu, name, contentItems, icon, tooltipText)
         const categoryButton = button(`jw-settings-${name}`, (event) => {
             settingsMenu.activateSubmenu(name, false, event && event.type !== 'enter');
             submenu.element().children[0].focus();
-            if (event && event.type !== 'enter') {
-                addClass(submenu.element().children[0], 'jw-no-focus');
-            }
         }, name, [icon]);
         const categoryButtonElement = categoryButton.element();
         categoryButtonElement.setAttribute('role', 'menuitemradio');

--- a/test/unit/play-display-icon-test.js
+++ b/test/unit/play-display-icon-test.js
@@ -3,7 +3,6 @@ import SimpleModel from 'model/simplemodel';
 
 describe('PlayDisplayIcon', function() {
     let model;
-    let displayIcon;
     let element;
     let icon;
     let svg;
@@ -21,7 +20,7 @@ describe('PlayDisplayIcon', function() {
         svg = document.createElement('svg');
         svg.className = 'jw-svg-icon jw-svg-icon-pause';
         icon = document.createElement('div');
-        icon.className = 'jw-icon-display';
+        icon.className = 'jw-icon jw-icon-display';
         icon.appendChild(svg);
         element = document.createElement('div');
         element.appendChild(icon);
@@ -30,14 +29,14 @@ describe('PlayDisplayIcon', function() {
     describe('on init', function() {
 
         it('should not add class if config is not set', function() {
-            displayIcon = new PlayDisplayIcon(model, {}, element);
+            const displayIcon = new PlayDisplayIcon(model, {}, element);
 
             expect(displayIcon.icon.className).to.not.include('jw-idle-label');
             expect(displayIcon.icon.lastChild.className).to.not.include('jw-idle-icon-text');
         });
 
         it('should not create element if displayPlaybackLabel is false', function () {
-            displayIcon = new PlayDisplayIcon(model, {}, element);
+            const displayIcon = new PlayDisplayIcon(model, {}, element);
 
             expect(displayIcon.icon.className).to.not.include('jw-idle-label');
             expect(displayIcon.icon.lastChild.className).to.not.include('jw-idle-icon-text');
@@ -45,7 +44,7 @@ describe('PlayDisplayIcon', function() {
 
         it('should create element when displayPlaybackLabel is true', function () {
             model.set('displayPlaybackLabel', true);
-            displayIcon = new PlayDisplayIcon(model, {}, element);
+            const displayIcon = new PlayDisplayIcon(model, {}, element);
 
             expect(displayIcon.icon.className).to.include('jw-idle-label');
             expect(displayIcon.icon.lastChild.className).to.include('jw-idle-icon-text');
@@ -56,7 +55,7 @@ describe('PlayDisplayIcon', function() {
             const defaultPlaybackLocalization = localization.playback;
             localization.playback = 'Jugar';
             model.set('displayPlaybackLabel', true);
-            displayIcon = new PlayDisplayIcon(model, {}, element);
+            const displayIcon = new PlayDisplayIcon(model, {}, element);
 
             expect(displayIcon.icon.className).to.include('jw-idle-label');
             expect(displayIcon.icon.lastChild.className).to.include('jw-idle-icon-text');
@@ -67,37 +66,37 @@ describe('PlayDisplayIcon', function() {
 
     describe('on state change', function() {
         it('should add playback aria label if new state is idle (stop playback)', function() {
-            displayIcon = new PlayDisplayIcon(model, {}, element);
+            const displayIcon = new PlayDisplayIcon(model, {}, element);
 
             model.set('state', 'complete');
             model.set('state', 'idle');
 
-            expect(displayIcon.el.getAttribute('aria-label')).to.equal(localization.playback);
+            expect(displayIcon.icon.getAttribute('aria-label')).to.equal(localization.playback);
         });
 
         it('should add pause aria label if old state is idle (start playback)', function() {
-            displayIcon = new PlayDisplayIcon(model, {}, element);
+            const displayIcon = new PlayDisplayIcon(model, {}, element);
 
             model.set('state', 'playing');
 
-            expect(displayIcon.el.getAttribute('aria-label')).to.equal(localization.pause);
+            expect(displayIcon.icon.getAttribute('aria-label')).to.equal(localization.pause);
         });
 
         it('should remove aria label if new state label is empty', function() {
             localization.replay = '';
-            displayIcon = new PlayDisplayIcon(model, {}, element);
+            const displayIcon = new PlayDisplayIcon(model, {}, element);
 
             model.set('state', 'complete');
 
-            expect(displayIcon.el.getAttribute('aria-label')).to.equal(null);
+            expect(displayIcon.icon.getAttribute('aria-label')).to.equal(null);
         });
 
         it('should remove aria label if new state is invalid', function() {
-            displayIcon = new PlayDisplayIcon(model, {}, element);
+            const displayIcon = new PlayDisplayIcon(model, {}, element);
 
             model.set('state', 'invalid');
 
-            expect(displayIcon.el.getAttribute('aria-label')).to.equal(null);
+            expect(displayIcon.icon.getAttribute('aria-label')).to.equal(null);
         });
     });
 });


### PR DESCRIPTION
### This PR will...
- Replace ".jw-no-focus" with ".jw-tab-focus" and only show focus outline when focus changes following a keyboard event
- Revert changes to listen for interactions on display-icon-container instead of display-icon
- Always use display icon for focus and interaction
- Remove `.jw-display-icon-container: pointer-events: all` styling which causes the display icon container to receive focus instead of only the display icons
- Remove ads `pointer-events: all` styling which causes icons to receive focus
- Remove ads `jw-nextup-container` styles (we never show nextup over ads)
- Add "jw-icon" class to mock icon element in play-display-icon-test and make `displayIcon` a local const
- Use `border` to style jw-icon elements. This fixes both Firefox outline issues surrounding child elements with absolute positioning, and Safari which sometimes doesn't paint outlines applied to svg elements

### Why is this Pull Request needed?
These changes prevent elements from getting focus that should not on IE and mobile. UI listeners should be attached to the elements assigned a tab index, not their parents.

#### Addresses Issue(s):
JW8-2519
