### PR TITLE
[JW8-1703] Set cast mediaModel currentTime to support resume from DVR casting

### DIFF
--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -197,13 +197,14 @@ class ProgramController extends Eventable {
         model.attributes.itemReady = false;
 
         const playlistItem = Object.assign({}, item);
-        playlistItem.starttime = model.mediaModel.get('currentTime');
+        const currentTime = playlistItem.starttime = model.mediaModel.get('currentTime');
 
         this._destroyActiveMedia();
 
         const castMediaController = new MediaController(castProvider, model);
         castMediaController.activeItem = playlistItem;
         this._setActiveMedia(castMediaController);
+        model.mediaModel.set('currentTime', currentTime);
     }
 
     /**


### PR DESCRIPTION
### This PR will...
Set casting `mediaModel.currentTime` to support resume from DVR casting.

### Why is this Pull Request needed?
So that the player's `currentTime` value before casting is available when starting a Chromecast media session.

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/6229

#### Addresses Issue(s):
JW8-1703

