### PR TITLE
Volume slider should not be hoverable when not showing

### DIFF
--- a/src/css/controls/imports/tooltip.less
+++ b/src/css/controls/imports/tooltip.less
@@ -2,7 +2,7 @@
 
 .jw-icon-tooltip.jw-open .jw-overlay {
     opacity: 1;
-    pointer-events: all;
+    pointer-events: auto;
     transition-delay: 0s;
 
     &:focus {

--- a/src/css/controls/imports/tooltip.less
+++ b/src/css/controls/imports/tooltip.less
@@ -2,6 +2,7 @@
 
 .jw-icon-tooltip.jw-open .jw-overlay {
     opacity: 1;
+    pointer-events: all;
     transition-delay: 0s;
 
     &:focus {
@@ -64,6 +65,7 @@
         min-height: @mobile-touch-target;
         min-width: @mobile-touch-target;
         opacity: 0;
+        pointer-events: none;
         transition: 150ms @default-timing-function;
         transition-property: opacity, visibility;
         transition-delay: 0s, 150ms;


### PR DESCRIPTION
### This PR will...
Fix a bug introduced in https://github.com/jwplayer/jwplayer/pull/3366 where hovering over the _time_ slider will open the volume slider instead of hovering _past_ it as was previous behavior.

### Why is this Pull Request needed?
This is because we removed `visibility: hidden` to make it select-able with `tab/shft+tab` but it didn't take into account hover behavior.

### Are there any points in the code the reviewer needs to double check?
None I can think of 

### Are there any Pull Requests open in other repos which need to be merged with this?
Nope

#### Addresses Issue(s):

JW8-5705
