### PR TITLE
Allow setting of playbackRates and playbackRateControls

### DIFF
--- a/src/js/api/set-config.js
+++ b/src/js/api/set-config.js
@@ -4,7 +4,9 @@ const supportedFields = [
     'repeat',
     'volume',
     'mute',
-    'autostart'
+    'autostart',
+    'playbackRates',
+    'playbackRateControls'
 ];
 
 function setAutoStart(model, controller, autoStart) {

--- a/src/js/view/controls/components/settings/menu.js
+++ b/src/js/view/controls/components/settings/menu.js
@@ -16,7 +16,7 @@ function focusSettingsElement(direction) {
     }
 }
 
-export function SettingsMenu(onVisibility, onMenuEmpty, localization) {
+export function SettingsMenu(onVisibility, buttonVisibilityChanges, localization) {
     const documentClickHandler = (e) => {
         // Close if anything other than the settings menu has been clicked
         // Let the display (jw-video) handles closing itself (display clicks do not pause if the menu is open)
@@ -149,8 +149,8 @@ export function SettingsMenu(onVisibility, onMenuEmpty, localization) {
                     sharingButton || closeButton.element()
                 );
             }
-
             settingsMenuElement.appendChild(submenu.element());
+            buttonVisibilityChanges.show();
         },
         getSubmenu(name) {
             return submenus[name];
@@ -170,7 +170,7 @@ export function SettingsMenu(onVisibility, onMenuEmpty, localization) {
 
             if (!Object.keys(submenus).length) {
                 this.close();
-                onMenuEmpty();
+                buttonVisibilityChanges.hide();
             }
         },
         activateSubmenu(name, focusOnLast) {

--- a/src/js/view/controls/settings-menu.js
+++ b/src/js/view/controls/settings-menu.js
@@ -12,11 +12,10 @@ import {
 
 export function createSettingsMenu(controlbar, onVisibility, localization) {
     const settingsButton = controlbar.elements.settingsButton;
-    const onMenuEmpty = () => {
-        settingsButton.hide();
-    };
-
-    const settingsMenu = SettingsMenu(onVisibility, onMenuEmpty, localization);
+    const settingsMenu = SettingsMenu(onVisibility, {
+        hide: () => settingsButton.hide(),
+        show: () => settingsButton.show()
+    }, localization);
 
     controlbar.on('settingsInteraction', (submenuName, isDefault, event) => {
         const submenu = settingsMenu.getSubmenu(submenuName);
@@ -204,6 +203,10 @@ export function setupSubmenuListeners(settingsMenu, controlbar, viewModel, api) 
         }
     }, settingsMenu);
 
+    model.change('playbackRateControls', () => {
+        setupPlaybackRatesMenu(model, model.get('playbackRates'));
+    });
+
     // Visual Quality
     model.on('change:visualQuality', (changedModel, quality) => {
         const qualitySubMenu = settingsMenu.getSubmenu('quality');
@@ -232,5 +235,4 @@ export function setupSubmenuListeners(settingsMenu, controlbar, viewModel, api) 
     model.on('change:streamType', () => {
         setupPlaybackRatesMenu(model, model.get('playbackRates'));
     }, settingsMenu);
-
 }

--- a/src/js/view/controls/settings-menu.js
+++ b/src/js/view/controls/settings-menu.js
@@ -203,7 +203,7 @@ export function setupSubmenuListeners(settingsMenu, controlbar, viewModel, api) 
         }
     }, settingsMenu);
 
-    model.change('playbackRateControls', () => {
+    model.on('change:playbackRateControls', () => {
         setupPlaybackRatesMenu(model, model.get('playbackRates'));
     });
 

--- a/test/unit/set-config-test.js
+++ b/test/unit/set-config-test.js
@@ -1,0 +1,47 @@
+import setConfig from 'api/set-config';
+
+let controller = {};
+
+function updateMockModel() {
+    controller._model = {
+        set: sinon.spy()
+    }
+}
+
+describe('#setConfig', function () {
+    beforeEach(() => {
+        updateMockModel();
+    });
+    describe('with a supported key', () => {
+        describe('when newConfig is empty', () => {
+            it('does nothing', () => {
+                setConfig(controller, {});
+                expect(controller._model.set.called).to.be.false;
+            });
+        });
+        describe('with playbackRates', () => {
+            it('correctly updates playbackRates on the model', () => {
+                setConfig(controller, {
+                    'playbackRates': [0.5, 1]
+                });
+                expect(controller._model.set.calledWith('playbackRates', [0.5, 1])).to.be.true;
+            });
+        });
+        describe('with playbackRateControls', () => {
+            it('correctly updates playbackRateControls on the model', () => {
+                setConfig(controller, {
+                    'playbackRateControls': true
+                });
+                expect(controller._model.set.calledWith('playbackRateControls', true)).to.be.true;
+            });
+        });
+    });
+    describe('with an unsupported key', () => {
+        it('does nothing', () => {
+            setConfig(controller, {
+                'notAKey': [0.5, 1]
+            });
+            expect(controller._model.set.called).to.be.false;
+        });
+    });
+});

--- a/test/unit/settings-menu-controls-test.js
+++ b/test/unit/settings-menu-controls-test.js
@@ -1,0 +1,71 @@
+import { SettingsMenu } from 'view/controls/components/settings/menu';
+
+const noop = () => {};
+const genTestElement = (name) => {
+    let element = document.createElement('div');
+    return {
+        name: name,
+        element: () => element,
+        categoryButtonElement: document.createElement('div'),
+        destroy: noop
+    };
+}
+
+describe('SettingsMenu', () => {
+    describe('#addSubmenu', () => {
+        it('causes the settings button to show properly', () => {
+            let showSpy = sinon.spy();
+            let hideSpy = sinon.spy();
+            let menu = SettingsMenu(noop, {
+                show: showSpy,
+                hide: hideSpy
+            }, {});
+
+            menu.addSubmenu(genTestElement('test'));
+
+            expect(showSpy.called).to.be.true;
+        });
+    });
+    describe('#removeSubmenu', () => {
+        describe('with more than 1 menu left', () => {
+            it('does not hide the settings menu', () => {
+                let showSpy = sinon.spy();
+                let hideSpy = sinon.spy();
+                let menu = SettingsMenu(noop, {
+                    show: showSpy,
+                    hide: hideSpy
+                }, {});
+
+                menu.addSubmenu(genTestElement('testOne'));
+                menu.addSubmenu(genTestElement('testTwo'));
+                menu.addSubmenu(genTestElement('testThree'));
+
+                showSpy.resetHistory();
+                hideSpy.resetHistory();
+
+                menu.removeSubmenu('testThree');
+                expect(showSpy.called).to.be.false;
+                expect(hideSpy.called).to.be.false;
+            });
+        });
+        describe('with no menus left', () => {
+            it('causes the settings button to hide properly', () => {
+                let showSpy = sinon.spy();
+                let hideSpy = sinon.spy();
+                let menu = SettingsMenu(noop, {
+                    show: showSpy,
+                    hide: hideSpy
+                }, {});
+
+                menu.addSubmenu(genTestElement('testOne'));
+
+                showSpy.resetHistory();
+                hideSpy.resetHistory();
+
+                menu.removeSubmenu('testOne');
+                expect(showSpy.called).to.be.false;
+                expect(hideSpy.called).to.be.true;
+            });
+        });
+    });
+});


### PR DESCRIPTION
### This PR will...
Allow users to reset playbackRates and playbackRateControls mid-playback

### Why is this Pull Request needed?
The SDKs need to be able to remove unsupported playback rates as well as disable controls until rates are known.

### Are there any points in the code the reviewer needs to double check?
None that I can think of beyond checking to see if I overlooked a simpler solution

### Are there any Pull Requests open in other repos which need to be merged with this?
Nope 

#### Addresses Issue(s):

JW8-2685

