### PR TITLE
[JW8-5618] Only autoPause if playing or buffering

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -359,7 +359,7 @@ Object.assign(Controller.prototype, {
                 if (!viewable) {
                     _updatePauseReason({ reason: 'viewable' });
                 }
-            } else if (playerState !== STATE_PAUSED && playerState !== STATE_IDLE) {
+            } else if (playerState === STATE_PLAYING || playerState === STATE_BUFFERING) {
                 if (!viewable) {
                     _this.pause({ reason: 'viewable' });
                     model.set('playOnViewable', !viewable);


### PR DESCRIPTION
### This PR will...

* Only autoPause outside of an adState if the player state is either buffering or playing.

### Why is this Pull Request needed?

* Before, outstream players were re-playing when scrolling out and back in to view because we weren't handling the complete state.

### Are there any points in the code the reviewer needs to double check?

n/a

### Are there any Pull Requests open in other repos which need to be merged with this?

n/a

#### Addresses Issue(s):

JW8-5618

