### PR TITLE
Set controlbar background on backdrop instead of controls element

### DIFF
--- a/src/css/controls/imports/drop-shadow-variants.less
+++ b/src/css/controls/imports/drop-shadow-variants.less
@@ -34,11 +34,5 @@
                 background-position: 50% 0;
             }
         }
-
-        &.jw-state-idle {
-            .jw-controls {
-                background-color: transparent;
-            }
-        }
     }
 }

--- a/src/css/controls/states.less
+++ b/src/css/controls/states.less
@@ -11,7 +11,7 @@
         }
     }
 
-    .jw-controls {
+    .jw-controls-backdrop {
         background: @controlbar-background;
     }
 
@@ -137,9 +137,8 @@
         }
     }
 
-    .jw-controls {
+    .jw-controls-backdrop {
         background: @controlbar-background;
-        height: 100%;
     }
 }
 


### PR DESCRIPTION
### This PR will...
- set the `@controlbar-background` background color (black with 0.4 opacity) on the `jw-controls-backdrop` instead of `jw-controls`
- remove obsolete background transparency (jw-controls is always transparent now)  and unnecessary css (height is always 100%)  
### Why is this Pull Request needed?
This change is needed for the iOS SDK. Unlike mobile safari, the iOS SDK uses our skin on fullscreen. Due to the fact that iOS on the iPhone X series has interaction listeners on its corners and edges, we must shrink our controls to fit the safe region. The shrinking logic is handled in the iOS SDK, by reducing the width and height of the `jw-controls`. This resulted in a box appearing on the idle state, since the jw-controls had a background color. By moving the background color to the jw-controls-backdrop, we ensure that the shading covers the entire player.
These changes have benefits for the web player: we were applying both the gradient and a dark background on the idle, error, and complete states, resulting in an unnecessary darker bottom. Since the jw-controls was already set to a dark background, there was no need for a gradient. An additional benefit is that we assign all the background shading responsibilities to one element, and we reduce the size of `drop-shadow-variants.less`. 
### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-ios-sdk/pull/1043
#### Addresses Issue(s):
https://jwplayer.atlassian.net/browse/SDK-3622
SDK-3622

