### PR TITLE
Prevent other svg icons from animating when displayPlaybackLabel is on

### DIFF
--- a/src/css/controls/states.less
+++ b/src/css/controls/states.less
@@ -29,17 +29,16 @@
 // buffering
 .jwplayer.jw-state-buffering {
     .jw-display-icon-display .jw-icon {
-        animation: spin 2s linear infinite;
-
         &:focus {
             border: none;
         }
 
         .jw-svg-icon-buffer {
+            animation: jw-spin 2s linear infinite;
             display: block;
         }
 
-        @keyframes spin {
+        @keyframes jw-spin {
             100% {
                 transform: rotate(360deg);
             }


### PR DESCRIPTION
### This PR will...

- Namespace the ```spin``` animation in ```states.less``` to ```jw-spin```
- Move the ```animation``` property to the svg buffer icon

### Why is this Pull Request needed?

To prevent the other svg icons from animating when transitioning from ```idle``` to ```play```

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-2614

