### PR TITLE
[DNM] Remove spinning transition from jw-idle-label class

### DIFF
--- a/src/css/controls/imports/playback-label.less
+++ b/src/css/controls/imports/playback-label.less
@@ -15,17 +15,16 @@
 .jw-idle-label {
     border-radius: 50%;
     color: @white;
-    filter: drop-shadow(1px 1px 5px rgba(12, 26, 71, 0.25));
     font: normal 16px/1 Arial, Helvetica, sans-serif;
     position: relative;
-    transition: background-color @default-transition;
-    transition-property: background-color, filter;
     -webkit-font-smoothing: antialiased;
 }
 
 .jw-state-idle {
     .jw-icon-display {
         &.jw-idle-label {
+            filter: drop-shadow(1px 1px 5px rgba(12, 26, 71, 0.25));
+
             .jw-idle-icon-text {
                 display: block;
             }


### PR DESCRIPTION
### This PR will...

- Remove ```transition``` and ```transition-property``` from ```.jw-idle.label```
- Move ```filter``` to be applied on idle state

### Why is this Pull Request needed?

```transition``` was causing the state icons to spin during playback.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-2614

