### PR TITLE
[JW8-6111] Revise keyboard shortcuts template

### DIFF
--- a/src/css/controls/imports/shortcuts-tooltip.less
+++ b/src/css/controls/imports/shortcuts-tooltip.less
@@ -48,10 +48,6 @@
         font-weight: bold;
     }
 
-    .jw-shortcuts-description {
-        margin-bottom: 30px;
-    }
-
     .jw-shortcuts-tooltip-list {
         display: flex;
         max-width: 340px;
@@ -77,8 +73,11 @@
             }
         }
 
-        li {
-            line-height: 34px;
+        .jw-shortcuts-tooltip-keys,
+        .jw-shortcuts-tooltip-descriptions {
+            div {
+                line-height: 34px;
+            }
         }
     }
 }

--- a/src/js/view/controls/templates/shortcuts-tooltip.js
+++ b/src/js/view/controls/templates/shortcuts-tooltip.js
@@ -4,8 +4,8 @@ export default (shortcuts = {}) => {
     const descriptionList = [];
     
     shortcuts.forEach(shortcut => {
-        keyList.push(`<li><span class="jw-hotkey">${shortcut.key}</span></li>`);
-        descriptionList.push(`<li><span class="jw-hotkey-description">${shortcut.description}</span></li>`);
+        keyList.push(`<div><span class="jw-hotkey">${shortcut.key}</span></div>`);
+        descriptionList.push(`<div><span class="jw-hotkey-description">${shortcut.description}</span></div>`);
     });
 
     return (
@@ -16,12 +16,12 @@ export default (shortcuts = {}) => {
             `<div class="jw-reset jw-shortcuts-container">` +
                 `<div class="jw-reset jw-shortcuts-title">Keyboard Shortcuts</div>` +
                 `<div class="jw-reset jw-shortcuts-tooltip-list">` +
-                    `<ul class="jw-shortcuts-tooltip-descriptions jw-reset jw-shortcuts-description">` +
+                    `<div class="jw-shortcuts-tooltip-descriptions jw-reset">` +
                         `${descriptionList.join('')}` +
-                    `</ul>` +
-                    `<ul class="jw-shortcuts-tooltip-keys jw-reset jw-shortcuts-description">` +
+                    `</div>` +
+                    `<div class="jw-shortcuts-tooltip-keys jw-reset">` +
                         `${keyList.join('')}` +
-                    `</ul>` +
+                    `</div>` +
                 `</div>` +
             `</div>` +
         `</div>`


### PR DESCRIPTION
### This PR will...
Revise the keyboard shortcuts template in a way where semi-generic global ul/li selector styles don't overwrite our own. Switching to divs.

### Why is this Pull Request needed?
As a customer, I like to style every ul/li because it's easier than adding classes, but I also am not trying to customize the keyboard shortcuts modal, which uses ul/li elements. This PR allows for that.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-6111

