### PR TITLE
Don't expect seekRange to be defined on the player model

### DIFF
--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -196,7 +196,7 @@ class TimeSlider extends Slider {
         if (duration === 0) {
             this._api.play(reasonInteraction());
         } else if (this.streamType === 'DVR') {
-            const seekRange = this._model.get('seekRange');
+            const seekRange = this._model.get('seekRange') || { start: 0 };
             const dvrSeekLimit = this._model.get('dvrSeekLimit');
             position = seekRange.start + (-duration - dvrSeekLimit) * percent / 100;
             this._api.seek(position, reasonInteraction());


### PR DESCRIPTION
### This PR will...
Prevent exceptions while seeking in DVR streams with providers that do not output `seekRange`.

### Why is this Pull Request needed?
Provider 'time' and 'meta' event overwrite model `seekRange`. If the value is undefined in these provider events, it will be undefined in the model.

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/6213

#### Addresses Issue(s):
JW8-1807

