### PR TITLE
Add CODEOWNERS for assigning reviewers to PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+# See https://help.github.com/en/articles/about-code-owners#example-of-a-codeowners-file for more details and examples
+
+*            @robwalch
+/test/unit/  @jnatalzia
+jwplayer/src/css/ @pajong @DanFerrer @robwalch

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,3 +5,4 @@
 *            @robwalch
 /test/unit/  @jnatalzia
 jwplayer/src/css/ @pajong @DanFerrer @robwalch
+jwplayer/src/js/program @johnBartos @robwalch

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,5 +4,5 @@
 
 *            @robwalch
 /test/unit/  @jnatalzia
-jwplayer/src/css/ @pajong @DanFerrer @robwalch
+jwplayer/src/css/ @pajong @DanFerrer @robwalch @jnatalzia
 jwplayer/src/js/program @johnBartos @robwalch

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,5 +4,11 @@
 
 *            @robwalch
 /test/unit/  @jnatalzia
-jwplayer/src/css/ @pajong @DanFerrer @robwalch @jnatalzia
-jwplayer/src/js/program @johnBartos @robwalch
+/src/css/ @pajong @DanFerrer @robwalch @jnatalzia
+/src/js/program @johnBartos @robwalch
+
+# Auto-translate
+/src/assets/translations @karimMourra
+/src/js/utils/language.js @karimMourra
+/src/js/api/setup-steps.js @karimMourra @robwalch
+/test/unit/language-test.js @karimMourra


### PR DESCRIPTION
### This PR will...
Add a CODEOWNERS file to the repo

### Why is this Pull Request needed?
Code owners are automatically requested for review when someone opens a pull request that modifies code that they own.
https://help.github.com/en/articles/about-code-owners#example-of-a-codeowners-file

