### PR TITLE
[autoPause] Handle VAST ads setting player to idle

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -363,7 +363,7 @@ Object.assign(Controller.prototype, {
             const adState = _getAdState();
             const playReason = model.get('playReason');
 
-            function pauseWhenVisible() {
+            function pauseWhenNotViewable() {
                 if (!viewable) {
                     _this.pause({ reason: 'viewable' });
                     model.set('playOnViewable', !viewable);
@@ -376,10 +376,10 @@ Object.assign(Controller.prototype, {
                     _updatePauseReason({ reason: 'viewable' });
                 }
             } else if (playerState === STATE_PLAYING || playerState === STATE_BUFFERING) {
-                pauseWhenVisible();
+                pauseWhenNotViewable();
             } else if (playerState === STATE_IDLE && playReason === 'playlist') {
                 // After VAST ads, instream is destroyed and player state is 'idle'
-                model.once('change:state', pauseWhenVisible);
+                model.once('change:state', pauseWhenNotViewable);
             }
         }
 

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -361,16 +361,25 @@ Object.assign(Controller.prototype, {
         function _checkPauseOnViewable(model, viewable) {
             const playerState = model.get('state');
             const adState = _getAdState();
+            const playReason = model.get('playReason');
+
+            function pauseWhenVisible() {
+                if (!viewable) {
+                    _this.pause({ reason: 'viewable' });
+                    model.set('playOnViewable', !viewable);
+                }
+            }
+
             if (adState) {
                 _this._instreamAdapter.noResume = !viewable;
                 if (!viewable) {
                     _updatePauseReason({ reason: 'viewable' });
                 }
             } else if (playerState === STATE_PLAYING || playerState === STATE_BUFFERING) {
-                if (!viewable) {
-                    _this.pause({ reason: 'viewable' });
-                    model.set('playOnViewable', !viewable);
-                }
+                pauseWhenVisible();
+            } else if (playerState === STATE_IDLE && playReason === 'playlist') {
+                // After VAST ads, instream is destroyed and player state is 'idle'
+                model.once('change:state', pauseWhenVisible);
             }
         }
 

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -358,17 +358,17 @@ Object.assign(Controller.prototype, {
             }
         }
 
+        function _pauseWhenNotViewable(viewable) {
+            if (!viewable) {
+                _this.pause({ reason: 'viewable' });
+                _model.set('playOnViewable', !viewable);
+            }
+        }
+
         function _checkPauseOnViewable(model, viewable) {
             const playerState = model.get('state');
             const adState = _getAdState();
             const playReason = model.get('playReason');
-
-            function pauseWhenNotViewable() {
-                if (!viewable) {
-                    _this.pause({ reason: 'viewable' });
-                    model.set('playOnViewable', !viewable);
-                }
-            }
 
             if (adState) {
                 _this._instreamAdapter.noResume = !viewable;
@@ -376,10 +376,12 @@ Object.assign(Controller.prototype, {
                     _updatePauseReason({ reason: 'viewable' });
                 }
             } else if (playerState === STATE_PLAYING || playerState === STATE_BUFFERING) {
-                pauseWhenNotViewable();
+                _pauseWhenNotViewable(viewable);
             } else if (playerState === STATE_IDLE && playReason === 'playlist') {
                 // After VAST ads, instream is destroyed and player state is 'idle'
-                model.once('change:state', pauseWhenNotViewable);
+                model.once('change:state', () => {
+                    _pauseWhenNotViewable(viewable);
+                });
             }
         }
 


### PR DESCRIPTION
### This PR will...

* Add check in `_checkPauseWhenViewable()` if the player is idle but the playReason is `'playlist'`. If so, once the state changes, pause.

### Why is this Pull Request needed?

* VAST is setting the player state to idle so subsequent playlist items were not pausing.

### Are there any points in the code the reviewer needs to double check?

n/a - This can probably be done better and/or we can dive in to the differences between VAST and IMA.

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer/pull/3300 would need to be merged first due to JS exceptions if it isn't.

#### Addresses Issue(s):

JW8-###

