### PR TITLE
[JW8-6077] [JW8-5715] Attach right click menu to wrapper instead of player

### DIFF
--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -124,18 +124,18 @@ export default class Controls extends Events {
         });
         //  Add keyboard shortcuts if not on mobi;e
         if (!OS.mobile) {
-            this.shortcutsTooltip = new ShortcutsTooltip(this.playerContainer, api, model);
+            this.shortcutsTooltip = new ShortcutsTooltip(this.wrapperElement, api, model);
         }
         this.rightClickMenu = new RightClick(this.infoOverlay, this.shortcutsTooltip);
         if (touchMode) {
             addClass(this.playerContainer, 'jw-flag-touch');
-            this.rightClickMenu.setup(model, this.playerContainer, this.playerContainer);
+            this.rightClickMenu.setup(model, this.wrapperElement, this.wrapperElement);
         } else {
             model.change('flashBlocked', (modelChanged, isBlocked) => {
                 if (isBlocked) {
                     this.rightClickMenu.destroy();
                 } else {
-                    this.rightClickMenu.setup(modelChanged, this.playerContainer, this.playerContainer);
+                    this.rightClickMenu.setup(modelChanged, this.wrapperElement, this.wrapperElement);
                 }
             }, this);
         }

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -129,13 +129,13 @@ export default class Controls extends Events {
         this.rightClickMenu = new RightClick(this.infoOverlay, this.shortcutsTooltip);
         if (touchMode) {
             addClass(this.playerContainer, 'jw-flag-touch');
-            this.rightClickMenu.setup(model, this.wrapperElement, this.wrapperElement);
+            this.rightClickMenu.setup(model, this.playerContainer, this.wrapperElement);
         } else {
             model.change('flashBlocked', (modelChanged, isBlocked) => {
                 if (isBlocked) {
                     this.rightClickMenu.destroy();
                 } else {
-                    this.rightClickMenu.setup(modelChanged, this.wrapperElement, this.wrapperElement);
+                    this.rightClickMenu.setup(modelChanged, this.playerContainer, this.wrapperElement);
                 }
             }, this);
         }

--- a/src/js/view/controls/rightclick.js
+++ b/src/js/view/controls/rightclick.js
@@ -75,7 +75,7 @@ export default class RightClick {
     }
 
     getOffset(evt) {
-        const playerBounds = bounds(this.playerElement);
+        const playerBounds = bounds(this.containerElement);
         let x = evt.pageX - playerBounds.left;
         let y = evt.pageY - playerBounds.top;
 
@@ -96,7 +96,7 @@ export default class RightClick {
         this.el.style.top = off.y + 'px';
         this.outCount = 0;
 
-        addClass(this.playerElement, 'jw-flag-rightclick-open');
+        addClass(this.containerElement.parentElement, 'jw-flag-rightclick-open');
         addClass(this.el, 'jw-open');
         clearTimeout(this._menuTimeout);
         this._menuTimeout = setTimeout(() => this.hideMenu(), 3000);
@@ -109,7 +109,7 @@ export default class RightClick {
             return;
         }
 
-        removeClass(this.playerElement, 'jw-flag-rightclick-open');
+        removeClass(this.containerElement.parentElement, 'jw-flag-rightclick-open');
         removeClass(this.el, 'jw-open');
     }
 
@@ -155,22 +155,22 @@ export default class RightClick {
         };
     }
 
-    setup(_model, _playerElement, layer) {
-        this.playerElement = _playerElement;
+    setup(_model, _containerElement, layer) {
+        this.containerElement = _containerElement;
         this.model = _model;
         this.mouseOverContext = false;
         this.layer = layer;
-        this.ui = new UI(_playerElement).on('longPress', this.rightClick, this);
+        this.ui = new UI(_containerElement).on('longPress', this.rightClick, this);
     }
 
     addHideMenuHandlers() {
         this.removeHideMenuHandlers();
 
-        this.playerElement.addEventListener('touchstart', this.hideMenuHandler);
+        this.containerElement.addEventListener('touchstart', this.hideMenuHandler);
         document.addEventListener('touchstart', this.hideMenuHandler);
 
         if (!OS.mobile) {
-            this.playerElement.addEventListener('click', this.hideMenuHandler);
+            this.containerElement.addEventListener('click', this.hideMenuHandler);
             document.addEventListener('click', this.hideMenuHandler);
             // Track if the mouse is above the menu or not
             this.el.addEventListener('mouseover', this.overHandler);
@@ -184,8 +184,8 @@ export default class RightClick {
     }
 
     removeHideMenuHandlers() {
-        if (this.playerElement) {
-            this.playerElement.removeEventListener('click', this.hideMenuHandler);
+        if (this.containerElement) {
+            this.containerElement.removeEventListener('click', this.hideMenuHandler);
         }
         if (this.el) {
             this.el.querySelector('.jw-info-overlay-item').removeEventListener('click', this.infoOverlayHandler);
@@ -209,9 +209,9 @@ export default class RightClick {
             this.el = null;
         }
 
-        if (this.playerElement) {
-            this.playerElement.oncontextmenu = null;
-            this.playerElement = null;
+        if (this.containerElement) {
+            this.containerElement.oncontextmenu = null;
+            this.containerElement = null;
         }
 
         if (this.model) {

--- a/src/js/view/controls/rightclick.js
+++ b/src/js/view/controls/rightclick.js
@@ -75,7 +75,7 @@ export default class RightClick {
     }
 
     getOffset(evt) {
-        const playerBounds = bounds(this.containerElement);
+        const playerBounds = bounds(this.wrapperElement);
         let x = evt.pageX - playerBounds.left;
         let y = evt.pageY - playerBounds.top;
 
@@ -96,7 +96,7 @@ export default class RightClick {
         this.el.style.top = off.y + 'px';
         this.outCount = 0;
 
-        addClass(this.player, 'jw-flag-rightclick-open');
+        addClass(this.playerContainer, 'jw-flag-rightclick-open');
         addClass(this.el, 'jw-open');
         clearTimeout(this._menuTimeout);
         this._menuTimeout = setTimeout(() => this.hideMenu(), 3000);
@@ -109,7 +109,7 @@ export default class RightClick {
             return;
         }
 
-        removeClass(this.player, 'jw-flag-rightclick-open');
+        removeClass(this.playerContainer, 'jw-flag-rightclick-open');
         removeClass(this.el, 'jw-open');
     }
 
@@ -129,7 +129,7 @@ export default class RightClick {
 
         this.html = html;
         this.el = createDomElement(this.html);
-        this.containerElement.appendChild(this.el);
+        this.wrapperElement.appendChild(this.el);
 
         this.hideMenuHandler = e => this.hideMenu(e);
         this.overHandler = () => {
@@ -155,22 +155,22 @@ export default class RightClick {
         };
     }
 
-    setup(_model, _player, _containerElement) {
-        this.containerElement = _containerElement;
+    setup(_model, _playerContainer, _wrapperElement) {
+        this.wrapperElement = _wrapperElement;
         this.model = _model;
         this.mouseOverContext = false;
-        this.player = _player;
-        this.ui = new UI(_containerElement).on('longPress', this.rightClick, this);
+        this.playerContainer = _playerContainer;
+        this.ui = new UI(_wrapperElement).on('longPress', this.rightClick, this);
     }
 
     addHideMenuHandlers() {
         this.removeHideMenuHandlers();
 
-        this.containerElement.addEventListener('touchstart', this.hideMenuHandler);
+        this.wrapperElement.addEventListener('touchstart', this.hideMenuHandler);
         document.addEventListener('touchstart', this.hideMenuHandler);
 
         if (!OS.mobile) {
-            this.containerElement.addEventListener('click', this.hideMenuHandler);
+            this.wrapperElement.addEventListener('click', this.hideMenuHandler);
             document.addEventListener('click', this.hideMenuHandler);
             // Track if the mouse is above the menu or not
             this.el.addEventListener('mouseover', this.overHandler);
@@ -184,8 +184,8 @@ export default class RightClick {
     }
 
     removeHideMenuHandlers() {
-        if (this.containerElement) {
-            this.containerElement.removeEventListener('click', this.hideMenuHandler);
+        if (this.wrapperElement) {
+            this.wrapperElement.removeEventListener('click', this.hideMenuHandler);
         }
         if (this.el) {
             this.el.querySelector('.jw-info-overlay-item').removeEventListener('click', this.infoOverlayHandler);
@@ -209,9 +209,9 @@ export default class RightClick {
             this.el = null;
         }
 
-        if (this.containerElement) {
-            this.containerElement.oncontextmenu = null;
-            this.containerElement = null;
+        if (this.wrapperElement) {
+            this.wrapperElement.oncontextmenu = null;
+            this.wrapperElement = null;
         }
 
         if (this.model) {

--- a/src/js/view/controls/rightclick.js
+++ b/src/js/view/controls/rightclick.js
@@ -96,7 +96,7 @@ export default class RightClick {
         this.el.style.top = off.y + 'px';
         this.outCount = 0;
 
-        addClass(this.containerElement.parentElement, 'jw-flag-rightclick-open');
+        addClass(this.player, 'jw-flag-rightclick-open');
         addClass(this.el, 'jw-open');
         clearTimeout(this._menuTimeout);
         this._menuTimeout = setTimeout(() => this.hideMenu(), 3000);
@@ -109,7 +109,7 @@ export default class RightClick {
             return;
         }
 
-        removeClass(this.containerElement.parentElement, 'jw-flag-rightclick-open');
+        removeClass(this.player, 'jw-flag-rightclick-open');
         removeClass(this.el, 'jw-open');
     }
 
@@ -129,7 +129,7 @@ export default class RightClick {
 
         this.html = html;
         this.el = createDomElement(this.html);
-        this.layer.appendChild(this.el);
+        this.containerElement.appendChild(this.el);
 
         this.hideMenuHandler = e => this.hideMenu(e);
         this.overHandler = () => {
@@ -155,11 +155,11 @@ export default class RightClick {
         };
     }
 
-    setup(_model, _containerElement, layer) {
+    setup(_model, _player, _containerElement) {
         this.containerElement = _containerElement;
         this.model = _model;
         this.mouseOverContext = false;
-        this.layer = layer;
+        this.player = _player;
         this.ui = new UI(_containerElement).on('longPress', this.rightClick, this);
     }
 


### PR DESCRIPTION
### This PR will...
Move the right click menu into jw-wrapper.

### Why is this Pull Request needed?
A recent change necessitated a higher z-index on the floating player (the topmost element of the floating player UI is jw-wrapper). As a result, the right click menu was being covered by the player when floating.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-6077 JW8-5715

