### PR TITLE
[JW8-2408] Close settings menu if visible when changing playlist item

### DIFF
--- a/src/js/view/controls/settings-menu.js
+++ b/src/js/view/controls/settings-menu.js
@@ -175,6 +175,11 @@ export function setupSubmenuListeners(settingsMenu, controlbar, viewModel, api) 
         // instead of dispatching an event is because we don't want to emit 'captionsList' if the new list is empty.
         removeCaptionsSubmenu(settingsMenu);
         controlbar.elements.captionsButton.hide();
+
+        // Settings menu should not be visible when switching playlist items via controls or .load()
+        if (settingsMenu.visible) {
+            settingsMenu.close();
+        }
     });
     model.change('captionsList', onCaptionsChanged, settingsMenu);
     model.change('captionsIndex', (changedModel, index) => {


### PR DESCRIPTION
JW8-2408

### This PR will...

Check to see if the settings menu is visible when the playlist item is changed and, if it is visible, close it.

### Why is this Pull Request needed?

Previously, when a new playlist item was loaded via `load()`, the settings menu will remain visible in the player's display.

### Are there any points in the code the reviewer needs to double check?

n/a

### Are there any Pull Requests open in other repos which need to be merged with this?

n/a

#### Addresses Issue(s):

JW8-2408

