### PR TITLE
[JW8-5715] Fix rightclick styles

### DIFF
--- a/src/css/controls/imports/shortcuts-tooltip.less
+++ b/src/css/controls/imports/shortcuts-tooltip.less
@@ -1,14 +1,14 @@
 //  Import added so this file can be used in unit testing.
 @import "../../shared-imports/mixins.less";
 
-@rightclick-primary-text: #fefefe;
-@rightclick-secondary-text: #333;
-@rightclick-bg: #333;
-@rightclick-secondary-bg: #fefefe;
-@ui-padding: 0.5em;
-@ui-margin: 20px;
-
 .jwplayer .jw-shortcuts-tooltip {
+    @rightclick-primary-text: #fefefe;
+    @rightclick-secondary-text: #333;
+    @rightclick-bg: #333;
+    @rightclick-secondary-bg: #fefefe;
+    @ui-padding: 0.5em;
+    @ui-margin: 20px;
+
     .topleft(50%, 50%);
     background: @menu-background-color;
     transform: translate(-50%, -50%);

--- a/src/js/view/controls/templates/rightclick.js
+++ b/src/js/view/controls/templates/rightclick.js
@@ -3,7 +3,7 @@ export default (menu, localization) => {
     const menuItems = items.map(item => rightClickItem(item, localization));
 
     return (
-        `<div class="jw-rightclick jw-modal jw-reset">` +
+        `<div class="jw-rightclick jw-reset">` +
             `<ul class="jw-rightclick-list jw-reset">${menuItems.join('')}</ul>` +
         `</div>`
     );


### PR DESCRIPTION
### This PR will...
Revert any intentional/unintentional style changes made to the rightclick menu during the shortcuts tooltip implementation.

### Why is this Pull Request needed?
The rightclick menu is not a "modal", and shouldn't be styled as one.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-5715

