### PR TITLE
Allow a 'disabled' property which stops any floating behavior

### DIFF
--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -120,7 +120,7 @@ export default class Controls extends Events {
             if (visible) {
                 //  Focus modal close button on open
                 this.div.querySelector('.jw-info-close').focus();
-            }  
+            }
         });
         //  Add keyboard shortcuts if not on mobi;e
         if (!OS.mobile) {
@@ -141,7 +141,9 @@ export default class Controls extends Events {
         }
 
         // Floating Close Button
-        const floatingConfig = model.get('floating');
+        let floatingConfig = model.get('floating');
+        floatingConfig = floatingConfig && floatingConfig.disabled ? null : floatingConfig;
+
         if (floatingConfig) {
             const floatCloseButton = new FloatingCloseButton(element, model.get('localization').close);
             const doNotForward = true;
@@ -296,7 +298,7 @@ export default class Controls extends Events {
                     }
                     if (this.shortcutsTooltip) {
                         this.shortcutsTooltip.close();
-                        
+
                     }
                     break;
                 case 13: // enter
@@ -398,7 +400,7 @@ export default class Controls extends Events {
             }
             this.playerContainer.removeEventListener('blur', onRemoveShortcutsDescription, true);
         };
-        
+
         if (this.shortcutsTooltip) {
             this.playerContainer.addEventListener('blur', onRemoveShortcutsDescription, true);
             this.onRemoveShortcutsDescription = onRemoveShortcutsDescription;
@@ -433,7 +435,7 @@ export default class Controls extends Events {
             removeClass(playerContainer, 'jw-flag-touch');
             div.parentNode.removeChild(div);
         }
-        
+
         if (controlbar) {
             controlbar.destroy();
         }

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -76,6 +76,7 @@ function View(_api, _model) {
     let _stateClassRequestId = -1;
 
     let _floatingConfig = _model.get('floating');
+    _floatingConfig = _floatingConfig && _floatingConfig.disabled ? null : _floatingConfig;
 
     this.dismissible = _floatingConfig && _floatingConfig.dismissible;
     let _canFloat = false;


### PR DESCRIPTION
### This PR will...
Allow a `disabled` property in the `floating` config block to stop any floating behavior.

### Why is this Pull Request needed?
When running A/B tests, we don't have any way to stop the test from running on a specific player. Since we don't want to force this behavior for all publishers players where we are running the a/b test, we need to give them an option to disable it.

### Are there any points in the code the reviewer needs to double check?

Is it non-standard to mutate config variables like this?

Also I checked the `controls` and `view` test files and didn't see any functionality related to the floating block. Given this is a fairly benign change, I didn't see a need to write unit tests for this config update. In the event either a.) there is a file or section in the tests related to this functionality I can update or b.) we view this as important enough to check with a unit test I'd be more than happy to add them.

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/6340

#### Addresses Issue(s):

JW8-5615

