### PR TITLE
Enable captions on muted start with config

### DIFF
--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -9,6 +9,7 @@ const Captions = function(_model) {
     let _tracks = [];
     let _tracksById = {};
     let _unknownCount = 0;
+    let _this = this;
 
     // Reset and load external captions on playlist item
     _model.on('change:playlistItem', (model) => {
@@ -51,6 +52,8 @@ const Captions = function(_model) {
         let track = null;
         if (captionsMenuIndex !== 0) {
             track = _tracks[captionsMenuIndex - 1];
+        } else {
+            this.enableOnLoad = false;
         }
         model.set('captionsTrack', track);
     }, this);
@@ -115,7 +118,11 @@ const Captions = function(_model) {
         // Because there is no explicit track for "Off"
         //  it is the implied zeroth track
         if (label === 'Off') {
-            _model.set('captionsIndex', 0);
+            if (_this.enableOnLoad && _tracks.length) {
+                _model.set('captionsIndex', 1);
+            } else {
+                _model.set('captionsIndex', 0);
+            }
             return;
         }
 

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -212,6 +212,10 @@ Object.assign(Controller.prototype, {
                 }
             });
 
+            if (_model.get('mute') && _model.get('enableCaptionsOnMute')) {
+                _captions.enableOnLoad = true;
+            }
+
             _view.init();
         };
 
@@ -502,6 +506,10 @@ Object.assign(Controller.prototype, {
 
                 // Only apply autostartMuted on un-muted autostart attempt.
                 if (result === AUTOPLAY_MUTED && !_this.getMute()) {
+                    if (_model.get('enableCaptionsOnMute')) {
+                        _captions.enableOnLoad = true;
+                    }
+
                     _model.set('autostartMuted', true);
                     updateProgramSoundSettings();
 


### PR DESCRIPTION
### This PR will...
- Enable captions by default if mute is true on initial start
-- Choose the first available caption
- Caption should still be enabled if the first playlist item does not have captions, and the second playlist item does
-- Even if unmuted before the start of the second playlist item
- As soon as the user sets the captions to `off`, this feature does not have an effect for following playlist items

### Why is this Pull Request needed?
- A/B testing

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-2641

