### PR TITLE
[JW8-5659] Nextup Overlay For Small Player Breakpoints

### DIFF
--- a/src/css/controls/imports/nextup.less
+++ b/src/css/controls/imports/nextup.less
@@ -19,7 +19,7 @@
     }
 
     .jw-flag-small-player & {
-        padding: 0;
+        padding: 0 12px 0 0;
 
         .jw-nextup-title,
         .jw-nextup-duration,
@@ -46,10 +46,10 @@
         }
 
         .jw-nextup {
-            max-width: 55px;
+            max-width: 65px;
 
             &.jw-nextup-thumbnail-visible {
-                max-width: 110px;
+                max-width: 120px;
             }
         }
     }

--- a/src/css/controls/imports/nextup.less
+++ b/src/css/controls/imports/nextup.less
@@ -19,6 +19,8 @@
     }
 
     .jw-flag-small-player & {
+        padding: 0;
+        
         .jw-nextup-title,
         .jw-nextup-duration,
         .jw-nextup-close {

--- a/src/css/controls/imports/nextup.less
+++ b/src/css/controls/imports/nextup.less
@@ -19,7 +19,8 @@
     }
 
     .jw-flag-small-player & {
-        padding: 0;        
+        padding: 0;
+
         .jw-nextup-title,
         .jw-nextup-duration,
         .jw-nextup-close {

--- a/src/css/controls/imports/nextup.less
+++ b/src/css/controls/imports/nextup.less
@@ -19,8 +19,6 @@
     }
 
     .jw-flag-small-player & {
-        padding: 2px;
-
         .jw-nextup-title,
         .jw-nextup-duration,
         .jw-nextup-close {

--- a/src/css/controls/imports/nextup.less
+++ b/src/css/controls/imports/nextup.less
@@ -19,8 +19,7 @@
     }
 
     .jw-flag-small-player & {
-        padding: 0;
-        
+        padding: 0;        
         .jw-nextup-title,
         .jw-nextup-duration,
         .jw-nextup-close {

--- a/src/css/controls/imports/nextup.less
+++ b/src/css/controls/imports/nextup.less
@@ -13,10 +13,45 @@
     visibility: hidden;
     width: 100%;
 
-    .jw-flag-small-player &,
     .jw-settings-open &,
     .jw-info-open & {
         display: none;
+    }
+
+    .jw-flag-small-player & {
+        padding: 2px;
+
+        .jw-nextup-title,
+        .jw-nextup-duration,
+        .jw-nextup-close {
+            display: none;
+        }
+
+        .jw-nextup-tooltip {
+            height: 30px;
+        }
+
+        .jw-nextup-header {
+            font-size: 12px;
+        }
+
+        .jw-nextup-body {
+            justify-content: center;
+            align-items: center;
+            padding: 0.75em 0.3em;
+        }
+
+        .jw-nextup-thumbnail {
+            width: 50%;
+        }
+
+        .jw-nextup {
+            max-width: 55px;
+
+            &.jw-nextup-thumbnail-visible {
+                max-width: 110px;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
### This PR will...
1. Show the nextup overlay on the small player breakpoints (Breakpoint 0 and 1).
2. Skin the overlay to match the design spec at those breakpoints

### Why is this Pull Request needed?
As a mobile user, I can't currently view the next up overlay. If it were enabled for those breakpoints without these changes, the overlay would take up an undesirably large amount of space.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-5659

