### PR TITLE
[JW8-5795] Increase z-index of floating player to max value

### DIFF
--- a/src/css/jwplayer/flags/floatingplayer.less
+++ b/src/css/jwplayer/flags/floatingplayer.less
@@ -6,7 +6,8 @@
 
     .jw-wrapper {
         position: fixed;
-        z-index: 1;
+        //  Maximum allowable z-index to ensure always on top.
+        z-index: 2147483647;
         animation: jw-float-to-bottom 150ms cubic-bezier(0, 0.25, 0.25, 1) forwards 1;
         top: auto;
         bottom: 1rem;


### PR DESCRIPTION
### This PR will...
Increase the z-index of floating player to highest allowed value, ensuring it's always the top element.

### Why is this Pull Request needed?
While we use a limited number of z-indexes (best practice), oftentimes customers/developers will have elements in their sites with arbitrarily high z-index values. This will mean there are times the player is covered by content, ads etc.

### Are there any points in the code the reviewer needs to double check?
Is there a way to do this without z-index? It's already position:fixed, so I doubt it, but you never know.

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):
https://jwplayer.atlassian.net/projects/JW8/issues/JW8-5795

JW8-5795

