### PR TITLE
Break out autoplay behavior into overrideable functions

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -711,7 +711,8 @@ Object.assign(Controller.prototype, {
             _actionOnAttach = _completeHandler;
 
             const idx = _model.get('item');
-            if (idx === _model.get('playlist').length - 1) {
+            let overrideAutoplay = _model.get('__autoplayOverride');
+            if (overrideAutoplay || idx === _model.get('playlist').length - 1) {
                 // If it's the last item in the playlist
                 if (_model.get('repeat')) {
                     _next({ reason: 'repeat' });


### PR DESCRIPTION
### This PR will...
Allow controllers to specifically short-circuit autoplay behavior that is the default in the open source player

### Why is this Pull Request needed?
We need to give the commercial controller the ability to disable the default behavior of the open source player given that it automatically advances any playlist which would override any options in `related` for playlists.

### Are there any points in the code the reviewer needs to double check?
Yes all of it please

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/6652

#### Addresses Issue(s):

JW8-9009

