### PR TITLE
Do not pause in _checkPlayOnViewable() during ads [JW8-5637]

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -345,6 +345,8 @@ Object.assign(Controller.prototype, {
         }
 
         function _checkPlayOnViewable(model, viewable) {
+            const adState = _getAdState();
+
             if (model.get('playOnViewable')) {
                 if (viewable) {
                     if (model.get('state') === STATE_IDLE) {
@@ -352,7 +354,7 @@ Object.assign(Controller.prototype, {
                     } else {
                         _play('viewable');
                     }
-                } else if (OS.mobile) {
+                } else if (OS.mobile && !adState) {
                     _this.pause({ reason: 'autostart' });
                 }
             }

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -345,8 +345,6 @@ Object.assign(Controller.prototype, {
         }
 
         function _checkPlayOnViewable(model, viewable) {
-            const adState = _getAdState();
-
             if (model.get('playOnViewable')) {
                 if (viewable) {
                     if (model.get('state') === STATE_IDLE) {
@@ -354,7 +352,7 @@ Object.assign(Controller.prototype, {
                     } else {
                         _play('viewable');
                     }
-                } else if (OS.mobile && !adState) {
+                } else if (OS.mobile && !_getAdState()) {
                     _this.pause({ reason: 'autostart' });
                 }
             }


### PR DESCRIPTION
### This PR will...

* Check for `adState` in `_checkPlayOnViewable()` and do not pause if both mobile and in ads

### Why is this Pull Request needed?

* Ads were pausing when `autostart: 'viewable'`

### Are there any points in the code the reviewer needs to double check?

n/a

### Are there any Pull Requests open in other repos which need to be merged with this?

n/a

#### Addresses Issue(s):

JW8-5637

