### PR TITLE
Add config option for disabling the next up overlay for an A/B test

### DIFF
--- a/src/js/controller/model.js
+++ b/src/js/controller/model.js
@@ -219,6 +219,10 @@ class Model extends SimpleModel {
         if (floating && !!floating.disabled) {
             delete cfg.floating;
         }
+
+        if (typeof cfg.abHideNextUpDisplay !== 'undefined') {
+            cfg.nextUpDisplay = !cfg.abHideNextUpDisplay;
+        }
     }
 }
 

--- a/test/unit/model/model-test.js
+++ b/test/unit/model/model-test.js
@@ -35,30 +35,57 @@ describe('Model', function() {
     });
 
     describe('#_normalizeConfig', () => {
-        it('should leave the floating block untouched when disabled is not true', () => {
-            let startingCfg = {
-                floating: { disabled: false }
-            };
-            model._normalizeConfig(startingCfg);
-            expect(startingCfg.floating).to.deep.eq({ disabled: false });
+        describe('floating block', () => {
+            it('should leave the floating block untouched when disabled is not true', () => {
+                let startingCfg = {
+                    floating: { disabled: false }
+                };
+                model._normalizeConfig(startingCfg);
+                expect(startingCfg.floating).to.deep.eq({ disabled: false });
 
-            startingCfg = {
-                floating: {}
-            };
-            model._normalizeConfig(startingCfg);
-            expect(startingCfg.floating).to.deep.eq({});
+                startingCfg = {
+                    floating: {}
+                };
+                model._normalizeConfig(startingCfg);
+                expect(startingCfg.floating).to.deep.eq({});
+            });
+            it('should delete the floating block when disabled is true', () => {
+                let startingCfg = {
+                    floating: {disabled: true}
+                };
+                model._normalizeConfig(startingCfg);
+                expect(startingCfg).to.not.have.property('floating');
+            });
+            it('should not touch the floating block when it is not otherwise present', () => {
+                let startingCfg = {};
+                model._normalizeConfig(startingCfg);
+                expect(startingCfg).to.not.have.property('floating');
+            });
         });
-        it('should delete the floating block when disabled is true', () => {
-            let startingCfg = {
-                floating: {disabled: true}
-            };
-            model._normalizeConfig(startingCfg);
-            expect(startingCfg).to.not.have.property('floating');
-        });
-        it('should not touch the floating block when it is not otherwise present', () => {
-            let startingCfg = {};
-            model._normalizeConfig(startingCfg);
-            expect(startingCfg).to.not.have.property('floating');
+        describe('next up overlay a/b test', () => {
+            it('should set nextUpDisplay to false when ab hide config is true', () => {
+                let startingCfg = {
+                    abHideNextUpDisplay: true,
+                    nextUpDisplay: 'blah'
+                };
+                model._normalizeConfig(startingCfg);
+                expect(startingCfg.nextUpDisplay).to.eq(false);
+            });
+            it('should set nextUpDisplay to true when ab hide config is false', () => {
+                let startingCfg = {
+                    abHideNextUpDisplay: false,
+                    nextUpDisplay: 'blah'
+                };
+                model._normalizeConfig(startingCfg);
+                expect(startingCfg.nextUpDisplay).to.eq(true);
+            });
+            it('should not touch the nextUpDisplay value when the a/b config is not present', () => {
+                let startingCfg = {
+                    nextUpDisplay: 'blah'
+                };
+                model._normalizeConfig(startingCfg);
+                expect(startingCfg.nextUpDisplay).to.eq('blah');
+            });
         });
     });
 });


### PR DESCRIPTION
### This PR will...
Adds normalization functionality to disabled the next up overlay upon model instantiation

### Why is this Pull Request needed?
we need the ability to disable this feature through an a/b test config option

### Are there any points in the code the reviewer needs to double check?
None that I can think of

### Are there any Pull Requests open in other repos which need to be merged with this?
Nope

#### Addresses Issue(s):

JW8-5657 

