### PR TITLE
Allow timeout to be passed into scriptloader function

### DIFF
--- a/src/js/utils/scriptloader.js
+++ b/src/js/utils/scriptloader.js
@@ -18,20 +18,19 @@ function makeStyleLink(styleUrl) {
     return link;
 }
 
-function makeScriptTag(scriptUrl) {
+function makeScriptTag(scriptUrl, timeout) {
     const scriptTag = document.createElement('script');
     scriptTag.type = 'text/javascript';
     scriptTag.charset = 'utf-8';
     scriptTag.async = true;
-    scriptTag.timeout = SCRIPT_LOAD_TIMEOUT;
+    scriptTag.timeout = timeout || SCRIPT_LOAD_TIMEOUT;
     scriptTag.src = scriptUrl;
     return scriptTag;
 }
 
-const ScriptLoader = function (url, isStyle) {
+const ScriptLoader = function (url, isStyle, scriptLoadTimeout) {
     const _this = this;
     let status = SCRIPT_LOAD_STATUS_NEW;
-
 
     function onError(evt) {
         status = SCRIPT_LOAD_STATUS_ERROR;
@@ -64,7 +63,7 @@ const ScriptLoader = function (url, isStyle) {
 
         promise = new Promise((resolve, reject) => {
             const makeTag = (isStyle ? makeStyleLink : makeScriptTag);
-            const scriptTag = makeTag(url);
+            const scriptTag = makeTag(url, scriptLoadTimeout);
             const doneLoading = function() {
                 // Handle memory leak in IE
                 scriptTag.onerror = scriptTag.onload = null;


### PR DESCRIPTION
### This PR will...
- Allow utils `ScriptLoader` to take a different timeout than the default

### Why is this Pull Request needed?
- We want to reuse the code in `header-bidding` module, but it requires a different timeout

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-ads-vast/pull/520
https://github.com/jwplayer/jwplayer-ads-googima/pull/488
https://github.com/jwplayer/jwplayer-ads-header-bidding/pull/115

#### Addresses Issue(s):

JW8-5841

