### PR TITLE
Sanitize html content before adding it to the DOM to prevent XSS attacks

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,7 +18,8 @@
     },
     "extends": "eslint:recommended",
     "plugins": [
-        "no-for-of-loops"
+        "no-for-of-loops",
+        "no-unsanitized"
     ],
     "rules": {
         "valid-jsdoc": 2,
@@ -30,6 +31,8 @@
             }
         ],
         "no-for-of-loops/no-for-of-loops": 2,
+        "no-unsanitized/method": 2,
+        "no-unsanitized/property": 2,
         "comma-dangle": 0,
         "no-cond-assign": 2,
         "no-console": ["warn", { "allow": ["warn", "error"] }],

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "eslint": "5.7.0",
     "eslint-plugin-import": "2.14.0",
     "eslint-plugin-no-for-of-loops": "1.0.0",
+    "eslint-plugin-no-unsanitized": "3.0.2",
     "esprima": "4.0.1",
     "fast-diff": "1.1.2",
     "file-loader": "1.1.11",

--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -1,7 +1,6 @@
 import { trim } from 'utils/strings';
 import { isString, contains, difference, isBoolean } from 'utils/underscore';
 
-const forEach = Array.prototype.forEach;
 let parser;
 
 export function hasClass(element, searchClass) {
@@ -21,9 +20,9 @@ function appendHtml(element, html) {
     // Add parsed html and text nodes to another element
     const fragment = document.createDocumentFragment();
     const nodes = htmlToParentElement(html).childNodes;
-    forEach.call(nodes, node => {
-        fragment.appendChild(node.cloneNode());
-    });
+    for (let i = 0; i < nodes.length; i++) {
+        fragment.appendChild(nodes[i].cloneNode());
+    }
     element.appendChild(fragment);
 }
 
@@ -35,24 +34,29 @@ function htmlToParentElement(html) {
 
     // Delete script nodes
     const scripts = parsedElement.querySelectorAll('script');
-    forEach.call(scripts, script => {
+    for (let i = 0; i < scripts.length; i++) {
+        const script = scripts[i];
         script.parentNode.removeChild(script);
-    });
-
+    }
     // Delete event handler attributes that could execute XSS JavaScript
     const insecureElements = parsedElement.querySelectorAll('img,svg');
-    forEach.call(insecureElements, sanitizeElementAttributes);
+
+    for (let i = 0; i < insecureElements.length; i++) {
+        const element = insecureElements[i];
+        sanitizeElementAttributes(element);
+    }
 
     return parsedElement;
 }
 
 export function sanitizeElementAttributes(element) {
-    forEach.call(element.attributes, attributeNode => {
-        const name = attributeNode.name;
+    const attributes = element.attributes;
+    for (let i = 0; i < attributes.length; i++) {
+        const name = attributes[i].name;
         if (/^on/.test(name)) {
             element.removeAttribute(name);
         }
-    });
+    }
     return element;
 }
 

--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -26,7 +26,7 @@ function appendHtml(element, html) {
     element.appendChild(fragment);
 }
 
-function htmlToParentElement(html) {
+export function htmlToParentElement(html) {
     if (!parser) {
         parser = new DOMParser();
     }

--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -12,7 +12,7 @@ export function createElement(html) {
     return htmlToParentElement(html).firstChild;
 }
 
-export function replaceHtml(element, html) {
+export function replaceInnerHtml(element, html) {
     emptyElement(element);
     appendHtml(element, html);
 }

--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -17,6 +17,9 @@ export function replaceInnerHtml(element, html) {
 }
 
 function appendHtml(element, html) {
+    if (!html) {
+        return;
+    }
     // Add parsed html and text nodes to another element
     const fragment = document.createDocumentFragment();
     const nodes = htmlToParentElement(html).childNodes;

--- a/src/js/utils/svgParser.js
+++ b/src/js/utils/svgParser.js
@@ -1,3 +1,5 @@
+import { sanitizeElementAttributes } from 'utils/dom';
+
 let parser;
 
 export default function svgParse(svgXml) {
@@ -5,5 +7,5 @@ export default function svgParse(svgXml) {
         parser = new DOMParser();
     }
 
-    return parser.parseFromString(svgXml, 'image/svg+xml').documentElement;
+    return sanitizeElementAttributes(parser.parseFromString(svgXml, 'image/svg+xml').documentElement);
 }

--- a/src/js/view/title.js
+++ b/src/js/view/title.js
@@ -1,4 +1,5 @@
 import { style } from 'utils/css';
+import { replaceHtml } from 'utils/dom';
 
 const Title = function(_model) {
     this.model = _model.player;
@@ -64,8 +65,8 @@ Object.assign(Title.prototype, {
     },
 
     updateText: function(title, description) {
-        this.title.innerHTML = title;
-        this.description.innerHTML = description;
+        replaceHtml(this.title, title);
+        replaceHtml(this.description, description);
 
         if (this.title.firstChild || this.description.firstChild) {
             this.show();

--- a/src/js/view/title.js
+++ b/src/js/view/title.js
@@ -1,5 +1,7 @@
 import { style } from 'utils/css';
-import { replaceHtml } from 'utils/dom';
+import {
+    replaceInnerHtml
+} from 'utils/dom';
 
 const Title = function(_model) {
     this.model = _model.player;
@@ -65,8 +67,8 @@ Object.assign(Title.prototype, {
     },
 
     updateText: function(title, description) {
-        replaceHtml(this.title, title);
-        replaceHtml(this.description, description);
+        replaceInnerHtml(this.title, title);
+        replaceInnerHtml(this.description, description);
 
         if (this.title.firstChild || this.description.firstChild) {
             this.show();

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -20,6 +20,7 @@ import {
     replaceClass,
     toggleClass,
     createElement,
+    htmlToParentElement,
     bounds,
 } from 'utils/dom';
 import {
@@ -732,9 +733,8 @@ function View(_api, _model) {
         }
 
         // Writing a string to innerHTML completely decodes multiple-encoded strings
-        const dummyDiv = document.createElement('div');
-        dummyDiv.innerHTML = playlistItem.title || '';
-        videotag.setAttribute('title', dummyDiv.textContent);
+        const body = htmlToParentElement(playlistItem.title || '');
+        videotag.setAttribute('title', body.textContent);
     }
 
     function setPosterImage(item) {

--- a/test/unit/replace-inner-html-test.js
+++ b/test/unit/replace-inner-html-test.js
@@ -34,4 +34,11 @@ describe('replaceInnerHtml', function () {
         expect(console.log).to.have.callCount(0);
         expect(element.firstChild).to.equal(null);
     });
+
+    it('should not append if html is an empty string', function() {
+        const empty = '';
+        replaceInnerHtml(element, empty);
+        expect(element.firstChild).to.equal(null);
+    });
+
 });

--- a/test/unit/replace-inner-html-test.js
+++ b/test/unit/replace-inner-html-test.js
@@ -1,0 +1,37 @@
+import { replaceInnerHtml } from 'utils/dom';
+import sinon from 'sinon';
+
+describe('replaceInnerHtml', function () {
+    const sandbox = sinon.sandbox.create();
+    let element;
+
+    beforeEach(() => {
+        element = document.createElement('div');
+        sandbox.spy(console, 'log');
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    it('should sanitize and append image tags', function() {
+        const imageHtml = '<img src=foo onerror="console.log(\'bar\')">';
+        replaceInnerHtml(element, imageHtml);
+        expect(console.log).to.have.callCount(0);
+        expect(element.firstChild.getAttribute('onerror')).to.equal(null);
+    });
+
+    it('should sanitizea and add svg tags', function() {
+        const svgHtml = '<svg xmlns="http://www.w3.org/2000/svg" onload="console.log(\'baz\')"/>';
+        replaceInnerHtml(element, svgHtml);
+        expect(console.log).to.have.callCount(0);
+        expect(element.firstChild.getAttribute('onload')).to.equal(null);
+    });
+
+    it('should remove script tags', function() {
+        const scriptHtml = '<script src="no.js" onerror="console.log(\'foobar\');"></script>';
+        replaceInnerHtml(element, scriptHtml);
+        expect(console.log).to.have.callCount(0);
+        expect(element.firstChild).to.equal(null);
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2974,6 +2974,11 @@ eslint-plugin-no-for-of-loops@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-no-for-of-loops/-/eslint-plugin-no-for-of-loops-1.0.0.tgz#a13d91a8f1922f7fefedeab351dc0055994601f6"
 
+eslint-plugin-no-unsanitized@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-no-unsanitized/-/eslint-plugin-no-unsanitized-3.0.2.tgz#83c6fcf8e34715112757e03dd4ee436dce29ed45"
+  integrity sha512-JnwpoH8Sv4QOjrTDutENBHzSnyYtspdjtglYtqUtAHe6f6LLKqykJle+UwFPg23GGwt5hI3amS9CRDezW8GAww==
+
 eslint-scope@^3.7.1:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"


### PR DESCRIPTION
### This PR will...
- Implement a util method `replaceInnerHtml` that replaces use of `innerHTML = `
- Replace use of `innerHTML` with `DOMParser...parseFromString(html, 'text/html')`
- Sanitize parsed HTML by:
  - deleting script elements
  - deleting event handler attributes that begin with `on`
- Prevent usage of innerHTML https://github.com/mozilla/eslint-plugin-no-unsanitized

### Why is this Pull Request needed?
To prevent XSS script execution from external player input for custom buttons, logo, about text, and playlist item title and description.

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-commercial/pull/6164
https://github.com/jwplayer/jwplayer-plugin-related/pull/369

#### Addresses Issue(s):
[JW8-718](https://jwplayer.atlassian.net/browse/JW8-718)
