### PR TITLE
Consider all falsy status codes a CORS error

### DIFF
--- a/src/js/providers/utils/network-error-parser.js
+++ b/src/js/providers/utils/network-error-parser.js
@@ -12,7 +12,8 @@ export default function parseNetworkError(baseCode, statusCode, url) {
         code += clampStatus(statusCode);
     } else if (('' + url).substring(0, 5) === 'http:' && document.location.protocol === 'https:') {
         code += 12;
-    } else if (statusCode === 0) {
+    } else if (!statusCode) {
+        // XHR returns a code of 0 for CORS errors; fetch returns a code of undefined
         code += 11;
     }
 

--- a/test/unit/network-error-parser-test.js
+++ b/test/unit/network-error-parser-test.js
@@ -20,6 +20,12 @@ describe('network error parser', function () {
         expect(key).to.equal('cantPlayVideo');
     });
 
+    it('appends a code of 11 if the status code is falsy with default message key', function () {
+        const { code, key } = parseNetworkError(900000, undefined);
+        expect(code).to.equal(901011);
+        expect(key).to.equal('cantPlayVideo');
+    });
+
     it('checks for access control errors insecure content with default message key', function () {
         const { code, key } = parseNetworkError(900000, 0, 'https:');
         // location.protocol cannot be stubbed so for now only only assert +12 when tests are run over https


### PR DESCRIPTION
### Why is this Pull Request needed?
Fetch returns with an undefined status code if encountering a CORS error, whereas XHR returns with 0.

### Are there any points in the code the reviewer needs to double check?
Should I put this code in the Hls.js provider (`code = code || 0`), or handle it here? I figure it'll be helpful for other providers too.

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):
Exposed by JW8-2565

