### PR TITLE
Trigger buffer events during ads

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -1058,6 +1058,9 @@ Object.assign(Controller.prototype, {
         this.createInstream = function() {
             this.instreamDestroy();
             this._instreamAdapter = new InstreamAdapter(this, _model, _view, mediaPool);
+            this._instreamAdapter.on('buffer', function (evt) {
+                _this.trigger(evt.type, evt);
+            });
             return this._instreamAdapter;
         };
 

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -826,8 +826,9 @@ Object.assign(Controller.prototype, {
             }
 
             _model.set('fullscreen', state);
-            if (_this._instreamAdapter && _this._instreamAdapter._adModel) {
-                _this._instreamAdapter._adModel.set('fullscreen', state);
+            const instream = _this._instreamAdapter;
+            if (instream && instream._adModel) {
+                instream._adModel.set('fullscreen', state);
             }
         }
 
@@ -1057,11 +1058,11 @@ Object.assign(Controller.prototype, {
 
         this.createInstream = function() {
             this.instreamDestroy();
-            this._instreamAdapter = new InstreamAdapter(this, _model, _view, mediaPool);
-            this._instreamAdapter.on('buffer', function (evt) {
+            const instream = this._instreamAdapter = new InstreamAdapter(this, _model, _view, mediaPool);
+            instream.on('buffer', function (evt) {
                 _this.trigger(evt.type, evt);
             });
-            return this._instreamAdapter;
+            return instream;
         };
 
         this.skipAd = function() {

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -104,7 +104,7 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
 
         // This enters the player into instream mode
         _model.set('instream', _adProgram);
-        _adProgram.model.set('state', STATE_BUFFERING);
+        _adProgram.model.set(PLAYER_STATE, STATE_BUFFERING);
 
         // don't trigger api play/pause on display click
         const clickHandler = _view.clickHandler();


### PR DESCRIPTION
### This PR will...
add a listener for `buffer` on instream and trigger a 'buffer' event when an ad is loaded.
### Why is this Pull Request needed?
Currently when a preRoll is loaded, the player state goes from `idle` to `buffering` but a buffer event is never triggered. I think a buffer event should fire because a developer should be able to rely on our events to detect state changes.

This bug was noticed while working on performance improvements for the iOS SDK. In the past, we would use the `getState` API to determine the state. This resulted in a large amount of javascript injections which are costly. To reduce the amount of javascript injections, and since WKWebView handles javascript asynchronously, we have decided to rely on the player's events to track the state. Given that the buffer event doesn't fire on ads, our state tracking gets out of sync. 

If firing buffer events during ad playback damages our event orders, we could look into changing the state in the SDK to buffer on other events such as playAttempt or adStart. Our preference though would be to rely on the player's buffer event. 
### Are there any points in the code the reviewer needs to double check?
Should we have a adBuffer event ?
### Are there any Pull Requests open in other repos which need to be merged with this?
n/a
#### Addresses Issue(s):
SDK-4152

