### PR TITLE
Do not apply new max-width to floating player

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -901,9 +901,7 @@ function View(_api, _model) {
         const width = _model.get('width');
         const height = _model.get('height');
         const styles = getPlayerSizeStyles(width);
-        if (isNumber(width)) {
-            styles.maxWidth = width;
-        }
+
         if (!_model.get('aspectratio')) {
             const containerWidth = _model.get('containerWidth');
             const containerHeight = _model.get('containerHeight');


### PR DESCRIPTION
### This PR will...
Not apply new max-width to the floating player

### Why is this Pull Request needed?
Applying new max-width made the floating player larger on desktop, which we did not want

### Are there any points in the code the reviewer needs to double check?
It looks like the code was added for mobile - I did a quick run on mobile and it looked fine removing this, but if there were some specific cases, please let me know

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-###

