### PR TITLE
prevent crash in async click handler when el is null

### DIFF
--- a/src/js/view/controls/rightclick.js
+++ b/src/js/view/controls/rightclick.js
@@ -119,7 +119,7 @@ export default class RightClick {
     }
 
     hideMenu(evt) {
-        if (evt && this.el.contains(evt.target)) {
+        if (evt && this.el && this.el.contains(evt.target)) {
             // Do not hide menu when clicking inside menu
             return;
         }


### PR DESCRIPTION
### This PR will...
Prevents an asynchronous crash in `hideMenu` when document click handler results in player remove().

### Why is this Pull Request needed?
On Edge browser if the user calls remove() inside the document click handler there will be crash because the hideMenu function is called with PointerEvent `evt` after destroy() sets `this.el` to null.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):
#3370

