### PR TITLE
Update the player state to "paused" after seeking...

### DIFF
--- a/src/js/program/program-listeners.js
+++ b/src/js/program/program-listeners.js
@@ -85,6 +85,14 @@ export function ProviderListener(mediaController) {
                 }
                 break;
             }
+            case MEDIA_SEEKED: {
+                // After seeking, if the video tag is in a paused state, update the player state to "paused"
+                const { mediaElement } = mediaController;
+                if (mediaElement && mediaElement.paused) {
+                    mediaModel.set('mediaState', 'paused');
+                }
+                break;
+            }
             case MEDIA_LEVELS:
                 mediaModel.set(MEDIA_LEVELS, data.levels);
                 /* falls through to update current level */


### PR DESCRIPTION
### This PR will...
Update the player state to "paused" after seeking when the video tag is in a paused state

### Why is this Pull Request needed?
If the provider changes the media state to "loading" and thus the player state to "buffering" while seeking, nothing is changing it back to paused when seeking is done.

### Are there any points in the code the reviewer needs to double check?
Ideally this would be done in each provider as providers are responsible for updating media state in most cases (re additional tech-debt in program and media controllers). For now this is safest and smaller in scope than addressing how each provider calls `setState` to `LOADING` and `PAUSED` when seeking or scrubbing.

#### Addresses Issue(s):
JW8-5704

