### PR TITLE
[JW8-8766] Only turn off viewable listener when autoPause is not enabled

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -278,12 +278,13 @@ Object.assign(Controller.prototype, {
 
             _model.change('viewable', viewableChange);
             _model.change('viewable', _checkPlayOnViewable);
-            _model.once('change:autostartFailed change:mute', function(model) {
-                model.off('change:viewable', _checkPlayOnViewable);
-            });
 
             if (_model.get('autoPause').viewability) {
                 _model.change('viewable', _checkPauseOnViewable);
+            } else {
+                _model.once('change:autostartFailed change:mute', function(model) {
+                    model.off('change:viewable', _checkPlayOnViewable);
+                });
             }
 
             // Run _checkAutoStart() last


### PR DESCRIPTION
JW8-8766

### This PR will...

* Move the logic to turn off the `change:viewable` listener that calls `_checkPlayOnViewable()` to a conditional that checks whether or not `autoPause` is enabled

### Why is this Pull Request needed?

* If a player is setup to be muted and to have autoPause enabled, if it was unmuted before scrolling the player out of view and then back, the content would not resume.

### Are there any points in the code the reviewer needs to double check?

n/a

### Are there any Pull Requests open in other repos which need to be merged with this?

n/a

#### Addresses Issue(s):

JW8-8766

