### PR TITLE
remove touchstart event listener

### DIFF
--- a/src/js/view/controls/rightclick.js
+++ b/src/js/view/controls/rightclick.js
@@ -201,6 +201,7 @@ export default class RightClick {
     removeHideMenuHandlers() {
         if (this.wrapperElement) {
             this.wrapperElement.removeEventListener('click', this.hideMenuHandler);
+            this.wrapperElement.removeEventListener('touchstart', this.hideMenuHandler);
         }
         if (this.el) {
             this.el.querySelector('.jw-info-overlay-item').removeEventListener('click', this.infoOverlayHandler);


### PR DESCRIPTION
### This PR will...
Remove the registered `touchstart` event listener from wrapper element

### Why is this Pull Request needed?
When `addHideMenuHandlers()` is called it adds an event listener for `touchstart` events on the `wrapperElement` but this event listener is never removed.

### Are there any points in the code the reviewer needs to double check?
See https://github.com/jwplayer/jwplayer/blob/master/src/js/view/controls/rightclick.js#L184

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

