### PR TITLE
Capture pointer on drag

### DIFF
--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -112,7 +112,6 @@ function initInteractionListeners(ui) {
             if (!passive) {
                 const { pointerId } = e;
                 ui.pointerId = pointerId;
-                el.setPointerCapture(pointerId);
             }
 
             addEventListener(ui, WINDOW_GROUP, 'pointermove', interactDragHandler, listenerOptions);
@@ -145,6 +144,10 @@ function initInteractionListeners(ui) {
             const moveX = pageX - ui.startX;
             const moveY = pageY - ui.startY;
             if (moveX * moveX + moveY * moveY > MOVEMENT_THRESHOLD * MOVEMENT_THRESHOLD) {
+                if (!passive && ui.pointerId) {
+                    el.setPointerCapture(ui.pointerId);
+                }
+
                 triggerEvent(ui, DRAG_START, e);
                 ui.dragged = true;
                 triggerEvent(ui, DRAG, e);

--- a/test/unit/ui-test.js
+++ b/test/unit/ui-test.js
@@ -579,18 +579,22 @@ describe('UI', function() {
         let result;
         let event;
         if (USE_POINTER_EVENTS) {
-            const pointerMouseOptions = xyCoords(0, 0, {
+            const pointerCoordsOptions = {
                 isPrimary: true,
                 pointerType: 'mouse',
+                pointerId: 1234,
                 view: window,
                 bubbles: true,
                 cancelable: true
-            });
+            };
+            const pointerMouseOptions = xyCoords(0, 0, pointerCoordsOptions);
+
             event = new PointerEvent('pointerdown', pointerMouseOptions);
             sandbox.stub(button, 'setPointerCapture').callsFake(sinon.spy());
             sandbox.stub(button, 'releasePointerCapture').callsFake(sinon.spy());
             sandbox.spy(event, 'preventDefault');
             result = button.dispatchEvent(event);
+            button.dispatchEvent(new PointerEvent('pointermove', xyCoords(5, 5, pointerCoordsOptions)));
             button.dispatchEvent(new PointerEvent('pointerup', pointerMouseOptions));
             expect(button.setPointerCapture).to.have.callCount(1);
             expect(button.releasePointerCapture).to.have.callCount(1);


### PR DESCRIPTION
### This PR will...
Call `setPointerCapture` to ui elements with `preventScrolling` options when dragging starts, instead of on `pointerdown`

### Why is this Pull Request needed?
`preventScrolling` option on desktop calls `el.setPointerCapture`, resulting the upcoming events to be only captured in that element.
Since `_wrapperElement` is the element (which contains controls), any events after `pointerdown` on controls that are forwarded to `_wrapperElement` are ignored, making the controls not clickable.

Since the goal of the `preventScrolling` option was to prevent scroll (not clicks), capture pointer should happen when we start dragging.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):
JW8-5643