### PR TITLE
[JW8-2648] Exempt jw-plugin-googima from jw-plugin styling

### DIFF
--- a/src/css/jwplayer/imports/jwplayerlayout.less
+++ b/src/css/jwplayer/imports/jwplayerlayout.less
@@ -61,8 +61,10 @@
 }
 
 .jw-plugin {
-    position: absolute;
-    bottom: (@mobile-touch-target * 1.5);
+    &:not(.jw-plugin-googima) {
+        position: absolute;
+        bottom: (@mobile-touch-target * 1.5);
+    }
 
     .jw-banner {
         max-width: 100%;


### PR DESCRIPTION
### This PR will...

Exempt elements with both `jw-plugin` and `jw-plugin-googima` classes from the `jw-plugin`-specific CSS rules.

### Why is this Pull Request needed?

Since we now set `opacity: 1` on IMA ads earlier (https://github.com/jwplayer/jwplayer-ads-googima/pull/453), the ad creative was appearing higher in the player very quickly before repositioning to the expected position.

This was caused by:
`.jw-plugin {
  position: absolute;
  bottom: (@mobile-touch-target * 1.5);
}`

### Are there any points in the code the reviewer needs to double check?

n/a

### Are there any Pull Requests open in other repos which need to be merged with this?

n/a

#### Addresses Issue(s):

JW8-2648

