### PR TITLE
[JW8-5170] Add addCues() api to append cues instead of clearing them

### DIFF
--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -253,6 +253,7 @@ export default function Api(element) {
 
         /**
          * Adds to the list of cues to be displayed on the time slider.
+         * New cues are appended to cues already on the time slider.
          * @param {Array.<SliderCue>} sliderCues - The list of cues.
          * @returns {Api} The Player API instance.
          */
@@ -327,7 +328,7 @@ export default function Api(element) {
         },
 
         /**
-         * Gets the list of cues
+         * Gets the list of cues displayed in the timeslider.
          * @returns {Array.<SliderCue>} sliderCues - The list of cues.
          */
         getCues() {

--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -258,7 +258,9 @@ export default function Api(element) {
          * @returns {Api} The Player API instance.
          */
         addCues(sliderCues) {
-            core.addCues(sliderCues);
+            if (Array.isArray(sliderCues)) {
+                core.addCues(sliderCues);
+            }
             return this;
         },
 
@@ -691,7 +693,9 @@ export default function Api(element) {
          * @returns {Api} The Player API instance.
          */
         setCues(sliderCues) {
-            core.setCues(sliderCues);
+            if (Array.isArray(sliderCues)) {
+                core.setCues(sliderCues);
+            }
             return this;
         },
 

--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -252,6 +252,16 @@ export default function Api(element) {
         },
 
         /**
+         * Adds to the list of cues to be displayed on the time slider.
+         * @param {Array.<SliderCue>} sliderCues - The list of cues.
+         * @returns {Api} The Player API instance.
+         */
+        addCues(sliderCues) {
+            core.addCues(sliderCues);
+            return this;
+        },
+
+        /**
          * Gets the list of available audio tracks.
          * @returns {Array.<AudioTrackOption>} An array of AudioTrackOption objects representing the current media's audio tracks.
          */
@@ -314,6 +324,14 @@ export default function Api(element) {
          */
         getControls() {
             return core.get('controls');
+        },
+
+        /**
+         * Gets the list of cues
+         * @returns {Array.<SliderCue>} sliderCues - The list of cues.
+         */
+        getCues() {
+            return core.get('cues');
         },
 
         /**

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -16,6 +16,7 @@ const Defaults = {
     bitrateSelection: null,
     castAvailable: false,
     controls: true,
+    cues: [],
     defaultPlaybackRate: 1,
     displaydescription: true,
     displaytitle: true,

--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -49,6 +49,7 @@ const CoreShim = function(originalContainer) {
         'setMute',
         'setVolume',
         'setPlaybackRate',
+        'addCues',
         'setCues',
         'setPlaylistItem',
 

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -977,9 +977,17 @@ Object.assign(Controller.prototype, {
             _programController.controls = mode;
         };
 
+        this.addCues = function (cues) {
+            const existingCues = this.getCues();
+            const newCues = existingCues ? existingCues.concat(cues) : cues;
+            this.setCues(newCues);
+        };
+
         this.setCues = function (cues) {
             _model.set('cues', cues);
         };
+
+        this.getCues = _model.get('cues');
 
         this.updatePlaylist = function(playlist, feedData) {
             try {

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -979,15 +979,19 @@ Object.assign(Controller.prototype, {
 
         this.addCues = function (cues) {
             const existingCues = this.getCues();
-            const newCues = existingCues ? existingCues.concat(cues) : cues;
+            const newCues = existingCues.concat(cues);
             this.setCues(newCues);
         };
 
         this.setCues = function (cues) {
-            _model.set('cues', cues);
+            if (Array.isArray(cues)) {
+                _model.set('cues', cues);
+            }
         };
 
-        this.getCues = _model.get('cues');
+        this.getCues = function() {
+            return _model.get('cues');
+        };
 
         this.updatePlaylist = function(playlist, feedData) {
             try {

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -978,19 +978,11 @@ Object.assign(Controller.prototype, {
         };
 
         this.addCues = function (cues) {
-            const existingCues = this.getCues();
-            const newCues = existingCues.concat(cues);
-            this.setCues(newCues);
+            this.setCues(_model.get('cues').concat(cues));
         };
 
         this.setCues = function (cues) {
-            if (Array.isArray(cues)) {
-                _model.set('cues', cues);
-            }
-        };
-
-        this.getCues = function() {
-            return _model.get('cues');
+            _model.set('cues', cues);
         };
 
         this.updatePlaylist = function(playlist, feedData) {

--- a/src/js/view/controls/components/chapters.mixin.js
+++ b/src/js/view/controls/components/chapters.mixin.js
@@ -33,8 +33,10 @@ const ChaptersMixin = {
     chaptersLoaded: function (evt) {
         const data = srt(evt.responseText);
         if (Array.isArray(data)) {
-            data.forEach((obj) => this.addCue(obj));
-            this.drawCues();
+            // Add chapter cues directly to model which will trigger addCue()
+            const existingCues = this._model.get('cues');
+            const newCues = existingCues ? existingCues.concat(data) : data;
+            this._model.set('cues', newCues);
         }
     },
 

--- a/src/js/view/controls/components/chapters.mixin.js
+++ b/src/js/view/controls/components/chapters.mixin.js
@@ -35,7 +35,7 @@ const ChaptersMixin = {
         if (Array.isArray(data)) {
             // Add chapter cues directly to model which will trigger addCue()
             const existingCues = this._model.get('cues');
-            const newCues = existingCues ? existingCues.concat(data) : data;
+            const newCues = existingCues.concat(data);
             this._model.set('cues', newCues);
         }
     },
@@ -65,7 +65,7 @@ const ChaptersMixin = {
         });
     },
 
-    resetChapters: function() {
+    resetCues: function() {
         this.cues.forEach((cue) => {
             if (cue.el.parentNode) {
                 cue.el.parentNode.removeChild(cue.el);

--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -95,7 +95,7 @@ class TimeSlider extends Slider {
 
         this._model
             .on('change:duration', this.onDuration, this)
-            .on('change:cues', this.addCues, this)
+            .on('change:cues', this.updateCues, this)
             .on('seeked', () => {
                 if (!this._model.get('scrubbing')) {
                     this.updateAriaText();
@@ -177,7 +177,7 @@ class TimeSlider extends Slider {
             return;
         }
         this.reset();
-        this.addCues(model, model.get('cues'));
+        this.updateCues(model, model.get('cues'));
 
         const tracks = playlistItem.tracks;
         each(tracks, function (track) {
@@ -279,7 +279,7 @@ class TimeSlider extends Slider {
         removeClass(this.timeTip.el, 'jw-open');
     }
 
-    addCues(model, cues) {
+    updateCues(model, cues) {
         // Only reset chapters if setCues() is called with empty array (to clear cues)
         if (cues && cues.length) {
             cues.forEach((ele) => {
@@ -287,7 +287,7 @@ class TimeSlider extends Slider {
             });
             this.drawCues();
         } else {
-            this.resetChapters();
+            this.resetCues();
         }
     }
 
@@ -314,7 +314,7 @@ class TimeSlider extends Slider {
 
     reset() {
         this.resetThumbnails();
-        this.resetChapters();
+        this.resetCues();
         this.timeTip.resetWidth();
         this.textLength = 0;
     }

--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -280,12 +280,14 @@ class TimeSlider extends Slider {
     }
 
     addCues(model, cues) {
-        this.resetChapters();
+        // Only reset chapters if setCues() is called with empty array (to clear cues)
         if (cues && cues.length) {
             cues.forEach((ele) => {
                 this.addCue(ele);
             });
             this.drawCues();
+        } else {
+            this.resetChapters();
         }
     }
 
@@ -312,6 +314,7 @@ class TimeSlider extends Slider {
 
     reset() {
         this.resetThumbnails();
+        this.resetChapters();
         this.timeTip.resetWidth();
         this.textLength = 0;
     }

--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -280,14 +280,12 @@ class TimeSlider extends Slider {
     }
 
     updateCues(model, cues) {
-        // Only reset chapters if setCues() is called with empty array (to clear cues)
+        this.resetCues();
         if (cues && cues.length) {
             cues.forEach((ele) => {
                 this.addCue(ele);
             });
             this.drawCues();
-        } else {
-            this.resetCues();
         }
     }
 

--- a/test/data/api-methods.js
+++ b/test/data/api-methods.js
@@ -7,6 +7,7 @@ export default {
     //   jw...: null,
 
     addButton: null,
+    addCues: null,
     addPlugin: null,
     getPlugin: null,
     castToggle: null,
@@ -21,6 +22,7 @@ export default {
     getConfig: null,
     getContainer: null,
     getControls: null,
+    getCues: null,
     getCurrentAudioTrack: null,
     getCurrentCaptions: null,
     getCurrentQuality: null,

--- a/test/data/model-properties.js
+++ b/test/data/model-properties.js
@@ -74,6 +74,7 @@ export default {
     base: '',
     controls: true,
     controlsEnabled: true,
+    cues: [],
     stretching: 'uniform',
     defaultPlaybackRate: 1.0,
     displaytitle: true,


### PR DESCRIPTION
JW8-5170

### This PR will...

* Create new `getCues()` API method that returns the list of cues on the model.
* Create new `addCues()` API method that gets the current cues and appends new cues.
* Make sure chapter cues are set to the model.
* Also call `resetChapters()` inside of `reset()` so it occurs on each playlist item

### Why is this Pull Request needed?

* When ad plugins were adding cues at different times than chapter cues, whatever cues were added first were cleared.

### Are there any points in the code the reviewer needs to double check?

n/a

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-ads-vast/pull/485
https://github.com/jwplayer/jwplayer-ads-googima/pull/466
https://github.com/jwplayer/jwplayer-ads-freewheel/pull/152

#### Addresses Issue(s):

JW8-5170

