### PR TITLE
[JW8-9022] Workaround iOS background bug 

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -57,6 +57,9 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
     // Are we buffering due to seek, or due to playback?
     this.seeking = false;
 
+    // Value of mediaElement.currentTime on last "timeupdate" used for decode error retry workaround
+    this.currentTime = 0;
+
     // Always render natively in iOS and Safari, where HLS is supported.
     // Otherwise, use native rendering when set in the config for browsers that have adequate support.
     // FF, IE & Edge are excluded due to styling/positioning drawbacks.
@@ -81,6 +84,7 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
         },
 
         timeupdate() {
+            _this.currentTime = _videotag.currentTime;
             // Keep track of position before seek in iOS fullscreen
             if (_iosFullscreenState && _timeBeforeSeek !== _videotag.currentTime) {
                 setTimeBeforeSeek(_videotag.currentTime);
@@ -186,6 +190,13 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
             const { video } = _this;
             const error = video.error;
             const errorCode = (error && error.code) || -1;
+
+            if (errorCode === 3 && _this.currentTime && OS.iOS) {
+                // Workaround iOS bug https://bugs.webkit.org/show_bug.cgi?id=195452
+                _videotag.src = '';
+                _completeLoad(_this.currentTime);
+                return;
+            }
             // Error code 2 from the video element is a network error
             let code = HTML5_BASE_MEDIA_ERROR;
             let key = MSG_CANT_PLAY_VIDEO;
@@ -393,6 +404,7 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
     }
 
     function setPlaylistItem(item) {
+        _this.currentTime = 0;
         minDvrWindow = item.minDvrWindow;
         _levels = item.sources;
         _currentQuality = _pickInitialQuality(_levels);
@@ -430,6 +442,7 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
     }
 
     function _completeLoad(startTime) {
+        _this.currentTime = 0;
         _delayedSeek = 0;
         clearTimeouts();
 

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -58,7 +58,7 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
     this.seeking = false;
 
     // Value of mediaElement.currentTime on last "timeupdate" used for decode error retry workaround
-    this.currentTime = 0;
+    this.currentTime = -1;
 
     // Always render natively in iOS and Safari, where HLS is supported.
     // Otherwise, use native rendering when set in the config for browsers that have adequate support.
@@ -191,10 +191,11 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
             const error = video.error;
             const errorCode = (error && error.code) || -1;
 
-            if (errorCode === 3 && _this.currentTime && OS.iOS) {
+            if (errorCode === 3 && _this.currentTime !== -1 && OS.iOS) {
                 // Workaround iOS bug https://bugs.webkit.org/show_bug.cgi?id=195452
-                _videotag.src = '';
-                _completeLoad(_this.currentTime);
+                _videotag.load();
+                _this.seek(_this.currentTime);
+                _this.currentTime = -1;
                 return;
             }
             // Error code 2 from the video element is a network error
@@ -404,7 +405,7 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
     }
 
     function setPlaylistItem(item) {
-        _this.currentTime = 0;
+        _this.currentTime = -1;
         minDvrWindow = item.minDvrWindow;
         _levels = item.sources;
         _currentQuality = _pickInitialQuality(_levels);
@@ -442,7 +443,7 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
     }
 
     function _completeLoad(startTime) {
-        _this.currentTime = 0;
+        _this.currentTime = -1;
         _delayedSeek = 0;
         clearTimeouts();
 


### PR DESCRIPTION
### This PR will...
Add a workaround iOS background bug  https://bugs.webkit.org/show_bug.cgi?id=195452

### Why is this Pull Request needed?
If iOS Safari throws a decode error when returning to a tab after it's been backgrounded, we can attempt to reload the video from where it left off until there is a fix for this issue https://bugs.webkit.org/show_bug.cgi?id=195452

The retry requires that it's a decode error, the OS is iOS, and that some video has loaded and played successfully. We will not retry if the currentTime equals 0(this could be an issue if you seek back to the start and then background Safari).
 
#### Addresses Issue(s):
JW8-9022


