### PR TITLE
[JW8-2383/JW8-2551] Respond to external resizing on ready

### DIFF
--- a/src/css/jwplayer/imports/jwplayerlayout.less
+++ b/src/css/jwplayer/imports/jwplayerlayout.less
@@ -110,3 +110,14 @@
     position: absolute;
     width: 1px;
 }
+
+.jw-contract-trigger::before {
+    content: "";
+    overflow: hidden;
+    width: 200%;
+    height: 200%;
+    display: block;
+    position: absolute;
+    top: 0;
+    left: 0;
+}

--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -15,6 +15,9 @@ import UI, { getElementWindow } from 'utils/ui';
 import { PlayerError, composePlayerError, convertToPlayerError,
     SETUP_ERROR_LOADING_PLAYLIST, SETUP_ERROR_PROMISE_API_CONFLICT, SETUP_ERROR_UNKNOWN,
     MSG_TECHNICAL_ERROR } from 'api/errors';
+// Import modules used by core and related (TODO: move related loading into core/controls)
+import 'view/utils/views-manager';
+import 'view/utils/resize-listener';
 
 const CoreShim = function(originalContainer) {
     this._events = {};

--- a/src/js/view/utils/resize-listener.js
+++ b/src/js/view/utils/resize-listener.js
@@ -89,12 +89,10 @@ export default class ResizeListener {
             if (index !== -1) {
                 instances.splice(index, 1);
             }
-            this.element.removeEventListener('scroll', this.scrollListener, true);
+            this.element.removeEventListener('scroll', scrollListener, true);
             this.element.removeChild(this.hiddenElement);
-            this.scrollListener =
-                this.view =
+            this.view =
                 this.model = null;
-
         }
     }
 }

--- a/src/js/view/utils/views-manager.js
+++ b/src/js/view/utils/views-manager.js
@@ -1,5 +1,4 @@
 import activeTab from 'utils/active-tab';
-import { requestAnimationFrame, cancelAnimationFrame } from 'utils/request-animation-frame';
 import { Browser, OS } from 'environment/environment';
 
 const views = [];
@@ -9,7 +8,6 @@ const hasOrientation = 'screen' in window && 'orientation' in window.screen;
 const isAndroidChrome = OS.android && Browser.chrome;
 
 let intersectionObserver;
-let responsiveRepaintRequestId = -1;
 
 function lazyInitIntersectionObserver() {
     const IntersectionObserver = window.IntersectionObserver;
@@ -35,27 +33,6 @@ function matchIntersection(entry, group) {
             break;
         }
     }
