### PR TITLE
Remove unnecessary aria-expanded

### DIFF
--- a/src/js/view/controls/components/simple-tooltip.js
+++ b/src/js/view/controls/components/simple-tooltip.js
@@ -18,7 +18,6 @@ export function SimpleTooltip(attachToElement, name, text, openCallback, closeCa
                 return;
             }
 
-            tooltipElement.setAttribute('aria-expanded', 'true');
             addClass(tooltipElement, 'jw-open');
 
             if (openCallback) {
@@ -30,7 +29,6 @@ export function SimpleTooltip(attachToElement, name, text, openCallback, closeCa
                 return;
             }
 
-            tooltipElement.setAttribute('aria-expanded', 'false');
             removeClass(tooltipElement, 'jw-open');
 
             if (closeCallback) {


### PR DESCRIPTION
### This PR will...
- remove aria-expanded from the tooltips
### Why is this Pull Request needed?
Per the [documentation](https://www.w3.org/WAI/PF/aria/states_and_properties#aria-expanded), `aria-expanded` should be used on elements which can be interacted with to expand or collapse content (i.e. a drop down list). This label is unnecessary for tooltips since they cannot be interacted with; the user can't tab into a tooltip. The tooltip's purpose is to display information; the same information is contained by the aria-labels on the actual buttons, and is announced by the screen reader.
### Are there any points in the code the reviewer needs to double check?
n/a
### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-plugin-related/pull/370
#### Addresses Issue(s):
JW8-2518

