### PR TITLE
[JW8-5649] Lazy DOM parsing for UI elements that are not shown on setup

### DIFF
--- a/src/js/view/controls/components/simple-tooltip.js
+++ b/src/js/view/controls/components/simple-tooltip.js
@@ -1,4 +1,4 @@
-import { addClass, removeClass, replaceInnerHtml } from 'utils/dom';
+import { toggleClass, replaceInnerHtml } from 'utils/dom';
 
 export function SimpleTooltip(attachToElement, name, text, openCallback, closeCallback) {
     const tooltipElement = document.createElement('div');
@@ -12,12 +12,15 @@ export function SimpleTooltip(attachToElement, name, text, openCallback, closeCa
     attachToElement.appendChild(tooltipElement);
 
     const instance = {
+        dirty: !!text,
+        opened: false,
+        text,
         open() {
             if (instance.touchEvent) {
                 return;
             }
 
-            addClass(tooltipElement, 'jw-open');
+            redraw(true);
 
             if (openCallback) {
                 openCallback();
@@ -28,18 +31,32 @@ export function SimpleTooltip(attachToElement, name, text, openCallback, closeCa
                 return;
             }
 
-            removeClass(tooltipElement, 'jw-open');
+            redraw(false);
 
             if (closeCallback) {
                 closeCallback();
             }
         },
         setText(newText) {
-            replaceInnerHtml(textElement, newText);
+            if (newText !== instance.text) {
+                instance.text = newText;
+                instance.dirty = true;
+            }
+            if (instance.opened) {
+                redraw(true);
+            }
         }
     };
 
-    instance.setText(text);
+    const redraw = (opened) => {
+        if (opened && instance.dirty) {
+            replaceInnerHtml(textElement, instance.text);
+            instance.dirty = false;
+        }
+
+        instance.opened = opened;
+        toggleClass(tooltipElement, 'jw-open', open);
+    };
 
     attachToElement.addEventListener('mouseover', instance.open);
     attachToElement.addEventListener('focus', instance.open);

--- a/src/js/view/controls/components/simple-tooltip.js
+++ b/src/js/view/controls/components/simple-tooltip.js
@@ -55,7 +55,7 @@ export function SimpleTooltip(attachToElement, name, text, openCallback, closeCa
         }
 
         instance.opened = opened;
-        toggleClass(tooltipElement, 'jw-open', open);
+        toggleClass(tooltipElement, 'jw-open', opened);
     };
 
     attachToElement.addEventListener('mouseover', instance.open);

--- a/src/js/view/controls/nextuptooltip.js
+++ b/src/js/view/controls/nextuptooltip.js
@@ -122,19 +122,19 @@ export default class NextUpTooltip {
 
             // Set header
             this.header = this.content.querySelector('.jw-nextup-header');
-            this.header.innerText = this.localization.nextUp;
+            this.header.textContent = this.localization.nextUp;
 
             // Set title
             this.title = this.content.querySelector('.jw-nextup-title');
             const title = nextUpItem.title;
             // createElement is used to leverage 'textContent', to protect against developers passing a title with html styling.
-            this.title.innerText = title ? createElement(title).textContent : '';
+            this.title.textContent = title ? createElement(title).textContent : '';
 
             // Set duration
             const duration = nextUpItem.duration;
             if (duration) {
                 this.duration = this.content.querySelector('.jw-nextup-duration');
-                this.duration.innerText = typeof duration === 'number' ? timeFormat(duration) : duration;
+                this.duration.textContent = typeof duration === 'number' ? timeFormat(duration) : duration;
             }
         }, 500);
     }


### PR DESCRIPTION
### This PR will...
- Lazy DOM parsing in tooltips
- Use textContent instead of innerText to set UI text content

### Why is this Pull Request needed?
Most users will never see tooltips - at least not all of them. So we should not populate these elements until they are first shown. This will speed up player setup.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):
JW8-5649
