### PR TITLE
[JW8-2531] AutoPause: Show Paused State After Pre-roll

### DIFF
--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -267,8 +267,15 @@ class ProgramController extends Events {
         }
 
         const attributes = backgroundMediaController.mediaModel.attributes;
-        if (attributes.mediaState !== 'paused') {
-            attributes.mediaState = 'buffering';
+        switch (attributes.mediaState) {
+            case 'paused':
+                break;
+            case 'idle':
+                attributes.mediaState = 'paused';
+                break;
+            default:
+                attributes.mediaState = 'buffering';
+                break;
         }
 
         this._setActiveMedia(backgroundMediaController);

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -4,7 +4,7 @@ import cancelable from 'utils/cancelable';
 import { MediaControllerListener } from 'program/program-listeners';
 import Events from 'utils/backbone.events';
 import BackgroundMedia from 'program/background-media';
-import { PLAYER_STATE, STATE_BUFFERING } from 'events/events';
+import { PLAYER_STATE, STATE_BUFFERING, STATE_IDLE, STATE_PAUSED } from 'events/events';
 import { PlayerError, MSG_CANT_PLAY_VIDEO, ERROR_PLAYLIST_ITEM_MISSING_SOURCE } from 'api/errors';
 
 class ProgramController extends Events {
@@ -267,15 +267,10 @@ class ProgramController extends Events {
         }
 
         const attributes = backgroundMediaController.mediaModel.attributes;
-        switch (attributes.mediaState) {
-            case 'paused':
-                break;
-            case 'idle':
-                attributes.mediaState = 'paused';
-                break;
-            default:
-                attributes.mediaState = 'buffering';
-                break;
+        if (attributes.mediaState === STATE_IDLE) {
+            attributes.mediaState = STATE_PAUSED;
+        } else if (attributes.mediaState !== STATE_PAUSED) {
+            attributes.mediaState = STATE_BUFFERING;
         }
 
         this._setActiveMedia(backgroundMediaController);


### PR DESCRIPTION
### This PR will...

* Change `program-controller.js` to account for when the `mediaState === 'idle'` in a pre-roll and set it to `paused`

### Why is this Pull Request needed?

* Previously, the player would be in a `idle` state after pre-roll which is not intended.

### Are there any points in the code the reviewer needs to double check?

n/a

### Are there any Pull Requests open in other repos which need to be merged with this?

n/a

#### Addresses Issue(s):

JW8-2531

