### PR TITLE
Fix removeEventListener call in ui.js

### DIFF
--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -378,7 +378,12 @@ function removeHandlers(ui, triggerName) {
     const listenerOptions = options[triggerName];
     if (listeners) {
         Object.keys(listeners).forEach(domEventName => {
-            element.removeEventListener(domEventName, listeners[domEventName], listenerOptions);
+            const useCapture = listenerOptions[domEventName];
+            if (typeof useCapture === 'boolean') {
+                element.removeEventListener(domEventName, listeners[domEventName], useCapture);
+            } else {
+                element.removeEventListener(domEventName, listeners[domEventName]);
+            }
         });
         handlers[triggerName] = null;
         options[triggerName] = null;


### PR DESCRIPTION
### This PR will...
Correct how we access `options` passed to `addEventListener(type, listener, options)` for removal and only pass the `useCapture` argument to `removeEventListener()` if it is a boolean.

### Why is this Pull Request needed?
For UI instance event listeners to be removed:

>[**Matching event listeners for removal**](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/removeEventListener#Matching_event_listeners_for_removal)
> Given an event listener previously added by calling `addEventListener()`, you may eventually come to a point at which you need to remove it. Obviously, you need to specify the same `type` and `listener` parameters to `removeEventListener()`, but what about the `options` or `useCapture` parameters?
> 
> While `addEventListener()` will let you add the same listener more than once for the same type if the options are different, the only option `removeEventListener()` checks is the `capture`/`useCapture` flag. Its value must match for `removeEventListener()` to match, but the other values don't.

#### Addresses Issue(s):
JW8-2527
