### PR TITLE
[JW8-5672] Clear cues on model when playlist item changes

### DIFF
--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -177,7 +177,7 @@ class TimeSlider extends Slider {
             return;
         }
         this.reset();
-        this.updateCues(model, []);
+        model.set('cues', []);
 
         const tracks = playlistItem.tracks;
         each(tracks, function (track) {
@@ -280,12 +280,6 @@ class TimeSlider extends Slider {
     }
 
     updateCues(model, cues) {
-        // If updateCues is called with cues === [], clear the cues on the model.
-        // This will clear out the cues on the model on new playlist items.
-        if (cues && cues.length === 0) {
-            model.set('cues', cues);
-        }
-
         this.resetCues();
         if (cues && cues.length) {
             cues.forEach((ele) => {

--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -177,7 +177,7 @@ class TimeSlider extends Slider {
             return;
         }
         this.reset();
-        this.updateCues(model, model.get('cues'));
+        this.updateCues(model, []);
 
         const tracks = playlistItem.tracks;
         each(tracks, function (track) {
@@ -280,6 +280,12 @@ class TimeSlider extends Slider {
     }
 
     updateCues(model, cues) {
+        // If updateCues is called with cues === [], clear the cues on the model.
+        // This will clear out the cues on the model on new playlist items.
+        if (cues && cues.length === 0) {
+            model.set('cues', cues);
+        }
+
         this.resetCues();
         if (cues && cues.length) {
             cues.forEach((ele) => {


### PR DESCRIPTION
### This PR will...

* Clear the cues on the model when the playlist item changes.
* Do not call `updateCues()` separately as it will be called when the cues on the model change

### Why is this Pull Request needed?

* Cues were not being cleared off the model when new playlist items are loaded. This results in the cues from the last playlist item to remain and be added to the new set of cues.

### Are there any points in the code the reviewer needs to double check?

n/a

### Are there any Pull Requests open in other repos which need to be merged with this?

n/a

#### Addresses Issue(s):

JW8-5672

