### PR TITLE
show time tooltip on drag 

### DIFF
--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -115,7 +115,7 @@ class TimeSlider extends Slider {
 
         // Show the tooltip on while dragging (touch) moving(mouse), or moving over(mouse)
         this.ui = (this.ui || new UI(sliderElement))
-            .on('move', this.showTimeTooltip, this)
+            .on('move drag', this.showTimeTooltip, this)
             .on('dragEnd out', this.hideTimeTooltip, this)
             .on('click', () => sliderElement.focus())
             .on('focus', this.updateAriaText, this);


### PR DESCRIPTION
### This PR will...
include drag in the list of events required to call `showTimeTooltip`.
### Why is this Pull Request needed?
On mobile devices we must show the thumbnail when the seek knob is dragged.
### Are there any points in the code the reviewer needs to double check?
n/a
### Are there any Pull Requests open in other repos which need to be merged with this?
n/a
#### Addresses Issue(s):

JW8-2370