-}
-
-function scheduleResponsiveRedraw() {
-    cancelAnimationFrame(responsiveRepaintRequestId);
-    // Batch DOM changes on animation frame
-    responsiveRepaintRequestId = requestAnimationFrame(function responsiveRepaint() {
-        // First read all DOM bounds (compute player size)
-        views.forEach(view => {
-            view.updateBounds();
-        });
-        // Then write all DOM changes (apply styles and classes based on player size)
-        views.forEach(view => {
-            if (view.model.get('visibility')) {
-                view.updateStyles();
-            }
-        });
-        // Finally dispatch events for any changes
-        views.forEach(view => {
-            view.checkResized();
-        });
-    });
 }
 
 function onOrientationChange() {
@@ -123,7 +100,6 @@ export default {
     size: function() {
         return views.length;
     },
-    scheduleResponsiveRedraw,
     observe(container) {
         lazyInitIntersectionObserver();
 

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -658,7 +658,6 @@ function View(_api, _model) {
             _model.set('fullscreen', newState);
         }
 
-        _responsiveListener();
         clearTimeout(_resizeMediaTimeout);
         _resizeMediaTimeout = setTimeout(_resizeMedia, 200);
     }
@@ -673,7 +672,6 @@ function View(_api, _model) {
         }
 
         _resizeMedia();
-        _responsiveListener();
     }
 
     function _setLiveMode(model, streamType) {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -912,9 +912,6 @@ function View(_api, _model) {
                 if (!_model.get('instreamMode')) {
                     _floatingUI.enable();
                 }
-
-                // Perform resize and trigger "float" event responsively to prevent layout thrashing
-                _responsiveListener();
             }
         } else {
             _this.stopFloating();
@@ -967,9 +964,6 @@ function View(_api, _model) {
                 margin: null
             });
             _floatingUI.disable();
-
-            // Perform resize and trigger "float" event responsively to prevent layout thrashing
-            _responsiveListener();
         }
     };
 

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -159,7 +159,7 @@ function View(_api, _model) {
         if (containerWidth !== _lastWidth || containerHeight !== _lastHeight) {
             if (!this.resizeListener) {
                 this.resizeListener =
-                    new ResizeListener(_wrapperElement, viewsManager.scheduleResponsiveRedraw, containerWidth);
+                    new ResizeListener(_wrapperElement, this, _model);
             }
             _lastWidth = containerWidth;
             _lastHeight = containerHeight;

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -157,6 +157,10 @@ function View(_api, _model) {
         const containerHeight = _model.get('containerHeight');
         const floating = _model.get('isFloating');
         if (containerWidth !== _lastWidth || containerHeight !== _lastHeight) {
+            if (!this.resizeListener) {
+                this.resizeListener =
+                    new ResizeListener(_wrapperElement, viewsManager.scheduleResponsiveRedraw, containerWidth);
+            }
             _lastWidth = containerWidth;
             _lastHeight = containerHeight;
             _this.trigger(RESIZE, {
@@ -338,9 +342,6 @@ function View(_api, _model) {
         // Triggering 'resize' resulting in player 'ready'
         _lastWidth = _lastHeight = null;
         this.checkResized();
-        if (!this.resizeListener) {
-            this.resizeListener = new ResizeListener(_playerElement, viewsManager.scheduleResponsiveRedraw);
-        }
     };
 
     function changeControls(model, enable) {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -158,8 +158,7 @@ function View(_api, _model) {
         const floating = _model.get('isFloating');
         if (containerWidth !== _lastWidth || containerHeight !== _lastHeight) {
             if (!this.resizeListener) {
-                this.resizeListener =
-                    new ResizeListener(_wrapperElement, this, _model);
+                this.resizeListener = new ResizeListener(_wrapperElement, this, _model);
             }
             _lastWidth = containerWidth;
             _lastHeight = containerHeight;
@@ -658,6 +657,7 @@ function View(_api, _model) {
             _model.set('fullscreen', newState);
         }
 
+        _responsiveListener();
         clearTimeout(_resizeMediaTimeout);
         _resizeMediaTimeout = setTimeout(_resizeMedia, 200);
     }
@@ -672,6 +672,7 @@ function View(_api, _model) {
         }
 
         _resizeMedia();
+        _responsiveListener();
     }
 
     function _setLiveMode(model, streamType) {
@@ -910,6 +911,9 @@ function View(_api, _model) {
                 if (!_model.get('instreamMode')) {
                     _floatingUI.enable();
                 }
+
+                // Perform resize and trigger "float" event responsively to prevent layout thrashing
+                _responsiveListener();
             }
         } else {
             _this.stopFloating();
@@ -962,6 +966,9 @@ function View(_api, _model) {
                 margin: null
             });
             _floatingUI.disable();
+
+            // Perform resize and trigger "float" event responsively to prevent layout thrashing
+            _responsiveListener();
         }
     };
 


### PR DESCRIPTION
### This PR will...
- Respond to external resizing on ready (JW8-2551)
- Batch resize-listener DOM style reads and updates using view methods
- Move static css into jwplayer css bundle added by webpack
- Insert resize listener element behind other player elements inside the wrapper element
- ~Let the resize listener handle floating and fullscreen player resizes~ (can't let resizing fail when we know to run the update loop for specific view)

### Why is this Pull Request needed?
This ensures that the player responds even to style changes made on the ready event while the resize-listener is setting up.

The batching improves performance when there is more than one player on the page by avoiding layout thrashing caused by recalculating styles and forcing layout.

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/6639

#### Addresses Issue(s):
JW8-2551

