### PR TITLE
[JW8-2566] Support legacy config options in translated localization block

### DIFF
--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -61,69 +61,14 @@ function _adjustDefaultBwEstimate(estimate) {
     return Defaults.bandwidthEstimate;
 }
 
-function _mergeProperty(localizationObj, allOptionsObj, prop) {
-    const propToCopy = localizationObj[prop] || allOptionsObj[prop];
-
-    if (propToCopy) {
-        localizationObj[prop] = propToCopy;
-    }
-}
-
-function _copyToLocalization(allOptions) {
-    const { advertising, related, sharing, abouttext } = allOptions;
-    const localization = Object.assign({}, allOptions.localization);
-
-    if (advertising) {
-        localization.advertising = localization.advertising || {};
-        _mergeProperty(localization.advertising, advertising, 'admessage');
-        _mergeProperty(localization.advertising, advertising, 'cuetext');
-        _mergeProperty(localization.advertising, advertising, 'loadingAd');
-        _mergeProperty(localization.advertising, advertising, 'podmessage');
-        _mergeProperty(localization.advertising, advertising, 'skipmessage');
-        _mergeProperty(localization.advertising, advertising, 'skiptext');
-    }
-
-    if (typeof localization.related === 'string') {
-        localization.related = {
-            heading: localization.related
-        };
-    } else {
-        localization.related = localization.related || {};
-    }
-
-    if (related) {
-        _mergeProperty(localization.related, related, 'autoplaymessage');
-    }
-
-    if (sharing) {
-        localization.sharing = localization.sharing || {};
-        _mergeProperty(localization.sharing, sharing, 'heading');
-        _mergeProperty(localization.sharing, sharing, 'copied');
-    }
-
-    if (abouttext) {
-        _mergeProperty(localization, allOptions, 'abouttext');
-    }
-
-    const localizationClose = localization.close || localization.nextUpClose;
-
-    if (localizationClose) {
-        localization.close = localizationClose;
-    }
-
-    allOptions.localization = localization;
-}
-
 const Config = function(options, persisted) {
     let allOptions = Object.assign({}, (window.jwplayer || {}).defaults, persisted, options);
-    _copyToLocalization(allOptions);
     _deserialize(allOptions);
 
     const language = allOptions.forceLocalizationDefaults ? Defaults.language : getLanguage();
-    const { localization } = allOptions;
     const intl = normalizeIntl(allOptions.intl);
 
-    allOptions.localization = applyTranslation(en, getCustomLocalization(localization, intl, language));
+    allOptions.localization = applyTranslation(en, getCustomLocalization(allOptions, intl, language));
 
     let config = Object.assign({}, Defaults, allOptions);
     if (config.base === '.') {

--- a/src/js/api/setup-steps.js
+++ b/src/js/api/setup-steps.js
@@ -99,7 +99,8 @@ export function loadSkin(_model) {
 export function loadTranslations(_model) {
     const { attributes } = _model;
     const { language, base, setupConfig, intl } = attributes;
-    const customLocalization = getCustomLocalization(setupConfig.localization, intl, language);
+
+    const customLocalization = getCustomLocalization(setupConfig, intl, language);
     if (!isTranslationAvailable(language) || isLocalizationComplete(customLocalization)) {
         return Promise.resolve();
     }

--- a/src/js/utils/language.js
+++ b/src/js/utils/language.js
@@ -96,8 +96,61 @@ export function isTranslationAvailable(language) {
     return translatedLanguageCodes.indexOf(normalizeLanguageCode(language)) >= 0;
 }
 
-export function getCustomLocalization(localization, intl, languageAndCountryCode) {
-    return Object.assign({}, localization, intl[normalizeLanguageCode(languageAndCountryCode)], intl[normalizeLanguageAndCountryCode(languageAndCountryCode)]);
+export function getCustomLocalization(config, intl, languageAndCountryCode) {
+    return Object.assign({}, getCustom(config), intl[normalizeLanguageCode(languageAndCountryCode)], intl[normalizeLanguageAndCountryCode(languageAndCountryCode)]);
+}
+
+function getCustom(config) {
+    const { advertising, related, sharing, abouttext } = config;
+    const localization = Object.assign({}, config.localization);
+
+    if (advertising) {
+        localization.advertising = localization.advertising || {};
+        mergeProperty(localization.advertising, advertising, 'admessage');
+        mergeProperty(localization.advertising, advertising, 'cuetext');
+        mergeProperty(localization.advertising, advertising, 'loadingAd');
+        mergeProperty(localization.advertising, advertising, 'podmessage');
+        mergeProperty(localization.advertising, advertising, 'skipmessage');
+        mergeProperty(localization.advertising, advertising, 'skiptext');
+    }
+
+    if (typeof localization.related === 'string') {
+        localization.related = {
+            heading: localization.related
+        };
+    } else {
+        localization.related = localization.related || {};
+    }
+
+    if (related) {
+        mergeProperty(localization.related, related, 'autoplaymessage');
+    }
+
+    if (sharing) {
+        localization.sharing = localization.sharing || {};
+        mergeProperty(localization.sharing, sharing, 'heading');
+        mergeProperty(localization.sharing, sharing, 'copied');
+    }
+
+    if (abouttext) {
+        mergeProperty(localization, config, 'abouttext');
+    }
+
+    const localizationClose = localization.close || localization.nextUpClose;
+
+    if (localizationClose) {
+        localization.close = localizationClose;
+    }
+
+    return localization;
+}
+
+function mergeProperty(localizationObj, allOptionsObj, prop) {
+    const propToCopy = localizationObj[prop] || allOptionsObj[prop];
+
+    if (propToCopy) {
+        localizationObj[prop] = propToCopy;
+    }
 }
 
 export function isLocalizationComplete(customLocalization) {

--- a/test/unit/language-test.js
+++ b/test/unit/language-test.js
@@ -325,7 +325,7 @@ describe('languageUtils', function() {
         });
 
         it('should override the custom localization with the intl block', function() {
-            const customLocalization = getCustomLocalization(localization, intl, 'fr');
+            const customLocalization = getCustomLocalization({ localization }, intl, 'fr');
             expect(customLocalization.play).to.equal(frPlay);
             expect(customLocalization.pause).to.equal(frPause);
             expect(customLocalization.stop).to.equal(localizationStop);
@@ -333,24 +333,62 @@ describe('languageUtils', function() {
         });
 
         it('should override the language code intl block with the language-Country code intl block', function() {
-            const customLocalization = getCustomLocalization(localization, intl, 'fr-HT');
+            const customLocalization = getCustomLocalization({ localization }, intl, 'fr-HT');
             expect(customLocalization.play).to.equal(frHtPlay);
             expect(customLocalization.pause).to.equal(frPause);
             expect(customLocalization.stop).to.equal(localizationStop);
         });
 
         it('should fallback to the intl block for the matching language code if the country code is different', function() {
-            const customLocalization = getCustomLocalization(localization, intl, 'fr-CA');
+            const customLocalization = getCustomLocalization({ localization }, intl, 'fr-CA');
             expect(customLocalization.play).to.equal(frPlay);
             expect(customLocalization.pause).to.equal(frPause);
             expect(customLocalization.stop).to.equal(localizationStop);
         });
 
         it('should fallback to localization if country code is not defined in intl block', function() {
-            const customLocalization = getCustomLocalization(localization, intl, 'zz');
+            const customLocalization = getCustomLocalization({ localization }, intl, 'zz');
             expect(customLocalization.play).to.equal(localizationPlay);
             expect(customLocalization.pause).to.equal(localizationPause);
             expect(customLocalization.stop).to.equal(localizationStop);
+        });
+
+        it('should copy custom config values regardless of language (Localization Backwards Support)', function() {
+            const config = {
+                abouttext: 'Custom about',
+                advertising: {
+                    admessage: 'admessage',
+                    cuetext: 'cuetext',
+                    loadingAd: 'loadingAd',
+                    podmessage: 'podmessage',
+                    skipmessage: 'skipmessage',
+                    skiptext: 'skiptext',
+                },
+                related: {
+                    autoplaymessage: 'autoplaymessage'
+                },
+                sharing: {
+                    heading: 'heading',
+                    copied: 'copied'
+                },
+                localization: Object.assign({
+                    nextUpClose: 'nextUpClose'
+                }, localization)
+            };
+
+            const customLocalization = getCustomLocalization(config, intl, 'fr');
+            expect(customLocalization.play).to.equal(frPlay);
+            expect(customLocalization.abouttext).to.equal('Custom about');
+            expect(customLocalization.advertising.admessage).to.equal('admessage');
+            expect(customLocalization.advertising.cuetext).to.equal('cuetext');
+            expect(customLocalization.advertising.loadingAd).to.equal('loadingAd');
+            expect(customLocalization.advertising.podmessage).to.equal('podmessage');
+            expect(customLocalization.advertising.skipmessage).to.equal('skipmessage');
+            expect(customLocalization.advertising.skiptext).to.equal('skiptext');
+            expect(customLocalization.related.autoplaymessage).to.equal('autoplaymessage');
+            expect(customLocalization.sharing.heading).to.equal('heading');
+            expect(customLocalization.sharing.copied).to.equal('copied');
+            expect(customLocalization.close).to.equal('nextUpClose');
         });
 
         it('should only use custom localization block if "forceLocalizationDefaults" is true', function() {


### PR DESCRIPTION
### This PR will...
Move legacy localization customization into the language module so that customizations are added when loading another language.

### Why is this Pull Request needed?
To support legacy config options like "abouttext" on non-English pages.

The value of `config.abouttext` was copied correctly to `config.localization.abouttext` in https://github.com/jwplayer/jwplayer/blob/v8.7.2/src/js/api/config.js#L119 but then was overwritten here https://github.com/jwplayer/jwplayer/blob/v8.7.2/src/js/api/setup-steps.js#L115

Copying the custom config values each time `getCustomLocalization` is called treats translated localization blocks the same as the default "en" localization.

#### Addresses Issue(s):
JW8-2566

