### PR TITLE
Clear model cues on playlist item in controller

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -263,6 +263,7 @@ Object.assign(Controller.prototype, {
                             // catch error that occurs when mediaSession fails to setup
                         }
                     }
+                    model.set('cues', []);
                     _this.trigger(PLAYLIST_ITEM, {
                         index: _model.get('item'),
                         item: playlistItem

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -263,7 +263,6 @@ Object.assign(Controller.prototype, {
                             // catch error that occurs when mediaSession fails to setup
                         }
                     }
-                    model.set('cues', []);
                     _this.trigger(PLAYLIST_ITEM, {
                         index: _model.get('item'),
                         item: playlistItem

--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -177,7 +177,7 @@ class TimeSlider extends Slider {
             return;
         }
         this.reset();
-        model.set('cues', []);
+        this.updateCues(model, model.get('cues'));
 
         const tracks = playlistItem.tracks;
         each(tracks, function (track) {

--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -176,7 +176,7 @@ class TimeSlider extends Slider {
 
     onPlaylistItem(model, playlistItem) {
         this.reset();
-        this.updateCues(model, model.get('cues'));
+        model.set('cues', []);
 
         const tracks = playlistItem.tracks;
         each(tracks, function (track) {

--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -101,16 +101,12 @@ class TimeSlider extends Slider {
                     this.updateAriaText();
                 }
             })
-            .change('playlistItem', this.onPlaylistItem, this)
             .change('position', this.onPosition, this)
             .change('buffer', this.onBuffer, this)
             .change('streamType', this.onStreamType, this);
 
         // Clear cues on player model's playlistItem change event
-        const { _model } = this._model;
-        _model.change('playlistItem', (model) => {
-            model.set('cues', []);
-        });
+        this._model.player.change('playlistItem', this.onPlaylistItem, this);
 
         const sliderElement = this.el;
         setAttribute(sliderElement, 'tabindex', '0');
@@ -179,9 +175,6 @@ class TimeSlider extends Slider {
     }
 
     onPlaylistItem(model, playlistItem) {
-        if (!playlistItem) {
-            return;
-        }
         this.reset();
         this.updateCues(model, model.get('cues'));
 

--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -106,6 +106,12 @@ class TimeSlider extends Slider {
             .change('buffer', this.onBuffer, this)
             .change('streamType', this.onStreamType, this);
 
+        // Clear cues on player model's playlistItem change event
+        const { _model } = this._model;
+        _model.change('playlistItem', (model) => {
+            model.set('cues', []);
+        });
+
         const sliderElement = this.el;
         setAttribute(sliderElement, 'tabindex', '0');
         setAttribute(sliderElement, 'role', 'slider');

--- a/test/unit/controlbar-test.js
+++ b/test/unit/controlbar-test.js
@@ -14,6 +14,10 @@ describe('Control Bar', function() {
     model.mediaController = {};
     model.mediaController.on = sinon.stub();
     model.mediaController.on.returnsThis();
+    const playerModel = new SimpleModel();
+    playerModel.change = sinon.stub();
+    playerModel.change.returnsThis();
+    model._model = playerModel;
 
     let accessibilityContainer;
     let controlBar;

--- a/test/unit/controlbar-test.js
+++ b/test/unit/controlbar-test.js
@@ -14,10 +14,6 @@ describe('Control Bar', function() {
     model.mediaController = {};
     model.mediaController.on = sinon.stub();
     model.mediaController.on.returnsThis();
-    const playerModel = new SimpleModel();
-    playerModel.change = sinon.stub();
-    playerModel.change.returnsThis();
-    model._model = playerModel;
 
     let accessibilityContainer;
     let controlBar;

--- a/test/unit/controlbar-test.js
+++ b/test/unit/controlbar-test.js
@@ -14,6 +14,10 @@ describe('Control Bar', function() {
     model.mediaController = {};
     model.mediaController.on = sinon.stub();
     model.mediaController.on.returnsThis();
+    const playerModel = new SimpleModel();
+    playerModel.change = sinon.stub();
+    playerModel.change.returnsThis();
+    model.player = playerModel;
 
     let accessibilityContainer;
     let controlBar;


### PR DESCRIPTION
### This PR will...
Clear model cues on `playlistItem`change in `controller`, rather than in `timeslider`

### Why is this Pull Request needed?
Timeslider's `model` is the `viewModel`, which updates the `playlistItem` every time we enter/exit ads mode.
We only want to clear cues on the `playlistItem` when the actual content item changes.
Moving the `model.set('cues', []);` to be called with `_model` in `controller` (which is the actual player model, not viewModel).

PLEASE NOTE: model from `model.set('cues, [])` is different from `_model` in controller (https://github.com/jwplayer/jwplayer/compare/bugfix/reset-cues-on-playlistItem?expand=1#diff-a181c6e20596563a55e5710b8f4dbab7R250)

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-5672

