### PR TITLE
[JW8-2504] Stop video on noResume.

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -574,6 +574,7 @@ Object.assign(Controller.prototype, {
                 if (instream) {
                     instream.noResume = true;
                 }
+                _actionOnAttach = () => _programController.stopVideo();
                 return;
             }
 

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -466,14 +466,10 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
         }
 
         // Re-attach the controller & resume playback
-        // when instream was inited and the player was not destroyed\
+        // when instream was inited and the player was not destroyed
         _controller.attachMedia();
 
-        if (this.noResume) {
-            return;
-        }
-
-        if (_beforeComplete) {
+        if (this.noResume || _beforeComplete) {
             _controller.stopVideo();
         } else {
             _controller.playVideo();

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -466,10 +466,14 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
         }
 
         // Re-attach the controller & resume playback
-        // when instream was inited and the player was not destroyed
+        // when instream was inited and the player was not destroyed\
         _controller.attachMedia();
 
-        if (this.noResume || _beforeComplete) {
+        if (this.noResume) {
+            return;
+        }
+
+        if (_beforeComplete) {
             _controller.stopVideo();
         } else {
             _controller.playVideo();


### PR DESCRIPTION
### This PR will...
Stop the video on `noResume`.

### Why is this Pull Request needed?
Fix a bug where, if `jwplayer().stop()` is called during an ad, the player would not be idle after the ad completes.

### Are there any points in the code the reviewer needs to double check?
N/A

### Are there any Pull Requests open in other repos which need to be merged with this?
N/A

#### Addresses Issue(s):
JW8-2504