### PR TITLE
About This Video' right click option doesn't work on mobile JW8-5632

### DIFF
--- a/src/css/controls/imports/shortcuts-tooltip.less
+++ b/src/css/controls/imports/shortcuts-tooltip.less
@@ -78,7 +78,7 @@
         }
 
         li {
-            line-height: 2.15rem;
+            line-height: 34px;
         }
     }
 }

--- a/src/js/view/controls/rightclick.js
+++ b/src/js/view/controls/rightclick.js
@@ -177,7 +177,10 @@ export default class RightClick {
             this.el.addEventListener('mouseout', this.outHandler);
         }
         this.el.querySelector('.jw-info-overlay-item').addEventListener('click', this.infoOverlayHandler);
-        this.el.querySelector('.jw-shortcuts-item').addEventListener('click', this.shortcutsTooltipHandler);
+
+        if (this.shortcutsTooltip) {
+            this.el.querySelector('.jw-shortcuts-item').addEventListener('click', this.shortcutsTooltipHandler);
+        }
     }
 
     removeHideMenuHandlers() {
@@ -186,9 +189,11 @@ export default class RightClick {
         }
         if (this.el) {
             this.el.querySelector('.jw-info-overlay-item').removeEventListener('click', this.infoOverlayHandler);
-            this.el.querySelector('.jw-shortcuts-item').removeEventListener('click', this.shortcutsTooltipHandler);
             this.el.removeEventListener('mouseover', this.overHandler);
             this.el.removeEventListener('mouseout', this.outHandler);
+            if (this.shortcutsTooltip) {
+                this.el.querySelector('.jw-shortcuts-item').removeEventListener('click', this.shortcutsTooltipHandler);
+            }
         }
         document.removeEventListener('click', this.hideMenuHandler);
         document.removeEventListener('touchstart', this.hideMenuHandler);

--- a/src/js/view/controls/shortcuts-tooltip.js
+++ b/src/js/view/controls/shortcuts-tooltip.js
@@ -4,10 +4,48 @@ import button from 'view/controls/components/button';
 import { cloneIcon } from 'view/controls/icons';
 import { STATE_PLAYING } from 'events/events';
 
+const shortcuts = [
+    {
+        key: 'SPACE',
+        description: 'play/pause'
+    },
+    {
+        key: '↑',
+        description: 'increase volume'
+    },
+    {
+        key: '↓',
+        description: 'decrease volume'
+    },
+    {
+        key: '→',
+        description: 'seek forwards'
+    },
+    {
+        key: '←',
+        description: 'seek backwards'
+    },
+    {
+        key: 'c',
+        description: 'toggle captions'
+    },
+    {
+        key: 'f',
+        description: 'toggle fullscreen',
+    },
+    {
+        key: 'm',
+        description: 'mute/unmute'
+    }, {
+        key: '0-9',
+        description: 'seek to %'
+    }
+];
+
 export default function (container, api, model) {
     let isOpen = false;
     let lastState = null;
-    const template = createElement(shortcutTooltipTemplate());
+    const template = createElement(shortcutTooltipTemplate(shortcuts));
     const settingsInteraction = { reason: 'settingsInteraction' };
 
     const open = () => {
@@ -40,56 +78,9 @@ export default function (container, api, model) {
         }
     };
     const render = () => {
-        const keyList = template.querySelector('.jw-shortcuts-tooltip-keys');
-        const descriptionList = template.querySelector('.jw-shortcuts-tooltip-descriptions');
-        const shortcuts = [
-            {
-                key: 'SPACE',
-                description: 'play/pause'
-            },
-            {
-                key: '↑',
-                description: 'increase volume'
-            },
-            {
-                key: '↓',
-                description: 'decrease volume'
-            },
-            {
-                key: '→',
-                description: 'seek forwards'
-            },
-            {
-                key: '←',
-                description: 'seek backwards'
-            },
-            {
-                key: 'c',
-                description: 'toggle captions'
-            },
-            {
-                key: 'f',
-                description: 'toggle fullscreen',
-            },
-            {
-                key: 'm',
-                description: 'mute/unmute'
-            }, {
-                key: '0-9',
-                description: 'seek to %'
-            }
-        ];
         const closeButton = button('jw-shortcuts-close', () => {
             close();
         }, model.get('localization').close, [cloneIcon('close')]);
-        
-        //  Iterate all shortcuts to create list of them. 
-        shortcuts.map(shortcut => {
-            const key = createElement(`<li><span class="jw-hotkey">${shortcut.key}</span></li>`);
-            const description = createElement(`<li><span class="jw-hotkey-description">${shortcut.description}</span></li>`);
-            keyList.appendChild(key);
-            descriptionList.appendChild(description);
-        });
 
         //  Append close button to modal.
         prependChild(template, closeButton.element());

--- a/src/js/view/controls/templates/shortcuts-tooltip.js
+++ b/src/js/view/controls/templates/shortcuts-tooltip.js
@@ -1,16 +1,29 @@
-export default () => (
-    `<div class="jw-shortcuts-tooltip jw-modal jw-reset" title="Keyboard Shortcuts">` +
-        `<span class="jw-hidden" id="jw-shortcuts-tooltip-explanation">` +
-            `Press shift question mark to access a list of keyboard shortcuts` +
-        `</span>` +
-        `<div class="jw-reset jw-shortcuts-container">` +
-            `<div class="jw-reset jw-shortcuts-title">Keyboard Shortcuts</div>` +
-            `<div class="jw-reset jw-shortcuts-tooltip-list">` +
-                `<ul class="jw-shortcuts-tooltip-descriptions jw-reset jw-shortcuts-description">` +
-                `</ul>` +
-                `<ul class="jw-shortcuts-tooltip-keys jw-reset jw-shortcuts-description">` +
-                `</ul>` +
+export default (shortcuts = {}) => {
+    //  Iterate all shortcuts to create list of them. 
+    const keyList = [];
+    const descriptionList = [];
+    
+    shortcuts.forEach(shortcut => {
+        keyList.push(`<li><span class="jw-hotkey">${shortcut.key}</span></li>`);
+        descriptionList.push(`<li><span class="jw-hotkey-description">${shortcut.description}</span></li>`);
+    });
+
+    return (
+        `<div class="jw-shortcuts-tooltip jw-modal jw-reset" title="Keyboard Shortcuts">` +
+            `<span class="jw-hidden" id="jw-shortcuts-tooltip-explanation">` +
+                `Press shift question mark to access a list of keyboard shortcuts` +
+            `</span>` +
+            `<div class="jw-reset jw-shortcuts-container">` +
+                `<div class="jw-reset jw-shortcuts-title">Keyboard Shortcuts</div>` +
+                `<div class="jw-reset jw-shortcuts-tooltip-list">` +
+                    `<ul class="jw-shortcuts-tooltip-descriptions jw-reset jw-shortcuts-description">` +
+                        `${descriptionList.join('')}` +
+                    `</ul>` +
+                    `<ul class="jw-shortcuts-tooltip-keys jw-reset jw-shortcuts-description">` +
+                        `${keyList.join('')}` +
+                    `</ul>` +
                 `</div>` +
-        `</div>` +
-    `</div>`
-);
+            `</div>` +
+        `</div>`
+    );
+};


### PR DESCRIPTION
### This PR will...
- Fix right-click menu error on mobile
- Optimize shortcuts modal template
- Fix style issues with rem units on unspecified font-size pages
- Move un-reassigned variables to const

### Why is this Pull Request needed?
Resolve the right click on mobile error, as well as add in optimizations and PR fixes from this review: https://github.com/jwplayer/jwplayer/pull/3319
### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):
https://jwplayer.atlassian.net/browse/JW8-5632
JW8-5632

