### PR TITLE
[JW8-2159]Toggle settings menu icon dependent on amount of submenus 

### DIFF
--- a/src/js/view/controls/components/settings/menu.js
+++ b/src/js/view/controls/components/settings/menu.js
@@ -16,7 +16,7 @@ function focusSettingsElement(direction) {
     }
 }
 
-export function SettingsMenu(onVisibility, onSubmenuAdded, onMenuEmpty, localization) {
+export function SettingsMenu(onVisibility, onMenuEmpty, localization) {
     const documentClickHandler = (e) => {
         // Close if anything other than the settings menu has been clicked
         // Let the display (jw-video) handles closing itself (display clicks do not pause if the menu is open)
@@ -151,11 +151,12 @@ export function SettingsMenu(onVisibility, onSubmenuAdded, onMenuEmpty, localiza
             }
 
             settingsMenuElement.appendChild(submenu.element());
-
-            onSubmenuAdded(Object.keys(submenus));
         },
         getSubmenu(name) {
             return submenus[name];
+        },
+        getSubmenuNames() {
+            return Object.keys(submenus);
         },
         removeSubmenu(name) {
             const submenu = submenus[name];

--- a/src/js/view/controls/components/settings/menu.js
+++ b/src/js/view/controls/components/settings/menu.js
@@ -152,7 +152,7 @@ export function SettingsMenu(onVisibility, onSubmenuAdded, onMenuEmpty, localiza
 
             settingsMenuElement.appendChild(submenu.element());
 
-            onSubmenuAdded();
+            onSubmenuAdded(Object.keys(submenus));
         },
         getSubmenu(name) {
             return submenus[name];

--- a/src/js/view/controls/settings-menu.js
+++ b/src/js/view/controls/settings-menu.js
@@ -54,7 +54,8 @@ export function createSettingsMenu(controlbar, onVisibility, localization) {
 function showSettingsMenuIcon(settingsMenu, controlbar) {
     // Show or hide settings menu icon dependant on amount of submenus
     const submenuNames = settingsMenu.getSubmenuNames();
-    controlbar.elements.settingsButton.toggle(submenuNames.indexOf('quality') > -1 || submenuNames.length > 1);
+    const toggleIcon = submenuNames.indexOf('quality') > -1 || submenuNames.indexOf('playbackRates') > -1;
+    controlbar.elements.settingsButton.toggle(toggleIcon || submenuNames.length > 1);
 }
 
 export function setupSubmenuListeners(settingsMenu, controlbar, viewModel, api) {

--- a/src/js/view/controls/settings-menu.js
+++ b/src/js/view/controls/settings-menu.js
@@ -12,8 +12,10 @@ import {
 
 export function createSettingsMenu(controlbar, onVisibility, localization) {
     const settingsButton = controlbar.elements.settingsButton;
-    const onSubmenuAdded = () => {
-        settingsButton.show();
+    const onSubmenuAdded = (submenuNames) => {
+        if (submenuNames.length > 1) {
+            settingsButton.show();
+        }
     };
     const onMenuEmpty = () => {
         settingsButton.hide();

--- a/src/js/view/controls/settings-menu.js
+++ b/src/js/view/controls/settings-menu.js
@@ -12,16 +12,11 @@ import {
 
 export function createSettingsMenu(controlbar, onVisibility, localization) {
     const settingsButton = controlbar.elements.settingsButton;
-    const onSubmenuAdded = (submenuNames) => {
-        if (submenuNames.length > 1) {
-            settingsButton.show();
-        }
-    };
     const onMenuEmpty = () => {
         settingsButton.hide();
     };
 
-    const settingsMenu = SettingsMenu(onVisibility, onSubmenuAdded, onMenuEmpty, localization);
+    const settingsMenu = SettingsMenu(onVisibility, onMenuEmpty, localization);
 
     controlbar.on('settingsInteraction', (submenuName, isDefault, event) => {
         const submenu = settingsMenu.getSubmenu(submenuName);
@@ -56,6 +51,11 @@ export function createSettingsMenu(controlbar, onVisibility, localization) {
     return settingsMenu;
 }
 
+function showSettingsMenuIcon(settingsMenu, controlbar) {
+    // Show or hide settings menu icon dependant on amount of submenus
+    const submenuNames = settingsMenu.getSubmenuNames();
+    controlbar.elements.settingsButton.toggle(submenuNames.indexOf('quality') > -1 || submenuNames.length > 1);
+}
 
 export function setupSubmenuListeners(settingsMenu, controlbar, viewModel, api) {
     const model = viewModel.player;
@@ -85,6 +85,7 @@ export function setupSubmenuListeners(settingsMenu, controlbar, viewModel, api) 
     const onQualitiesChanged = (changedModel, levels) => {
         if (!levels || levels.length <= 1) {
             removeQualitiesSubmenu(settingsMenu);
+            showSettingsMenuIcon(settingsMenu, controlbar);
             return;
         }
 
@@ -98,6 +99,8 @@ export function setupSubmenuListeners(settingsMenu, controlbar, viewModel, api) 
             hd,
             auto
         );
+
+        showSettingsMenuIcon(settingsMenu, controlbar);
     };
 
     const onCaptionsChanged = (changedModel, captionsList) => {

--- a/src/js/view/controls/settings-menu.js
+++ b/src/js/view/controls/settings-menu.js
@@ -54,8 +54,10 @@ export function createSettingsMenu(controlbar, onVisibility, localization) {
 function showSettingsMenuIcon(settingsMenu, controlbar) {
     // Show or hide settings menu icon dependant on amount of submenus
     const submenuNames = settingsMenu.getSubmenuNames();
-    const toggleIcon = submenuNames.indexOf('quality') > -1 || submenuNames.indexOf('playbackRates') > -1;
-    controlbar.elements.settingsButton.toggle(toggleIcon || submenuNames.length > 1);
+    const toggleIcon = submenuNames.length > 1 ||
+                        submenuNames.some(name => (name === 'quality' || name === 'playbackRates'));
+
+    controlbar.elements.settingsButton.toggle(toggleIcon);
 }
 
 export function setupSubmenuListeners(settingsMenu, controlbar, viewModel, api) {
@@ -86,21 +88,18 @@ export function setupSubmenuListeners(settingsMenu, controlbar, viewModel, api) 
     const onQualitiesChanged = (changedModel, levels) => {
         if (!levels || levels.length <= 1) {
             removeQualitiesSubmenu(settingsMenu);
-            showSettingsMenuIcon(settingsMenu, controlbar);
-            return;
+        } else {
+            const { hd, auto } = model.get('localization');
+
+            addQualitiesSubmenu(
+                settingsMenu,
+                levels,
+                (index) => api.setCurrentQuality(index),
+                model.get('currentLevel'),
+                hd,
+                auto
+            );
         }
-
-        const { hd, auto } = model.get('localization');
-
-        addQualitiesSubmenu(
-            settingsMenu,
-            levels,
-            (index) => api.setCurrentQuality(index),
-            model.get('currentLevel'),
-            hd,
-            auto
-        );
-
         showSettingsMenuIcon(settingsMenu, controlbar);
     };
 


### PR DESCRIPTION
### This PR will...

Toggle settings menu on the controlbar dependent on the number submenu items an item has

### Why is this Pull Request needed?

Improvement for the controlbar. We don't want to see two buttons in the control bar that do the exact same thing, if there is no difference between them (ex: Captions is the only submenu and we show both the captions icon and settings icon)

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-2159

