### PR TITLE
[JW8-5640] Fix behavior where browser overwrites CC custom style

### DIFF
--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -57,7 +57,6 @@ function createCastButton(castToggle, localization) {
 
 
     const castButton = document.createElement('google-cast-launcher');
-    setAttribute(castButton, 'type', 'button');
     setAttribute(castButton, 'tabindex', '-1');
     castButton.className += ' jw-reset';
 


### PR DESCRIPTION
### This PR will...
Allow custom background styles on chromecast button to work properly.

### Why is this Pull Request needed?
User agent styles are defaulting it to gray. Chrome now does this under the hood so styling --webkit-appearance isn't enough to hide the background, type has to be changed from "button"

### Are there any points in the code the reviewer needs to double check?
Are there any type="button" specific interactions for this button I may have missed?

### Are there any Pull Requests open in other repos which need to be merged with this?
None

#### Addresses Issue(s):

JW8-5640

