### PR TITLE
Unit tests - Ensure translations are always complete

### DIFF
--- a/test/unit/language-test.js
+++ b/test/unit/language-test.js
@@ -257,25 +257,28 @@ describe('languageUtils', function() {
             expect(languageCodes).to.deep.equal(translatedLanguageCodes);
         });
 
-        it('should have same structure as localization default', function() {
-           function compareNestedKeys(originalObj, customObj) {
-               expect(customObj).to.have.all.keys(originalObj);
-               Object.keys(originalObj).forEach(key => {
-                   const customProperty = customObj[key];
-                   const originalProperty = originalObj[key];
-                   const originalPropertyType = typeof originalProperty;
 
-                   expect(customProperty).to.be.a(originalPropertyType);
-                   if (originalPropertyType === 'object') {
-                       compareNestedKeys(originalProperty, customProperty);
-                   }
-               });
-           }
+        function compareNestedKeys(originalObj, customObj) {
+            expect(customObj).to.have.all.keys(originalObj);
+            Object.keys(originalObj).forEach(key => {
+                const customProperty = customObj[key];
+                const originalProperty = originalObj[key];
+                const originalPropertyType = typeof originalProperty;
 
-           languageCodes.forEach(languageCode => {
-               const translation = require('../../src/assets/translations/' + languageCode + '.json');
-               compareNestedKeys(en, translation);
-           });
+                expect(customProperty).to.be.a(originalPropertyType);
+                if (originalPropertyType === 'object') {
+                    compareNestedKeys(originalProperty, customProperty);
+                }
+            });
+        }
+
+        languageCodes.forEach(languageCode => {
+            describe(languageCode + '.json', function () {
+                it('should have same structure as localization default', function() {
+                    const translation = require('../../src/assets/translations/' + languageCode + '.json');
+                    compareNestedKeys(en, translation);
+                });
+            });
         });
     });
 

--- a/test/unit/language-test.js
+++ b/test/unit/language-test.js
@@ -258,8 +258,24 @@ describe('languageUtils', function() {
         });
 
         it('should have same structure as localization default', function() {
-            // TODO: add test that compares the structure of all the translation jsons to that of the default localization block to ensure consistency.
-            // Limitation: require('../../src/assets/translations/fr.json') returns '264cfd10c44360a54a0772a576aa3dfd.json'
+           function compareNestedKeys(originalObj, customObj) {
+               expect(customObj).to.have.all.keys(originalObj);
+               Object.keys(originalObj).forEach(key => {
+                   const customProperty = customObj[key];
+                   const originalProperty = originalObj[key];
+                   const originalPropertyType = typeof originalProperty;
+
+                   expect(customProperty).to.be.a(originalPropertyType);
+                   if (originalPropertyType === 'object') {
+                       compareNestedKeys(originalProperty, customProperty);
+                   }
+               });
+           }
+
+           languageCodes.forEach(languageCode => {
+               const translation = require('../../src/assets/translations/' + languageCode + '.json');
+               compareNestedKeys(en, translation);
+           });
         });
     });
 


### PR DESCRIPTION
### This PR will...
add a unit test to check that all JSON translations have the same keys as the english defaults. The comparison checks that each property is of the same type, and uses recursion when a property is an object.
### Why is this Pull Request needed?
This unit test will ensure that fields are added to the default localization, without forgetting the translation. It will also prevent contributors from submitting incomplete translations.   
### Are there any points in the code the reviewer needs to double check?
n/a
### Are there any Pull Requests open in other repos which need to be merged with this?
n/a
#### Addresses Issue(s):

n/a

