### PR TITLE
Mute button incorrectly announced as slider

### DIFF
--- a/src/js/view/controls/components/volumetooltip.js
+++ b/src/js/view/controls/components/volumetooltip.js
@@ -15,8 +15,7 @@ export default class VolumeTooltip extends Tooltip {
 
         const volumeSliderElement = this.volumeSlider.element();
         volumeSliderElement.classList.remove('jw-background-color');
-
-
+        
         const overlay = this.container;
         setAttribute(overlay, 'tabindex', '0');
         setAttribute(overlay, 'aria-label', localization.volumeSlider);

--- a/src/js/view/controls/components/volumetooltip.js
+++ b/src/js/view/controls/components/volumetooltip.js
@@ -15,10 +15,15 @@ export default class VolumeTooltip extends Tooltip {
 
         const volumeSliderElement = this.volumeSlider.element();
         volumeSliderElement.classList.remove('jw-background-color');
-        setAttribute(volumeSliderElement, 'aria-label', localization.volumeSlider);
+
 
         const overlay = this.container;
         setAttribute(overlay, 'tabindex', '0');
+        setAttribute(overlay, 'aria-label', localization.volumeSlider);
+        setAttribute(overlay, 'aria-orientation', 'vertical');
+        setAttribute(overlay, 'aria-valuemin', 0);
+        setAttribute(overlay, 'aria-valuemax', 100);
+        setAttribute(overlay, 'role', 'slider');
 
         this.addContent(volumeSliderElement);
 

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -120,7 +120,7 @@ export default class Controlbar {
         const timeSlider = new TimeSlider(_model, _api, _accessibilityContainer.querySelector('.jw-time-update'));
         const menus = this.menus = [];
         this.ui = [];
-        let volumeButton;
+        let volumeGroup;
         let muteButton;
         let feedShownId = '';
 
@@ -128,7 +128,7 @@ export default class Controlbar {
 
         // Do not show the volume toggle in the mobile SDKs or <iOS10
         if (!_model.get('sdkplatform') && !(OS.iOS && OS.version.major < 10)) {
-            // Clone icons so that can be used in volumeButton
+            // Clone icons so that can be used in volumeGroup
             const svgIcons = cloneIcons('volume-0,volume-100');
             muteButton = button('jw-icon-volume', () => {
                 _api.setMute();
@@ -137,11 +137,11 @@ export default class Controlbar {
 
         // Do not initialize volume slider or tooltip on mobile
         if (!this._isMobile) {
-            volumeButton = new VolumeTooltip(_model, 'jw-icon-volume', vol,
+            volumeGroup = new VolumeTooltip(_model, 'jw-icon-volume', vol,
                 cloneIcons('volume-0,volume-50,volume-100'));
 
-            const volumeButtonEl = volumeButton.element();
-            menus.push(volumeButton);
+            const volumeButtonEl = volumeGroup.element();
+            menus.push(volumeGroup);
             setAttribute(volumeButtonEl, 'role', 'button');
             _model.change('mute', (model, muted) => {
                 const muteText = muted ? localization.unmute : localization.mute;
@@ -183,7 +183,7 @@ export default class Controlbar {
             time: timeSlider,
             duration: textIcon('jw-text-duration', 'timer'),
             mute: muteButton,
-            volumetooltip: volumeButton,
+            volumetooltip: volumeGroup,
             cast: createCastButton(() => {
                 _api.castToggle();
             }, localization),
@@ -365,17 +365,17 @@ export default class Controlbar {
 
     renderVolume(muted, vol) {
         const mute = this.elements.mute;
-        const volumeButton = this.elements.volumetooltip;
+        const volumeGroup = this.elements.volumetooltip;
         // mute, volume, and volumetooltip do not exist on mobile devices.
         if (mute) {
             toggleClass(mute.element(), 'jw-off', muted);
             toggleClass(mute.element(), 'jw-full', !muted);
         }
-        if (volumeButton) {
+        if (volumeGroup) {
             const volume = muted ? 0 : vol;
-            const volumeButtonEl = volumeButton.element();
-            volumeButton.volumeSlider.render(volume);
-            const volumeSliderContainer = volumeButton.container;
+            const volumeButtonEl = volumeGroup.element();
+            volumeGroup.volumeSlider.render(volume);
+            const volumeSliderContainer = volumeGroup.container;
             toggleClass(volumeButtonEl, 'jw-off', muted);
             toggleClass(volumeButtonEl, 'jw-full', vol >= 75 && !muted);
             setAttribute(volumeSliderContainer, 'aria-valuenow', volume);

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -120,7 +120,7 @@ export default class Controlbar {
         const timeSlider = new TimeSlider(_model, _api, _accessibilityContainer.querySelector('.jw-time-update'));
         const menus = this.menus = [];
         this.ui = [];
-        let volumeTooltip;
+        let volumeButton;
         let muteButton;
         let feedShownId = '';
 
@@ -128,7 +128,7 @@ export default class Controlbar {
 
         // Do not show the volume toggle in the mobile SDKs or <iOS10
         if (!_model.get('sdkplatform') && !(OS.iOS && OS.version.major < 10)) {
-            // Clone icons so that can be used in VolumeTooltip
+            // Clone icons so that can be used in volumeButton
             const svgIcons = cloneIcons('volume-0,volume-100');
             muteButton = button('jw-icon-volume', () => {
                 _api.setMute();
@@ -137,18 +137,15 @@ export default class Controlbar {
 
         // Do not initialize volume slider or tooltip on mobile
         if (!this._isMobile) {
-            volumeTooltip = new VolumeTooltip(_model, 'jw-icon-volume', vol,
+            volumeButton = new VolumeTooltip(_model, 'jw-icon-volume', vol,
                 cloneIcons('volume-0,volume-50,volume-100'));
 
-            const volumeTooltipEl = volumeTooltip.element();
-            menus.push(volumeTooltip);
-            setAttribute(volumeTooltipEl, 'aria-valuemin', 0);
-            setAttribute(volumeTooltipEl, 'aria-valuemax', 100);
-            setAttribute(volumeTooltipEl, 'aria-orientation', 'vertical');
-            setAttribute(volumeTooltipEl, 'role', 'slider');
+            const volumeButtonEl = volumeButton.element();
+            menus.push(volumeButton);
+            setAttribute(volumeButtonEl, 'role', 'button');
             _model.change('mute', (model, muted) => {
                 const muteText = muted ? localization.unmute : localization.mute;
-                setAttribute(volumeTooltipEl, 'aria-label', muteText);
+                setAttribute(volumeButtonEl, 'aria-label', muteText);
             }, this);
         }
 
@@ -186,7 +183,7 @@ export default class Controlbar {
             time: timeSlider,
             duration: textIcon('jw-text-duration', 'timer'),
             mute: muteButton,
-            volumetooltip: volumeTooltip,
+            volumetooltip: volumeButton,
             cast: createCastButton(() => {
                 _api.castToggle();
             }, localization),
@@ -368,22 +365,24 @@ export default class Controlbar {
 
     renderVolume(muted, vol) {
         const mute = this.elements.mute;
-        const volumeTooltip = this.elements.volumetooltip;
+        const volumeButton = this.elements.volumetooltip;
         // mute, volume, and volumetooltip do not exist on mobile devices.
         if (mute) {
             toggleClass(mute.element(), 'jw-off', muted);
             toggleClass(mute.element(), 'jw-full', !muted);
         }
-        if (volumeTooltip) {
+        if (volumeButton) {
             const volume = muted ? 0 : vol;
-            const volumeTooltipEl = volumeTooltip.element();
-            volumeTooltip.volumeSlider.render(volume);
-            toggleClass(volumeTooltipEl, 'jw-off', muted);
-            toggleClass(volumeTooltipEl, 'jw-full', vol >= 75 && !muted);
-            setAttribute(volumeTooltipEl, 'aria-valuenow', volume);
+            const volumeButtonEl = volumeButton.element();
+            const volumeSlider = volumeButton.volumeSlider;
+            volumeSlider.render(volume);
+            const volumeSliderEl = volumeSlider.element();
+            toggleClass(volumeButtonEl, 'jw-off', muted);
+            toggleClass(volumeButtonEl, 'jw-full', vol >= 75 && !muted);
+            setAttribute(volumeSliderEl, 'aria-valuenow', volume);
             const ariaText = `Volume ${volume}%`;
-            setAttribute(volumeTooltipEl, 'aria-valuetext', ariaText);
-            if (document.activeElement !== volumeTooltipEl) {
+            setAttribute(volumeSliderEl, 'aria-valuetext', ariaText);
+            if (document.activeElement !== volumeButtonEl) {
                 this._volumeAnnouncer.textContent = ariaText;
             }
         }

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -374,15 +374,14 @@ export default class Controlbar {
         if (volumeButton) {
             const volume = muted ? 0 : vol;
             const volumeButtonEl = volumeButton.element();
-            const volumeSlider = volumeButton.volumeSlider;
-            volumeSlider.render(volume);
-            const volumeSliderEl = volumeSlider.element();
+            volumeButton.volumeSlider.render(volume);
+            const volumeSliderContainer = volumeButton.container;
             toggleClass(volumeButtonEl, 'jw-off', muted);
             toggleClass(volumeButtonEl, 'jw-full', vol >= 75 && !muted);
-            setAttribute(volumeSliderEl, 'aria-valuenow', volume);
+            setAttribute(volumeSliderContainer, 'aria-valuenow', volume);
             const ariaText = `Volume ${volume}%`;
-            setAttribute(volumeSliderEl, 'aria-valuetext', ariaText);
-            if (document.activeElement !== volumeButtonEl) {
+            setAttribute(volumeSliderContainer, 'aria-valuetext', ariaText);
+            if (document.activeElement !== volumeSliderContainer) {
                 this._volumeAnnouncer.textContent = ariaText;
             }
         }


### PR DESCRIPTION
### This PR will...
- rename the `volumeTooltip` controlbar element to `volumeGroup`
- remove the aria information specific to the volume slider from the mute button, and add it to the volumeGroup's overlay (the volume slider)
- set the mute button's role to  'button'

### Why is this Pull Request needed?
the mute button was being announced by screen readers as a slider, when instead it should be announced as a button. I think this bug was partially caused by the fact that `VolumeTooltip` is a very misleading name since it creates an element containing a tooltip as a child element, instead of creating an actual tooltip. To reduce confusion, `volumeTooltip` was renamed to `volumeGroup` and tech debt item https://github.com/jwplayer/jwplayer/issues/3240 was created to refactor `VolumeTooltip.js` and `Tooltip.js`.
### Are there any points in the code the reviewer needs to double check?
n/a
### Are there any Pull Requests open in other repos which need to be merged with this?
n/a
#### Addresses Issue(s):
JW8-2567

