### PR TITLE
Fix issue where fullscreen tooltip won't go away

### DIFF
--- a/src/css/controls/imports/tooltip.less
+++ b/src/css/controls/imports/tooltip.less
@@ -133,10 +133,6 @@
             }
         }
     }
-
-    .jw-icon:focus > .jw-tooltip {
-        &:extend(.jw-controlbar .jw-tooltip.jw-open);
-    }
 }
 
 .jw-tooltip-time {


### PR DESCRIPTION
### This PR will...
Remove redundant controlbar and settings menu tooltip rule that force display of tooltips for all focus state.

### Why is this Pull Request needed?
There are already rules for showing tooltips on hover and tab focus. Clicking the fullscreen button results in the button having focus. That should not result in the tooltip getting staying open while in fullscreen or after exiting fullscreen.

#### Addresses Issue(s):
JW8-###

