### PR TITLE
Maintain original mobile autostart play/pause on viewable behavior

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -347,13 +347,15 @@ Object.assign(Controller.prototype, {
         function _checkPlayOnViewable(model, viewable) {
             if (model.get('playOnViewable')) {
                 if (viewable) {
+                    const reason = 'viewable';
                     if (model.get('state') === STATE_IDLE) {
-                        _autoStart('viewable');
+                        _autoStart(reason);
                     } else {
-                        _play('viewable');
+                        _play({ reason });
                     }
                 } else if (OS.mobile && !_getAdState()) {
                     _this.pause({ reason: 'autostart' });
+                    _model.set('playOnViewable', true);
                 }
             }
         }


### PR DESCRIPTION
### This PR will...
- Restore original mobile autostart play/pause on viewable behavior.
- Properly specify play reason when resuming playback on viewable change

### Why is this Pull Request needed?
Mobile autostart players only start when viewable. They also pause when not viewable. Auto-**pause** changes introduces a regression that paused mobile autostart players, but never resumed playback when the player came back into view. This is because the `"playOnViewable"` state was not managed correctly in `_checkPlayOnViewable` when pausing, and also in other parts of the player that set  `"playOnViewable"` based on `playReason` which was not properly passed into `_play` in `_checkPlayOnViewable`.

#### Addresses Issue(s):
JW8-5678
