### PR TITLE
[HAC-56 - DO NOT MERGE] Ad Media Background Loading.

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -346,7 +346,7 @@ Object.assign(Controller.prototype, {
         function _load(item, feedData) {
 
             const instream = _this._instreamAdapter;
-            if (instream) {
+            if (_model.get('instreamMode')) {
                 instream.noResume = true;
             }
             _this.trigger('destroyPlugin', {});

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -286,6 +286,20 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
     }
 
     /**
+     * Preload an Item.
+     * @param {Item|Array.<Item>} item - The ad item or ad pod array of items to be preloaded.
+     */
+    this.preloadItem = function(item) {
+        if (_destroyed) {
+            return;
+        }
+
+        if (_adProgram.backgroundLoading) {
+            _adProgram.backgroundLoad(item);
+        }
+    };
+
+    /**
      * Load an Item, playing it as an insteam ad.
      * @param {Item|Array.<Item>} item - The ad item or ad pod array of items to be played.
      * @param {Object|Array.<Object>} options - The ad options or ad pod array of options.

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -73,6 +73,8 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
         }
     };
 
+    this.isInitialized = () => _inited;
+
     /**
      * Put the player in instream ads mode, detaching media, and preparing the ad program for
      * instream playback

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -288,6 +288,7 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
     /**
      * Preload an Item.
      * @param {Item|Array.<Item>} item - The ad item or ad pod array of items to be preloaded.
+     * @returns {void}
      */
     this.preloadItem = function(item) {
         if (_destroyed) {

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -296,7 +296,7 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
         }
 
         if (_adProgram.backgroundLoading) {
-            _adProgram.backgroundLoad(item);
+            _adProgram.backgroundLoad(Array.isArray(item) ? item[_arrayIndex] : item);
         }
     };
 

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -73,8 +73,6 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
         }
     };
 
-    this.isInitialized = () => _inited;
-
     /**
      * Put the player in instream ads mode, detaching media, and preparing the ad program for
      * instream playback
@@ -502,7 +500,7 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
      * @return {string|boolean} The ad player's playback state
      */
     this.getState = function() {
-        if (_destroyed) {
+        if (_destroyed || !_inited) {
             // api expects false to know we aren't in instreamMode
             return false;
         }


### PR DESCRIPTION
### What does this Pull Request do?
POC for Ad Media Background Loading.

### Why is this Pull Request needed?
Create a true "bufferless" player - honestly, I just need the automated test results.

### Are there any points in the code the reviewer needs to double check?
I don't anticipate for this PR to require any additional changes - the ad plugin should really only need `instream.preloadItem`.

### If this Pull Request introduces new config option(s), is the config schema updated?
N/A

### Are there any Pull Requests open in other repos which need to be merged with this?
jwplayer/jwplayer-ads-vast#477

#### Addresses Issue(s):
HAC-56