### PR TITLE
Floating Player Improvements [JW8-2530] [JW8-5643]

### DIFF
--- a/src/css/jwplayer/flags/floatingplayer.less
+++ b/src/css/jwplayer/flags/floatingplayer.less
@@ -17,7 +17,7 @@
         margin: 0 auto;
 
         @media screen and (max-width : 480px) {
-            width: 100% !important; /* stylelint-disable-line declaration-no-important */
+            width: 100%;
             left: 0;
             right: 0;
         }
@@ -25,11 +25,11 @@
         .jw-flag-touch& {
             @media screen and (max-device-width : 480px) and (orientation: portrait) {
                 animation: jw-float-to-top 150ms cubic-bezier(0, 0.25, 0.25, 1) forwards 1;
-                top: 125px;
+                top: 62px;
                 bottom: auto;
                 left: 0;
                 right: 0;
-                max-width: none !important; /* stylelint-disable-line declaration-no-important */
+                max-width: none;
                 max-height: none;
             }
         }

--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -112,6 +112,7 @@ function initInteractionListeners(ui) {
             if (!passive) {
                 const { pointerId } = e;
                 ui.pointerId = pointerId;
+                el.setPointerCapture(pointerId);
             }
 
             addEventListener(ui, WINDOW_GROUP, 'pointermove', interactDragHandler, listenerOptions);
@@ -144,10 +145,6 @@ function initInteractionListeners(ui) {
             const moveX = pageX - ui.startX;
             const moveY = pageY - ui.startY;
             if (moveX * moveX + moveY * moveY > MOVEMENT_THRESHOLD * MOVEMENT_THRESHOLD) {
-                if (!passive && ui.pointerId) {
-                    el.setPointerCapture(ui.pointerId);
-                }
-
                 triggerEvent(ui, DRAG_START, e);
                 ui.dragged = true;
                 triggerEvent(ui, DRAG, e);

--- a/src/js/view/floating-drag-ui.js
+++ b/src/js/view/floating-drag-ui.js
@@ -3,7 +3,8 @@ import { style } from 'utils/css';
 
 export default class FloatingDragUI {
     constructor(element) {
-        this.element = element;
+        this.container = element;
+        this.input = element.querySelector('.jw-media');
     }
 
     disable() {
@@ -19,19 +20,19 @@ export default class FloatingDragUI {
         let innerHeight;
         let innerWidth;
         const auto = 'auto';
-        const { element } = this;
-        const ui = this.ui = new UI(element, { preventScrolling: true })
+        const { container, input } = this;
+        const ui = this.ui = new UI(input, { preventScrolling: true })
             .on('dragStart', () => {
-                playerLeft = element.offsetLeft;
-                playerTop = element.offsetTop;
+                playerLeft = container.offsetLeft;
+                playerTop = container.offsetTop;
                 innerHeight = window.innerHeight;
                 innerWidth = window.innerWidth;
             })
             .on('drag', (e) => {
                 let left = Math.max(playerLeft + e.pageX - ui.startX, 0);
                 let top = Math.max(playerTop + e.pageY - ui.startY, 0);
-                let right = Math.max(innerWidth - (left + element.clientWidth), 0);
-                let bottom = Math.max(innerHeight - (top + element.clientHeight), 0);
+                let right = Math.max(innerWidth - (left + container.clientWidth), 0);
+                let bottom = Math.max(innerHeight - (top + container.clientHeight), 0);
 
                 if (right === 0) {
                     left = auto;
@@ -44,7 +45,7 @@ export default class FloatingDragUI {
                     top = auto;
                 }
 
-                style(element, {
+                style(container, {
                     left,
                     right,
                     top,

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -80,6 +80,7 @@ function View(_api, _model) {
 
     this.dismissible = _floatingConfig && _floatingConfig.dismissible;
     let _canFloat = false;
+    let playerBounds = {};
 
     let displayClickHandler;
     let fullscreenHelpers;
@@ -100,6 +101,7 @@ function View(_api, _model) {
         const rect = bounds(currentElement);
         const containerWidth = Math.round(rect.width);
         const containerHeight = Math.round(rect.height);
+        playerBounds = bounds(_playerElement);
 
         // If the container is the same size as before, return early
         if (containerWidth === _lastWidth && containerHeight === _lastHeight) {
@@ -911,10 +913,11 @@ function View(_api, _model) {
         const width = _model.get('width');
         const height = _model.get('height');
         const styles = getPlayerSizeStyles(width);
+        styles.maxWidth = Math.min(400, playerBounds.width);
 
         if (!_model.get('aspectratio')) {
-            const containerWidth = _model.get('containerWidth');
-            const containerHeight = _model.get('containerHeight');
+            const containerWidth = playerBounds.width;
+            const containerHeight = playerBounds.height;
             let aspectRatio = (containerHeight / containerWidth) || 0.5625; // (fallback to 16 by 9)
             if (isNumber(width) && isNumber(height)) {
                 aspectRatio = height / width;
@@ -940,6 +943,7 @@ function View(_api, _model) {
             // Wrapper should inherit from parent unless floating.
             style(_playerElement, { backgroundImage: null }); // Reset to avoid flicker.
             style(_wrapperElement, {
+                maxWidth: null,
                 width: null,
                 height: null,
                 left: null,


### PR DESCRIPTION
### This PR will...
- [JW8-2530] Maintain responsive player width with margins when floating
- [JW8-2530] Make the header margin for floating players on mobile pages 62px
- [JW8-5643] Fix UI controls while dragging floating player

### Why is this Pull Request needed?
- The player's size when floating should match the player bounds before floating (100% + margins)
- `height: 62px;` is a common main-header size 
- The player container and wrapper should not be draggable. These elements contain controls which are also draggable.

