### PR TITLE
[JW8-5170] Ad and Chapters Cues Should Both Appear on Timeline

### DIFF
--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -317,6 +317,14 @@ export default function Api(element) {
         },
 
         /**
+         * Gets the list of cues
+         * @returns {Array.<SliderCue>} sliderCues - The list of cues.
+         */
+        getCues() {
+            return core.get('cues');
+        },
+
+        /**
          * Gets the index of the active audio track.
          * @returns {number} The index of the active audio track, or -1 if there are no alternative audio tracks.
          */

--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -252,6 +252,16 @@ export default function Api(element) {
         },
 
         /**
+         * Adds to the list of cues to be displayed on the time slider.
+         * @param {Array.<SliderCue>} sliderCues - The list of cues.
+         * @returns {Api} The Player API instance.
+         */
+        addCues(sliderCues) {
+            core.addCues(sliderCues);
+            return this;
+        },
+
+        /**
          * Gets the list of available audio tracks.
          * @returns {Array.<AudioTrackOption>} An array of AudioTrackOption objects representing the current media's audio tracks.
          */

--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -49,6 +49,7 @@ const CoreShim = function(originalContainer) {
         'setMute',
         'setVolume',
         'setPlaybackRate',
+        'addCues',
         'setCues',
         'setPlaylistItem',
 

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -981,6 +981,8 @@ Object.assign(Controller.prototype, {
             _model.set('cues', cues);
         };
 
+        this.getCues = _model.get('cues');
+
         this.updatePlaylist = function(playlist, feedData) {
             try {
                 const filteredPlaylist = filterPlaylist(playlist, _model, feedData);

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -978,8 +978,14 @@ Object.assign(Controller.prototype, {
         };
 
         this.setCues = function (cues) {
-            const existingCues = _model.get('cues');
-            const newCues = existingCues ? existingCues.concat(cues) : cues;
+            let newCues = [];
+            if (cues && cues.length) {
+                // If setCues() is called with empty array, we want to clear the cues.
+                // Otherwise, add the new cues to the existing cues.
+                // This allows setting of cues by ad plugins or setCues() API.
+                const existingCues = _model.get('cues');
+                newCues = existingCues ? existingCues.concat(cues) : cues;
+            }
             _model.set('cues', newCues);
         };
 

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -977,16 +977,14 @@ Object.assign(Controller.prototype, {
             _programController.controls = mode;
         };
 
+        this.addCues = function (cues) {
+            const existingCues = this.getCues();
+            const newCues = existingCues ? existingCues.concat(cues) : cues;
+            this.setCues(newCues);
+        };
+
         this.setCues = function (cues) {
-            let newCues = [];
-            if (cues && cues.length) {
-                // If setCues() is called with empty array, we want to clear the cues.
-                // Otherwise, add the new cues to the existing cues.
-                // This allows setting of cues by ad plugins or setCues() API.
-                const existingCues = _model.get('cues');
-                newCues = existingCues ? existingCues.concat(cues) : cues;
-            }
-            _model.set('cues', newCues);
+            _model.set('cues', cues);
         };
 
         this.getCues = _model.get('cues');

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -978,8 +978,8 @@ Object.assign(Controller.prototype, {
         };
 
         this.setCues = function (cues) {
-            const existingCues = this._model.get('cues');
-            const newCues = existingCues.concat(cues);
+            const existingCues = _model.get('cues');
+            const newCues = existingCues ? existingCues.concat(cues) : cues;
             _model.set('cues', newCues);
         };
 

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -978,7 +978,9 @@ Object.assign(Controller.prototype, {
         };
 
         this.setCues = function (cues) {
-            _model.set('cues', cues);
+            const existingCues = this._model.get('cues');
+            const newCues = existingCues.concat(cues);
+            _model.set('cues', newCues);
         };
 
         this.getCues = _model.get('cues');

--- a/src/js/view/controls/components/chapters.mixin.js
+++ b/src/js/view/controls/components/chapters.mixin.js
@@ -52,6 +52,11 @@ const ChaptersMixin = {
         }
 
         this.cues.forEach((cue) => {
+            this._model.get('cues').forEach((existingCue) => {
+                if (cue.time === existingCue.begin) {
+                    cue.text = existingCue.text;
+                }
+            });
             cue.align(duration);
             cue.el.addEventListener('mouseover', () => {
                 this.activeCue = cue;

--- a/src/js/view/controls/components/chapters.mixin.js
+++ b/src/js/view/controls/components/chapters.mixin.js
@@ -35,6 +35,9 @@ const ChaptersMixin = {
         if (Array.isArray(data)) {
             data.forEach((obj) => this.addCue(obj));
             this.drawCues();
+            const existingCues = this._model.get('cues');
+            const playerCues = existingCues.concat(data);
+            this._model.set('cues', playerCues);
         }
     },
 

--- a/src/js/view/controls/components/chapters.mixin.js
+++ b/src/js/view/controls/components/chapters.mixin.js
@@ -39,7 +39,9 @@ const ChaptersMixin = {
         if (Array.isArray(data)) {
             data.forEach((obj) => this.addCue(obj));
             this.drawCues();
-            this._model.set('cues', data);
+            const existingCues = this._model.get('cues');
+            const playerCues = existingCues.concat(data);
+            this._model.set('cues', playerCues);
         }
     },
 

--- a/src/js/view/controls/components/chapters.mixin.js
+++ b/src/js/view/controls/components/chapters.mixin.js
@@ -41,7 +41,20 @@ const ChaptersMixin = {
     chaptersFailed: function () {},
 
     addCue: function (obj) {
+        this.cues.forEach((cue) => {
+            if (cue.time === obj.begin) {
+                this.removeCue(cue);
+            }
+        });
         this.cues.push(new Cue(obj.begin, obj.text));
+    },
+
+    removeCue: function (cueToRemove) {
+        const cueIndex = this.cues.findIndex(cue => cue.time === cueToRemove.time);
+        if (cueToRemove.el.parentNode) {
+            cueToRemove.el.parentNode.removeChild(cueToRemove.el);
+        }
+        this.cues.splice(cueIndex, 1);
     },
 
     drawCues: function () {
@@ -52,11 +65,6 @@ const ChaptersMixin = {
         }
 
         this.cues.forEach((cue) => {
-            this._model.get('cues').forEach((existingCue) => {
-                if (cue.time === existingCue.begin) {
-                    cue.text = existingCue.text;
-                }
-            });
             cue.align(duration);
             cue.el.addEventListener('mouseover', () => {
                 this.activeCue = cue;
@@ -69,11 +77,7 @@ const ChaptersMixin = {
     },
 
     resetChapters: function() {
-        this.cues.forEach((cue) => {
-            if (cue.el.parentNode) {
-                cue.el.parentNode.removeChild(cue.el);
-            }
-        });
+        this.cues.forEach((cue) => this.removeCue(cue));
         this.cues = [];
     }
 };

--- a/src/js/view/controls/components/chapters.mixin.js
+++ b/src/js/view/controls/components/chapters.mixin.js
@@ -33,11 +33,8 @@ const ChaptersMixin = {
     chaptersLoaded: function (evt) {
         const data = srt(evt.responseText);
         if (Array.isArray(data)) {
-            data.forEach((obj) => this.addCue(obj));
-            this.drawCues();
-            const existingCues = this._model.get('cues');
-            const playerCues = existingCues.concat(data);
-            this._model.set('cues', playerCues);
+            // Add chapter cues directly to model which will trigger addCue()
+            this._model.set('cues', data);
         }
     },
 

--- a/src/js/view/controls/components/chapters.mixin.js
+++ b/src/js/view/controls/components/chapters.mixin.js
@@ -35,9 +35,6 @@ const ChaptersMixin = {
         if (Array.isArray(data)) {
             data.forEach((obj) => this.addCue(obj));
             this.drawCues();
-            const existingCues = this._model.get('cues');
-            const playerCues = existingCues.concat(data);
-            this._model.set('cues', playerCues);
         }
     },
 

--- a/src/js/view/controls/components/chapters.mixin.js
+++ b/src/js/view/controls/components/chapters.mixin.js
@@ -34,7 +34,9 @@ const ChaptersMixin = {
         const data = srt(evt.responseText);
         if (Array.isArray(data)) {
             // Add chapter cues directly to model which will trigger addCue()
-            this._model.set('cues', data);
+            const existingCues = this._model.get('cues');
+            const newCues = existingCues ? existingCues.concat(data) : data;
+            this._model.set('cues', newCues);
         }
     },
 

--- a/src/js/view/controls/components/chapters.mixin.js
+++ b/src/js/view/controls/components/chapters.mixin.js
@@ -10,10 +10,6 @@ class Cue {
     }
 
     align(duration) {
-        if (!this.time) {
-            return;
-        }
-
         // If a percentage, use it, else calculate the percentage
         if (this.time.toString().slice(-1) === '%') {
             this.pct = this.time;

--- a/src/js/view/controls/components/chapters.mixin.js
+++ b/src/js/view/controls/components/chapters.mixin.js
@@ -10,6 +10,10 @@ class Cue {
     }
 
     align(duration) {
+        if (!this.time) {
+            return;
+        }
+
         // If a percentage, use it, else calculate the percentage
         if (this.time.toString().slice(-1) === '%') {
             this.pct = this.time;

--- a/src/js/view/controls/components/chapters.mixin.js
+++ b/src/js/view/controls/components/chapters.mixin.js
@@ -41,18 +41,7 @@ const ChaptersMixin = {
     chaptersFailed: function () {},
 
     addCue: function (obj) {
-        this.cues.forEach((cue) => {
-            if (cue.time === obj.begin) {
-                this.removeCue(cue);
-            }
-        });
         this.cues.push(new Cue(obj.begin, obj.text));
-    },
-
-    removeCue: function (cueToRemove) {
-        if (cueToRemove.el.parentNode) {
-            cueToRemove.el.parentNode.removeChild(cueToRemove.el);
-        }
     },
 
     drawCues: function () {
@@ -75,7 +64,11 @@ const ChaptersMixin = {
     },
 
     resetChapters: function() {
-        this.cues.forEach((cue) => this.removeCue(cue));
+        this.cues.forEach((cue) => {
+            if (cue.el.parentNode) {
+                cue.el.parentNode.removeChild(cue.el);
+            }
+        });
         this.cues = [];
     }
 };

--- a/src/js/view/controls/components/chapters.mixin.js
+++ b/src/js/view/controls/components/chapters.mixin.js
@@ -35,6 +35,7 @@ const ChaptersMixin = {
         if (Array.isArray(data)) {
             data.forEach((obj) => this.addCue(obj));
             this.drawCues();
+            this._model.set('cues', data);
         }
     },
 
@@ -50,11 +51,9 @@ const ChaptersMixin = {
     },
 
     removeCue: function (cueToRemove) {
-        const cueIndex = this.cues.findIndex(cue => cue.time === cueToRemove.time);
         if (cueToRemove.el.parentNode) {
             cueToRemove.el.parentNode.removeChild(cueToRemove.el);
         }
-        this.cues.splice(cueIndex, 1);
     },
 
     drawCues: function () {

--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -280,7 +280,6 @@ class TimeSlider extends Slider {
     }
 
     addCues(model, cues) {
-        this.resetChapters();
         if (cues && cues.length) {
             cues.forEach((ele) => {
                 this.addCue(ele);
@@ -312,6 +311,7 @@ class TimeSlider extends Slider {
 
     reset() {
         this.resetThumbnails();
+        this.resetChapters();
         this.timeTip.resetWidth();
         this.textLength = 0;
     }

--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -280,6 +280,7 @@ class TimeSlider extends Slider {
     }
 
     addCues(model, cues) {
+        this.resetChapters();
         if (cues && cues.length) {
             cues.forEach((ele) => {
                 this.addCue(ele);
@@ -311,7 +312,6 @@ class TimeSlider extends Slider {
 
     reset() {
         this.resetThumbnails();
-        this.resetChapters();
         this.timeTip.resetWidth();
         this.textLength = 0;
     }

--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -312,6 +312,7 @@ class TimeSlider extends Slider {
 
     reset() {
         this.resetThumbnails();
+        this.resetChapters();
         this.timeTip.resetWidth();
         this.textLength = 0;
     }

--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -280,12 +280,14 @@ class TimeSlider extends Slider {
     }
 
     addCues(model, cues) {
-        this.resetChapters();
+        // Only reset chapters if setCues() is called with empty array (to clear cues)
         if (cues && cues.length) {
             cues.forEach((ele) => {
                 this.addCue(ele);
             });
             this.drawCues();
+        } else {
+            this.resetChapters();
         }
     }
 

--- a/test/data/api-methods.js
+++ b/test/data/api-methods.js
@@ -7,6 +7,7 @@ export default {
     //   jw...: null,
 
     addButton: null,
+    addCues: null,
     addPlugin: null,
     getPlugin: null,
     castToggle: null,

--- a/test/data/api-methods.js
+++ b/test/data/api-methods.js
@@ -21,6 +21,7 @@ export default {
     getConfig: null,
     getContainer: null,
     getControls: null,
+    getCues: null,
     getCurrentAudioTrack: null,
     getCurrentCaptions: null,
     getCurrentQuality: null,


### PR DESCRIPTION
JW8-5170

### This PR will...

* Create new `getCues()` API method that returns the list of cues on the model.
* Create new `addCues()` API method that gets the current cues and appends new cues.
* Make sure chapter cues are set to the model.
* Also call `resetChapters()` inside of `reset()` so it occurs on each playlist item

### Why is this Pull Request needed?

* When ad plugins were adding cues at different times than chapter cues, whatever cues were added first were cleared.

### Are there any points in the code the reviewer needs to double check?

n/a

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-ads-vast/pull/485
https://github.com/jwplayer/jwplayer-ads-googima/pull/466
https://github.com/jwplayer/jwplayer-ads-freewheel/pull/152

#### Addresses Issue(s):

JW8-5170

