### PR TITLE
[JW8-2530] [JW8-5612] Update float on scroll resizing on mobile and desktop

### DIFF
--- a/src/css/controls/imports/settings-menu.less
+++ b/src/css/controls/imports/settings-menu.less
@@ -59,7 +59,7 @@
     background-color: @controlbar-background;
     display: flex;
     flex: 0 0 auto;
-    padding: 3px 5px 0;
+    padding: @dismiss-top-padding @dismiss-right-padding 0;
     width: 100%;
 
     .jw-settings-close {

--- a/src/css/jwplayer/flags/floatingplayer.less
+++ b/src/css/jwplayer/flags/floatingplayer.less
@@ -9,6 +9,7 @@
         bottom: 1rem;
         left: auto;
         position: fixed;
+        width: 100%;
         z-index: 1;
 
         @media screen and (max-width: 419px) and (orientation: portrait) {

--- a/src/css/jwplayer/flags/floatingplayer.less
+++ b/src/css/jwplayer/flags/floatingplayer.less
@@ -3,14 +3,23 @@
     background-color: #000;
 
     .jw-wrapper {
-        animation: jw-float 150ms cubic-bezier(0, 0.25, 0.25, 1) forwards 1;
-        top: auto;
-        right: 1rem;
-        bottom: 1rem;
         left: auto;
+        right: 1rem;
         position: fixed;
         width: 100%;
         z-index: 1;
+
+        &.jw-float-bottom {
+            animation: jw-float-to-bottom 150ms cubic-bezier(0, 0.25, 0.25, 1) forwards 1;
+            top: auto;
+            bottom: 1rem;
+        }
+
+        &.jw-float-top {
+            animation: jw-float-to-top 150ms cubic-bezier(0, 0.25, 0.25, 1) forwards 1;
+            top: 2rem;
+            bottom: auto;
+        }
 
         @media screen and (max-width: 419px) and (orientation: portrait) {
             left: 0;
@@ -57,9 +66,19 @@
     justify-content: center;
 }
 
-@keyframes jw-float {
+@keyframes jw-float-to-bottom {
     from {
         transform: translateY(100%);
+    }
+
+    to {
+        transform: translateY(0);
+    }
+}
+
+@keyframes jw-float-to-top {
+    from {
+        transform: translateY(-100%);
     }
 
     to {

--- a/src/css/jwplayer/flags/floatingplayer.less
+++ b/src/css/jwplayer/flags/floatingplayer.less
@@ -1,3 +1,5 @@
+@import "../../shared-imports/vars.less";
+
 .jw-flag-floating {
     background-size: cover;
     background-color: #000;
@@ -64,8 +66,8 @@
 .jw-float-icon {
     display: none;
     position: absolute;
-    top: 0;
-    right: 0;
+    top: @dismiss-top-padding;
+    right: @dismiss-right-padding;
     align-items: center;
     justify-content: center;
 }

--- a/src/css/jwplayer/flags/floatingplayer.less
+++ b/src/css/jwplayer/flags/floatingplayer.less
@@ -13,13 +13,12 @@
 
         @media screen and (max-width: 419px) and (orientation: portrait) {
             animation: jw-float-to-top 150ms cubic-bezier(0, 0.25, 0.25, 1) forwards 1;
-            top: 2rem;
+            top: 125px;
             bottom: auto;
             left: 0;
             right: 0;
             margin-left: auto;
             margin-right: auto;
-            width: 100%;
         }
     }
 

--- a/src/css/jwplayer/flags/floatingplayer.less
+++ b/src/css/jwplayer/flags/floatingplayer.less
@@ -17,7 +17,8 @@
 
         @media screen and (max-width : 400px) {
             width: 100% !important; /* stylelint-disable-line declaration-no-important */
-            right: auto;
+            left: 0;
+            right: 0;
         }
 
         .jw-flag-touch& {

--- a/src/css/jwplayer/flags/floatingplayer.less
+++ b/src/css/jwplayer/flags/floatingplayer.less
@@ -6,26 +6,23 @@
         left: auto;
         right: 1rem;
         position: fixed;
-        width: 100%;
         z-index: 1;
 
-        &.jw-float-bottom {
+        @media screen and (min-width: 420px) {
             animation: jw-float-to-bottom 150ms cubic-bezier(0, 0.25, 0.25, 1) forwards 1;
             top: auto;
             bottom: 1rem;
         }
 
-        &.jw-float-top {
+        @media screen and (max-width: 419px) and (orientation: portrait) {
             animation: jw-float-to-top 150ms cubic-bezier(0, 0.25, 0.25, 1) forwards 1;
             top: 2rem;
             bottom: auto;
-        }
-
-        @media screen and (max-width: 419px) and (orientation: portrait) {
             left: 0;
             right: 0;
             margin-left: auto;
             margin-right: auto;
+            width: 100%;
         }
     }
 

--- a/src/css/jwplayer/flags/floatingplayer.less
+++ b/src/css/jwplayer/flags/floatingplayer.less
@@ -7,12 +7,10 @@
         right: 1rem;
         position: fixed;
         z-index: 1;
+        animation: jw-float-to-bottom 150ms cubic-bezier(0, 0.25, 0.25, 1) forwards 1;
+        top: auto;
+        bottom: 1rem;
 
-        @media screen and (min-width: 420px) {
-            animation: jw-float-to-bottom 150ms cubic-bezier(0, 0.25, 0.25, 1) forwards 1;
-            top: auto;
-            bottom: 1rem;
-        }
 
         @media screen and (max-width: 419px) and (orientation: portrait) {
             animation: jw-float-to-top 150ms cubic-bezier(0, 0.25, 0.25, 1) forwards 1;

--- a/src/css/jwplayer/flags/floatingplayer.less
+++ b/src/css/jwplayer/flags/floatingplayer.less
@@ -16,7 +16,7 @@
         max-height: 400px;
         margin: 0 auto;
 
-        @media screen and (max-width : 400px) {
+        @media screen and (max-width : 480px) {
             width: 100% !important; /* stylelint-disable-line declaration-no-important */
             left: 0;
             right: 0;
@@ -29,7 +29,7 @@
                 bottom: auto;
                 left: 0;
                 right: 0;
-                max-width: none;
+                max-width: none !important; /* stylelint-disable-line declaration-no-important */
                 max-height: none;
             }
         }

--- a/src/css/jwplayer/flags/floatingplayer.less
+++ b/src/css/jwplayer/flags/floatingplayer.less
@@ -14,6 +14,7 @@
         right: 1rem;
         max-width: 400px;
         max-height: 400px;
+        margin: 0 auto;
 
         @media screen and (max-width : 400px) {
             width: 100% !important; /* stylelint-disable-line declaration-no-important */
@@ -30,8 +31,6 @@
                 right: 0;
                 max-width: none;
                 max-height: none;
-                margin-left: auto;
-                margin-right: auto;
             }
         }
     }

--- a/src/css/jwplayer/flags/floatingplayer.less
+++ b/src/css/jwplayer/flags/floatingplayer.less
@@ -3,22 +3,33 @@
     background-color: #000;
 
     .jw-wrapper {
-        left: auto;
-        right: 1rem;
         position: fixed;
         z-index: 1;
         animation: jw-float-to-bottom 150ms cubic-bezier(0, 0.25, 0.25, 1) forwards 1;
         top: auto;
         bottom: 1rem;
+        left: auto;
+        right: 1rem;
+        max-width: 400px;
+        max-height: 400px;
 
-        @media screen and (max-width: 419px) and (orientation: portrait) {
-            animation: jw-float-to-top 150ms cubic-bezier(0, 0.25, 0.25, 1) forwards 1;
-            top: 125px;
-            bottom: auto;
-            left: 0;
-            right: 0;
-            margin-left: auto;
-            margin-right: auto;
+        @media screen and (max-width : 400px) {
+            width: 100% !important; /* stylelint-disable-line declaration-no-important */
+            right: auto;
+        }
+
+        .jw-flag-touch& {
+            @media screen and (max-device-width : 480px) and (orientation: portrait) {
+                animation: jw-float-to-top 150ms cubic-bezier(0, 0.25, 0.25, 1) forwards 1;
+                top: 125px;
+                bottom: auto;
+                left: 0;
+                right: 0;
+                max-width: none;
+                max-height: none;
+                margin-left: auto;
+                margin-right: auto;
+            }
         }
     }
 

--- a/src/css/jwplayer/flags/floatingplayer.less
+++ b/src/css/jwplayer/flags/floatingplayer.less
@@ -11,7 +11,6 @@
         top: auto;
         bottom: 1rem;
 
-
         @media screen and (max-width: 419px) and (orientation: portrait) {
             animation: jw-float-to-top 150ms cubic-bezier(0, 0.25, 0.25, 1) forwards 1;
             top: 2rem;

--- a/src/css/shared-imports/vars.less
+++ b/src/css/shared-imports/vars.less
@@ -108,3 +108,7 @@
 // Transition animation
 @default-timing-function: cubic-bezier(0, 0.25, 0.25, 1);
 @default-transition: 150ms @default-timing-function;
+
+// Settings menu and floating player close buttons
+@dismiss-top-padding: 3px;
+@dismiss-right-padding: 5px;

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -79,7 +79,12 @@ Object.assign(Controller.prototype, {
         const viewModel = new ViewModel(_model);
 
         _view = this._view = new View(_api, viewModel);
-        _view.on('all', _trigger, _this);
+        _view.on('all', (type, event) => {
+            if (event && event.doNotForward) {
+                return;
+            }
+            _trigger(type, event);
+        }, _this);
 
         const _programController = this._programController = new ProgramController(_model, mediaPool);
         updateProgramSoundSettings();

--- a/src/js/templates/floating-close-button.js
+++ b/src/js/templates/floating-close-button.js
@@ -1,6 +1,6 @@
 export default (ariaLabel) => {
     return (
-        `<div class="jw-float-icon jw-icon jw-reset" aria-label=${ariaLabel} tabindex="0">` +
+        `<div class="jw-float-icon jw-icon jw-button-color jw-reset" aria-label=${ariaLabel} tabindex="0">` +
         `</div>`
     );
 };

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -34,9 +34,9 @@ instances.forEach(api => {
 const reasonInteraction = function() {
     return { reason: 'interaction' };
 };
-export default class Controls {
+export default class Controls extends Events {
     constructor(context, playerContainer) {
-        Object.assign(this, Events);
+        super();
 
         // Alphabetic order
         // Any property on the prototype should be initialized here first
@@ -134,7 +134,8 @@ export default class Controls {
         const floatingConfig = model.get('floating');
         if (floatingConfig) {
             const floatCloseButton = new FloatingCloseButton(element, model.get('localization').close);
-            floatCloseButton.on(USER_ACTION, () => this.trigger('dismissFloating'));
+            const doNotForward = true;
+            floatCloseButton.on(USER_ACTION, () => this.trigger('dismissFloating', { doNotForward }));
 
             if (floatingConfig.dismissible !== false) {
                 addClass(this.playerContainer, 'jw-floating-dismissible');

--- a/src/js/view/utils/views-manager.js
+++ b/src/js/view/utils/views-manager.js
@@ -41,6 +41,9 @@ function scheduleResponsiveRedraw() {
     cancelAnimationFrame(responsiveRepaintRequestId);
     responsiveRepaintRequestId = requestAnimationFrame(function responsiveRepaint() {
         views.forEach(view => {
+            view.resizeFloatingPlayer();
+        });
+        views.forEach(view => {
             view.updateBounds();
         });
         views.forEach(view => {

--- a/src/js/view/utils/views-manager.js
+++ b/src/js/view/utils/views-manager.js
@@ -39,20 +39,21 @@ function matchIntersection(entry, group) {
 
 function scheduleResponsiveRedraw() {
     cancelAnimationFrame(responsiveRepaintRequestId);
+    // Batch DOM changes on animation frame
     responsiveRepaintRequestId = requestAnimationFrame(function responsiveRepaint() {
+        // First read all DOM bounds (compute player size)
         views.forEach(view => {
             view.updateBounds();
         });
+        // Then write all DOM changes (apply styles and classes based on player size)
         views.forEach(view => {
             if (view.model.get('visibility')) {
                 view.updateStyles();
             }
         });
+        // Finally dispatch events for any changes
         views.forEach(view => {
             view.checkResized();
-        });
-        views.forEach(view => {
-            view.resizeFloatingPlayer();
         });
     });
 }
@@ -61,7 +62,7 @@ function onOrientationChange() {
     views.forEach(view => {
         const model = view.model;
         if (model.get('audioMode') || !model.get('controls') || model.get('visibility') < 0.75) {
-            // return early if chromless player/audio only mode and player is less than 75% visible
+            // return early if chromeless player/audio only mode and player is less than 75% visible
             return;
         }
 

--- a/src/js/view/utils/views-manager.js
+++ b/src/js/view/utils/views-manager.js
@@ -51,6 +51,9 @@ function scheduleResponsiveRedraw() {
         views.forEach(view => {
             view.checkResized();
         });
+        views.forEach(view => {
+            view.resizeFloatingPlayer();
+        });
     });
 }
 

--- a/src/js/view/utils/views-manager.js
+++ b/src/js/view/utils/views-manager.js
@@ -41,9 +41,6 @@ function scheduleResponsiveRedraw() {
     cancelAnimationFrame(responsiveRepaintRequestId);
     responsiveRepaintRequestId = requestAnimationFrame(function responsiveRepaint() {
         views.forEach(view => {
-            view.resizeFloatingPlayer();
-        });
-        views.forEach(view => {
             view.updateBounds();
         });
         views.forEach(view => {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -576,7 +576,7 @@ function View(_api, _model) {
             _model.set('height', playerHeight);
         }
 
-        if (_floatingConfig && _resizeOnFloat) {
+        if (_floatingConfig && _resizeOnFloat && playerStyle.width !== _model.get('containerWidth')) {
             style(_wrapperElement, playerStyle);
         } else {
             style(_playerElement, playerStyle);
@@ -876,20 +876,15 @@ function View(_api, _model) {
             _this.trigger(FLOAT, { floating: true });
             _model.set('isFloating', true);
 
-            if (_isMobile) {
-                addClass(_wrapperElement, 'jw-float-top');
-            } else {
-                addClass(_wrapperElement, 'jw-float-bottom');
-                _resizeOnFloat = true;
+            _resizeOnFloat = true;
 
-                // Resize within MAX_FLOATING_WIDTH×MAX_FLOATING_HEIGHT bounds, never enlarge.
-                const { width, height } = _this.getSafeRegion(false);
-                const floatingWidth = Math.min(width, MAX_FLOATING_WIDTH);
-                const floatingHeight = Math.min(height * floatingWidth / width, MAX_FLOATING_HEIGHT);
-                _this.resize(floatingWidth, floatingHeight, true);
+            // Resize within MAX_FLOATING_WIDTH×MAX_FLOATING_HEIGHT bounds, never enlarge.
+            const { width, height } = _this.getSafeRegion(false);
+            const floatingWidth = Math.min(width, MAX_FLOATING_WIDTH);
+            const floatingHeight = Math.min(height * floatingWidth / width, MAX_FLOATING_HEIGHT);
+            _this.resize(floatingWidth, floatingHeight, true);
 
-                _resizeOnFloat = false;
-            }
+            _resizeOnFloat = false;
         } else if (isVisible) {
             _this.stopFloating();
         }

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -858,7 +858,19 @@ function View(_api, _model) {
     };
 
     function _getCurrentElement() {
-        return _model.get('isFloating') ? _wrapperElement : _playerElement;
+        return _model.get('isFloating') && _resizeOnFloat ? _wrapperElement : _playerElement;
+    }
+
+    function _getFloatingDimensions() {
+        // Resize within MAX_FLOATING_WIDTH×MAX_FLOATING_HEIGHT bounds, never enlarge.
+        const { width, height } = _this.getSafeRegion(false);
+        const floatingWidth = Math.min(width, MAX_FLOATING_WIDTH);
+        const floatingHeight = Math.min(height * floatingWidth / width, MAX_FLOATING_HEIGHT);
+
+        return {
+            floatingWidth,
+            floatingHeight
+        };
     }
 
     function _updateFloating(intersectionRatio) {
@@ -878,10 +890,8 @@ function View(_api, _model) {
 
             _resizeOnFloat = true;
 
-            // Resize within MAX_FLOATING_WIDTH×MAX_FLOATING_HEIGHT bounds, never enlarge.
-            const { width, height } = _this.getSafeRegion(false);
-            const floatingWidth = Math.min(width, MAX_FLOATING_WIDTH);
-            const floatingHeight = Math.min(height * floatingWidth / width, MAX_FLOATING_HEIGHT);
+            const { floatingWidth, floatingHeight } = _getFloatingDimensions();
+        
             _this.resize(floatingWidth, floatingHeight);
 
             _resizeOnFloat = false;
@@ -892,11 +902,7 @@ function View(_api, _model) {
 
     this.resizeFloatingPlayer = function() {
         if (floatingPlayer && !_resizeOnFloat) {
-            const rect = bounds(_playerElement);
-            const containerWidth = Math.round(rect.width);
-            const containerHeight = Math.round(rect.height);
-            const floatingWidth = Math.min(containerWidth, MAX_FLOATING_WIDTH);
-            const floatingHeight = Math.min(containerHeight * floatingWidth / containerWidth, MAX_FLOATING_HEIGHT);
+            const { floatingWidth, floatingHeight } = _getFloatingDimensions();
             _resizeOnFloat = true;
             _resizePlayer(floatingWidth, floatingHeight, true);
             _resizeOnFloat = false;

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -876,20 +876,23 @@ function View(_api, _model) {
             _this.trigger(FLOAT, { floating: true });
             _model.set('isFloating', true);
 
-            if (!_isMobile) {
+            if (_isMobile) {
+                addClass(_wrapperElement, 'jw-float-top');
+            } else {
                 addClass(_wrapperElement, 'jw-float-bottom');
                 _resizeOnFloat = true;
 
                 // Resize within MAX_FLOATING_WIDTH×MAX_FLOATING_HEIGHT bounds, never enlarge.
-                const { width, height } = _this.getSafeRegion(false);
+                const {
+                    width,
+                    height
+                } = _this.getSafeRegion(false);
                 const ratio = Math.min(1, MAX_FLOATING_WIDTH / width, MAX_FLOATING_HEIGHT / height);
                 const floatingWidth = Math.min(MAX_FLOATING_WIDTH, width);
                 const floatingHeight = floatingWidth === MAX_FLOATING_WIDTH ? height * ratio : height;
                 _this.resize(floatingWidth, floatingHeight, true);
 
                 _resizeOnFloat = false;
-            } else {
-                addClass(_wrapperElement, 'jw-float-top');
             }
         } else if (isVisible) {
             _this.stopFloating();

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -880,8 +880,9 @@ function View(_api, _model) {
 
             // Resize within MAX_FLOATING_WIDTH×MAX_FLOATING_HEIGHT bounds, never enlarge.
             const { width, height } = _this.getSafeRegion(false);
+            const ratio = Math.min(1, MAX_FLOATING_WIDTH / width, MAX_FLOATING_HEIGHT / height);
             const floatingWidth = Math.min(MAX_FLOATING_WIDTH, width);
-            const floatingHeight = height * Math.min(1, MAX_FLOATING_WIDTH / width, MAX_FLOATING_HEIGHT / height);
+            const floatingHeight = floatingWidth === MAX_FLOATING_WIDTH ? height * ratio : height;
             _this.resize(floatingWidth, floatingHeight, true);
 
             _resizeOnFloat = false;

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -880,7 +880,7 @@ function View(_api, _model) {
                 _resizeOnFloat = true;
 
                 // Resize within MAX_FLOATING_WIDTH×MAX_FLOATING_HEIGHT bounds, never enlarge.
-                const { width,height } = _this.getSafeRegion(false);
+                const { width, height } = _this.getSafeRegion(false);
                 const ratio = Math.min(1, MAX_FLOATING_WIDTH / width, MAX_FLOATING_HEIGHT / height);
                 const floatingWidth = Math.min(MAX_FLOATING_WIDTH, width);
                 const floatingHeight = floatingWidth === MAX_FLOATING_WIDTH ? height * ratio : height;

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -890,6 +890,19 @@ function View(_api, _model) {
         }
     }
 
+    this.resizeFloatingPlayer = function() {
+        if (floatingPlayer && !_resizeOnFloat) {
+            const rect = bounds(_playerElement);
+            const containerWidth = Math.round(rect.width);
+            const containerHeight = Math.round(rect.height);
+            const floatingWidth = Math.min(containerWidth, MAX_FLOATING_WIDTH);
+            const floatingHeight = Math.min(containerHeight * floatingWidth / containerWidth, MAX_FLOATING_HEIGHT);
+            _resizeOnFloat = true;
+            _resizePlayer(floatingWidth, floatingHeight, true);
+            _resizeOnFloat = false;
+        }
+    };
+
     this.stopFloating = function(forever) {
         if (forever) {
             _floatingConfig = null;

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -576,7 +576,7 @@ function View(_api, _model) {
             _model.set('height', playerHeight);
         }
 
-        if (_floatingConfig && _resizeOnFloat && playerStyle.width !== _model.get('containerWidth')) {
+        if (_floatingConfig && _resizeOnFloat) {
             style(_wrapperElement, playerStyle);
         } else {
             style(_playerElement, playerStyle);

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -883,13 +883,10 @@ function View(_api, _model) {
                 _resizeOnFloat = true;
 
                 // Resize within MAX_FLOATING_WIDTH×MAX_FLOATING_HEIGHT bounds, never enlarge.
-                const {
-                    width,
-                    height
-                } = _this.getSafeRegion(false);
+                const { width, height } = _this.getSafeRegion(false);
                 const ratio = Math.min(1, MAX_FLOATING_WIDTH / width, MAX_FLOATING_HEIGHT / height);
                 const floatingWidth = Math.min(MAX_FLOATING_WIDTH, width);
-                const floatingHeight = floatingWidth === MAX_FLOATING_WIDTH ? height * ratio : height;
+                const floatingHeight = Math.min(MAX_FLOATING_HEIGHT, height) * ratio;
                 _this.resize(floatingWidth, floatingHeight, true);
 
                 _resizeOnFloat = false;

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -863,7 +863,7 @@ function View(_api, _model) {
 
     function _updateFloating(intersectionRatio) {
         // Player is 50% visible or less and no floating player already in the DOM.
-        const isVisible = intersectionRatio > 0.5;
+        const isVisible = intersectionRatio >= 0.5;
         if (!isVisible && _model.get('state') !== STATE_IDLE && floatingPlayer === null) {
             floatingPlayer = _playerElement;
 
@@ -884,9 +884,8 @@ function View(_api, _model) {
 
                 // Resize within MAX_FLOATING_WIDTH×MAX_FLOATING_HEIGHT bounds, never enlarge.
                 const { width, height } = _this.getSafeRegion(false);
-                const ratio = Math.min(1, MAX_FLOATING_WIDTH / width, MAX_FLOATING_HEIGHT / height);
-                const floatingWidth = Math.min(MAX_FLOATING_WIDTH, width);
-                const floatingHeight = Math.min(MAX_FLOATING_HEIGHT, height) * ratio;
+                const floatingWidth = Math.min(width, MAX_FLOATING_WIDTH);
+                const floatingHeight = Math.min(height * floatingWidth / width, MAX_FLOATING_HEIGHT);
                 _this.resize(floatingWidth, floatingHeight, true);
 
                 _resizeOnFloat = false;

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -616,6 +616,9 @@ function View(_api, _model) {
             _model.set('height', playerHeight);
         }
         style(_playerElement, styles);
+        if (_model.get('isFloating')) {
+            updateFloatingSize();
+        }
         _responsiveUpdate();
     };
     this.resizeMedia = _resizeMedia;
@@ -882,22 +885,7 @@ function View(_api, _model) {
                     backgroundImage: _preview.el.style.backgroundImage || _model.get('image')
                 });
 
-                // Always use aspect ratio to determine floating player size
-                // This allows us to support fixed pixel width/height or 100%*100% by matching the player container
-                const width = _model.get('width');
-                const height = _model.get('height');
-                const styles = getPlayerSizeStyles(width);
-                if (!_model.get('aspectratio')) {
-                    const containerWidth = _model.get('containerWidth');
-                    const containerHeight = _model.get('containerHeight');
-                    let aspectRatio = (containerHeight / containerWidth) || 0.5625; // (fallback to 16 by 9)
-                    if (isNumber(width) && isNumber(height)) {
-                        aspectRatio = height / width;
-                    }
-                    onAspectRatioChange(_model, (aspectRatio * 100) + '%');
-                }
-
-                style(_wrapperElement, styles);
+                updateFloatingSize();
 
                 // Perform resize and trigger "float" event responsively to prevent layout thrashing
                 _responsiveListener();
@@ -905,6 +893,26 @@ function View(_api, _model) {
         } else {
             _this.stopFloating();
         }
+    }
+
+    function updateFloatingSize() {
+        // Always use aspect ratio to determine floating player size
+        // This allows us to support fixed pixel width/height or 100%*100% by matching the player container
+        const width = _model.get('width');
+        const height = _model.get('height');
+        const styles = getPlayerSizeStyles(width);
+        styles.maxWidth = width;
+        if (!_model.get('aspectratio')) {
+            const containerWidth = _model.get('containerWidth');
+            const containerHeight = _model.get('containerHeight');
+            let aspectRatio = (containerHeight / containerWidth) || 0.5625; // (fallback to 16 by 9)
+            if (isNumber(width) && isNumber(height)) {
+                aspectRatio = height / width;
+            }
+            onAspectRatioChange(_model, (aspectRatio * 100) + '%');
+        }
+
+        style(_wrapperElement, styles);
     }
 
     this.stopFloating = function(forever) {
@@ -921,7 +929,7 @@ function View(_api, _model) {
 
             // Wrapper should inherit from parent unless floating.
             style(_playerElement, { backgroundImage: null }); // Reset to avoid flicker.
-            style(_wrapperElement, { width: null, height: null });
+            style(_wrapperElement, { width: null, maxWidth: null });
 
             // Perform resize and trigger "float" event responsively to prevent layout thrashing
             _responsiveListener();

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -510,12 +510,7 @@ function View(_api, _model) {
             _api.pause({ reason: 'interaction' });
         });
 
-        controls.on('all', (type, event) => {
-            if (event && event.doNotForward) {
-                return;
-            }
-            _this.trigger(type, event);
-        }, _this);
+        controls.on('all', _this.trigger, _this);
 
         if (_model.get('instream')) {
             _controls.setupInstream();

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -40,8 +40,8 @@ require('css/jwplayer.less');
 
 let ControlsModule;
 
-const MAX_FLOATING_WIDTH = 320;
-const MAX_FLOATING_HEIGHT = 320;
+const MAX_FLOATING_WIDTH = 400;
+const MAX_FLOATING_HEIGHT = 400;
 
 const _isMobile = OS.mobile;
 const _isIE = Browser.ie;
@@ -880,8 +880,9 @@ function View(_api, _model) {
 
             // Resize within MAX_FLOATING_WIDTH×MAX_FLOATING_HEIGHT bounds, never enlarge.
             const { width, height } = _this.getSafeRegion(false);
-            const ratio = Math.min(1, MAX_FLOATING_WIDTH / width, MAX_FLOATING_HEIGHT / height);
-            _this.resize(width * ratio, height * ratio, true);
+            const floatingWidth = Math.min(MAX_FLOATING_WIDTH, width);
+            const floatingHeight = height * Math.min(1, MAX_FLOATING_WIDTH / width, MAX_FLOATING_HEIGHT / height);
+            _this.resize(floatingWidth, floatingHeight, true);
 
             _resizeOnFloat = false;
         } else if (isVisible) {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -877,6 +877,7 @@ function View(_api, _model) {
             _model.set('isFloating', true);
 
             if (!_isMobile) {
+                addClass(_wrapperElement, 'jw-float-bottom');
                 _resizeOnFloat = true;
 
                 // Resize within MAX_FLOATING_WIDTH×MAX_FLOATING_HEIGHT bounds, never enlarge.
@@ -887,6 +888,8 @@ function View(_api, _model) {
                 _this.resize(floatingWidth, floatingHeight, true);
 
                 _resizeOnFloat = false;
+            } else {
+                addClass(_wrapperElement, 'jw-float-top');
             }
         } else if (isVisible) {
             _this.stopFloating();

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -882,7 +882,7 @@ function View(_api, _model) {
             const { width, height } = _this.getSafeRegion(false);
             const floatingWidth = Math.min(width, MAX_FLOATING_WIDTH);
             const floatingHeight = Math.min(height * floatingWidth / width, MAX_FLOATING_HEIGHT);
-            _this.resize(floatingWidth, floatingHeight, true);
+            _this.resize(floatingWidth, floatingHeight);
 
             _resizeOnFloat = false;
         } else if (isVisible) {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -876,16 +876,18 @@ function View(_api, _model) {
             _this.trigger(FLOAT, { floating: true });
             _model.set('isFloating', true);
 
-            _resizeOnFloat = true;
+            if (!_isMobile) {
+                _resizeOnFloat = true;
 
-            // Resize within MAX_FLOATING_WIDTH×MAX_FLOATING_HEIGHT bounds, never enlarge.
-            const { width, height } = _this.getSafeRegion(false);
-            const ratio = Math.min(1, MAX_FLOATING_WIDTH / width, MAX_FLOATING_HEIGHT / height);
-            const floatingWidth = Math.min(MAX_FLOATING_WIDTH, width);
-            const floatingHeight = floatingWidth === MAX_FLOATING_WIDTH ? height * ratio : height;
-            _this.resize(floatingWidth, floatingHeight, true);
+                // Resize within MAX_FLOATING_WIDTH×MAX_FLOATING_HEIGHT bounds, never enlarge.
+                const { width,height } = _this.getSafeRegion(false);
+                const ratio = Math.min(1, MAX_FLOATING_WIDTH / width, MAX_FLOATING_HEIGHT / height);
+                const floatingWidth = Math.min(MAX_FLOATING_WIDTH, width);
+                const floatingHeight = floatingWidth === MAX_FLOATING_WIDTH ? height * ratio : height;
+                _this.resize(floatingWidth, floatingHeight, true);
 
-            _resizeOnFloat = false;
+                _resizeOnFloat = false;
+            }
         } else if (isVisible) {
             _this.stopFloating();
         }

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -901,7 +901,9 @@ function View(_api, _model) {
         const width = _model.get('width');
         const height = _model.get('height');
         const styles = getPlayerSizeStyles(width);
-        styles.maxWidth = width;
+        if (isNumber(width)) {
+            styles.maxWidth = width;
+        }
         if (!_model.get('aspectratio')) {
             const containerWidth = _model.get('containerWidth');
             const containerHeight = _model.get('containerHeight');

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -862,8 +862,8 @@ function View(_api, _model) {
     }
 
     function _updateFloating(intersectionRatio) {
-        // Entirely invisible and no floating player already in the DOM.
-        const isVisible = intersectionRatio === 1;
+        // Player is 50% visible or less and no floating player already in the DOM.
+        const isVisible = intersectionRatio > 0.5;
         if (!isVisible && _model.get('state') !== STATE_IDLE && floatingPlayer === null) {
             floatingPlayer = _playerElement;
 


### PR DESCRIPTION
### This PR will...

- Float when the player is 50% visible and unfloat otherwise.
- Make ```MAX_FLOATING_WIDTH``` and ```MAX_FLOATING_HEIGHT```  ```400px```.
- Height is based off aspect ratio of the floating player:
    -  Adjust height by ratio if the width of the player is equal to the ```MAX_FLOATING_WIDTH```.
    -  Retain height (and width) if  the width of the player is smaller than ```MAX_FLOATING_WIDTH```.
- Use media query for mobile portrait float behavior when screen is less than or equal to ```419px```
- Float player 125px below the top of the page to account for sticky headers.
- Create a new function called ```resizeFloatingPlayer``` to handle resize when switching from```portrait``` to ```landscape``` and vice-versa.
- Make player fill 100% of the viewport if mobile and portrait view.

### Why is this Pull Request needed?

Improvements to player float on scroll behavior.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-2530

