### PR TITLE
[JW8-2595] Return in getElementWindow() if element is null

### DIFF
--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -159,6 +159,9 @@ function initInteractionListeners(ui) {
 
     const interactEndHandler = (e) => {
         clearTimeout(longPressTimeout);
+        if (!ui.el) {
+            return;
+        }
         releasePointerCapture(ui);
         removeHandlers(ui, WINDOW_GROUP);
         if (ui.dragged) {
@@ -348,10 +351,6 @@ const eventRegisters = {
 };
 
 export function getElementWindow(element) {
-    if (!element) {
-        return window;
-    }
-
     const document = element.ownerDocument || element;
     return (document.defaultView || document.parentWindow || window);
 }

--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -348,6 +348,10 @@ const eventRegisters = {
 };
 
 export function getElementWindow(element) {
+    if (!element) {
+        return;
+    }
+
     const document = element.ownerDocument || element;
     return (document.defaultView || document.parentWindow || window);
 }

--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -349,7 +349,7 @@ const eventRegisters = {
 
 export function getElementWindow(element) {
     if (!element) {
-        return;
+        return window;
     }
 
     const document = element.ownerDocument || element;


### PR DESCRIPTION
JW8-2595

### This PR will...

Return `window` if `getElementWindow(element)` (in `ui.js`) if `element` is falsy.

### Why is this Pull Request needed?

* In IE 11 and Edge, `getElementWindow(element)` was being called when `element === null`.
* This appears to be caused by when IE11 and Edge fire pointer events compared to other browsers. In IE 11/Edge, `this.destroy()` in `dismissButton.js` is setting the element to `null` before `interactEndHandler` is bring run.
* This caused a JavaScript exception in those environments.
* Functionality was not affected but we should avoid JavaScript exceptions when possible.
* The stack trace went back to minified jQuery code so I couldn't find the exact cause.

### Are there any points in the code the reviewer needs to double check?

n/a

### Are there any Pull Requests open in other repos which need to be merged with this?

n/a

#### Addresses Issue(s):

JW8-2595

