### PR TITLE
Remove visibility hidden to allow volume slider to be focused

### DIFF
--- a/src/css/controls/imports/tooltip.less
+++ b/src/css/controls/imports/tooltip.less
@@ -3,7 +3,6 @@
 .jw-icon-tooltip.jw-open .jw-overlay {
     opacity: 1;
     transition-delay: 0s;
-    visibility: visible;
 
     &:focus {
         outline: none;
@@ -69,7 +68,6 @@
         transition-property: opacity, visibility;
         transition-delay: 0s, 150ms;
         transform: translate(-50%, 0);
-        visibility: hidden;
         width: 100%;
         z-index: 1;
 


### PR DESCRIPTION
### This PR will...
Allow the volume slider to be focused when using `shift+tab` to focus backwards through the control bar

### Why is this Pull Request needed?
Accessibility requirements

### Are there any points in the code the reviewer needs to double check?
Don't think so

### Are there any Pull Requests open in other repos which need to be merged with this?
Nope

#### Addresses Issue(s):

JW8-5705

