### PR TITLE
JW8-2183 Audio mode  horizontal volume slider

### DIFF
--- a/src/css/controls/flags/audioplayer.less
+++ b/src/css/controls/flags/audioplayer.less
@@ -88,18 +88,18 @@
             }
 
             &.jw-open {
-                transition: width 300ms @default-timing-function;
                 width: @volume-rail-length;
 
                 .jw-slider-volume {
                     padding: 0 12px;
+                    transition: opacity 300ms;
                     opacity: 1;
                 }
 
                 ~ .jw-slider-time {
                     flex: 1 1 auto;
                     width: auto;
-                    transition: opacity 1000ms;
+                    transition: opacity 300ms, width 300ms;
                 }
             }
         }

--- a/src/css/controls/flags/audioplayer.less
+++ b/src/css/controls/flags/audioplayer.less
@@ -80,6 +80,7 @@
             height: 17px;
             align-items: center;
             width: 0;
+            outline: none;
 
             &.jw-tab-focus:focus {
                 outline: @ui-focus;

--- a/src/css/controls/flags/audioplayer.less
+++ b/src/css/controls/flags/audioplayer.less
@@ -77,9 +77,10 @@
         }
 
         .jw-horizontal-volume-container {
+            transition: width 300ms @default-timing-function;
+            width: 0;
             height: 17px;
             align-items: center;
-            width: 0;
             outline: none;
 
             &.jw-tab-focus:focus {
@@ -87,7 +88,7 @@
             }
 
             &.jw-open {
-                transition: width 1000ms @default-timing-function;
+                transition: width 300ms @default-timing-function;
                 width: @volume-rail-length;
 
                 .jw-slider-volume {

--- a/src/css/controls/flags/audioplayer.less
+++ b/src/css/controls/flags/audioplayer.less
@@ -16,6 +16,10 @@
         min-height: @mobile-touch-target;
     }
 
+    .jw-spacer {
+        display: none;
+    }
+
     .jw-preview, // overrides 'block' from .jw-state-idle
     .jw-display, // overrides 'block' from .jw-flag-touch.jw-state-paused
     .jw-title, // overrides 'block' from .jw-state-idle
@@ -63,14 +67,27 @@
             order: 1;
         }
 
+        .jw-icon-volume {
+            margin-right: 0;
+            transition: margin-right @default-transition;
+
+            .jw-overlay {
+                display: none;
+            }
+        }
+
         .jw-horizontal-volume-container {
             height: 17px;
             align-items: center;
             width: 0;
 
+            &.jw-tab-focus:focus {
+                outline: @ui-focus;
+            }
+
             &.jw-open {
                 transition: width 1000ms @default-timing-function;
-                width: 100%;
+                width: @volume-rail-length;
 
                 .jw-slider-volume {
                     padding: 0 12px;
@@ -80,13 +97,12 @@
                 ~ .jw-slider-time {
                     flex: 1 1 auto;
                     width: auto;
-                    transition: opacity 1000ms @default-timing-function;
+                    transition: opacity 1000ms;
                 }
             }
         }
 
         .jw-slider-volume {
-            width: 100%;
             opacity: 0;
 
             .jw-knob {
@@ -96,6 +112,13 @@
             ~ .jw-icon-volume {
                 margin-right: @volume-rail-length;
             }
+        }
+    }
+
+    &.jw-breakpoint-1,
+    &.jw-breakpoint-2 {
+        .jw-horizontal-volume-container.jw-open ~ .jw-slider-time {
+            opacity: 0;
         }
     }
 

--- a/src/css/controls/flags/audioplayer.less
+++ b/src/css/controls/flags/audioplayer.less
@@ -37,7 +37,7 @@
             display: none;
         }
 
-        .jw-icon-volume:not(.jw-icon-tooltip),
+        .jw-icon-volume,
         .jw-icon-playback,
         .jw-icon-next,
         .jw-icon-rewind,
@@ -57,9 +57,45 @@
         }
 
         .jw-slider-time {
-            display: flex;
             flex: 0 1 auto;
             align-items: center;
+            display: flex;
+            order: 1;
+        }
+
+        .jw-horizontal-volume-container {
+            height: 17px;
+            align-items: center;
+            width: 0;
+
+            &.jw-open {
+                transition: width 1000ms @default-timing-function;
+                width: 100%;
+
+                .jw-slider-volume {
+                    padding: 0 12px;
+                    opacity: 1;
+                }
+
+                ~ .jw-slider-time {
+                    flex: 1 1 auto;
+                    width: auto;
+                    transition: opacity 1000ms @default-timing-function;
+                }
+            }
+        }
+
+        .jw-slider-volume {
+            width: 100%;
+            opacity: 0;
+
+            .jw-knob {
+                transform: translate(-50%, -50%);
+            }
+
+            ~ .jw-icon-volume {
+                margin-right: @volume-rail-length;
+            }
         }
     }
 

