### PR TITLE
Improve horizontal volume slider styles

### DIFF
--- a/src/css/controls/flags/audioplayer.less
+++ b/src/css/controls/flags/audioplayer.less
@@ -79,19 +79,12 @@
         .jw-horizontal-volume-container {
             transition: width 300ms @default-timing-function;
             width: 0;
-            height: 17px;
-            align-items: center;
-            outline: none;
-
-            &.jw-tab-focus:focus {
-                outline: @ui-focus;
-            }
 
             &.jw-open {
                 width: @volume-rail-length;
 
                 .jw-slider-volume {
-                    padding: 0 12px;
+                    padding-right: 24px;
                     transition: opacity 300ms;
                     opacity: 1;
                 }

--- a/src/css/controls/imports/slider.less
+++ b/src/css/controls/imports/slider.less
@@ -120,6 +120,10 @@
     align-items: center;
     background: transparent none;
     padding: 0 12px;
+}
+
+.jw-slider-time,
+.jw-horizontal-volume-container {
     z-index: 1;
     outline: none;
 

--- a/src/css/controls/imports/slider.less
+++ b/src/css/controls/imports/slider.less
@@ -1,5 +1,12 @@
 @import "../../shared-imports/vars.less";
 
+.jw-slider-components() {
+    backface-visibility: hidden;
+    height: 100%;
+    transform: translate(0, -50%) scale(1, 0.6);
+    transition: transform 150ms ease-in-out;
+}
+
 .jw-slider-container {
     display: flex;
     align-items: center;
@@ -122,6 +129,14 @@
     padding: 0 12px;
 }
 
+.jw-slider-time .jw-cue {
+    .jw-slider-components();
+    background-color: @background-color;
+    cursor: pointer;
+    position: absolute;
+    width: 6px;
+}
+
 .jw-slider-time,
 .jw-horizontal-volume-container {
     z-index: 1;
@@ -129,19 +144,8 @@
 
     .jw-rail,
     .jw-buffer,
-    .jw-progress,
-    .jw-cue {
-        backface-visibility: hidden;
-        height: 100%;
-        transform: translate(0, -50%) scale(1, 0.6);
-        transition: transform 150ms ease-in-out;
-    }
-
-    .jw-cue {
-        background-color: @background-color;
-        cursor: pointer;
-        position: absolute;
-        width: 6px;
+    .jw-progress {
+        .jw-slider-components();
     }
 
     &:hover,

--- a/src/css/controls/imports/slider.less
+++ b/src/css/controls/imports/slider.less
@@ -1,12 +1,5 @@
 @import "../../shared-imports/vars.less";
 
-.jw-slider-components() {
-    backface-visibility: hidden;
-    height: 100%;
-    transform: translate(0, -50%) scale(1, 0.6);
-    transition: transform 150ms ease-in-out;
-}
-
 .jw-slider-container {
     display: flex;
     align-items: center;
@@ -130,7 +123,6 @@
 }
 
 .jw-slider-time .jw-cue {
-    .jw-slider-components();
     background-color: @background-color;
     cursor: pointer;
     position: absolute;
@@ -144,8 +136,12 @@
 
     .jw-rail,
     .jw-buffer,
-    .jw-progress {
-        .jw-slider-components();
+    .jw-progress,
+    .jw-cue {
+        backface-visibility: hidden;
+        height: 100%;
+        transform: translate(0, -50%) scale(1, 0.6);
+        transition: transform 150ms ease-in-out;
     }
 
     &:hover,


### PR DESCRIPTION
### This PR will...
- Add more padding to the right side of the horizontal volume slider when it opens, so that it is not so close with the currentTime/duration ui
- Remove tab focus outline on the container of the slider rail
- Apply css to correct classes so that `focus`/`hover` styles to increase the slider size works

### Why is this Pull Request needed?
- Styles were not applied to correct classes, resulting `hover` and `focus` styles to be not applied
- Horizontal volume is closer to the currentTime/duration mark than to the mute icon

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):
JW8-5651

