### PR TITLE
JW8 - add title secondary in player and info overlay

### DIFF
--- a/src/css/jwplayer/imports/title.less
+++ b/src/css/jwplayer/imports/title.less
@@ -8,7 +8,8 @@
 
 // if we set color on the parent, it is overwritten by the reset
 .jw-title-primary,
-.jw-title-secondary {
+.jw-title-secondary,
+.jw-title-description {
     color: @white;
     // ensure there's padding even when the logo is positioned in the top-left
     padding-left: @ui-margin;

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -18,6 +18,7 @@ const Defaults = {
     defaultPlaybackRate: 1,
     displaydescription: true,
     displaytitle: true,
+    displaytitleSecondary: true,
     displayPlaybackLabel: false,
     height: 360,
     intl: {},
@@ -121,6 +122,7 @@ const Config = function(options, persisted) {
         const obj = pick(config, [
             'title',
             'description',
+            'titleSecondary',
             'type',
             'mediaid',
             'image',
@@ -130,7 +132,6 @@ const Config = function(options, persisted) {
             'preload',
             'duration'
         ]);
-
         config.playlist = [ obj ];
     } else if (Array.isArray(configPlaylist.playlist)) {
         // The "playlist" in the config is actually a feed that contains a playlist

--- a/src/js/templates/player.js
+++ b/src/js/templates/player.js
@@ -10,6 +10,7 @@ export default (id, ariaLabel) => {
                 `<div class="jw-title jw-reset-text" dir="auto">` +
                     `<div class="jw-title-primary jw-reset-text"></div>` +
                     `<div class="jw-title-secondary jw-reset-text"></div>` +
+                    `<div class="jw-title-description jw-reset-text"></div>` +
                 `</div>` +
                 `<div class="jw-overlays jw-reset"></div>` +
                 `<div class="jw-hidden-accessibility">` +

--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -159,9 +159,6 @@ function initInteractionListeners(ui) {
 
     const interactEndHandler = (e) => {
         clearTimeout(longPressTimeout);
-        if (!ui.el) {
-            return;
-        }
         releasePointerCapture(ui);
         removeHandlers(ui, WINDOW_GROUP);
         if (ui.dragged) {

--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -159,6 +159,9 @@ function initInteractionListeners(ui) {
 
     const interactEndHandler = (e) => {
         clearTimeout(longPressTimeout);
+        if (!ui.el) {
+            return;
+        }
         releasePointerCapture(ui);
         removeHandlers(ui, WINDOW_GROUP);
         if (ui.dragged) {

--- a/src/js/view/controls/info-overlay.js
+++ b/src/js/view/controls/info-overlay.js
@@ -31,13 +31,15 @@ export default function (container, model, api, onVisibility) {
 
     function attachListeners() {
         const titleContainer = template.querySelector('.jw-info-title');
+        const titleSecondaryContainer = template.querySelector('.jw-info-title-secondary');
         const durationContainer = template.querySelector('.jw-info-duration');
         const descriptionContainer = template.querySelector('.jw-info-description');
         const clientIdContainer = template.querySelector('.jw-info-clientid');
 
         model.change('playlistItem', (changeModel, item) => {
-            const { description, title } = item;
+            const { description, title, titleSecondary } = item;
             replaceInnerHtml(descriptionContainer, description || '');
+            replaceInnerHtml(titleSecondaryContainer, titleSecondary || '');
             replaceInnerHtml(titleContainer, title || 'Unknown Title');
         });
         model.change('duration', (changeModel, duration) => {

--- a/src/js/view/controls/templates/info-overlay.js
+++ b/src/js/view/controls/templates/info-overlay.js
@@ -2,6 +2,7 @@ export default () => (
     `<div class="jw-reset jw-info-overlay">` +
         `<div class="jw-reset jw-info-container">` +
             `<div class="jw-reset jw-info-title"></div>` +
+            `<div class="jw-reset jw-info-title-secondary"></div>` +
             `<div class="jw-reset jw-info-duration"></div>` +
             `<div class="jw-reset jw-info-description"></div>` +
         `</div>` +

--- a/src/js/view/title.js
+++ b/src/js/view/title.js
@@ -22,8 +22,9 @@ Object.assign(Title.prototype, {
 
         // Perform the DOM search only once
         const arr = this.el.getElementsByTagName('div');
-        this.title = arr[0];
-        this.description = arr[1];
+        this.title = arr[0]; 
+        this.titleSecondary = arr[1];
+        this.description = arr[2];
 
         this.model.on('change:logoWidth', this.update, this);
         this.model.change('playlistItem', this.playlistItem, this);
@@ -49,28 +50,35 @@ Object.assign(Title.prototype, {
         if (!item) {
             return;
         }
-        if (model.get('displaytitle') || model.get('displaydescription')) {
+        
+        if (model.get('displaytitle') || model.get('displaydescription') || model.get('displaytitleSecondary')) {
             let title = '';
             let description = '';
+            let titleSecondary = '';
 
             if (item.title && model.get('displaytitle')) {
                 title = item.title;
             }
+
             if (item.description && model.get('displaydescription')) {
                 description = item.description;
             }
-
-            this.updateText(title, description);
+                    
+            if (item.titleSecondary && model.get('displaytitleSecondary')) {
+                titleSecondary = item.titleSecondary;
+            }
+            this.updateText(title, description, titleSecondary);
         } else {
             this.hide();
         }
     },
 
-    updateText: function(title, description) {
+    updateText: function(title, description, titleSecondary) {
         replaceInnerHtml(this.title, title);
         replaceInnerHtml(this.description, description);
+        replaceInnerHtml(this.titleSecondary, titleSecondary);
 
-        if (this.title.firstChild || this.description.firstChild) {
+        if (this.title.firstChild || this.description.firstChild || this.titleSecondary.firstChild) {
             this.show();
         } else {
             this.hide();

--- a/src/js/view/utils/skin.js
+++ b/src/js/view/utils/skin.js
@@ -119,6 +119,7 @@ export function handleColorOverrides(playerId, skin) {
             '.jw-controlbar .jw-icon-inline.jw-text',
             '.jw-title-primary',
             '.jw-title-secondary',
+            '.jw-title-description',
         ], 'color', config.text);
 
         if (config.icons) {

--- a/test/data/model-properties.js
+++ b/test/data/model-properties.js
@@ -76,6 +76,7 @@ export default {
     stretching: 'uniform',
     defaultPlaybackRate: 1.0,
     displaytitle: true,
+    displaytitleSecondary: true,
     displaydescription: true,
     displayPlaybackLabel: false,
     playbackRateControls: true,

--- a/test/data/mp4.js
+++ b/test/data/mp4.js
@@ -11,24 +11,28 @@ export default {
         file: 'http://playertest.longtailvideo.com/starscape.mp4',
         image: 'http://playertest.longtailvideo.com/starscape.jpg',
         title: 'Impressive Starscape',
+        titleSecondary: 'Science and our galaxy',
         description: 'Science is cool!'
     },
     stuffBreaking: {
         file: 'http://playertest.longtailvideo.com/stuff_breaking.mp4',
         image: 'http://playertest.longtailvideo.com/stuff_breaking.jpg',
         title: 'Stuff Breaking Spectacularly',
+        titleSecondary: 'Resistance is futile',
         description: 'Hopefully not this demo'
     },
     buckBunnie: {
         file: 'http://content.jwplatform.com/videos/bkaovAYt-el5vTWpr.mp4',
         image: 'http://content.jwplatform.com/thumbs/bkaovAYt-480.jpg',
         title: 'Big Buck Bunny Trailer',
+        titleSecondary: 'Big Buck Bunny animated',
         description: 'Big Buck Bunny is a short animated film by the Blender Institute. It is made using free and open source software.'
     },
     sintel: {
         file: 'http://content.jwplatform.com/videos/3XnJSIm4-el5vTWpr.mp4',
         image: 'http://content.jwplatform.com/thumbs/3XnJSIm4-480.jpg',
         title: 'Sintel Trailer',
+        titleSecondary: 'Sintel - Fantasy animation',
         description: 'Sintel is a fantasy computer generated short movie. It\'s the third release from the Blender Open Movie Project.'
     }
 };

--- a/test/mock/mock-model.js
+++ b/test/mock/mock-model.js
@@ -19,6 +19,7 @@ export default class MockModel extends SimpleModel {
             file: '//playertest.longtailvideo.com/bunny.mp4',
             image: '//d3el35u4qe4frz.cloudfront.net/bkaovAYt-480.jpg',
             title: 'Big Buck Bunny',
+            titleSecondary: 'Buck Bunny animated',
             description: 'One caption track',
             tracks: [
                 {

--- a/test/unit/playlist-item-test.js
+++ b/test/unit/playlist-item-test.js
@@ -16,7 +16,7 @@ describe('playlist item', function() {
     function testItemComplete(config) {
         const playlistItem = testItem(config);
 
-        const attrs = ['image', 'description', 'mediaid', 'title', 'minDvrWindow'];
+        const attrs = ['image', 'description', 'mediaid', 'title', 'minDvrWindow', 'titleSecondary'];
         _.each(attrs, function (a) {
             expect(_.has(playlistItem, a), 'Item has ' + a + ' attribute').to.be.true;
         });
@@ -57,6 +57,7 @@ describe('playlist item', function() {
                 }
             ],
             title: 'title',
+            titleSecondary: 'titleSecondary',
             mediaid: 12345,
             tracks: [
                 {

--- a/test/unit/skin-test.js
+++ b/test/unit/skin-test.js
@@ -91,6 +91,7 @@ describe('Skin Customization', function() {
             expect(cssText).to.contain('#id .jw-controlbar .jw-icon-inline.jw-text');
             expect(cssText).to.contain('#id .jw-title-primary');
             expect(cssText).to.contain('#id .jw-title-secondary');
+            expect(cssText).to.contain('#id .jw-title-description');
             expect(cssText).to.contain('color: green');
         });
 
@@ -107,6 +108,7 @@ describe('Skin Customization', function() {
             expect(cssText).to.contain('#id .jw-controlbar .jw-icon-inline.jw-text');
             expect(cssText).to.contain('#id .jw-title-primary');
             expect(cssText).to.contain('#id .jw-title-secondary');
+            expect(cssText).to.contain('#id .jw-title-description');
             expect(cssText).to.contain('color: green');
             expect(cssText).to.contain('#id .jw-button-color:not(.jw-icon-cast)');
             expect(cssText).to.contain('#id .jw-button-color.jw-toggle.jw-off:not(.jw-icon-cast)');


### PR DESCRIPTION
### This PR will ...
modify the code to add a secondary title (subtitle) of a media in the player and in the content of the info overlay

### Why is this Pull Request needed?
For our project, we need to display a subtitle (secondary title) in the player and in the info overlay.
For example, show the episode title under the serie title.

### Are there any points in the code the reviewer needs to double check?
no

### Are there any Pull Requests open in other repos which need to be merged with this?
no

#### Addresses Issue(s):

JW8-3285 https://github.com/jwplayer/jwplayer/issues/3285

