### PR TITLE
[JW8-2607] Keep controls visible is activated via keyboard

### DIFF
--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -76,12 +76,12 @@ export default class Controls {
             }
             this.userInactive();
         };
-        this.resetActiveTimeout = () => {
-            console.log('im hit', this);
-            clearTimeout(this.activeTimeout);
-            this.activeTimeout = -1;
-            this.inactiveTime = 0;
-        };
+    }
+
+    resetActiveTimeout() {
+        clearTimeout(this.activeTimeout);
+        this.activeTimeout = -1;
+        this.inactiveTime = 0;
     }
 
     enable(api, model) {

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -33,7 +33,6 @@ instances.forEach(api => {
 const reasonInteraction = function() {
     return { reason: 'interaction' };
 };
-
 export default class Controls {
     constructor(context, playerContainer) {
         Object.assign(this, Events);
@@ -71,9 +70,17 @@ export default class Controls {
                 this.activeTimeout = setTimeout(this.userInactiveTimeout, remainingTime);
                 return;
             }
-            if (!this.playerContainer.querySelector('.jw-tab-focus')) {
-                this.userInactive();
+            if (this.playerContainer.querySelector('.jw-tab-focus')) {
+                this.resetActiveTimeout();
+                return;
             }
+            this.userInactive();
+        };
+        this.resetActiveTimeout = () => {
+            console.log('im hit', this);
+            clearTimeout(this.activeTimeout);
+            this.activeTimeout = -1;
+            this.inactiveTime = 0;
         };
     }
 
@@ -476,9 +483,7 @@ export default class Controls {
                 this.activeTimeout = setTimeout(this.userInactiveTimeout, timeout);
             }
         } else {
-            clearTimeout(this.activeTimeout);
-            this.activeTimeout = -1;
-            this.inactiveTime = 0;
+            this.resetActiveTimeout();
         }
         if (!this.showing) {
             removeClass(this.playerContainer, 'jw-flag-user-inactive');

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -71,7 +71,9 @@ export default class Controls {
                 this.activeTimeout = setTimeout(this.userInactiveTimeout, remainingTime);
                 return;
             }
-            this.userInactive();
+            if (!this.playerContainer.querySelector('.jw-tab-focus')) {
+                this.userInactive();
+            }
         };
     }
 


### PR DESCRIPTION
### This PR will...

Only call ```this.userInactive``` inside the ```userInactiveTimeout``` if players controls weren't shown through a keyboard interaction.

### Why is this Pull Request needed?

We want to keep the controls visible when a user is currently focused on the player for better accessibility.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-2607

