### PR TITLE
JW8-2662 Captions not on by default if not muted

### DIFF
--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -159,6 +159,8 @@ const Captions = function(_model) {
 
     this.setSubtitlesTracks = _setSubtitlesTracks;
 
+    this.selectDefaultIndex = _selectDefaultIndex;
+
     this.getCurrentIndex = function() {
         return _model.get('captionsIndex');
     };

--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -9,7 +9,7 @@ const Captions = function(_model) {
     let _tracks = [];
     let _tracksById = {};
     let _unknownCount = 0;
-    let _captionsByDefault;
+    let _defaultIndex;
 
     // Reset and load external captions on playlist item
     _model.on('change:playlistItem', (model) => {
@@ -109,8 +109,7 @@ const Captions = function(_model) {
         return list;
     }
 
-    function _selectDefaultIndex(captionsByDefault) {
-        _captionsByDefault = _captionsByDefault || captionsByDefault;
+    function _selectDefaultIndex() {
         let captionsMenuIndex = 0;
         const label = _model.get('captionLabel');
 
@@ -132,7 +131,7 @@ const Captions = function(_model) {
                 // TODO: auto select track by comparing track.language to system lang
             }
         }
-        if (_captionsByDefault && !captionsMenuIndex) {
+        if (_defaultIndex && !captionsMenuIndex) {
             captionsMenuIndex = 1;
         }
         // set the index without the side effect of storing the Off label in _selectCaptions
@@ -161,7 +160,10 @@ const Captions = function(_model) {
 
     this.setSubtitlesTracks = _setSubtitlesTracks;
 
-    this.selectDefaultIndex = _selectDefaultIndex;
+    this.selectDefaultIndex = function(defaultIndex) {
+        _defaultIndex = defaultIndex;
+        _selectDefaultIndex();
+    };
 
     this.getCurrentIndex = function() {
         return _model.get('captionsIndex');

--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -9,6 +9,7 @@ const Captions = function(_model) {
     let _tracks = [];
     let _tracksById = {};
     let _unknownCount = 0;
+    let _captionsByDefault;
 
     // Reset and load external captions on playlist item
     _model.on('change:playlistItem', (model) => {
@@ -108,7 +109,8 @@ const Captions = function(_model) {
         return list;
     }
 
-    function _selectDefaultIndex() {
+    function _selectDefaultIndex(captionsByDefault) {
+        _captionsByDefault = _captionsByDefault || captionsByDefault;
         let captionsMenuIndex = 0;
         const label = _model.get('captionLabel');
 
@@ -130,10 +132,10 @@ const Captions = function(_model) {
                 // TODO: auto select track by comparing track.language to system lang
             }
         }
-        // set the index without the side effect of storing the Off label in _selectCaptions
-        if (_model.get('enableDefaultCaptions') && _model.get('autostart') && !captionsMenuIndex) {
+        if (_captionsByDefault && !captionsMenuIndex) {
             captionsMenuIndex = 1;
         }
+        // set the index without the side effect of storing the Off label in _selectCaptions
         _setCurrentIndex(captionsMenuIndex);
     }
 

--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -9,7 +9,7 @@ const Captions = function(_model) {
     let _tracks = [];
     let _tracksById = {};
     let _unknownCount = 0;
-    let _defaultIndex;
+    let _defaultIndex = 0;
 
     // Reset and load external captions on playlist item
     _model.on('change:playlistItem', (model) => {
@@ -109,8 +109,8 @@ const Captions = function(_model) {
         return list;
     }
 
-    function _selectDefaultIndex() {
-        let captionsMenuIndex = 0;
+    function _selectDefaultIndex(defaultIndex) {
+        let captionsMenuIndex = _defaultIndex = defaultIndex;
         const label = _model.get('captionLabel');
 
         // Because there is no explicit track for "Off"
@@ -131,9 +131,6 @@ const Captions = function(_model) {
                 // TODO: auto select track by comparing track.language to system lang
             }
         }
-        if (_defaultIndex && !captionsMenuIndex) {
-            captionsMenuIndex = 1;
-        }
         // set the index without the side effect of storing the Off label in _selectCaptions
         _setCurrentIndex(captionsMenuIndex);
     }
@@ -149,7 +146,7 @@ const Captions = function(_model) {
     function _setCaptionsList() {
         const captionsList = _captionsMenu();
         if (listIdentity(captionsList) !== listIdentity(_model.get('captionsList'))) {
-            _selectDefaultIndex();
+            _selectDefaultIndex(_defaultIndex);
             _model.set('captionsList', captionsList);
         }
     }
@@ -160,10 +157,7 @@ const Captions = function(_model) {
 
     this.setSubtitlesTracks = _setSubtitlesTracks;
 
-    this.selectDefaultIndex = function(defaultIndex) {
-        _defaultIndex = defaultIndex;
-        _selectDefaultIndex();
-    };
+    this.selectDefaultIndex = _selectDefaultIndex;
 
     this.getCurrentIndex = function() {
         return _model.get('captionsIndex');

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -512,7 +512,7 @@ Object.assign(Controller.prototype, {
                 }
 
                 if (_this.getMute() && _model.get('enableDefaultCaptions')) {
-                    _captions.selectDefaultIndex(true);
+                    _captions.selectDefaultIndex(1);
                 }
 
                 // Enable autoPause behavior.

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -511,9 +511,8 @@ Object.assign(Controller.prototype, {
                     });
                 }
 
-                if (!_this.getMute()) {
-                    _model.set('enableDefaultCaptions', false);
-                    _captions.selectDefaultIndex();
+                if (_this.getMute() && _model.get('enableDefaultCaptions')) {
+                    _captions.selectDefaultIndex(true);
                 }
 
                 // Enable autoPause behavior.
@@ -531,9 +530,6 @@ Object.assign(Controller.prototype, {
             }).catch(error => {
                 _model.set('canAutoplay', AUTOPLAY_DISABLED);
                 _model.set('autostart', false);
-                _model.set('enableDefaultCaptions', false);
-                _captions.selectDefaultIndex();
-
                 // Emit event unless test was explicitly canceled.
                 if (!checkAutoStartCancelable.cancelled()) {
                     const { reason } = error;

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -513,6 +513,7 @@ Object.assign(Controller.prototype, {
 
                 if (!_this.getMute()) {
                     _model.set('enableDefaultCaptions', false);
+                    _captions.selectDefaultIndex();
                 }
 
                 // Enable autoPause behavior.
@@ -530,6 +531,8 @@ Object.assign(Controller.prototype, {
             }).catch(error => {
                 _model.set('canAutoplay', AUTOPLAY_DISABLED);
                 _model.set('autostart', false);
+                _model.set('enableDefaultCaptions', false);
+                _captions.selectDefaultIndex();
 
                 // Emit event unless test was explicitly canceled.
                 if (!checkAutoStartCancelable.cancelled()) {


### PR DESCRIPTION
### This PR will...
Select default index again after checking for autostart.

### Why is this Pull Request needed?
`enableDefaultCaptions` option should not turn captions on if the player is not muted when autostarting.
Depending on the browser, the captions may have already been loaded and default may have already been chosen without knowing whether AUTOPLAY is enabled, resulting captions to be turned on for players that are not muted when autostarting.

Choosing the default captions again AFTER autoplay check fixes the issue.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-2662

