### PR TITLE
Continue floating on complete

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -726,7 +726,6 @@ function View(_api, _model) {
             case STATE_IDLE:
             case STATE_ERROR:
             case STATE_COMPLETE:
-                _this.stopFloating();
                 if (_captionsRenderer) {
                     _captionsRenderer.hide();
                 }

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -722,12 +722,10 @@ function View(_api, _model) {
         }
         replaceClass(_playerElement, /jw-state-\S+/, 'jw-state-' + state);
 
-        if (state === STATE_ERROR) {
-            _this.stopFloating();
-        }
-
         switch (state) {
             case STATE_ERROR:
+                _this.stopFloating();
+                 /* falls through to update captions renderer */
             case STATE_IDLE:
             case STATE_COMPLETE:
                 if (_captionsRenderer) {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -722,13 +722,12 @@ function View(_api, _model) {
         }
         replaceClass(_playerElement, /jw-state-\S+/, 'jw-state-' + state);
 
+        if (state === STATE_ERROR) {
+            _this.stopFloating();
+        }
+
         switch (state) {
             case STATE_ERROR:
-                _this.stopFloating();
-                if (_captionsRenderer) {
-                    _captionsRenderer.hide();
-                }
-                break;
             case STATE_IDLE:
             case STATE_COMPLETE:
                 if (_captionsRenderer) {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -723,8 +723,13 @@ function View(_api, _model) {
         replaceClass(_playerElement, /jw-state-\S+/, 'jw-state-' + state);
 
         switch (state) {
-            case STATE_IDLE:
             case STATE_ERROR:
+                _this.stopFloating();
+                if (_captionsRenderer) {
+                    _captionsRenderer.hide();
+                }
+                break;
+            case STATE_IDLE:
             case STATE_COMPLETE:
                 if (_captionsRenderer) {
                     _captionsRenderer.hide();


### PR DESCRIPTION
### This PR will...
Update the player so it no longer stops floating when entering the complete state.

### Why is this Pull Request needed?
Players should remain in the floating position on complete unless scrolling away from an originally positioned player and in final complete state (no playlist). In that case the player should not float.

### Are there any points in the code the reviewer needs to double check?
Nope

### Are there any Pull Requests open in other repos which need to be merged with this?
None

#### Addresses Issue(s):

JW8-5717

