### PR TITLE
Clear cues before firing playlistItem event

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -263,6 +263,7 @@ Object.assign(Controller.prototype, {
                             // catch error that occurs when mediaSession fails to setup
                         }
                     }
+                    model.set('cues', []);
                     _this.trigger(PLAYLIST_ITEM, {
                         index: _model.get('item'),
                         item: playlistItem

--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -176,7 +176,6 @@ class TimeSlider extends Slider {
 
     onPlaylistItem(model, playlistItem) {
         this.reset();
-        this.updateCues(model, model.get('cues'));
 
         const tracks = playlistItem.tracks;
         each(tracks, function (track) {
@@ -311,7 +310,6 @@ class TimeSlider extends Slider {
 
     reset() {
         this.resetThumbnails();
-        this.resetCues();
         this.timeTip.resetWidth();
         this.textLength = 0;
     }

--- a/src/js/view/controls/components/timeslider.js
+++ b/src/js/view/controls/components/timeslider.js
@@ -176,7 +176,7 @@ class TimeSlider extends Slider {
 
     onPlaylistItem(model, playlistItem) {
         this.reset();
-        model.set('cues', []);
+        this.updateCues(model, model.get('cues'));
 
         const tracks = playlistItem.tracks;
         each(tracks, function (track) {


### PR DESCRIPTION
### This PR will...
- Reset cues before firing `playlistItem` event
- Remove `resetCues` from `reset` function so that it is not called on `change:playlistItem`

### Why is this Pull Request needed?
`playerViewModel`'s `change:playlistItem` fires AFTER the player `playlistItem` event, resulting ads plugins to add the cues before the timeslider's `onPlaylistItem` function call.

The cues are being reset every time there is an update to `cues` in `model`, so we do not need to call `resetCues` on playerViewModel's `change:playlistItem` - it removes already updated cues.

### Are there any points in the code the reviewer needs to double check?
@robwalch We either have to do this, or listen to the player model in `timeslider` - the player view model playlist item change comes too late when non-VMAP ads are set up.

The config to reproduce the issue (2nd playlistItem): 
```
{
    "playlist": [
        {
            "sources": [
                {
                    "file": "https://content.jwplatform.com/manifests/YXkJrbkQ.m3u8"
                }
            ],
            "adschedule": {
                "adbreak1": {
                    "offset": 20,
                    "ad": {
                        "tag": "//playertest.longtailvideo.com/mid.xml"
                    }
                }
            }
        },
        {
            "sources": [
                {
                    "file": "https://content.jwplatform.com/manifests/FR1xB6OK.m3u8"
                }
            ],
            "adschedule": {
                "adbreak1": {
                    "offset": 15,
                    "ad": {
                        "tag": "//playertest.longtailvideo.com/mid.xml"
                    }
                }
            }
        }
    ],
    "advertising": {
        "client": "../../bin-debug/vast.js",
        "skipoffset": 2
    }
}
```

### Are there any Pull Requests open in other repos which need to be merged with this?


#### Addresses Issue(s):

JW8-5672