### PR TITLE
Increase sensitivity of intersection observer

### DIFF
--- a/src/js/view/utils/views-manager.js
+++ b/src/js/view/utils/views-manager.js
@@ -23,7 +23,7 @@ function lazyInitIntersectionObserver() {
                     matchIntersection(entry, widgets);
                 }
             }
-        }, { threshold: [0, 0.25, 0.5, 0.75, 1] });
+        }, { threshold: [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1] });
     }
 }
 


### PR DESCRIPTION
### This PR will...
Increase sensitivity on our intersection observer to 10ths instead of 4ths.

### Why is this Pull Request needed?
Because of the large gaps in the percentage, customers were seeing the player fail to float until much after the 50% mark. This makes it so that the player is more responsive to intersection changes by tweaking the sensitivity thresholds

**Notes**
I ran some light profiling before and after the change. Our `matchIntersection` handler which is called by the `IntersectionObserver` component is _wildly_ performant (often completing a full cycle of changing floating state in under 1ms). There was no noticed degradation in the performance of this handler and the only noticeable impact was the handler being fired more often.

### Are there any points in the code the reviewer needs to double check?
Are there other performance aspects I should measure before merging this?

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-5712

