### PR TITLE
'About This Video' right click option doesn't work on mobile JW8-5632

### DIFF
--- a/src/css/controls/imports/shortcuts-tooltip.less
+++ b/src/css/controls/imports/shortcuts-tooltip.less
@@ -78,7 +78,7 @@
         }
 
         li {
-            line-height: 2.15rem;
+            line-height: 34px;
         }
     }
 }

--- a/src/js/view/controls/rightclick.js
+++ b/src/js/view/controls/rightclick.js
@@ -191,9 +191,9 @@ export default class RightClick {
             this.el.querySelector('.jw-info-overlay-item').removeEventListener('click', this.infoOverlayHandler);
             this.el.removeEventListener('mouseover', this.overHandler);
             this.el.removeEventListener('mouseout', this.outHandler);
-        }
-        if (this.shortcutsTooltip) {
-            this.el.querySelector('.jw-shortcuts-item').removeEventListener('click', this.shortcutsTooltipHandler);
+            if (this.shortcutsTooltip) {
+                this.el.querySelector('.jw-shortcuts-item').removeEventListener('click', this.shortcutsTooltipHandler);
+            }
         }
         document.removeEventListener('click', this.hideMenuHandler);
         document.removeEventListener('touchstart', this.hideMenuHandler);

--- a/src/js/view/controls/rightclick.js
+++ b/src/js/view/controls/rightclick.js
@@ -195,6 +195,9 @@ export default class RightClick {
                 this.el.querySelector('.jw-shortcuts-item').removeEventListener('click', this.shortcutsTooltipHandler);
             }
         }
+        if (this.shortcutsTooltip) {
+            this.el.querySelector('.jw-shortcuts-item').removeEventListener('click', this.shortcutsTooltipHandler);
+        }
         document.removeEventListener('click', this.hideMenuHandler);
         document.removeEventListener('touchstart', this.hideMenuHandler);
     }

--- a/src/js/view/controls/rightclick.js
+++ b/src/js/view/controls/rightclick.js
@@ -177,7 +177,10 @@ export default class RightClick {
             this.el.addEventListener('mouseout', this.outHandler);
         }
         this.el.querySelector('.jw-info-overlay-item').addEventListener('click', this.infoOverlayHandler);
