### PR TITLE
[JW8-8782] autoPause/autostart refinements

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -345,19 +345,10 @@ Object.assign(Controller.prototype, {
             }
         }
 
-        function _checkPlayOnViewable(model, viewable) {
-            if (model.get('playOnViewable')) {
-                if (viewable) {
-                    const reason = 'viewable';
-                    if (model.get('state') === STATE_IDLE) {
-                        _autoStart(reason);
-                    } else {
-                        _play({ reason });
-                    }
-                } else if (OS.mobile && !_getAdState()) {
-                    _this.pause({ reason: 'autostart' });
-                    _model.set('playOnViewable', true);
-                }
+        function _pauseAfterAd(viewable) {
+            _this._instreamAdapter.noResume = !viewable;
+            if (!viewable) {
+                _updatePauseReason({ reason: 'viewable' });
             }
         }
 
@@ -368,16 +359,36 @@ Object.assign(Controller.prototype, {
             }
         }
 
+        function _checkPlayOnViewable(model, viewable) {
+            const adState = _getAdState();
+            if (model.get('playOnViewable')) {
+                if (viewable) {
+                    const reason = 'viewable';
+                    if (model.get('state') === STATE_IDLE) {
+                        _autoStart(reason);
+                    } else {
+                        _play({ reason });
+                    }
+                } else if (OS.mobile && !adState) {
+                    _this.pause({ reason: 'autostart' });
+                    _model.set('playOnViewable', true);
+                }
+
+                if (OS.mobile && adState) {
+                    // If during an ad on mobile, we should always be paused after the ad,
+                    // if not viewable, regardless of autoPause setting.
+                    _pauseAfterAd(viewable);
+                }
+            }
+        }
+
         function _checkPauseOnViewable(model, viewable) {
             const playerState = model.get('state');
             const adState = _getAdState();
             const playReason = model.get('playReason');
 
             if (adState) {
-                _this._instreamAdapter.noResume = !viewable;
-                if (!viewable) {
-                    _updatePauseReason({ reason: 'viewable' });
-                }
+                _pauseAfterAd(viewable);
             } else if (playerState === STATE_PLAYING || playerState === STATE_BUFFERING) {
                 _pauseWhenNotViewable(viewable);
             } else if (playerState === STATE_IDLE && playReason === 'playlist') {
@@ -503,7 +514,7 @@ Object.assign(Controller.prototype, {
                     mediaPool.prime();
                 }
 
-                if (playReason === 'playlist') {
+                if (playReason === 'playlist' && _model.get('autoPause').viewability) {
                     _checkPauseOnViewable(_model, _model.get('viewable'));
                 }
 
@@ -782,6 +793,10 @@ Object.assign(Controller.prototype, {
         function _detachMedia() {
             if (_beforePlay) {
                 _interruptPlay = true;
+            }
+
+            if (_model.get('autoPause').viewability) {
+                _checkPauseOnViewable(_model, _model.get('viewable'));
             }
 
             if (_backgroundLoading) {


### PR DESCRIPTION
### This PR will...

* Call `_checkPauseOnViewable()` inside of `attachMedia()`, if `autoPause.viewability` is enabled.
* Set `noResume = true` on the instream adapter on any autostart player on mobile, regardless of `autoPause` setting.

### Why is this Pull Request needed?

* If `autoPause` and `autostart` was enabled on desktop, if the player begins pre-roll playback out of view, the content will begin playing after the ad (it shouldn't - the player should be paused after the pre-roll).
* Regardless if `autoPause` is set, if `autostart` is enabled on mobile, the content would play after ad breaks if not visible.

### Are there any points in the code the reviewer needs to double check?

* There is a manual test page in the commercial repository.
* There is also a link in the JIRA ticket for a Google Sheet I created with various scenarios.

### Are there any Pull Requests open in other repos which need to be merged with this?

n/a

#### Addresses Issue(s):

JW8-8782

