### PR TITLE
Do not float player on complete state

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -865,7 +865,8 @@ function View(_api, _model) {
     function _updateFloating(intersectionRatio) {
         // Entirely invisible and no floating player already in the DOM.
         const isVisible = intersectionRatio === 1;
-        if (!isVisible && _model.get('state') !== STATE_IDLE && _model.get('state') !== STATE_COMPLETE && floatingPlayer === null) {
+        const state = _model.get('state');
+        if (!isVisible && state !== STATE_IDLE && state !== STATE_COMPLETE && floatingPlayer === null) {
             floatingPlayer = _playerElement;
 
             // Copy background from preview element, fallback to image config.

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -718,6 +718,7 @@ function View(_api, _model) {
             case STATE_IDLE:
             case STATE_ERROR:
             case STATE_COMPLETE:
+                _this.stopFloating();
                 if (_captionsRenderer) {
                     _captionsRenderer.hide();
                 }
@@ -864,7 +865,7 @@ function View(_api, _model) {
     function _updateFloating(intersectionRatio) {
         // Entirely invisible and no floating player already in the DOM.
         const isVisible = intersectionRatio === 1;
-        if (!isVisible && _model.get('state') !== STATE_IDLE && floatingPlayer === null) {
+        if (!isVisible && _model.get('state') !== STATE_IDLE && _model.get('state') !== STATE_COMPLETE && floatingPlayer === null) {
             floatingPlayer = _playerElement;
 
             // Copy background from preview element, fallback to image config.


### PR DESCRIPTION
### This PR will...
- Stop floating if the player goes into complete state
- Do not let a player in complete state to float

### Why is this Pull Request needed?
We don't want completed video to be floating.
Checked with playlists and repeating playlists that the video doesn't stop floating in between playlist items.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-2683