--- a/src/css/controls/imports/slider.less
+++ b/src/css/controls/imports/slider.less
@@ -114,7 +114,7 @@
     outline: @ui-focus;
 }
 
-.jw-slider-time {
+.jw-slider-time, .jw-flag-audio-player .jw-slider-volume {
     .rect(100%, 17px);
     align-items: center;
     background: transparent none;
@@ -172,4 +172,9 @@
         bottom: calc(100% - 17px);
         left: 0;
     }
+
+    &.jw-tab-focus:focus .jw-rail {
+        outline: @ui-focus;
+    }
+
 }

--- a/src/css/controls/imports/slider.less
+++ b/src/css/controls/imports/slider.less
@@ -114,7 +114,8 @@
     outline: @ui-focus;
 }
 
-.jw-slider-time, .jw-flag-audio-player .jw-slider-volume {
+.jw-slider-time,
+.jw-flag-audio-player .jw-slider-volume {
     .rect(100%, 17px);
     align-items: center;
     background: transparent none;
@@ -176,5 +177,4 @@
     &.jw-tab-focus:focus .jw-rail {
         outline: @ui-focus;
     }
-
 }

--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -5,11 +5,11 @@ import { timeFormat } from 'utils/parser';
 import { addClass, removeClass, setAttribute, bounds } from 'utils/dom';
 import UI from 'utils/ui';
 import Slider from 'view/controls/components/slider';
-import Tooltip from 'view/controls/components/tooltip';
+import TooltipIcon from 'view/controls/components/tooltipicon';
 import ChaptersMixin from 'view/controls/components/chapters.mixin';
 import ThumbnailsMixin from 'view/controls/components/thumbnails.mixin';
 
-class TimeTip extends Tooltip {
+class TimeTipIcon extends TooltipIcon {
 
     setup() {
         this.text = document.createElement('span');
@@ -52,7 +52,7 @@ class TimeTip extends Tooltip {
             return;
         }
 
-        if (!this.container) {
+        if (!this.tooltip) {
             return;
         }
 
@@ -77,7 +77,7 @@ class TimeSlider extends Slider {
 
         this.timeUpdateKeeper = _timeUpdateKeeper;
 
-        this.timeTip = new TimeTip('jw-tooltip-time', null, true);
+        this.timeTip = new TimeTipIcon('jw-tooltip-time', null, true);
         this.timeTip.setup();
 
         this.cues = [];

--- a/src/js/view/controls/components/tooltipicon.js
+++ b/src/js/view/controls/components/tooltipicon.js
@@ -3,8 +3,8 @@ import ariaLabel from 'utils/aria';
 import { toggleClass } from 'utils/dom';
 import svgParse from 'utils/svgParser';
 
-export default class Tooltip {
-    constructor(name, ariaText, elementShown, svgIcons) {
+export default class TooltipIcon {
+    constructor(name, ariaText, elementShown, svgIcons, container) {
         Object.assign(this, Events);
         this.el = document.createElement('div');
         let className = 'jw-icon jw-icon-tooltip ' + name + ' jw-button-color jw-reset';
@@ -15,12 +15,15 @@ export default class Tooltip {
         ariaLabel(this.el, ariaText);
 
         this.el.className = className;
-        this.container = document.createElement('div');
-        this.container.className = 'jw-overlay jw-reset';
         this.openClass = 'jw-open';
         this.componentType = 'tooltip';
 
-        this.el.appendChild(this.container);
+        if (!container) {
+            container = document.createElement('div');
+            container.className = 'jw-overlay jw-reset';
+            this.el.appendChild(container);
+        }
+        this.tooltip = container;
         if (svgIcons && svgIcons.length > 0) {
             Array.prototype.forEach.call(svgIcons, svgIcon => {
                 if (typeof svgIcon === 'string') {
@@ -38,12 +41,12 @@ export default class Tooltip {
         }
 
         this.content = elem;
-        this.container.appendChild(elem);
+        this.tooltip.appendChild(elem);
     }
 
     removeContent() {
         if (this.content) {
-            this.container.removeChild(this.content);
+            this.tooltip.removeChild(this.content);
             this.content = null;
         }
     }
@@ -61,6 +64,7 @@ export default class Tooltip {
             this.trigger('open-' + this.componentType, evt, { isOpen: true });
             this.isOpen = true;
             toggleClass(this.el, this.openClass, this.isOpen);
+            toggleClass(this.tooltip, this.openClass, this.isOpen);
         }
     }
 
@@ -69,6 +73,7 @@ export default class Tooltip {
             this.trigger('close-' + this.componentType, evt, { isOpen: false });
             this.isOpen = false;
             toggleClass(this.el, this.openClass, this.isOpen);
+            toggleClass(this.tooltip, this.openClass, this.isOpen);
         }
     }
 

--- a/src/js/view/controls/components/tooltipicon.js
+++ b/src/js/view/controls/components/tooltipicon.js
@@ -4,7 +4,7 @@ import { toggleClass } from 'utils/dom';
 import svgParse from 'utils/svgParser';
 
 export default class TooltipIcon {
-    constructor(name, ariaText, elementShown, svgIcons, container) {
+    constructor(name, ariaText, elementShown, svgIcons) {
         Object.assign(this, Events);
         this.el = document.createElement('div');
         let className = 'jw-icon jw-icon-tooltip ' + name + ' jw-button-color jw-reset';
@@ -15,15 +15,12 @@ export default class TooltipIcon {
         ariaLabel(this.el, ariaText);
 
         this.el.className = className;
+        this.tooltip = document.createElement('div');
+        this.tooltip.className = 'jw-overlay jw-reset';
         this.openClass = 'jw-open';
         this.componentType = 'tooltip';
 
-        if (!container) {
-            container = document.createElement('div');
-            container.className = 'jw-overlay jw-reset';
-            this.el.appendChild(container);
-        }
-        this.tooltip = container;
+        this.el.appendChild(this.tooltip);
         if (svgIcons && svgIcons.length > 0) {
             Array.prototype.forEach.call(svgIcons, svgIcon => {
                 if (typeof svgIcon === 'string') {

--- a/src/js/view/controls/components/tooltipicon.js
+++ b/src/js/view/controls/components/tooltipicon.js
@@ -61,7 +61,6 @@ export default class TooltipIcon {
             this.trigger('open-' + this.componentType, evt, { isOpen: true });
             this.isOpen = true;
             toggleClass(this.el, this.openClass, this.isOpen);
-            toggleClass(this.tooltip, this.openClass, this.isOpen);
         }
     }
 
@@ -70,7 +69,6 @@ export default class TooltipIcon {
             this.trigger('close-' + this.componentType, evt, { isOpen: false });
             this.isOpen = false;
             toggleClass(this.el, this.openClass, this.isOpen);
-            toggleClass(this.tooltip, this.openClass, this.isOpen);
         }
     }
 

--- a/src/js/view/controls/components/volumetooltipicon.js
+++ b/src/js/view/controls/components/volumetooltipicon.js
@@ -52,27 +52,27 @@ export default class VolumeTooltipIcon extends TooltipIcon {
             .on('click enter', this.toggleValue, this)
             .on('tap', this.toggleOpenState, this);
 
-        this.addTooltipHandlers(this.ui);
-        this.addTooltipHandlers(this.horizontalSlider.uiOver);
-        this.addTooltipHandlers(this.verticalSlider.uiOver);
+        this.addSliderHandlers(this.ui);
+        this.addSliderHandlers(this.horizontalSlider.uiOver);
+        this.addSliderHandlers(this.verticalSlider.uiOver);
 
         this._model.on('change:volume', this.onVolume, this);
     }
 
-    addTooltipHandlers(ui) {
-        const { openTooltip, closeTooltip } = this;
-        ui.on('over', openTooltip, this)
-            .on('out', closeTooltip, this)
-            .on('focus', openTooltip, this)
-            .on('blur', closeTooltip, this);
+    addSliderHandlers(ui) {
+        const { openSlider, closeSlider } = this;
+        ui.on('over', openSlider, this)
+            .on('out', closeSlider, this)
+            .on('focus', openSlider, this)
+            .on('blur', closeSlider, this);
     }
 
-    openTooltip(evt) {
+    openSlider(evt) {
         super.openTooltip(evt);
         toggleClass(this.horizontalContainer, this.openClass, this.isOpen);
     }
 
-    closeTooltip(evt) {
+    closeSlider(evt) {
         super.closeTooltip(evt);
         toggleClass(this.horizontalContainer, this.openClass, this.isOpen);
     }

--- a/src/js/view/controls/components/volumetooltipicon.js
+++ b/src/js/view/controls/components/volumetooltipicon.js
@@ -56,7 +56,15 @@ export default class VolumeTooltipIcon extends TooltipIcon {
         this.addSliderHandlers(this.horizontalSlider.uiOver);
         this.addSliderHandlers(this.verticalSlider.uiOver);
 
+        this.onAudioMode(null, _model.get('audioMode'));
+
+        this._model.on('change:audioMode', this.onAudioMode, this);
         this._model.on('change:volume', this.onVolume, this);
+    }
+
+    onAudioMode(model, val) {
+        const tabIndex = val ? 0 : -1;
+        setAttribute(this.horizontalContainer, 'tabindex', tabIndex);
     }
 
     addSliderHandlers(ui) {

--- a/src/js/view/controls/components/volumetooltipicon.js
+++ b/src/js/view/controls/components/volumetooltipicon.js
@@ -48,6 +48,21 @@ export default class VolumeTooltipIcon extends TooltipIcon {
             this.trigger('update', evt);
         }, this);
 
+        this.horizontalSlider.uiOver.on('keydown', (evt) => {
+            const event = evt.sourceEvent;
+            switch (event.keyCode) {
+                case 37:
+                    event.stopPropagation();
+                    this.trigger('adjustVolume', -10);
+                    break;
+                case 39:
+                    event.stopPropagation();
+                    this.trigger('adjustVolume', 10);
+                    break;
+                default:
+            }
+        });
+
         this.ui = new UI(this.el, { directSelect: true })
             .on('click enter', this.toggleValue, this)
             .on('tap', this.toggleOpenState, this);

--- a/src/js/view/controls/components/volumetooltipicon.js
+++ b/src/js/view/controls/components/volumetooltipicon.js
@@ -75,6 +75,7 @@ export default class VolumeTooltipIcon extends TooltipIcon {
     closeSlider(evt) {
         super.closeTooltip(evt);
         toggleClass(this.horizontalContainer, this.openClass, this.isOpen);
+        this.horizontalContainer.blur();
     }
 
     toggleValue() {

--- a/src/js/view/controls/components/volumetooltipicon.js
+++ b/src/js/view/controls/components/volumetooltipicon.js
@@ -77,12 +77,12 @@ export default class VolumeTooltipIcon extends TooltipIcon {
 
     openSlider(evt) {
         super.openTooltip(evt);
-        toggleClass(this.horizontalContainer, this.openClass, this.isOpen);
+        toggleClass(this.horizontalContainer, this.openClass, true);
     }
 
     closeSlider(evt) {
         super.closeTooltip(evt);
-        toggleClass(this.horizontalContainer, this.openClass, this.isOpen);
+        toggleClass(this.horizontalContainer, this.openClass, false);
         this.horizontalContainer.blur();
     }
 

--- a/src/js/view/controls/components/volumetooltipicon.js
+++ b/src/js/view/controls/components/volumetooltipicon.js
@@ -1,22 +1,25 @@
-import Tooltip from 'view/controls/components/tooltip';
+import TooltipIcon from 'view/controls/components/tooltipicon';
 import Slider from 'view/controls/components/slider';
 import UI from 'utils/ui';
 import { setAttribute } from 'utils/dom';
 
-export default class VolumeTooltip extends Tooltip {
-    constructor(_model, name, ariaText, svgIcons) {
-        super(name, ariaText, true, svgIcons);
+export default class VolumeTooltipIcon extends TooltipIcon {
+    constructor(_model, name, ariaText, svgIcons, container) {
+        super(name, ariaText, true, svgIcons, container);
 
         const localization = _model.get('localization');
+        const audioMode = _model.get('audioMode');
+        const orientation = audioMode ? 'horizontal' : 'vertical';
 
         this._model = _model;
-        this.volumeSlider = new Slider('jw-slider-volume jw-volume-tip', 'vertical');
+        this.volumeSlider = new Slider('jw-slider-volume jw-volume-tip', orientation);
+        //toggleClass(this.volumeSlider.element(), 'jw-volume-tip', !audioMode);
         this.volumeSlider.setup();
 
         const volumeSliderElement = this.volumeSlider.element();
         volumeSliderElement.classList.remove('jw-background-color');
         
-        const overlay = this.container;
+        const overlay = this.tooltip;
         setAttribute(overlay, 'tabindex', '0');
         setAttribute(overlay, 'aria-label', localization.volumeSlider);
         setAttribute(overlay, 'aria-orientation', 'vertical');
@@ -34,6 +37,8 @@ export default class VolumeTooltip extends Tooltip {
         const { openTooltip, closeTooltip } = this;
         this.uiOver = new UI(overlay)
             .on('click', function() {}, this)
+            .on('over', openTooltip, this)
+            .on('out', closeTooltip, this)
             .on('focus', openTooltip, this)
             .on('blur', closeTooltip, this);
 

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -121,7 +121,7 @@ export default class Controlbar {
         const menus = this.menus = [];
         this.ui = [];
         let volumeGroup;
-        let volumeContainer;
+        let horizontalVolumeContainer;
         let muteButton;
         let feedShownId = '';
 
@@ -138,12 +138,11 @@ export default class Controlbar {
 
         // Do not initialize volume slider or tooltip on mobile
         if (!this._isMobile) {
-            if (_model.get('audioMode')) {
-                volumeContainer = document.createElement('div');
-                volumeContainer.className = 'jw-horizontal-volume-container';
-            }
+            horizontalVolumeContainer = document.createElement('div');
+            horizontalVolumeContainer.className = 'jw-horizontal-volume-container';
+
             volumeGroup = new VolumeTooltipIcon(_model, 'jw-icon-volume', vol,
-                cloneIcons('volume-0,volume-50,volume-100'), volumeContainer);
+                cloneIcons('volume-0,volume-50,volume-100'), horizontalVolumeContainer);
 
             const volumeButtonEl = volumeGroup.element();
             menus.push(volumeGroup);
@@ -189,7 +188,7 @@ export default class Controlbar {
             duration: textIcon('jw-text-duration', 'timer'),
             mute: muteButton,
             volumetooltip: volumeGroup,
-            volumeContainer,
+            horizontalVolumeContainer,
             cast: createCastButton(() => {
                 _api.castToggle();
             }, localization),
@@ -240,7 +239,7 @@ export default class Controlbar {
             elements.next,
             elements.volumetooltip,
             elements.mute,
-            elements.volumeContainer,
+            elements.horizontalVolumeContainer,
             elements.alt,
             elements.live,
             elements.elapsed,
@@ -382,13 +381,16 @@ export default class Controlbar {
             const volume = muted ? 0 : vol;
             const volumeButtonEl = volumeGroup.element();
             volumeGroup.volumeSlider.render(volume);
-            const volumeSliderContainer = volumeGroup.tooltip;
+            volumeGroup.horizontalSlider.render(volume);
+            const { tooltip, horizontalContainer } = volumeGroup;
             toggleClass(volumeButtonEl, 'jw-off', muted);
             toggleClass(volumeButtonEl, 'jw-full', vol >= 75 && !muted);
-            setAttribute(volumeSliderContainer, 'aria-valuenow', volume);
+            setAttribute(tooltip, 'aria-valuenow', volume);
+            setAttribute(horizontalContainer, 'aria-valuenow', volume);
             const ariaText = `Volume ${volume}%`;
-            setAttribute(volumeSliderContainer, 'aria-valuetext', ariaText);
-            if (document.activeElement !== volumeSliderContainer) {
+            setAttribute(tooltip, 'aria-valuetext', ariaText);
+            setAttribute(horizontalContainer, 'aria-valuetext', ariaText);
+            if (document.activeElement !== tooltip && document.activeElement !== horizontalContainer) {
                 this._volumeAnnouncer.textContent = ariaText;
             }
         }

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -127,15 +127,6 @@ export default class Controlbar {
 
         const vol = localization.volume;
 
-        // Do not show the volume toggle in the mobile SDKs or <iOS10
-        if (this._isMobile && !_model.get('sdkplatform') && !(OS.iOS && OS.version.major < 10)) {
-            // Clone icons so that can be used in volumeGroup
-            const svgIcons = cloneIcons('volume-0,volume-100');
-            muteButton = button('jw-icon-volume', () => {
-                _api.setMute();
-            }, vol, svgIcons);
-        }
-
         // Do not initialize volume slider or tooltip on mobile
         if (!this._isMobile) {
             horizontalVolumeContainer = document.createElement('div');
@@ -151,6 +142,13 @@ export default class Controlbar {
                 const muteText = muted ? localization.unmute : localization.mute;
                 setAttribute(volumeButtonEl, 'aria-label', muteText);
             }, this);
+        } else if (!_model.get('sdkplatform') && !(OS.iOS && OS.version.major < 10)) {
+            // Do not show the volume toggle in the mobile SDKs or <iOS10
+            // Clone icons so that can be used in volumeGroup
+            const svgIcons = cloneIcons('volume-0,volume-100');
+            muteButton = button('jw-icon-volume', () => {
+                _api.setMute();
+            }, vol, svgIcons);
         }
 
         const nextButton = button('jw-icon-next', () => {
@@ -329,6 +327,9 @@ export default class Controlbar {
             }, this);
             elements.volumetooltip.on('toggleValue', function () {
                 this._api.setMute();
+            }, this);
+            elements.volumetooltip.on('adjustVolume', function(evt) {
+                this.trigger('adjustVolume', evt);
             }, this);
         }
 

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -380,7 +380,7 @@ export default class Controlbar {
         if (volumeGroup) {
             const volume = muted ? 0 : vol;
             const volumeButtonEl = volumeGroup.element();
-            volumeGroup.volumeSlider.render(volume);
+            volumeGroup.verticalSlider.render(volume);
             volumeGroup.horizontalSlider.render(volume);
             const { tooltip, horizontalContainer } = volumeGroup;
             toggleClass(volumeButtonEl, 'jw-off', muted);

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -2,7 +2,7 @@ import { OS } from 'environment/environment';
 import { DISPLAY_CLICK, USER_ACTION, STATE_PAUSED, STATE_PLAYING, STATE_ERROR } from 'events/events';
 import Events from 'utils/backbone.events';
 import { between } from 'utils/math';
-import { addClass, hasClass, removeClass, toggleClass } from 'utils/dom';
+import { addClass, removeClass, toggleClass } from 'utils/dom';
 import { now } from 'utils/date';
 import button from 'view/controls/components/button';
 import Controlbar from 'view/controls/controlbar';
@@ -136,7 +136,7 @@ export default class Controls {
         controlbar.on('nextShown', function (data) {
             this.trigger('nextShown', data);
         }, this);
-        const horizontalVolumeContainer = controlbar.element().querySelector('.jw-horizontal-volume-container');
+        controlbar.on('adjustVolume', adjustVolume, this);
 
         // Next Up Tooltip
         if (model.get('nextUpDisplay') && !controlbar.nextUpToolTip) {
@@ -251,8 +251,6 @@ export default class Controls {
             }
             const menuHidden = !this.settingsMenu.visible;
             const adMode = this.instreamState;
-            const horizontalVolumeActive = document.activeElement === horizontalVolumeContainer &&
-                hasClass(horizontalVolumeContainer, 'jw-open');
 
             switch (evt.keyCode) {
                 case 27: // Esc
@@ -272,16 +270,12 @@ export default class Controls {
                     api.playToggle(reasonInteraction());
                     break;
                 case 37: // left-arrow, if not adMode and settings menu is hidden
-                    if (horizontalVolumeActive) {
-                        adjustVolume(-10);
-                    } else if (!adMode && menuHidden) {
+                    if (!adMode && menuHidden) {
                         adjustSeek(-5);
                     }
                     break;
                 case 39: // right-arrow, if not adMode and settings menu is hidden
-                    if (horizontalVolumeActive) {
-                        adjustVolume(10);
-                    } else if (!adMode && menuHidden) {
+                    if (!adMode && menuHidden) {
                         adjustSeek(5);
                     }
                     break;

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -2,7 +2,7 @@ import { OS } from 'environment/environment';
 import { DISPLAY_CLICK, USER_ACTION, STATE_PAUSED, STATE_PLAYING, STATE_ERROR } from 'events/events';
 import Events from 'utils/backbone.events';
 import { between } from 'utils/math';
-import { addClass, removeClass, toggleClass } from 'utils/dom';
+import { addClass, hasClass, removeClass, toggleClass } from 'utils/dom';
 import { now } from 'utils/date';
 import button from 'view/controls/components/button';
 import Controlbar from 'view/controls/controlbar';
@@ -251,7 +251,8 @@ export default class Controls {
             }
             const menuHidden = !this.settingsMenu.visible;
             const adMode = this.instreamState;
-            const horizontalVolumeActive = document.activeElement === horizontalVolumeContainer;
+            const horizontalVolumeActive = document.activeElement === horizontalVolumeContainer &&
+                hasClass(horizontalVolumeContainer, 'jw-open');
 
             switch (evt.keyCode) {
                 case 27: // Esc

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -2,7 +2,7 @@ import { OS } from 'environment/environment';
 import { DISPLAY_CLICK, USER_ACTION, STATE_PAUSED, STATE_PLAYING, STATE_ERROR } from 'events/events';
 import Events from 'utils/backbone.events';
 import { between } from 'utils/math';
-import { addClass, hasClass, removeClass, toggleClass } from 'utils/dom';
+import { addClass, removeClass, toggleClass } from 'utils/dom';
 import { now } from 'utils/date';
 import button from 'view/controls/components/button';
 import Controlbar from 'view/controls/controlbar';

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -2,7 +2,7 @@ import { OS } from 'environment/environment';
 import { DISPLAY_CLICK, USER_ACTION, STATE_PAUSED, STATE_PLAYING, STATE_ERROR } from 'events/events';
 import Events from 'utils/backbone.events';
 import { between } from 'utils/math';
-import { addClass, removeClass, toggleClass } from 'utils/dom';
+import { addClass, hasClass, removeClass, toggleClass } from 'utils/dom';
 import { now } from 'utils/date';
 import button from 'view/controls/components/button';
 import Controlbar from 'view/controls/controlbar';
@@ -136,6 +136,7 @@ export default class Controls {
         controlbar.on('nextShown', function (data) {
             this.trigger('nextShown', data);
         }, this);
+        const horizontalVolumeContainer = controlbar.element().querySelector('.jw-horizontal-volume-container');
 
         // Next Up Tooltip
         if (model.get('nextUpDisplay') && !controlbar.nextUpToolTip) {
@@ -250,6 +251,7 @@ export default class Controls {
             }
             const menuHidden = !this.settingsMenu.visible;
             const adMode = this.instreamState;
+            const horizontalVolumeActive = document.activeElement === horizontalVolumeContainer;
 
             switch (evt.keyCode) {
                 case 27: // Esc
@@ -269,12 +271,16 @@ export default class Controls {
                     api.playToggle(reasonInteraction());
                     break;
                 case 37: // left-arrow, if not adMode and settings menu is hidden
-                    if (!adMode && menuHidden) {
+                    if (horizontalVolumeActive) {
+                        adjustVolume(-10);
+                    } else if (!adMode && menuHidden) {
                         adjustSeek(-5);
                     }
                     break;
                 case 39: // right-arrow, if not adMode and settings menu is hidden
-                    if (!adMode && menuHidden) {
+                    if (horizontalVolumeActive) {
+                        adjustVolume(10);
+                    } else if (!adMode && menuHidden) {
                         adjustSeek(5);
                     }
                     break;


### PR DESCRIPTION
### This PR will...
- Add horizontal volume slider to control bar only player
- Rename `Tooltip` `VolumeTooltip` `Timetip` to `TooltipIcon` `VolumeTooltipIcon` `TimetipIcon`, since they are creating an icon that has a tooltip on hover. Instead of `container`, those classes now contain `tooltip` which makes more sense.

### Why is this Pull Request needed?

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-2183

