### PR TITLE
Enable captions on autostart muted with config

### DIFF
--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -131,9 +131,8 @@ const Captions = function(_model) {
             }
         }
         // set the index without the side effect of storing the Off label in _selectCaptions
-        if (_model.get('enableDefaultCaptions') && _model.get('autostart')) {
-            _setCurrentIndex(1);
-            return;
+        if (_model.get('enableDefaultCaptions') && _model.get('autostart') && !captionsMenuIndex) {
+            captionsMenuIndex = 1;
         }
         _setCurrentIndex(captionsMenuIndex);
     }

--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -131,6 +131,10 @@ const Captions = function(_model) {
             }
         }
         // set the index without the side effect of storing the Off label in _selectCaptions
+        if (_model.get('enableDefaultCaptions') && _model.get('autostart')) {
+            _setCurrentIndex(1);
+            return;
+        }
         _setCurrentIndex(captionsMenuIndex);
     }
 

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -511,6 +511,10 @@ Object.assign(Controller.prototype, {
                     });
                 }
 
+                if (!_this.getMute()) {
+                    _model.set('enableDefaultCaptions', false);
+                }
+
                 // Enable autoPause behavior.
                 const autoPause = _model.get('autoPause');
                 if (autoPause && autoPause.viewability) {


### PR DESCRIPTION
### This PR will...
- Add new boolean config `enableDefaultCaptions` which when set to true:
-- Enable captions by default if mute is true on initial start
-- Choose the first available caption
- Caption should still be enabled if the first playlist item does not have captions, and the second playlist item does
-- Even if unmuted before the start of the second playlist item
- As soon as the user sets the captions to `off`, this feature does not have an effect for following playlist items

### Why is this Pull Request needed?
- A/B testing

### Are there any points in the code the reviewer needs to double check?
Closed the previous PR: https://github.com/jwplayer/jwplayer/pull/3269/files

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):
JW8-2641

