### PR TITLE
[JW8-5643] Limit prevent scrolling to mobile

### DIFF
--- a/src/js/view/floating-drag-ui.js
+++ b/src/js/view/floating-drag-ui.js
@@ -1,5 +1,6 @@
 import UI from 'utils/ui';
 import { style } from 'utils/css';
+import { OS } from 'environment/environment';
 
 export default class FloatingDragUI {
     constructor(element) {
@@ -20,7 +21,7 @@ export default class FloatingDragUI {
         let innerWidth;
         const auto = 'auto';
         const { element } = this;
-        const ui = this.ui = new UI(element, { preventScrolling: true })
+        const ui = this.ui = new UI(element, { preventScrolling:  OS.mobile })
             .on('dragStart', () => {
                 playerLeft = element.offsetLeft;
                 playerTop = element.offsetTop;

--- a/src/js/view/floating-drag-ui.js
+++ b/src/js/view/floating-drag-ui.js
@@ -2,6 +2,8 @@ import UI from 'utils/ui';
 import { style } from 'utils/css';
 import { OS } from 'environment/environment';
 
+const _isMobile = OS.mobile;
+
 export default class FloatingDragUI {
     constructor(element) {
         this.element = element;
@@ -21,7 +23,7 @@ export default class FloatingDragUI {
         let innerWidth;
         const auto = 'auto';
         const { element } = this;
-        const ui = this.ui = new UI(element, { preventScrolling:  OS.mobile })
+        const ui = this.ui = new UI(element, { preventScrolling: _isMobile })
             .on('dragStart', () => {
                 playerLeft = element.offsetLeft;
                 playerTop = element.offsetTop;


### PR DESCRIPTION
### This PR will...
Limit prevent scrolling for drag floating player to mobile devices.

### Why is this Pull Request needed?
"preventScrolling" option on desktop calls `el.setPointerCapture`, resulting the upcoming events to be only captured in that element.
Since `_wrapperElement` is the element (which contains controls), any events after `pointerdown` on controls are ignored, making the controls not clickable.
Mobile doesn't have the issue, because `el.setPointerCapture` is only called on `pointerdown`

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):
JW8-5643

