### PR TITLE
Autopause Refinements

### DIFF
--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -84,6 +84,13 @@ const Config = function(options, persisted) {
     config.language = language;
     config.intl = intl;
 
+    // If autoPause is configured with an empty block,
+    // default autoPause.viewability to true.
+    let autoPause = config.autoPause;
+    if (autoPause && !autoPause.viewability) {
+        autoPause.viewability = true;
+    }
+
     let rateControls = config.playbackRateControls;
 
     if (rateControls) {

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -87,8 +87,8 @@ const Config = function(options, persisted) {
 
     // If autoPause is configured with an empty block,
     // default autoPause.viewability to true.
-    let autoPause = allOptions.autoPause || {};
-    config.autoPause.viewability = ('viewability' in autoPause) ? !!autoPause.viewability : true;
+    let autoPause = allOptions.autoPause;
+    config.autoPause.viewability = (autoPause && ('viewability' in autoPause)) ? !!autoPause.viewability : true;
 
     let rateControls = config.playbackRateControls;
 

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -88,7 +88,9 @@ const Config = function(options, persisted) {
     // If autoPause is configured with an empty block,
     // default autoPause.viewability to true.
     let autoPause = allOptions.autoPause;
-    config.autoPause.viewability = (autoPause && ('viewability' in autoPause)) ? !!autoPause.viewability : true;
+    if (autoPause) {
+        config.autoPause.viewability = ('viewability' in autoPause) ? !!autoPause.viewability : true;
+    }
 
     let rateControls = config.playbackRateControls;
 

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -87,7 +87,7 @@ const Config = function(options, persisted) {
     // If autoPause is configured with an empty block,
     // default autoPause.viewability to true.
     let autoPause = config.autoPause;
-    if (autoPause && !autoPause.viewability) {
+    if (autoPause && !autoPause.hasOwnProperty('viewability')) {
         autoPause.viewability = true;
     }
 

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -10,6 +10,7 @@ import { getLanguage, getCustomLocalization, applyTranslation, normalizeIntl } f
 // Defaults
 // Alphabetical order
 const Defaults = {
+    autoPause: { viewability: false },
     autostart: false,
     bandwidthEstimate: null,
     bitrateSelection: null,
@@ -87,9 +88,7 @@ const Config = function(options, persisted) {
     // If autoPause is configured with an empty block,
     // default autoPause.viewability to true.
     let autoPause = config.autoPause;
-    if (autoPause && !autoPause.hasOwnProperty('viewability')) {
-        autoPause.viewability = true;
-    }
+    autoPause.viewability = ('viewability' in autoPause) ? !!autoPause.viewability : true;
 
     let rateControls = config.playbackRateControls;
 

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -87,8 +87,8 @@ const Config = function(options, persisted) {
 
     // If autoPause is configured with an empty block,
     // default autoPause.viewability to true.
-    let autoPause = config.autoPause;
-    autoPause.viewability = ('viewability' in autoPause) ? !!autoPause.viewability : true;
+    let autoPause = allOptions.autoPause || {};
+    config.autoPause.viewability = ('viewability' in autoPause) ? !!autoPause.viewability : true;
 
     let rateControls = config.playbackRateControls;
 

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -298,7 +298,7 @@ Object.assign(Controller.prototype, {
 
             // Autostart immediately if we're not waiting for the player to become viewable first.
             if (_model.get('autostart') === true && !_model.get('playOnViewable')) {
-                _autoStart({ reason: 'autostart' });
+                _autoStart('autostart');
             }
             apiQueue.flush();
         }
@@ -338,7 +338,7 @@ Object.assign(Controller.prototype, {
         function _checkPlayOnViewable(model, viewable) {
             if (model.get('playOnViewable')) {
                 if (viewable) {
-                    _autoStart({ reason: 'viewability' });
+                    _autoStart('viewability');
                 } else if (OS.mobile) {
                     _this.pause({ reason: 'autostart' });
                 }
@@ -352,7 +352,7 @@ Object.assign(Controller.prototype, {
 
             const adState = _getAdState();
             if (!adState) {
-                _this.pause({ reason: 'viewability' });
+                _this.pause({ reason: 'viewable' });
             } else if (model.get('activeTab') && adState !== 'paused') {
                 const instream = _this._instreamAdapter;
                 if (instream) {
@@ -534,7 +534,7 @@ Object.assign(Controller.prototype, {
                     _model.set('enableDefaultCaptions', false);
                 }
 
-                return _play(reason).catch(() => {
+                return _play({ reason }).catch(() => {
                     if (!_this._instreamAdapter) {
                         _model.set('autostartFailed', true);
                     }
@@ -593,7 +593,7 @@ Object.assign(Controller.prototype, {
             if (state !== STATE_PAUSED && state !== STATE_IDLE) {
                 const pauseReason = _getReason(meta);
                 _model.set('pauseReason', pauseReason);
-                _model.set('playOnViewable', (pauseReason === 'viewability'));
+                _model.set('playOnViewable', (pauseReason === 'viewable'));
             }
 
             const adState = _getAdState();

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -353,12 +353,12 @@ Object.assign(Controller.prototype, {
             const adState = _getAdState();
             if (!adState) {
                 _this.pause({ reason: 'viewability' });
-            } else if (adState !== 'paused') {
+            } else if (model.get('activeTab') && adState !== 'paused') {
                 const instream = _this._instreamAdapter;
                 if (instream) {
                     instream.noResume = true;
-                    model.set('playOnViewable', true);
                 }
+                model.set('playOnViewable', true);
             }
         }
 

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -269,7 +269,6 @@ Object.assign(Controller.prototype, {
 
             _model.change('viewable', viewableChange);
             _model.change('viewable', _checkPlayOnViewable);
-            _model.change('viewable', _checkPauseOnViewable);
             _model.once('change:autostartFailed change:mute', function(model) {
                 model.off('change:viewable', _checkPlayOnViewable);
             });
@@ -310,6 +309,8 @@ Object.assign(Controller.prototype, {
             });
 
             preload();
+
+            _checkPauseOnViewable(model, viewable);
         }
 
         function preload() {
@@ -348,12 +349,11 @@ Object.assign(Controller.prototype, {
             _model.set('pauseOnViewable', true);
         }
 
-        function _checkPauseOnViewable() {
+        function _checkPauseOnViewable(model, viewable) {
             const adState = _getAdState();
-            const viewable = _model.get('viewable');
-            const isPaused = _model.get('state') === 'paused';
+            const isPaused = model.get('state') === 'paused';
 
-            if (_model.get('pauseOnViewable') && !viewable && !adState && !isPaused) {
+            if (!viewable && model.get('pauseOnViewable') && !adState && !isPaused) {
                 _this.pause({ reason: 'viewability' });
             }
         }

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -353,7 +353,7 @@ Object.assign(Controller.prototype, {
             const adState = _getAdState();
             if (!adState) {
                 _this.pause({ reason: 'viewability' });
-            } else {
+            } else if (adState !== 'paused') {
                 const instream = _this._instreamAdapter;
                 if (instream) {
                     instream.noResume = true;

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -340,7 +340,11 @@ Object.assign(Controller.prototype, {
         function _checkPlayOnViewable(model, viewable) {
             if (model.get('playOnViewable')) {
                 if (viewable) {
-                    _play('viewable');
+                    if (model.get('state') === STATE_IDLE) {
+                        _autoStart('viewable');
+                    } else {
+                        _play('viewable');
+                    }
                 } else if (OS.mobile) {
                     _this.pause({ reason: 'autostart' });
                 }
@@ -508,7 +512,7 @@ Object.assign(Controller.prototype, {
 
         function _autoStart(reason) {
             const state = _getState();
-            if (state !== STATE_IDLE && state !== STATE_PAUSED) {
+            if (state !== STATE_IDLE) {
                 return;
             }
 

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -273,6 +273,10 @@ Object.assign(Controller.prototype, {
                 model.off('change:viewable', _checkPlayOnViewable);
             });
 
+            if (_model.get('autoPause').viewability) {
+                _model.change('viewable', _checkPauseOnViewable);
+            }
+
             // Run _checkAutoStart() last
             // 'viewable' changes can result in preload() being called on the initial provider instance
             _checkAutoStart();
@@ -309,8 +313,6 @@ Object.assign(Controller.prototype, {
             });
 
             preload();
-
-            _checkPauseOnViewable(model, viewable);
         }
 
         function preload() {
@@ -354,7 +356,7 @@ Object.assign(Controller.prototype, {
                 instream.noResume = false;
                 model.set('playOnViewable', true);
                 return;
-            } else if (viewable || !model.get('autoPause').viewability) {
+            } else if (viewable) {
                 return;
             }
 

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -341,10 +341,13 @@ Object.assign(Controller.prototype, {
         }
 
         function _checkPlayOnViewable(model, viewable) {
+            const autoPauseViewability = model.get('autoPause') && model.get('autoPause').viewability;
+            const adState = _getAdState();
+
             if (model.get('playOnViewable')) {
                 if (viewable) {
                     _autoStart();
-                } else if (OS.mobile || (model.get('autoPause') && model.get('autoPause').viewability)) {
+                } else if (OS.mobile || (autoPauseViewability && !adState)) {
                     _this.pause({ reason: 'autostart' });
                 }
             }

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -497,7 +497,7 @@ Object.assign(Controller.prototype, {
             return 'external';
         }
 
-        function _autoStart(autostartReason) {
+        function _autoStart(reason) {
             const state = _getState();
             if (state !== STATE_IDLE && state !== STATE_PAUSED) {
                 return;
@@ -536,7 +536,7 @@ Object.assign(Controller.prototype, {
                     _model.set('playOnViewable', true);
                 }
 
-                return _play(autostartReason).catch(() => {
+                return _play(reason).catch(() => {
                     if (!_this._instreamAdapter) {
                         _model.set('autostartFailed', true);
                     }
@@ -548,10 +548,9 @@ Object.assign(Controller.prototype, {
 
                 // Emit event unless test was explicitly canceled.
                 if (!checkAutoStartCancelable.cancelled()) {
-                    const { reason } = error;
                     const code = getPlayAttemptFailedErrorCode(error);
                     _this.trigger(AUTOSTART_NOT_ALLOWED, {
-                        reason,
+                        reason: error.reason,
                         code,
                         error
                     });

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -89,7 +89,7 @@ Object.assign(Controller.prototype, {
         // Enable autoPause behavior.
         const autoPause = _model.get('autoPause');
         const autostart = _model.get('autostart');
-        if (autostart && (autoPause && autoPause.viewability)) {
+        if (autoPause && autoPause.viewability) {
             _model.set('playOnViewable', true);
         }
 
@@ -197,6 +197,9 @@ Object.assign(Controller.prototype, {
                 };
                 mediaModel.on('change:position', onPosition, this);
             }
+            mediaModel.on('change:started', function() {
+                _checkPlayOnViewable(model, model.get('viewable'));
+            });
         });
 
         // Ensure captionsList event is raised after playlistItem
@@ -348,7 +351,8 @@ Object.assign(Controller.prototype, {
                 if (viewable) {
                     _autoStart();
                 } else if (OS.mobile || (autoPauseViewability && !adState)) {
-                    _this.pause({ reason: 'autostart' });
+                    const pauseReason = OS.mobile ? 'autostart' : 'viewability';
+                    _this.pause({ reason: pauseReason });
                 }
             }
         }

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -348,26 +348,19 @@ Object.assign(Controller.prototype, {
         }
 
         function _checkPauseOnViewable(model, viewable) {
-            const instream = _this._instreamAdapter;
-
-            // If player left view and came back before ad completes,
-            // the player should begin/resume playing content.
-            if (viewable && instream && instream.noResume) {
-                instream.noResume = false;
-                model.set('playOnViewable', true);
-                return;
-            } else if (viewable) {
-                return;
-            }
-
+            const playerState = model.get('state');
+            const pauseReason = model.get('pauseReason');
             const adState = _getAdState();
-            if (!adState) {
-                _this.pause({ reason: 'viewable' });
-            } else if (model.get('activeTab') && adState !== 'paused') {
-                if (instream) {
-                    instream.noResume = true;
+            if (adState) {
+                _this._instreamAdapter.noResume = !viewable;
+                if (!viewable) {
+                    _updatePauseReason({ reason: 'viewable' });
                 }
-                model.set('playOnViewable', true);
+            } else if (playerState !== STATE_PAUSED && playerState !== STATE_IDLE && pauseReason !== 'interaction') {
+                if (!viewable) {
+                    _this.pause({ reason: 'viewable' });
+                    model.set('playOnViewable', !viewable);
+                }
             }
         }
 

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -589,7 +589,7 @@ Object.assign(Controller.prototype, {
             _actionOnAttach = null;
             checkAutoStartCancelable.cancel();
 
-            const state = _getState();
+            const state = _model.get('state');
             if (state !== STATE_PAUSED && state !== STATE_IDLE) {
                 const pauseReason = _getReason(meta);
                 _model.set('pauseReason', pauseReason);
@@ -618,7 +618,7 @@ Object.assign(Controller.prototype, {
         }
 
         function _isIdle() {
-            const state = _getState();
+            const state = _model.get('state');
             return (state === STATE_IDLE || state === STATE_COMPLETE || state === STATE_ERROR);
         }
 

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -86,6 +86,13 @@ Object.assign(Controller.prototype, {
         addProgramControllerListeners();
         initQoe(_model, _programController);
 
+        // Enable autoPause behavior.
+        const autoPause = _model.get('autoPause');
+        const autostart = _model.get('autostart');
+        if (autostart && (autoPause && autoPause.viewability)) {
+            _model.set('playOnViewable', true);
+        }
+
         _model.on(ERROR, _this.triggerError, _this);
 
         _model.on('change:state', (model, newstate, oldstate) => {
@@ -430,6 +437,10 @@ Object.assign(Controller.prototype, {
             const playReason = _getReason(meta);
             _model.set('playReason', playReason);
 
+            if (!autostart && (autoPause && autoPause.viewability)) {
+                _model.set('playOnViewable', true);
+            }
+
             const adState = _getAdState();
             if (adState) {
                 // this will resume the ad. _api.playAd would load a new ad
@@ -513,12 +524,6 @@ Object.assign(Controller.prototype, {
 
                 if (!_this.getMute()) {
                     _model.set('enableDefaultCaptions', false);
-                }
-
-                // Enable autoPause behavior.
-                const autoPause = _model.get('autoPause');
-                if (autoPause && autoPause.viewability) {
-                    _model.set('playOnViewable', true);
                 }
 
                 return _play({ reason: 'autostart' }).catch(() => {

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -592,28 +592,29 @@ Object.assign(Controller.prototype, {
             _programController.stopVideo();
         }
 
+        function _updatePauseReason(meta) {
+            const pauseReason = _getReason(meta);
+            _model.set('pauseReason', pauseReason);
+            _model.set('playOnViewable', (pauseReason === 'viewable'));
+        }
+
         function _pause(meta) {
             _actionOnAttach = null;
             checkAutoStartCancelable.cancel();
 
-            const state = _model.get('state');
-            if (state !== STATE_PAUSED && state !== STATE_IDLE) {
-                const pauseReason = _getReason(meta);
-                _model.set('pauseReason', pauseReason);
-                _model.set('playOnViewable', (pauseReason === 'viewable'));
-            }
-
             const adState = _getAdState();
-            if (adState) {
+            if (adState && adState !== STATE_PAUSED) {
+                _updatePauseReason(meta);
                 _api.pauseAd(true, meta);
                 return;
             }
 
-            switch (state) {
+            switch (_model.get('state')) {
                 case STATE_ERROR:
                     return;
                 case STATE_PLAYING:
                 case STATE_BUFFERING: {
+                    _updatePauseReason(meta);
                     _programController.pause();
                     break;
                 }

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -298,7 +298,7 @@ Object.assign(Controller.prototype, {
 
             // Autostart immediately if we're not waiting for the player to become viewable first.
             if (_model.get('autostart') === true && !_model.get('playOnViewable')) {
-                _autoStart();
+                _autoStart({ reason: 'autostart' });
             }
             apiQueue.flush();
         }
@@ -338,7 +338,7 @@ Object.assign(Controller.prototype, {
         function _checkPlayOnViewable(model, viewable) {
             if (model.get('playOnViewable')) {
                 if (viewable) {
-                    _autoStart();
+                    _autoStart({ reason: 'viewability' });
                 } else if (OS.mobile) {
                     _this.pause({ reason: 'autostart' });
                 }
@@ -497,7 +497,7 @@ Object.assign(Controller.prototype, {
             return 'external';
         }
 
-        function _autoStart() {
+        function _autoStart(autostartReason) {
             const state = _getState();
             if (state !== STATE_IDLE && state !== STATE_PAUSED) {
                 return;
@@ -536,7 +536,7 @@ Object.assign(Controller.prototype, {
                     _model.set('playOnViewable', true);
                 }
 
-                return _play({ reason: 'autostart' }).catch(() => {
+                return _play(autostartReason).catch(() => {
                     if (!_this._instreamAdapter) {
                         _model.set('autostartFailed', true);
                     }

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -340,7 +340,7 @@ Object.assign(Controller.prototype, {
         function _checkPlayOnViewable(model, viewable) {
             if (model.get('playOnViewable')) {
                 if (viewable) {
-                    _autoStart('viewable');
+                    _play('viewable');
                 } else if (OS.mobile) {
                     _this.pause({ reason: 'autostart' });
                 }
@@ -349,14 +349,13 @@ Object.assign(Controller.prototype, {
 
         function _checkPauseOnViewable(model, viewable) {
             const playerState = model.get('state');
-            const pauseReason = model.get('pauseReason');
             const adState = _getAdState();
             if (adState) {
                 _this._instreamAdapter.noResume = !viewable;
                 if (!viewable) {
                     _updatePauseReason({ reason: 'viewable' });
                 }
-            } else if (playerState !== STATE_PAUSED && playerState !== STATE_IDLE && pauseReason !== 'interaction') {
+            } else if (playerState !== STATE_PAUSED && playerState !== STATE_IDLE) {
                 if (!viewable) {
                     _this.pause({ reason: 'viewable' });
                     model.set('playOnViewable', !viewable);
@@ -365,7 +364,6 @@ Object.assign(Controller.prototype, {
         }
 
         function _load(item, feedData) {
-
             const instream = _this._instreamAdapter;
             if (instream) {
                 instream.noResume = true;
@@ -452,6 +450,11 @@ Object.assign(Controller.prototype, {
             _model.set('playReason', playReason);
 
             const adState = _getAdState();
+            const pauseReason = _model.get('pauseReason');
+            if (adState && pauseReason === 'viewable' && playReason !== 'interaction') {
+                return;
+            }
+
             if (adState) {
                 // this will resume the ad. _api.playAd would load a new ad
                 _api.pauseAd(false, meta);

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -345,14 +345,20 @@ Object.assign(Controller.prototype, {
             }
         }
 
-        if (_model.get('autoPause') && _model.get('autoPause').viewability) {
-            _model.set('pauseOnViewable', true);
-        }
-
         function _checkPauseOnViewable(model, viewable) {
+            if (viewable || !model.get('autoPause').viewability) {
+                return;
+            }
+
             const adState = _getAdState();
-            if (!viewable && model.get('pauseOnViewable') && !adState) {
+            if (!adState) {
                 _this.pause({ reason: 'viewability' });
+            } else {
+                const instream = _this._instreamAdapter;
+                if (instream) {
+                    instream.noResume = true;
+                    model.set('playOnViewable', true);
+                }
             }
         }
 

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -335,8 +335,6 @@ Object.assign(Controller.prototype, {
         }
 
         function _checkPlayOnViewable(model, viewable) {
-            // const isAutoPaused = (model.get('state') === 'paused') && model.get('pauseReason') === 'viewability';
-            // if (model.get('playOnViewable') || isAutoPaused) {
             if (model.get('playOnViewable')) {
                 if (viewable) {
                     _autoStart();

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -351,7 +351,7 @@ Object.assign(Controller.prototype, {
 
         function _checkPauseOnViewable(model, viewable) {
             const adState = _getAdState();
-            const isPaused = model.get('state') === 'paused';
+            const isPaused = model.get('state') === STATE_PAUSED;
 
             if (!viewable && model.get('pauseOnViewable') && !adState && !isPaused) {
                 _this.pause({ reason: 'viewability' });

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -277,8 +277,11 @@ Object.assign(Controller.prototype, {
             eventsReadyQueue.destroy();
             eventsReadyQueue = null;
 
+            if (autostart) {
+                _model.change('viewable', _checkPlayOnViewable);
+            }
+
             _model.change('viewable', viewableChange);
-            _model.change('viewable', _checkPlayOnViewable);
             _model.once('change:autostartFailed change:mute', function(model) {
                 model.off('change:viewable', _checkPlayOnViewable);
             });
@@ -446,6 +449,7 @@ Object.assign(Controller.prototype, {
 
             if (!autostart && (autoPause && autoPause.viewability)) {
                 _model.set('playOnViewable', true);
+                _model.change('viewable', _checkPlayOnViewable);
             }
 
             const adState = _getAdState();

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -338,7 +338,7 @@ Object.assign(Controller.prototype, {
         function _checkPlayOnViewable(model, viewable) {
             if (model.get('playOnViewable')) {
                 if (viewable) {
-                    _autoStart('viewability');
+                    _autoStart('viewable');
                 } else if (OS.mobile) {
                     _this.pause({ reason: 'autostart' });
                 }
@@ -346,7 +346,15 @@ Object.assign(Controller.prototype, {
         }
 
         function _checkPauseOnViewable(model, viewable) {
-            if (viewable || !model.get('autoPause').viewability) {
+            const instream = _this._instreamAdapter;
+
+            // If player left view and came back before ad completes,
+            // the player should begin/resume playing content.
+            if (viewable && instream && instream.noResume) {
+                instream.noResume = false;
+                model.set('playOnViewable', true);
+                return;
+            } else if (viewable || !model.get('autoPause').viewability) {
                 return;
             }
 
@@ -354,7 +362,6 @@ Object.assign(Controller.prototype, {
             if (!adState) {
                 _this.pause({ reason: 'viewable' });
             } else if (model.get('activeTab') && adState !== 'paused') {
-                const instream = _this._instreamAdapter;
                 if (instream) {
                     instream.noResume = true;
                 }

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -473,15 +473,10 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
             return;
         }
 
-        const viewable = _model.get('viewable');
         if (_beforeComplete) {
             _controller.stopVideo();
-        } else if (!_model.get('pauseOnViewable') || (_model.get('pauseOnViewable') && viewable)) {
-            // Play the content if pauseOnViewable is not set or if it is but player is viewable
-            _controller.playVideo();
         } else {
-            // If pauseOnViewable is set up and player is not viewable, resume when viewable
-            _model.set('playOnViewable', true);
+            _controller.playVideo();
         }
     };
 

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -475,7 +475,7 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
 
         if (_beforeComplete) {
             _controller.stopVideo();
-        } else {
+        } else if (!_model.get('autoPause')) {
             _controller.playVideo();
         }
     };

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -473,10 +473,15 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
             return;
         }
 
+        const viewable = _model.get('viewable');
         if (_beforeComplete) {
             _controller.stopVideo();
-        } else if (!_model.get('autoPause')) {
+        } else if (!_model.get('pauseOnViewable') || (_model.get('pauseOnViewable') && viewable)) {
+            // Play the content if pauseOnViewable is not set or if it is but player is viewable
             _controller.playVideo();
+        } else {
+            // If pauseOnViewable is set up and player is not viewable, resume when viewable
+            _model.set('playOnViewable', true);
         }
     };
 

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -268,6 +268,7 @@ class ProgramController extends Events {
 
         const autoPause = model.get('autoPause');
 
+        // If background loading and using autoPause, we want to show the paused state after ads.
         backgroundMediaController.mediaModel.attributes.mediaState = autoPause ? 'paused' : 'buffering';
         this._setActiveMedia(backgroundMediaController);
         backgroundMediaController.background = false;

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -266,9 +266,9 @@ class ProgramController extends Events {
             return;
         }
 
-        let mediaState = backgroundMediaController.mediaModel.attributes.mediaState;
-        if (mediaState !== 'paused') {
-            backgroundMediaController.mediaModel.attributes.mediaState = 'buffering';
+        const attributes = backgroundMediaController.mediaModel.attributes;
+        if (attributes.mediaState !== 'paused') {
+            attributes.mediaState = 'buffering';
         }
 
         this._setActiveMedia(backgroundMediaController);

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -266,7 +266,11 @@ class ProgramController extends Events {
             return;
         }
 
-        backgroundMediaController.mediaModel.attributes.mediaState = 'buffering';
+        let mediaState = backgroundMediaController.mediaModel.attributes.mediaState;
+        if (mediaState !== 'paused') {
+            mediaState = 'buffering';
+        }
+
         this._setActiveMedia(backgroundMediaController);
         backgroundMediaController.background = false;
         background.currentMedia = null;

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -268,7 +268,7 @@ class ProgramController extends Events {
 
         let mediaState = backgroundMediaController.mediaModel.attributes.mediaState;
         if (mediaState !== 'paused') {
-            mediaState = 'buffering';
+            backgroundMediaController.mediaModel.attributes.mediaState = 'buffering';
         }
 
         this._setActiveMedia(backgroundMediaController);

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -254,7 +254,7 @@ class ProgramController extends Events {
      */
     restoreBackgroundMedia() {
         this.adPlaying = false;
-        const { background, mediaController, model } = this;
+        const { background, mediaController } = this;
         const backgroundMediaController = background.currentMedia;
         if (!backgroundMediaController) {
             return;
@@ -266,10 +266,7 @@ class ProgramController extends Events {
             return;
         }
 
-        const autoPause = model.get('autoPause');
-
-        // If background loading and using autoPause, we want to show the paused state after ads.
-        backgroundMediaController.mediaModel.attributes.mediaState = autoPause ? 'paused' : 'buffering';
+        backgroundMediaController.mediaModel.attributes.mediaState = 'buffering';
         this._setActiveMedia(backgroundMediaController);
         backgroundMediaController.background = false;
         background.currentMedia = null;

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -254,7 +254,7 @@ class ProgramController extends Events {
      */
     restoreBackgroundMedia() {
         this.adPlaying = false;
-        const { background, mediaController } = this;
+        const { background, mediaController, model } = this;
         const backgroundMediaController = background.currentMedia;
         if (!backgroundMediaController) {
             return;
@@ -266,7 +266,9 @@ class ProgramController extends Events {
             return;
         }
 
-        backgroundMediaController.mediaModel.attributes.mediaState = 'buffering';
+        const autoPause = model.get('autoPause');
+
+        backgroundMediaController.mediaModel.attributes.mediaState = autoPause ? 'paused' : 'buffering';
         this._setActiveMedia(backgroundMediaController);
         backgroundMediaController.background = false;
         background.currentMedia = null;

--- a/test/data/model-properties.js
+++ b/test/data/model-properties.js
@@ -69,6 +69,7 @@ export const addedProperties = {
 
 export default {
     id: '',
+    autoPause: { viewability: false },
     autostart: false,
     base: '',
     controls: true,


### PR DESCRIPTION
### This PR will...

* Decouple `autoPause` from `autostart`. Now, autostarting will not be required to autoPause.
* If `autoPause.viewability` is not set in the config, it will default to `true`. This means autoPause can be set up with an empty object.
* Add logic to controller and have it check each time the player's viewability change. If `autoPause` is enabled and the player goes out of view, the autoPause functionality will take affect.
* Ensure ads will continue playing when scrolling out of view. If autoPause is enabled and player is still out of view when the ad break ends, the player will then pause.
* Added `'viewability'` as a `pauseReason` and `playReason` and set it if paused/resumed due to autoPause.

### Why is this Pull Request needed?

* Publishers want to be able to automatically pause when not in view to save on streaming costs and ensure higher engagement.
* Publishers do not want ads to pause when scrolling out of view due to its affect on ad complete rates.

### Are there any points in the code the reviewer needs to double check?

There is no impact on anything (i.e. analytics) for changing the `pauseReason` and `playReason` reasons, right?

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-commercial/pull/6287

#### Addresses Issue(s):

JW8-2531

