### PR TITLE
Prevent exception exiting fullscreen via escape key

### DIFF
--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -233,20 +233,6 @@ export default class Controls {
             api.setVolume(newVol);
         }
 
-        function onEscape() {
-            if (model.get('fullscreen')) {
-                api.setFullscreen(false);
-                this.playerContainer.blur();
-                this.userInactive();
-                return;
-            }
-
-            const related = api.getPlugin('related');
-            if (related) {
-                related.close({ type: 'escape' });
-            }
-        }
-
         const handleKeydown = (evt) => {
             // If Meta keys return
             if (evt.ctrlKey || evt.metaKey) {
@@ -258,7 +244,16 @@ export default class Controls {
 
             switch (evt.keyCode) {
                 case 27: // Esc
-                    onEscape();
+                    if (model.get('fullscreen')) {
+                        api.setFullscreen(false);
+                        this.playerContainer.blur();
+                        this.userInactive();
+                    } else {
+                        const related = api.getPlugin('related');
+                        if (related) {
+                            related.close({ type: 'escape' });
+                        }
+                    }
                     break;
                 case 13: // enter
                 case 32: // space

--- a/src/js/view/utils/request-fullscreen-helper.js
+++ b/src/js/view/utils/request-fullscreen-helper.js
@@ -33,13 +33,17 @@ export default function(elementContext, documentContext, changeCallback) {
             requestFullscreen.apply(elementContext);
         },
         exitFullscreen: function() {
-            exitFullscreen.apply(documentContext);
+            if (this.fullscreenElement() !== null) {
+                exitFullscreen.apply(documentContext);
+            }
         },
         fullscreenElement: function() {
-            return documentContext.fullscreenElement ||
-                documentContext.webkitCurrentFullScreenElement ||
-                documentContext.mozFullScreenElement ||
-                documentContext.msFullscreenElement;
+            const { fullscreenElement, webkitCurrentFullScreenElement, mozFullScreenElement, msFullscreenElement } =
+                documentContext;
+            if (fullscreenElement === null) {
+                return fullscreenElement;
+            }
+            return fullscreenElement || webkitCurrentFullScreenElement || mozFullScreenElement || msFullscreenElement;
         },
         destroy: function() {
             for (let i = DOCUMENT_FULLSCREEN_EVENTS.length; i--;) {


### PR DESCRIPTION
### This PR will...
1. Prevent exception exiting fullscreen via escape key.
2. Cleanup key handler that called a function where `this` is undefined (it's only defined in the `handleKeydown` arrow function).

### Why is this Pull Request needed?
`document.exitFullscreen` throws an except in Chrome and Firefox when `document.fullscreenElement` is `null`. These changes allow for backwards compatibility with browsers where `document.fullscreenElement` is always `undefined` .
 
We can't try catch because `exitFullscreen` will throw an unhandled promise rejection. We don't need to support the promise implementation of fullscreen methods at this point as that would require a ton of polyfilling and player changes.

#### Addresses Issue(s):
JW8-2587
Fixes #3168