### PR TITLE
[JW8-9040] Prevent accidental showing of horizontal volume slider knob

### DIFF
--- a/src/css/controls/imports/slider.less
+++ b/src/css/controls/imports/slider.less
@@ -154,7 +154,10 @@
         .jw-cue {
             transform: translate(0, -50%) scale(1, 1);
         }
+    }
 
+    &:hover,
+    &:focus {
         .jw-knob {
             transform: translate(-50%, -50%) scale(1);
         }


### PR DESCRIPTION
### This PR will...
Modify the styles, so when the dragging flag is on the player, only the currently active slider knob is showing.

### Why is this Pull Request needed?
Currently, the horizontal volume slider knob appears when dragging the time slider.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-9040

