### PR TITLE
[JW8-5688] Use querySelector to check for XML parsererrors.

### DIFF
--- a/src/js/utils/parser.js
+++ b/src/js/utils/parser.js
@@ -1,5 +1,5 @@
 import { exists } from 'utils/validator';
-import { any, isNaN } from 'utils/underscore';
+import { isNaN } from 'utils/underscore';
 
 // Returns the absolute file path based on a relative filepath, and optional base path
 export function getAbsolutePath(path, base) {
@@ -43,20 +43,13 @@ export function isAbsolutePath(path) {
     return /^(?:(?:https?|file):)?\/\//.test(path);
 }
 
-function containsParserErrors(childNodes) {
-    return any(childNodes, function(node) {
-        return node.nodeName === 'parsererror';
-    });
-}
-
 // Returns an XML object for the given XML string, or null if the input cannot be parsed.
 export function parseXML(input) {
     let parsedXML = null;
     try {
         parsedXML = (new window.DOMParser()).parseFromString(input, 'text/xml');
         // In Firefox the XML doc may contain the parsererror, other browsers it's further down
-        if (containsParserErrors(parsedXML.childNodes) ||
-            (parsedXML.childNodes && containsParserErrors(parsedXML.childNodes[0].childNodes))) {
+        if (parsedXML.querySelector('parsererror')) {
             parsedXML = null;
         }
     } catch (e) {/* Expected when content is not XML */}


### PR DESCRIPTION
### This PR will...
Update `parseXML` to look for a `parsererror` anywhere in the DOM, rather then two-levels deep.

### Why is this Pull Request needed?
Different browsers return the `parsererror` in a different structure. Rather than relying on looping to a certain level, why not use `querySelector` instead.

### Are there any points in the code the reviewer needs to double check?
N/A

### Are there any Pull Requests open in other repos which need to be merged with this?
jwplayer/jwplayer-ads-header-bidding#108
jwplayer/jwplayer-ads-googima#479
jwplayer/jwplayer-ads-vast#505

#### Addresses Issue(s):
JW8-5688