### PR TITLE
Fix iOS fullscreen native caption position

### DIFF
--- a/src/css/controls/flags/touch.less
+++ b/src/css/controls/flags/touch.less
@@ -8,12 +8,6 @@
             /* control bar is (1.5*2.5 = 3.75)em for mobile, so bottom should be 0.5 above that */
             bottom: 4.25em;
         }
-
-        /* captions styles code specific to native text track rendering */
-        video::-webkit-media-text-track-container {
-            /* need to compensate for the control bar being 3.75em on mobile */
-            max-height: calc(100% - 60px);
-        }
     }
 
     .jw-controlbar .jw-icon-volume {

--- a/src/css/jwplayer/imports/captions.less
+++ b/src/css/jwplayer/imports/captions.less
@@ -62,12 +62,6 @@
             justify-content: flex-start;
         }
 
-        /* captions styles code specific to native text track rendering */
-        &::-webkit-media-text-track-container {
-            max-height: calc(100% - 60px);
-            line-height: normal;
-        }
-
         /* Ensure captions aren't cropped when the pseudo element's width cannot accommodate all the text */
         &::-webkit-media-text-track-display {
             min-width: -webkit-min-content;
@@ -82,4 +76,9 @@
             display: none;
         }
     }
+}
+
+.jwplayer:not(.jw-flag-ios-fullscreen) video::-webkit-media-text-track-container {
+    /* captions styles code specific to native text track rendering */
+    max-height: calc(100% - 60px);
 }

--- a/src/css/shared-imports/mixins.less
+++ b/src/css/shared-imports/mixins.less
@@ -32,7 +32,7 @@
             max-height: calc(100% - 46px);
         }
 
-        .jwplayer& {
+        .jwplayer:not(.jw-flag-ios-fullscreen)& {
             /* captions styles code specific to native text track rendering */
             video::-webkit-media-text-track-container {
                 max-height: calc(100% - 46px);
@@ -266,7 +266,7 @@
                 max-height: calc(100% - 38px);
             }
 
-            .jwplayer& {
+            .jwplayer:not(.jw-flag-ios-fullscreen)& {
                 /* captions styles code specific to native text track rendering */
                 video::-webkit-media-text-track-container {
                     max-height: calc(100% - 38px);

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -558,6 +558,7 @@ function View(_api, _model) {
             const provider = model.getVideo() || instreamProvider;
             if (provider && provider.setFullscreen) {
                 provider.setFullscreen(state);
+                toggleClass(_playerElement, 'jw-flag-ios-fullscreen', state);
             }
         }
     };


### PR DESCRIPTION
### This PR will...
Remove max-height to the native captions on iOS native fullscreen.

### Why is this Pull Request needed?
The styles added to the native captions container positions the captions too high on iPhone fullscreen.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-2660


