### PR TITLE
Fix native fullscreen handler for ad program controller

### DIFF
--- a/src/js/program/ad-program-controller.js
+++ b/src/js/program/ad-program-controller.js
@@ -113,6 +113,7 @@ export default class AdProgramController extends ProgramController {
             event.oldstate = model.get(PLAYER_STATE);
             adMediaModelContext.set('mediaState', event.newstate);
         });
+        this.off();
         this.on('fullscreenchange', this._nativeFullscreenHandler, this);
         adMediaModelContext.on('change:mediaState', (changeAdModel, state) => {
             this._stateHandler(state);
@@ -143,6 +144,7 @@ export default class AdProgramController extends ProgramController {
     destroy() {
         const { model, mediaPool, playerModel } = this;
         model.off();
+        this.off();
 
         // We only use one media element from ads; getPrimedElement will return it
         const mediaElement = mediaPool.getPrimedElement();

--- a/src/js/program/ad-program-controller.js
+++ b/src/js/program/ad-program-controller.js
@@ -3,6 +3,7 @@ import ProgramController from 'program/program-controller';
 import Model from 'controller/model';
 import changeStateEvent from 'events/change-state-event';
 import SharedMediaPool from 'program/shared-media-pool';
+import { NATIVE_FULLSCREEN } from "../events/events";
 
 export default class AdProgramController extends ProgramController {
     constructor(model, mediaPool) {
@@ -113,8 +114,9 @@ export default class AdProgramController extends ProgramController {
             event.oldstate = model.get(PLAYER_STATE);
             adMediaModelContext.set('mediaState', event.newstate);
         });
-        this.off();
-        this.on('fullscreenchange', this._nativeFullscreenHandler, this);
+        provider.on(NATIVE_FULLSCREEN, (event) => {
+            this._nativeFullscreenHandler(Object.assign({}, event, { type: NATIVE_FULLSCREEN }));
+        });
         adMediaModelContext.on('change:mediaState', (changeAdModel, state) => {
             this._stateHandler(state);
         });
@@ -144,7 +146,6 @@ export default class AdProgramController extends ProgramController {
     destroy() {
         const { model, mediaPool, playerModel } = this;
         model.off();
-        this.off();
 
         // We only use one media element from ads; getPrimedElement will return it
         const mediaElement = mediaPool.getPrimedElement();

--- a/src/js/program/ad-program-controller.js
+++ b/src/js/program/ad-program-controller.js
@@ -57,7 +57,6 @@ export default class AdProgramController extends ProgramController {
             skipButton: false
         });
 
-        model.on('fullscreenchange', this._nativeFullscreenHandler);
         model.on('change:state', changeStateEvent, this);
         model.on(ERROR, function(data) {
             this.trigger(ERROR, data);
@@ -114,6 +113,7 @@ export default class AdProgramController extends ProgramController {
             event.oldstate = model.get(PLAYER_STATE);
             adMediaModelContext.set('mediaState', event.newstate);
         });
+        this.on('fullscreenchange', this._nativeFullscreenHandler, this);
         adMediaModelContext.on('change:mediaState', (changeAdModel, state) => {
             this._stateHandler(state);
         });

--- a/src/js/program/ad-program-controller.js
+++ b/src/js/program/ad-program-controller.js
@@ -114,9 +114,7 @@ export default class AdProgramController extends ProgramController {
             event.oldstate = model.get(PLAYER_STATE);
             adMediaModelContext.set('mediaState', event.newstate);
         });
-        provider.on(NATIVE_FULLSCREEN, (event) => {
-            this._nativeFullscreenHandler(Object.assign({}, event, { type: NATIVE_FULLSCREEN }));
-        });
+        provider.on(NATIVE_FULLSCREEN, this._nativeFullscreenHandler, this);
         adMediaModelContext.on('change:mediaState', (changeAdModel, state) => {
             this._stateHandler(state);
         });
@@ -180,8 +178,7 @@ export default class AdProgramController extends ProgramController {
     }
 
     _nativeFullscreenHandler(evt) {
-        const { model } = this;
-        model.trigger(evt.type, evt);
+        this.model.trigger(NATIVE_FULLSCREEN, evt);
         this.trigger(FULLSCREEN, {
             fullscreen: evt.jwstate
         });


### PR DESCRIPTION
### This PR will...
- Listen to `Provider` for `fullscreenchange` event instead of listening to `model` within `AdProgramController`

### Why is this Pull Request needed?
- Native fullscreen is handled and triggered by `html5.js`. Listening to `model` to trigger `fullscreenchange` event does not do anything. 

### Are there any points in the code the reviewer needs to double check?
- Are there any cases where we would need to listen to `model` instead of `Provider`?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):
JW8-2326


