### PR TITLE
Parse HTML for titles and localization

### DIFF
--- a/src/js/view/controls/components/simple-tooltip.js
+++ b/src/js/view/controls/components/simple-tooltip.js
@@ -1,4 +1,4 @@
-import { addClass, removeClass } from 'utils/dom';
+import { addClass, removeClass, replaceInnerHtml } from 'utils/dom';
 
 export function SimpleTooltip(attachToElement, name, text, openCallback, closeCallback) {
     const tooltipElement = document.createElement('div');
@@ -7,7 +7,6 @@ export function SimpleTooltip(attachToElement, name, text, openCallback, closeCa
 
     const textElement = document.createElement('div');
     textElement.className = 'jw-text';
-    textElement.textContent = text;
 
     tooltipElement.appendChild(textElement);
     attachToElement.appendChild(tooltipElement);
@@ -36,9 +35,11 @@ export function SimpleTooltip(attachToElement, name, text, openCallback, closeCa
             }
         },
         setText(newText) {
-            tooltipElement.querySelector('.jw-text').textContent = newText;
+            replaceInnerHtml(textElement, newText);
         }
     };
+
+    instance.setText(text);
 
     attachToElement.addEventListener('mouseover', instance.open);
     attachToElement.addEventListener('focus', instance.open);

--- a/src/js/view/controls/info-overlay.js
+++ b/src/js/view/controls/info-overlay.js
@@ -1,5 +1,5 @@
 import InfoOverlayTemplate from 'view/controls/templates/info-overlay';
-import { createElement, prependChild } from 'utils/dom';
+import { createElement, prependChild, replaceInnerHtml } from 'utils/dom';
 import { STATE_PLAYING, STATE_PAUSED } from 'events/events';
 import button from 'view/controls/components/button';
 import { cloneIcon } from 'view/controls/icons';
@@ -37,8 +37,8 @@ export default function (container, model, api, onVisibility) {
 
         model.change('playlistItem', (changeModel, item) => {
             const { description, title } = item;
-            descriptionContainer.textContent = description || '';
-            titleContainer.textContent = title || 'Unknown Title';
+            replaceInnerHtml(descriptionContainer, description || '');
+            replaceInnerHtml(titleContainer, title || 'Unknown Title');
         });
         model.change('duration', (changeModel, duration) => {
             const streamType = model.get('streamType');

--- a/src/js/view/controls/play-display-icon.js
+++ b/src/js/view/controls/play-display-icon.js
@@ -44,9 +44,8 @@ export default class PlayDisplayIcon extends Eventable {
         if (_model.get('displayPlaybackLabel')) {
             let iconText = this.icon.getElementsByClassName('jw-idle-icon-text')[0];
             if (!iconText) {
-                iconText = createElement(`<div class="jw-idle-icon-text"></div>`);
+                iconText = createElement(`<div class="jw-idle-icon-text">${localization.playback}</div>`);
                 addClass(this.icon, 'jw-idle-label');
-                iconText.textContent = localization.playback;
                 this.icon.appendChild(iconText);
             }
         }


### PR DESCRIPTION
### This PR will...
Address handling of HTML and HTML encoded characters in content titles and localization options.

### Why is this Pull Request needed?
The player supports display of html characters in the title and description on the idle screen, but not in other parts of the player. These include the right click info overlay, related overlays, and localizations options where html encoded characters may be included in the translations.

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-plugin-related/pull/371

#### Addresses Issue(s):

JW8-2605

