### PR TITLE
Change floatOnScroll boolean to float object

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -219,7 +219,7 @@ function View(_api, _model) {
 
         if (_floatOnScroll && _floatOnScroll.dismissible !== false) {
             const floatCloseButton = new FloatingCloseButton(_wrapperElement.querySelector('.jw-top'));
-            floatCloseButton.setup(() => _stopFloating(true), _localization.close);
+            floatCloseButton.setup(() => this.stopFloating(true, true), _localization.close);
         }
 
         _model.on('change:hideAdsControls', function (model, val) {
@@ -877,17 +877,19 @@ function View(_api, _model) {
 
             _resizeOnFloat = false;
         } else if (isVisible) {
-            _stopFloating();
+            this.stopFloating();
         }
     }
 
-    function _stopFloating(forever) {
+    this.stopFloating = function(forever, isClicked) {
         if (floatingPlayer === _playerElement) {
             floatingPlayer = null;
 
             if (forever) {
                 _floatOnScroll = null;
-                _api.pause({ reason: 'interaction' });
+                if (isClicked) {
+                    _api.pause({ reason: 'interaction' });
+                }
             }
 
             removeClass(_playerElement, 'jw-flag-floating');
@@ -899,7 +901,7 @@ function View(_api, _model) {
             style(_wrapperElement, { width: null, height: null });
             _this.resize(_model.get('width'), _model.get('aspectratio') ? undefined : _model.get('height'));
         }
-    }
+    };
 
 
     this.destroy = function () {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -77,7 +77,7 @@ function View(_api, _model) {
     let _resizeOnFloat = false;
     let _stateClassRequestId = -1;
 
-    let _floatOnScroll = _model.get('floatOnScroll');
+    let _floatOnScroll = _model.get('float');
     let _canFloat = false;
 
     let displayClickHandler;
@@ -217,7 +217,7 @@ function View(_api, _model) {
         focusHelper = new UI(_playerElement).on('click', function() {});
         fullscreenHelpers = requestFullscreenHelper(_playerElement, document, _fullscreenChangeHandler);
 
-        if (_floatOnScroll) {
+        if (_floatOnScroll && _floatOnScroll.dismissible !== false) {
             const floatCloseButton = new FloatingCloseButton(_wrapperElement.querySelector('.jw-top'));
             floatCloseButton.setup(() => _stopFloating(true), _localization.close);
         }
@@ -886,7 +886,8 @@ function View(_api, _model) {
             floatingPlayer = null;
 
             if (forever) {
-                _floatOnScroll = false;
+                _floatOnScroll = null;
+                _api.pause({ reason: 'interaction' });
             }
 
             removeClass(_playerElement, 'jw-flag-floating');

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -77,7 +77,7 @@ function View(_api, _model) {
     let _resizeOnFloat = false;
     let _stateClassRequestId = -1;
 
-    let _floatOnScroll = _model.get('float');
+    let _float = _model.get('float');
     let _canFloat = false;
 
     let displayClickHandler;
@@ -217,9 +217,12 @@ function View(_api, _model) {
         focusHelper = new UI(_playerElement).on('click', function() {});
         fullscreenHelpers = requestFullscreenHelper(_playerElement, document, _fullscreenChangeHandler);
 
-        if (_floatOnScroll && _floatOnScroll.dismissible !== false) {
+        if (_float && _float.dismissible !== false) {
             const floatCloseButton = new FloatingCloseButton(_wrapperElement.querySelector('.jw-top'));
-            floatCloseButton.setup(() => this.stopFloating(true, true), _localization.close);
+            floatCloseButton.setup(() => {
+                this.stopFloating(true);
+                _api.pause({ reason: 'interaction' });
+            }, _localization.close);
         }
 
         _model.on('change:hideAdsControls', function (model, val) {
@@ -569,7 +572,7 @@ function View(_api, _model) {
             _model.set('height', playerHeight);
         }
 
-        if (_floatOnScroll && _resizeOnFloat) {
+        if (_float && _resizeOnFloat) {
             style(_wrapperElement, playerStyle);
         } else {
             style(_playerElement, playerStyle);
@@ -840,7 +843,7 @@ function View(_api, _model) {
         const intersectionRatio = Math.round(entry.intersectionRatio * 100) / 100;
         _model.set('intersectionRatio', intersectionRatio);
 
-        if (_floatOnScroll) {
+        if (_float) {
             // Only start floating if player has been entirely visible at least once.
             _canFloat = _canFloat || intersectionRatio === 1;
             if (_canFloat) {
@@ -881,15 +884,12 @@ function View(_api, _model) {
         }
     }
 
-    this.stopFloating = function(forever, isClicked) {
+    this.stopFloating = function(forever) {
         if (floatingPlayer === _playerElement) {
             floatingPlayer = null;
 
             if (forever) {
-                _floatOnScroll = null;
-                if (isClicked) {
-                    _api.pause({ reason: 'interaction' });
-                }
+                _float = null;
             }
 
             removeClass(_playerElement, 'jw-flag-floating');

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -77,7 +77,7 @@ function View(_api, _model) {
     let _resizeOnFloat = false;
     let _stateClassRequestId = -1;
 
-    let _float = _model.get('float');
+    let _floatingConfig = _model.get('float');
     let _canFloat = false;
 
     let displayClickHandler;
@@ -217,7 +217,7 @@ function View(_api, _model) {
         focusHelper = new UI(_playerElement).on('click', function() {});
         fullscreenHelpers = requestFullscreenHelper(_playerElement, document, _fullscreenChangeHandler);
 
-        if (_float && _float.dismissible !== false) {
+        if (_floatingConfig && _floatingConfig.dismissible !== false) {
             const floatCloseButton = new FloatingCloseButton(_wrapperElement.querySelector('.jw-top'));
             floatCloseButton.setup(() => {
                 this.stopFloating(true);
@@ -572,7 +572,7 @@ function View(_api, _model) {
             _model.set('height', playerHeight);
         }
 
-        if (_float && _resizeOnFloat) {
+        if (_floatingConfig && _resizeOnFloat) {
             style(_wrapperElement, playerStyle);
         } else {
             style(_playerElement, playerStyle);
@@ -843,7 +843,7 @@ function View(_api, _model) {
         const intersectionRatio = Math.round(entry.intersectionRatio * 100) / 100;
         _model.set('intersectionRatio', intersectionRatio);
 
-        if (_float) {
+        if (_floatingConfig) {
             // Only start floating if player has been entirely visible at least once.
             _canFloat = _canFloat || intersectionRatio === 1;
             if (_canFloat) {
@@ -889,7 +889,7 @@ function View(_api, _model) {
             floatingPlayer = null;
 
             if (forever) {
-                _float = null;
+                _floatingConfig = null;
             }
 
             removeClass(_playerElement, 'jw-flag-floating');


### PR DESCRIPTION
### This PR will...
Change the name to `float`, and making it an object.
Add a new param `dismissible` in the `float` object to remove the close button for floating player if set to false.

### Why is this Pull Request needed?
`floatOnScroll` config option used to be boolean.
We want that to be an object so that we are able to have other options to configure different functionalities for floating player.
Some customers do not want the close button to un-float the floating player, so adding an option to disable the close button.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?
Config schema update: https://github.com/jwplayer/jwplayer-commercial/pull/6238

#### Addresses Issue(s):

JW8-2624 JW8-2631

