### PR TITLE
Change hidden vol/time readers from <p> to <span>

### DIFF
--- a/src/templates/player.js
+++ b/src/templates/player.js
@@ -13,8 +13,8 @@ export default (id, ariaLabel) => {
                 `</div>` +
                 `<div class="jw-overlays jw-reset"></div>` +
                 `<div class="jw-hidden-accessibility">` +
-                    `<p class="jw-time-update" aria-live="assertive"></p>` +
-                    `<p class="jw-volume-update" aria-live="assertive"></p>` +
+                    `<span class="jw-time-update" aria-live="assertive"></span>` +
+                    `<span class="jw-volume-update" aria-live="assertive"></span>` +
                 `</div>` +
             `</div>` +
         `</div>`


### PR DESCRIPTION
### This PR will...
Change hidden volume and time update readers from `<p>` to `<span>`

### Why is this Pull Request needed?
Safari with VoiceOver does not announce the update to the first `<p>` in a hidden `<div>` if more than one `<p>` exist in the same `<div>`, because `<p>` starts a new line.
Changing to `<span>` works because `<span>` is an inline element.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):
JW8-2517

