### PR TITLE
Fix DVR seeking in html5 provider

### DIFF
--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -518,11 +518,11 @@ export default class Controlbar {
 
     goToLiveEdge() {
         if (this._model.get('streamType') === 'DVR') {
-            // Seek to "Live" position within live buffer, but not before current position
-            const currentPosition = this._model.get('position');
+            // Seek to "Live" position within live buffer, but not before the dvr position which must be negative
+            const dvrPosition = Math.min(this._model.get('position'), -1);
             const dvrSeekLimit = this._model.get('dvrSeekLimit');
 
-            this._api.seek(Math.max(-dvrSeekLimit, currentPosition), reasonInteraction());
+            this._api.seek(Math.max(-dvrSeekLimit, dvrPosition), reasonInteraction());
         }
     }
 


### PR DESCRIPTION
### This PR will...
Fix issues with seeking to the live edge and rewinding 10 seconds during DVR playback in Safari with the html5 provider.

### Why is this Pull Request needed?
`position` and `dvrPosition` should always be `0` or less during DVR playback. `0` would indicate that you are at the live edge. Positive values caused seek time calculated to target the start of a stream instead of the end.

When seek is called with a negative value, we should seek back from the live edge which is `seekRange.end`. Instead we were subtracting from `seekRange.start + seekRange.end` which resulted in drift making the rewind button seek target drift forward the longer a DVR stream was played.

#### Addresses Issue(s):
JW8-716 JW8-2594
