### PR TITLE
Add XHR file protocol error code

### DIFF
--- a/src/js/utils/ajax.js
+++ b/src/js/utils/ajax.js
@@ -169,9 +169,8 @@ function _readyStateChangeHandler(options) {
                 return _ajaxComplete(options)(e);
             }
             // regex checks that the url is relative or protocol relative
-            if (status === 0 && isFileProtocol() && !/^(?:(?:https?|file):\/\/)/.test(options.url)) {
+            if (status === 0 && isFileProtocol() && !/^[a-z][a-z0-9+.-]*:/.test(options.url)) {
                 _error(options, MSG_CANT_PLAY_VIDEO, ERROR_XHR_FILE_PROTOCOL);
-
             }
         }
     };

--- a/src/js/utils/ajax.js
+++ b/src/js/utils/ajax.js
@@ -168,7 +168,7 @@ function _readyStateChangeHandler(options) {
             if (status === 200) {
                 return _ajaxComplete(options)(e);
             }
-            // verify that the error is due to a relative or protocol relative url being requested on page hosted over file: protocol
+            // regex checks that the url is relative or protocol relative
             if (status === 0 && isFileProtocol() && !/^(?:(?:https?|file):\/\/)/.test(options.url)) {
                 _error(options, MSG_CANT_PLAY_VIDEO, ERROR_XHR_FILE_PROTOCOL);
 

--- a/src/js/utils/ajax.js
+++ b/src/js/utils/ajax.js
@@ -1,4 +1,5 @@
-import { parseXML } from 'utils/parser';
+import { parseXML, isAbsolutePath } from 'utils/parser';
+import { isFileProtocol } from 'utils/validator';
 import { PlayerError, MSG_TECHNICAL_ERROR, MSG_CANT_PLAY_VIDEO } from 'api/errors';
 
 // XHR Request Errors
@@ -158,12 +159,17 @@ function _readyStateChangeHandler(options) {
         const xhr = e.currentTarget || options.xhr;
         if (xhr.readyState === 4) {
             clearTimeout(options.timeoutId);
-            if (xhr.status >= 400) {
-                _error(options, MSG_CANT_PLAY_VIDEO, (xhr.status < 600) ? xhr.status : ERROR_XHR_UNKNOWN);
+            const status = xhr.status;
+            if (status >= 400) {
+                _error(options, MSG_CANT_PLAY_VIDEO, (status < 600) ? status : ERROR_XHR_UNKNOWN);
                 return;
             }
-            if (xhr.status === 200) {
+            if (status === 200) {
                 return _ajaxComplete(options)(e);
+            }
+            if (status === 0 && isFileProtocol() && !isAbsolutePath(options.url)) {
+                _error(options, MSG_CANT_PLAY_VIDEO, 999);
+
             }
         }
     };

--- a/src/js/utils/ajax.js
+++ b/src/js/utils/ajax.js
@@ -168,7 +168,8 @@ function _readyStateChangeHandler(options) {
             if (status === 200) {
                 return _ajaxComplete(options)(e);
             }
-            if (status === 0 && isFileProtocol() && !/^(?:(?:https?|file):)?/.test(options.url)) {
+            // verify that the error is due to a relative or protocol relative url being requested on page hosted over file: protocol
+            if (status === 0 && isFileProtocol() && !/^(?:(?:https?|file):\/\/)/.test(options.url)) {
                 _error(options, MSG_CANT_PLAY_VIDEO, ERROR_XHR_FILE_PROTOCOL);
 
             }

--- a/src/js/utils/ajax.js
+++ b/src/js/utils/ajax.js
@@ -1,4 +1,4 @@
-import { parseXML, isAbsolutePath } from 'utils/parser';
+import { parseXML } from 'utils/parser';
 import { isFileProtocol } from 'utils/validator';
 import { PlayerError, MSG_TECHNICAL_ERROR, MSG_CANT_PLAY_VIDEO } from 'api/errors';
 
@@ -9,6 +9,7 @@ const ERROR_XHR_OPEN = 3;
 const ERROR_XHR_SEND = 4;
 const ERROR_XHR_FILTER = 5;
 const ERROR_XHR_UNKNOWN = 6;
+const ERROR_XHR_FILE_PROTOCOL = 7;
 
 // Network Responses with http status 400-599
 // will produce an error with the http status code
@@ -167,8 +168,8 @@ function _readyStateChangeHandler(options) {
             if (status === 200) {
                 return _ajaxComplete(options)(e);
             }
-            if (status === 0 && isFileProtocol() && !isAbsolutePath(options.url)) {
-                _error(options, MSG_CANT_PLAY_VIDEO, 999);
+            if (status === 0 && isFileProtocol() && !/^(?:(?:https?|file):)?/.test(options.url)) {
+                _error(options, MSG_CANT_PLAY_VIDEO, ERROR_XHR_FILE_PROTOCOL);
 
             }
         }

--- a/src/js/utils/playerutils.js
+++ b/src/js/utils/playerutils.js
@@ -1,4 +1,5 @@
 import { version } from 'version';
+import { isFileProtocol } from 'utils/validator';
 
 export const getScriptPath = function(scriptName) {
     const scripts = document.getElementsByTagName('script');
@@ -21,7 +22,7 @@ export const repo = function () {
     }
 
     const playerRepo = __REPO__;
-    const protocol = (playerRepo && window.location.protocol === 'file:') ? 'https:' : '';
+    const protocol = (playerRepo && isFileProtocol()) ? 'https:' : '';
     return `${protocol}${playerRepo}`;
 };
 

--- a/src/js/utils/validator.js
+++ b/src/js/utils/validator.js
@@ -1,5 +1,7 @@
 /** @module */
 
+const protocol = window.location.protocol;
+
 /**
  * @param {any} item - The variable to test.
  * @returns {boolean} Is the value of `item` null, undefined or an empty string?
@@ -21,21 +23,14 @@ export function exists(item) {
  * @returns {boolean} Is the current page hosted over HTTPS?
  */
 export function isHTTPS() {
-    return getProtocol() === 'https:';
+    return protocol === 'https:';
 }
 
 /**
  * @returns {boolean} Is the current page hosted over the File protocol?
  */
 export function isFileProtocol() {
-    return getProtocol() === 'file:';
-}
-
-/**
- * @returns {string} the protocol of the current page
- */
-function getProtocol() {
-    return window.location.protocol;
+    return protocol === 'file:';
 }
 
 /**

--- a/src/js/utils/validator.js
+++ b/src/js/utils/validator.js
@@ -21,7 +21,21 @@ export function exists(item) {
  * @returns {boolean} Is the current page hosted over HTTPS?
  */
 export function isHTTPS() {
-    return (window.location.protocol === 'https:');
+    return getProtocol() === 'https:';
+}
+
+/**
+ * @returns {boolean} Is the current page hosted over the File protocol?
+ */
+export function isFileProtocol() {
+    return getProtocol() === 'file:';
+}
+
+/**
+ * @returns {string} the protocol of the current page
+ */
+function getProtocol() {
+    return window.location.protocol;
 }
 
 /**


### PR DESCRIPTION
### This PR will...
check if XHR errors are caused by requesting a relative or protocol relative path on a page hosted over the `file:` protocol.
### Why is this Pull Request needed?
Customers are seeing the unknown XHR error (`006`) in webviews when the page is hosted in the native app. When a playlist feed without a protocol is loaded in the player, XHR assumes the protocol should be `file:`, resulting in an error when the asset is not hosted in the app.
### Are there any points in the code the reviewer needs to double check?
Do you agree with the error code ?
### Are there any Pull Requests open in other repos which need to be merged with this?
[Docs PR](https://github.com/jwplayer/jwplayer-docs-new/pull/280)
#### Addresses Issue(s):
JW8-2474

