### PR TITLE
Replace window resize listener with more holistic solution

### DIFF
--- a/src/js/view/utils/resize-listener.js
+++ b/src/js/view/utils/resize-listener.js
@@ -51,7 +51,6 @@ export default class ResizeListener {
         this.resizeRaf = -1;
         this.lastWidth = 0;
         this.currentWidth = element.offsetWidth;
-
         this.scrollListener = (e) => {
             let resizeRaf = this.resizeRaf;
             if (resizeRaf) {

--- a/src/js/view/utils/resize-listener.js
+++ b/src/js/view/utils/resize-listener.js
@@ -1,6 +1,6 @@
-import { requestAnimationFrame, cancelAnimationFrame } from 'os/utils/request-animation-frame';
-import { createElement } from 'os/utils/dom';
-import { css, style } from 'os/utils/css';
+import { requestAnimationFrame, cancelAnimationFrame } from 'utils/request-animation-frame';
+import { createElement } from 'utils/dom';
+import { css, style } from 'utils/css';
 
 export default class ResizeListener {
 

--- a/src/js/view/utils/views-manager.js
+++ b/src/js/view/utils/views-manager.js
@@ -93,7 +93,6 @@ function removeFromGroup(view, group) {
 
 document.addEventListener('visibilitychange', onVisibilityChange);
 document.addEventListener('webkitvisibilitychange', onVisibilityChange);
-window.addEventListener('orientationchange', scheduleResponsiveRedraw);
 
 if (isAndroidChrome && hasOrientation) {
     window.screen.orientation.addEventListener('change', onOrientationChange);
@@ -102,7 +101,6 @@ if (isAndroidChrome && hasOrientation) {
 window.addEventListener('beforeunload', () => {
     document.removeEventListener('visibilitychange', onVisibilityChange);
     document.removeEventListener('webkitvisibilitychange', onVisibilityChange);
-    window.removeEventListener('orientationchange', scheduleResponsiveRedraw);
 
     if (isAndroidChrome && hasOrientation) {
         window.screen.orientation.removeEventListener('change', onOrientationChange);
@@ -111,6 +109,7 @@ window.addEventListener('beforeunload', () => {
 
 export default {
     add: function(view) {
+        view.setResponsiveResizeCallback(scheduleResponsiveRedraw);
         views.push(view);
     },
     remove: function(view) {

--- a/src/js/view/utils/views-manager.js
+++ b/src/js/view/utils/views-manager.js
@@ -93,7 +93,6 @@ function removeFromGroup(view, group) {
 
 document.addEventListener('visibilitychange', onVisibilityChange);
 document.addEventListener('webkitvisibilitychange', onVisibilityChange);
-window.addEventListener('resize', scheduleResponsiveRedraw);
 window.addEventListener('orientationchange', scheduleResponsiveRedraw);
 
 if (isAndroidChrome && hasOrientation) {
@@ -103,7 +102,6 @@ if (isAndroidChrome && hasOrientation) {
 window.addEventListener('beforeunload', () => {
     document.removeEventListener('visibilitychange', onVisibilityChange);
     document.removeEventListener('webkitvisibilitychange', onVisibilityChange);
-    window.removeEventListener('resize', scheduleResponsiveRedraw);
     window.removeEventListener('orientationchange', scheduleResponsiveRedraw);
 
     if (isAndroidChrome && hasOrientation) {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -75,6 +75,8 @@ function View(_api, _model) {
     let _lastHeight;
     let _currentlyFloating;
 
+    let _responsiveResizeCallback;
+
     let _resizeMediaTimeout = -1;
     let _resizeContainerRequestId = -1;
     let _stateClassRequestId = -1;
@@ -299,10 +301,7 @@ function View(_api, _model) {
             viewsManager.observe(_playerElement);
         }
         _model.set('inDom', inDOM);
-
-        if (!this.resizeListener) {
-            this.resizeListener = new ResizeListener(_playerElement, () => _responsiveListener());
-        }
+        this.resizeListener = new ResizeListener(_playerElement, _responsiveResizeCallback);
     };
 
     function updateVisibility() {
@@ -619,6 +618,7 @@ function View(_api, _model) {
         const styles = getPlayerSizeStyles(playerWidth, playerHeight, true);
         const widthSet = playerWidth !== undefined;
         const heightSet = playerHeight !== undefined;
+
         if (widthSet && heightSet) {
             _model.set('width', playerWidth);
             _model.set('height', playerHeight);
@@ -940,6 +940,10 @@ function View(_api, _model) {
 
         style(_wrapperElement, styles);
     }
+
+    this.setResponsiveResizeCallback = function(callback) {
+        _responsiveResizeCallback = callback;
+    };
 
     this.stopFloating = function(forever) {
         if (forever) {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -38,6 +38,7 @@ import Logo from 'view/logo';
 import Preview from 'view/preview';
 import Title from 'view/title';
 import FloatingDragUI from 'view/floating-drag-ui';
+import ResizeListener from 'view/utils/resize-listener';
 
 
 require('css/jwplayer.less');
@@ -100,6 +101,7 @@ function View(_api, _model) {
         cancelAnimationFrame(_resizeContainerRequestId);
         const currentElement = _getCurrentElement();
         const inDOM = document.body.contains(currentElement);
+
         const rect = bounds(currentElement);
         const containerWidth = Math.round(rect.width);
         const containerHeight = Math.round(rect.height);
@@ -297,6 +299,10 @@ function View(_api, _model) {
             viewsManager.observe(_playerElement);
         }
         _model.set('inDom', inDOM);
+
+        if (!this.resizeListener) {
+            this.resizeListener = new ResizeListener(_playerElement, () => _responsiveListener());
+        }
     };
 
     function updateVisibility() {
@@ -1001,6 +1007,9 @@ function View(_api, _model) {
             _logo = null;
         }
         clearCss(_model.get('id'));
+        if (this.resizeListener) {
+            this.resizeListener.destroy();
+        }
     };
 }
 

--- a/test/unit/view-manager-test.js
+++ b/test/unit/view-manager-test.js
@@ -1,0 +1,17 @@
+import sinon from 'sinon';
+import ViewsManager from 'view/utils/views-manager';
+
+describe('ViewsManager', function() {
+    describe('#add', () => {
+        it('sets the responsive sizing function of the passed in view', () => {
+            let funcMock = sinon.spy();
+            let view = {
+                setResponsiveResizeCallback: funcMock
+            };
+
+            ViewsManager.add(view);
+            expect(funcMock.called).to.be.true;
+            expect(typeof funcMock.getCall(0).args[0]).to.eq('function');
+        });
+    });
+});


### PR DESCRIPTION
### This PR will...
Replace the current responsive resize listener with one that adapts to player container changes

### Why is this Pull Request needed?
We do not track resizes of the player if it is `100%` width and a parent container changes size

### Are there any points in the code the reviewer needs to double check?
Yes. I double checked the listener was only firing once and checked window resize and parent conditions but could be some perf impact I'm overlooking

### Are there any Pull Requests open in other repos which need to be merged with this?
Nope

#### Addresses Issue(s):

JW8-2383