-        this.el.querySelector('.jw-shortcuts-item').addEventListener('click', this.shortcutsTooltipHandler);
+        if (this.shortcutsTooltip) {
+            this.el.querySelector('.jw-shortcuts-item').addEventListener('click', this.shortcutsTooltipHandler);
+        }
+        
     }
 
     removeHideMenuHandlers() {
@@ -186,9 +189,11 @@ export default class RightClick {
         }
         if (this.el) {
             this.el.querySelector('.jw-info-overlay-item').removeEventListener('click', this.infoOverlayHandler);
-            this.el.querySelector('.jw-shortcuts-item').removeEventListener('click', this.shortcutsTooltipHandler);
             this.el.removeEventListener('mouseover', this.overHandler);
             this.el.removeEventListener('mouseout', this.outHandler);
+        }
+        if (this.shortcutsTooltip) {
+            this.el.querySelector('.jw-shortcuts-item').removeEventListener('click', this.shortcutsTooltipHandler);
         }
         document.removeEventListener('click', this.hideMenuHandler);
         document.removeEventListener('touchstart', this.hideMenuHandler);

--- a/src/js/view/controls/shortcuts-tooltip.js
+++ b/src/js/view/controls/shortcuts-tooltip.js
@@ -79,10 +79,13 @@ export default function (container, api, model) {
     };
     const render = () => {
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
         const keyList = template.querySelector('.jw-shortcuts-tooltip-keys');
         const descriptionList = template.querySelector('.jw-shortcuts-tooltip-descriptions');
 >>>>>>> 'About This Video' right click option doesn't work on mobile JW8-5632
+=======
+>>>>>>> remove two lines of dead code
         const closeButton = button('jw-shortcuts-close', () => {
             close();
         }, model.get('localization').close, [cloneIcon('close')]);

--- a/src/js/view/controls/shortcuts-tooltip.js
+++ b/src/js/view/controls/shortcuts-tooltip.js
@@ -78,8 +78,6 @@ export default function (container, api, model) {
         }
     };
     const render = () => {
-        const keyList = template.querySelector('.jw-shortcuts-tooltip-keys');
-        const descriptionList = template.querySelector('.jw-shortcuts-tooltip-descriptions');
         const closeButton = button('jw-shortcuts-close', () => {
             close();
         }, model.get('localization').close, [cloneIcon('close')]);

--- a/src/js/view/controls/shortcuts-tooltip.js
+++ b/src/js/view/controls/shortcuts-tooltip.js
@@ -78,6 +78,11 @@ export default function (container, api, model) {
         }
     };
     const render = () => {
+<<<<<<< HEAD
+=======
+        const keyList = template.querySelector('.jw-shortcuts-tooltip-keys');
+        const descriptionList = template.querySelector('.jw-shortcuts-tooltip-descriptions');
+>>>>>>> 'About This Video' right click option doesn't work on mobile JW8-5632
         const closeButton = button('jw-shortcuts-close', () => {
             close();
         }, model.get('localization').close, [cloneIcon('close')]);

--- a/src/js/view/controls/shortcuts-tooltip.js
+++ b/src/js/view/controls/shortcuts-tooltip.js
@@ -4,10 +4,48 @@ import button from 'view/controls/components/button';
 import { cloneIcon } from 'view/controls/icons';
 import { STATE_PLAYING } from 'events/events';
 
+const shortcuts = [
+    {
+        key: 'SPACE',
+        description: 'play/pause'
+    },
+    {
+        key: '↑',
+        description: 'increase volume'
+    },
+    {
+        key: '↓',
+        description: 'decrease volume'
+    },
+    {
+        key: '→',
+        description: 'seek forwards'
+    },
+    {
+        key: '←',
+        description: 'seek backwards'
+    },
+    {
+        key: 'c',
+        description: 'toggle captions'
+    },
+    {
+        key: 'f',
+        description: 'toggle fullscreen',
+    },
+    {
+        key: 'm',
+        description: 'mute/unmute'
+    }, {
+        key: '0-9',
+        description: 'seek to %'
+    }
+];
+
 export default function (container, api, model) {
     let isOpen = false;
     let lastState = null;
-    const template = createElement(shortcutTooltipTemplate());
+    const template = createElement(shortcutTooltipTemplate(shortcuts));
     const settingsInteraction = { reason: 'settingsInteraction' };
 
     const open = () => {
@@ -42,54 +80,9 @@ export default function (container, api, model) {
     const render = () => {
         const keyList = template.querySelector('.jw-shortcuts-tooltip-keys');
         const descriptionList = template.querySelector('.jw-shortcuts-tooltip-descriptions');
-        const shortcuts = [
-            {
-                key: 'SPACE',
-                description: 'play/pause'
-            },
-            {
-                key: '↑',
-                description: 'increase volume'
-            },
-            {
-                key: '↓',
-                description: 'decrease volume'
-            },
-            {
-                key: '→',
-                description: 'seek forwards'
-            },
-            {
-                key: '←',
-                description: 'seek backwards'
-            },
-            {
-                key: 'c',
-                description: 'toggle captions'
-            },
-            {
-                key: 'f',
-                description: 'toggle fullscreen',
-            },
-            {
-                key: 'm',
-                description: 'mute/unmute'
-            }, {
-                key: '0-9',
-                description: 'seek to %'
-            }
-        ];
         const closeButton = button('jw-shortcuts-close', () => {
             close();
         }, model.get('localization').close, [cloneIcon('close')]);
-        
-        //  Iterate all shortcuts to create list of them. 
-        shortcuts.map(shortcut => {
-            const key = createElement(`<li><span class="jw-hotkey">${shortcut.key}</span></li>`);
-            const description = createElement(`<li><span class="jw-hotkey-description">${shortcut.description}</span></li>`);
-            keyList.appendChild(key);
-            descriptionList.appendChild(description);
-        });
 
         //  Append close button to modal.
         prependChild(template, closeButton.element());

--- a/src/js/view/controls/templates/shortcuts-tooltip.js
+++ b/src/js/view/controls/templates/shortcuts-tooltip.js
@@ -1,9 +1,12 @@
 export default (shortcuts = {}) => {
     //  Iterate all shortcuts to create list of them. 
-    const shortcutsKey = (key) => `<li><span class="jw-hotkey">${key}</span></li>`;
-    const shortcutsDescription = (description) => `<li><span class="jw-hotkey-description">${description}</span></li>`;
-    const keyList = shortcuts.map(shortcut => shortcutsKey(shortcut.key));
-    const descriptionList = shortcuts.map(shortcut => shortcutsDescription(shortcut.description));
+    const keyList = [];
+    const descriptionList = [];
+    
+    shortcuts.forEach(shortcut => {
+        keyList.push(`<li><span class="jw-hotkey">${shortcut.key}</span></li>`);
+        descriptionList.push(`<li><span class="jw-hotkey-description">${shortcut.description}</span></li>`);
+    });
 
     return (
         `<div class="jw-shortcuts-tooltip jw-modal jw-reset" title="Keyboard Shortcuts">` +

--- a/src/js/view/controls/templates/shortcuts-tooltip.js
+++ b/src/js/view/controls/templates/shortcuts-tooltip.js
@@ -1,16 +1,26 @@
-export default () => (
-    `<div class="jw-shortcuts-tooltip jw-modal jw-reset" title="Keyboard Shortcuts">` +
-        `<span class="jw-hidden" id="jw-shortcuts-tooltip-explanation">` +
-            `Press shift question mark to access a list of keyboard shortcuts` +
-        `</span>` +
-        `<div class="jw-reset jw-shortcuts-container">` +
-            `<div class="jw-reset jw-shortcuts-title">Keyboard Shortcuts</div>` +
-            `<div class="jw-reset jw-shortcuts-tooltip-list">` +
-                `<ul class="jw-shortcuts-tooltip-descriptions jw-reset jw-shortcuts-description">` +
-                `</ul>` +
-                `<ul class="jw-shortcuts-tooltip-keys jw-reset jw-shortcuts-description">` +
-                `</ul>` +
+export default (shortcuts = {}) => {
+    //  Iterate all shortcuts to create list of them. 
+    const shortcutsKey = (key) => `<li><span class="jw-hotkey">${key}</span></li>`;
+    const shortcutsDescription = (description) => `<li><span class="jw-hotkey-description">${description}</span></li>`;
+    let keyList = shortcuts.map(shortcut => shortcutsKey(shortcut.key));
+    let descriptionList = shortcuts.map(shortcut => shortcutsDescription(shortcut.description));
+
+    return (
+        `<div class="jw-shortcuts-tooltip jw-modal jw-reset" title="Keyboard Shortcuts">` +
+            `<span class="jw-hidden" id="jw-shortcuts-tooltip-explanation">` +
+                `Press shift question mark to access a list of keyboard shortcuts` +
+            `</span>` +
+            `<div class="jw-reset jw-shortcuts-container">` +
+                `<div class="jw-reset jw-shortcuts-title">Keyboard Shortcuts</div>` +
+                `<div class="jw-reset jw-shortcuts-tooltip-list">` +
+                    `<ul class="jw-shortcuts-tooltip-descriptions jw-reset jw-shortcuts-description">` +
+                        `${descriptionList.join('')}` +
+                    `</ul>` +
+                    `<ul class="jw-shortcuts-tooltip-keys jw-reset jw-shortcuts-description">` +
+                        `${keyList.join('')}` +
+                    `</ul>` +
                 `</div>` +
-        `</div>` +
-    `</div>`
-);
+            `</div>` +
+        `</div>`
+    );
+};

--- a/src/js/view/controls/templates/shortcuts-tooltip.js
+++ b/src/js/view/controls/templates/shortcuts-tooltip.js
@@ -2,8 +2,8 @@ export default (shortcuts = {}) => {
     //  Iterate all shortcuts to create list of them. 
     const shortcutsKey = (key) => `<li><span class="jw-hotkey">${key}</span></li>`;
     const shortcutsDescription = (description) => `<li><span class="jw-hotkey-description">${description}</span></li>`;
-    let keyList = shortcuts.map(shortcut => shortcutsKey(shortcut.key));
-    let descriptionList = shortcuts.map(shortcut => shortcutsDescription(shortcut.description));
+    const keyList = shortcuts.map(shortcut => shortcutsKey(shortcut.key));
+    const descriptionList = shortcuts.map(shortcut => shortcutsDescription(shortcut.description));
 
     return (
         `<div class="jw-shortcuts-tooltip jw-modal jw-reset" title="Keyboard Shortcuts">` +

--- a/src/js/view/floating-drag-ui.js
+++ b/src/js/view/floating-drag-ui.js
@@ -2,8 +2,6 @@ import UI from 'utils/ui';
 import { style } from 'utils/css';
 import { OS } from 'environment/environment';
 
-const _isMobile = OS.mobile;
-
 export default class FloatingDragUI {
     constructor(element) {
         this.element = element;
@@ -23,7 +21,7 @@ export default class FloatingDragUI {
         let innerWidth;
         const auto = 'auto';
         const { element } = this;
-        const ui = this.ui = new UI(element, { preventScrolling: _isMobile })
+        const ui = this.ui = new UI(element, { preventScrolling: OS.mobile })
             .on('dragStart', () => {
                 playerLeft = element.offsetLeft;
                 playerTop = element.offsetTop;

--- a/src/js/view/floating-drag-ui.js
+++ b/src/js/view/floating-drag-ui.js
@@ -1,6 +1,5 @@
 import UI from 'utils/ui';
 import { style } from 'utils/css';
-import { OS } from 'environment/environment';
 
 export default class FloatingDragUI {
     constructor(element) {
@@ -21,7 +20,7 @@ export default class FloatingDragUI {
         let innerWidth;
         const auto = 'auto';
         const { element } = this;
-        const ui = this.ui = new UI(element, { preventScrolling: OS.mobile })
+        const ui = this.ui = new UI(element, { preventScrolling: true })
             .on('dragStart', () => {
                 playerLeft = element.offsetLeft;
                 playerTop = element.offsetTop;

--- a/test/unit/controls/shortcuts-tooltip.js
+++ b/test/unit/controls/shortcuts-tooltip.js
@@ -2,13 +2,13 @@ import sinon from 'sinon';
 import MockModel from 'mock/mock-model';
 import MockApi from 'mock/mock-api';
 import ShortcutsTooltip from 'view/controls/shortcuts-tooltip';
-import { STATE_PLAYING, STATE_PAUSED } from 'events/events';
+import { STATE_PLAYING } from 'events/events';
 
 require('css/controls/imports/shortcuts-tooltip.less');
 
 describe('Keyboard Shortcuts Modal Test', function() {
     function isHidden (el) {
-        var style = window.getComputedStyle(el);
+        const style = window.getComputedStyle(el);
         return (style.display === 'none')
     }
     function isVisible (el) {
@@ -18,7 +18,7 @@ describe('Keyboard Shortcuts Modal Test', function() {
     const api = new MockApi();
     let player;
     let shortcutsTooltip;
-    beforeEach(function(){
+    beforeEach(function() {
         player = document.createElement('div');
         player.classList.add('jwplayer');
         model.setup({});


### PR DESCRIPTION
### This PR will...
Fix the mobile right click menu (presently it errors, preventing the about this video link from working).
Optimize template rendering by replacing DOM manipulations with string manipulations.
Remove rem line heights to prevent issues with edge cases (ie: no font size on html).

### Why is this Pull Request needed?
Customers need their right click menus

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):
https://jwplayer.atlassian.net/browse/JW8-5632
JW8-5632

