### PR TITLE
[JW8-5638] Add check for dragging ui before destroying 

### DIFF
--- a/src/js/view/floating-drag-ui.js
+++ b/src/js/view/floating-drag-ui.js
@@ -11,7 +11,10 @@ export default class FloatingDragUI {
     }
 
     disable() {
-        this.ui.destroy();
+        if (this.ui) {
+            this.ui.destroy();
+            this.ui = null;
+        }
     }
 
     enable() {


### PR DESCRIPTION
### This PR will...
Put safeguard around destroying `this.ui`

### Why is this Pull Request needed?
`this.ui` may not exist when we call `disable` function

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-5638

