### PR TITLE
Insert cues in time order in IE/Edge 

### DIFF
--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -535,6 +535,9 @@ function _addCueToTrack(renderNatively, track, vttCue) {
 
 function insertCueInOrder(track, vttCue) {
     const temp = [];
+    // If the track mode is 'disabled', track.cues will be null; set it to hidden so that we can access.
+    const mode = track.mode;
+    track.mode = 'hidden';
     const cues = track.cues;
     for (let i = cues.length - 1; i >= 0; i--) {
         if (cues[i].startTime > vttCue.startTime) {
@@ -546,6 +549,8 @@ function insertCueInOrder(track, vttCue) {
     }
     track.addCue(vttCue);
     temp.forEach(cue => track.addCue(cue));
+    // Restore the original track state
+    track.mode = mode;
 }
 
 function _removeCues(renderNatively, tracks) {


### PR DESCRIPTION
### Why is this Pull Request needed?
Because IE/Edge will throw an exception if cues are not inserted in order

### Are there any points in the code the reviewer needs to double check?

Did I mess up my discrete math?
```
!(Browser.ie && renderNatively) || !window.TextTrackCue

is equal to:

!Browser.ie || !renderNatively || !window.TextTrackCue

and when negated becomes:

Browser.ie && renderNatively && window.TextTrackCue
```


### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-2521

