### PR TITLE
Set Chromecast item startTime to currentTime to support DVR live edge

### DIFF
--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -197,7 +197,7 @@ class ProgramController extends Eventable {
         model.attributes.itemReady = false;
 
         const playlistItem = Object.assign({}, item);
-        playlistItem.starttime = model.mediaModel.get('position');
+        playlistItem.starttime = model.mediaModel.get('currentTime');
 
         this._destroyActiveMedia();
 


### PR DESCRIPTION
### This PR will...

Seek to the live edge when casting Live/DVR Streams.

### Why is this Pull Request needed?
When casting, the Chromecast module will tell the receiver to seek to the current item's `startTime`. Since receivers seek using `currentTime` we should always set `startTime` to this value.

### Are there any Pull Requests open in other repos which need to be merged with this?
Changes to the Chromecast provider in commercial enable DVR controls with time events that include currentTime and seekable ranges.
https://github.com/jwplayer/jwplayer-commercial/pull/6208

#### Addresses Issue(s):
JW8-1703

