### PR TITLE
[JW8-2531] Handle autoPause for subsequent playlist items

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -133,8 +133,6 @@ Object.assign(Controller.prototype, {
             if (reason === 'clickthrough' || reason === 'interaction' || reason === 'external') {
                 _model.set('playOnViewable', false);
                 _model.off('change:playReason change:pauseReason', changeReason);
-            } else if (reason === 'playlist') {
-                _checkPauseOnViewable(_model, _model.get('viewable'));
             }
         };
         _model.on('change:playReason change:pauseReason', changeReason);
@@ -482,6 +480,10 @@ Object.assign(Controller.prototype, {
 
                 if (_inInteraction(window.event) && !mediaPool.primed()) {
                     mediaPool.prime();
+                }
+
+                if (playReason === 'playlist') {
+                    _checkPauseOnViewable(_model, _model.get('viewable'));
                 }
 
                 if (_interruptPlay) {

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -133,6 +133,8 @@ Object.assign(Controller.prototype, {
             if (reason === 'clickthrough' || reason === 'interaction' || reason === 'external') {
                 _model.set('playOnViewable', false);
                 _model.off('change:playReason change:pauseReason', changeReason);
+            } else if (reason === 'playlist') {
+                _checkPauseOnViewable(_model, _model.get('viewable'));
             }
         };
         _model.on('change:playReason change:pauseReason', changeReason);


### PR DESCRIPTION
### This PR will...

* Check if `changeReason === 'playlist'` and run another `_checkPauseOnViewable()`

### Why is this Pull Request needed?

* When `_checkPauseOnViewable()` was run between a post-roll and the subsequent playlist item's pre-roll, the `adState` was false when the check was happening.

### Are there any points in the code the reviewer needs to double check?

n/a

### Are there any Pull Requests open in other repos which need to be merged with this?

n/a

#### Addresses Issue(s):

JW8-2531

