### PR TITLE
Make the API easier to wrap with a decorator

### DIFF
--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -98,6 +98,7 @@ export default function Api(element) {
          * @readonly
          */
         id: {
+            enumerable: true,
             get() {
                 return playerId;
             }
@@ -108,6 +109,7 @@ export default function Api(element) {
          * @readonly
          */
         uniqueId: {
+            enumerable: true,
             get() {
                 return uniqueId;
             }
@@ -118,6 +120,7 @@ export default function Api(element) {
          * @readonly
          */
         plugins: {
+            enumerable: true,
             get() {
                 return pluginsMap;
             }
@@ -128,6 +131,7 @@ export default function Api(element) {
          * @readonly
          */
         _qoe: {
+            enumerable: true,
             get() {
                 return qoeTimer;
             }
@@ -139,6 +143,7 @@ export default function Api(element) {
          * @readonly
          */
         version: {
+            enumerable: true,
             get() {
                 return version;
             }
@@ -151,6 +156,7 @@ export default function Api(element) {
          * @readonly
          */
         Events: {
+            enumerable: true,
             get() {
                 return Events;
             }
@@ -163,6 +169,7 @@ export default function Api(element) {
          * @readonly
          */
         utils: {
+            enumerable: true,
             get() {
                 return utils;
             }
@@ -175,6 +182,7 @@ export default function Api(element) {
          * @readonly
          */
         _: {
+            enumerable: true,
             get() {
                 return _;
             }

--- a/src/js/jwplayer.js
+++ b/src/js/jwplayer.js
@@ -62,27 +62,31 @@ function playerById(id) {
     return null;
 }
 
-Object.defineProperties(jwplayer, {
-    api: {
-        get() {
-            return GlobalApi;
+export function assignLibraryProperties(jwplayerLib) {
+    Object.defineProperties(jwplayerLib, {
+        api: {
+            get() {
+                return GlobalApi;
+            },
+            set() {}
         },
-        set() {}
-    },
-    version: {
-        get() {
-            return version;
+        version: {
+            get() {
+                return version;
+            },
+            set() {}
         },
-        set() {}
-    },
-    debug: {
-        get() {
-            return ApiSettings.debug;
-        },
-        set(value) {
-            ApiSettings.debug = !!value;
+        debug: {
+            get() {
+                return ApiSettings.debug;
+            },
+            set(value) {
+                ApiSettings.debug = !!value;
+            }
         }
-    }
-});
+    });
+}
+
+assignLibraryProperties(jwplayer);
 
 export default jwplayer;

--- a/test/data/api-members.js
+++ b/test/data/api-members.js
@@ -8,5 +8,6 @@ export default {
     _events: {},
     Events: function() {},
     utils: {},
-    _: _
+    _: _,
+    plugins: {}
 };

--- a/test/unit/api-test.js
+++ b/test/unit/api-test.js
@@ -207,7 +207,7 @@ describe('Api', function() {
             if (isApiMethod) {
                 expect(api, property).to.have.property(property).which.is.a('function');
             } else if (isApiMember) {
-                expect(api, property).to.have.property(property).which.is.not.a('function');
+                expect(api, property).to.have.property(property).which.is.a(typeof apiMembers[property]);
             } else {
                 const expectedMessage = 'api.' + property + ' is undefined';
                 const actualdMessage = 'api.' + property + ' is a ' + (typeof api[property]);


### PR DESCRIPTION
### This PR will...
Export `assignLibraryProperties` and make `Api` getters enumerable so that we can easily generate decorators for all methods and getters.

### Are there any Pull Requests open in other repos which need to be merged with this?
This PR can be merged as-is. The only difference is that getters are enumerable.

#### Addresses Issue(s):
JW8-8871

