### PR TITLE
UI preventScrolling - Only capture subsequent events if event target matches

### DIFF
--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -109,7 +109,7 @@ function initInteractionListeners(ui) {
 
         removeHandlers(ui, WINDOW_GROUP);
         if (type === 'pointerdown' && e.isPrimary) {
-            if (!passive) {
+            if (!passive && e.target === el) {
                 const { pointerId } = e;
                 ui.pointerId = pointerId;
                 el.setPointerCapture(pointerId);

--- a/src/js/view/floating-drag-ui.js
+++ b/src/js/view/floating-drag-ui.js
@@ -1,5 +1,6 @@
 import UI from 'utils/ui';
 import { style } from 'utils/css';
+import { OS } from 'environment/environment';
 
 export default class FloatingDragUI {
     constructor(element) {
@@ -20,7 +21,7 @@ export default class FloatingDragUI {
         let innerWidth;
         const auto = 'auto';
         const { element } = this;
-        const ui = this.ui = new UI(element, { preventScrolling: true })
+        const ui = this.ui = new UI(element, { preventScrolling: OS.mobile })
             .on('dragStart', () => {
                 playerLeft = element.offsetLeft;
                 playerTop = element.offsetTop;

--- a/src/js/view/floating-drag-ui.js
+++ b/src/js/view/floating-drag-ui.js
@@ -1,6 +1,5 @@
 import UI from 'utils/ui';
 import { style } from 'utils/css';
-import { OS } from 'environment/environment';
 
 export default class FloatingDragUI {
     constructor(element) {
@@ -21,7 +20,7 @@ export default class FloatingDragUI {
         let innerWidth;
         const auto = 'auto';
         const { element } = this;
-        const ui = this.ui = new UI(element, { preventScrolling: OS.mobile })
+        const ui = this.ui = new UI(element, { preventScrolling: true })
             .on('dragStart', () => {
                 playerLeft = element.offsetLeft;
                 playerTop = element.offsetTop;


### PR DESCRIPTION
### This PR will...
Call `setPointerCapture` to ui elements with `preventScrolling` options only if the event target matches the ui element.

### Why is this Pull Request needed?
"preventScrolling" option on desktop calls `el.setPointerCapture`, resulting the upcoming events to be only captured in that element.
Since `_wrapperElement` is the element (which contains controls), any events after `pointerdown` on controls that are forwarded to `_wrapperElement` are ignored, making the controls not clickable.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):
JW8-5643