### PR TITLE
[JW8-5644] Fix audio only live player ui

### DIFF
--- a/src/css/controls/flags/audioplayer.less
+++ b/src/css/controls/flags/audioplayer.less
@@ -16,7 +16,7 @@
         min-height: @mobile-touch-target;
     }
 
-    .jw-spacer {
+    &:not(.jw-flag-live) .jw-spacer {
         display: none;
     }
 


### PR DESCRIPTION

### This PR will...
- stop hiding `jw-spacer` on audioplayer if the stream is live.

### Why is this Pull Request needed?
Live mode does not have the time slider which takes up the maximum space, preventing controls from being centered.
Our spacer needs to be there in live mode to prevent centering.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-5644


