### PR TITLE
[JW8-2594] Support seeking in DVR using currentTime

### DIFF
--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -450,15 +450,20 @@ export default class Controlbar {
     }
 
     rewind() {
-        const currentPosition = this._model.get('position');
-        const duration = this._model.get('duration');
-        const rewindPosition = currentPosition - 10;
+        let rewindPosition;
         let startPosition = 0;
+        const currentTime = this._model.get('currentTime');
+        if (currentTime) {
+            rewindPosition = currentTime - 10;
+        } else {
+            rewindPosition = this._model.get('position') - 10;
 
-        // duration is negative in DVR mode
-        if (this._model.get('streamType') === 'DVR') {
-            startPosition = duration;
+            // duration is negative in DVR mode
+            if (this._model.get('streamType') === 'DVR') {
+                startPosition = this._model.get('duration');
+            }
         }
+
         // Seek 10s back. Seek value should be >= 0 in VOD mode and >= (negative) duration in DVR mode
         this._api.seek(Math.max(rewindPosition, startPosition), reasonInteraction());
     }


### PR DESCRIPTION
### This PR will...
Support seeking in DVR using currentTime

### Why is this Pull Request needed?
In DVR mode we fudge seek time based on how long it's been since we updated `dvrPosition` which is a negative value representing the estimated distance from the live edge. This fudging is only necessary when handling a negative time argument in `seek` because it is an offset of `dvrPosition`. If we get a positive value, we can trust that it is based on `currentTime` and does not need to be fudged.

Also cleaned up handling of time before the media element seek event by making it based on `currentTime` rather than `dvrPosition`, and only updating it on timeupdate when necessary (webkit fullscreen mode).

These changes allow the rewind button seek back 10 seconds more consistently because the logic is based on the absolute `currentTime` instead of the approximate `dvrPosition` which changes with the DVR window (`video.seekable.end()`).

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/6230

#### Addresses Issue(s):
JW8-2594

