### PR TITLE
[JW8-5650] Add support for Program-Date-Time metadata in Safari

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -1,8 +1,10 @@
 import { qualityLevel } from 'providers/data-normalizer';
 import { Browser, OS } from 'environment/environment';
 import { isAndroidHls } from 'providers/html5-android-hls';
-import { STATE_IDLE, STATE_PLAYING, STATE_STALLED, MEDIA_META, MEDIA_ERROR, MEDIA_VISUAL_QUALITY, MEDIA_TYPE,
-    MEDIA_LEVELS, MEDIA_LEVEL_CHANGED, MEDIA_SEEK, NATIVE_FULLSCREEN, STATE_LOADING } from 'events/events';
+import {
+    STATE_IDLE, STATE_PLAYING, STATE_STALLED, MEDIA_META_CUE_PARSED, MEDIA_META, MEDIA_ERROR,
+    MEDIA_VISUAL_QUALITY, MEDIA_TYPE, MEDIA_LEVELS, MEDIA_LEVEL_CHANGED, MEDIA_SEEK, NATIVE_FULLSCREEN, STATE_LOADING
+} from 'events/events';
 import VideoEvents from 'providers/video-listener-mixin';
 import VideoAction from 'providers/video-actions-mixin';
 import VideoAttached from 'providers/video-attached-mixin';
@@ -128,6 +130,7 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
         },
 
         loadeddata() {
+            checkStartDateTime();
             VideoEvents.loadeddata.call(_this);
             _setAudioTracks(_videotag.audioTracks);
             _checkDelayedSeek(_this.getDuration());
@@ -294,9 +297,9 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
     let dvrPosition = null;
     let dvrUpdatedTime = 0;
 
-    this.isSDK = !!_playerConfig.sdkplatform;
     this.video = _videotag;
     this.supportsPlaybackRate = true;
+    this.startDateTime = 0;
 
     function checkVisualQuality() {
         const level = visualQuality.level;
@@ -315,6 +318,32 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
             level.label = _levels[_currentQuality].label;
             _this.trigger(MEDIA_VISUAL_QUALITY, visualQuality);
             visualQuality.reason = '';
+        }
+    }
+
+    function checkStartDateTime() {
+        if (_videotag.getStartDate) {
+            const startDate = _videotag.getStartDate();
+            const startDateTime = startDate.getTime();
+            if (startDateTime !== _this.startDateTime && !isNaN(startDateTime)) {
+                _this.startDateTime = startDateTime;
+                const programDateTime = startDate.toISOString();
+                const { start, end } = _this.getSeekRange();
+                const metadataType = 'program-date-time';
+                const metadata = {
+                    metadataType,
+                    programDateTime,
+                    start,
+                    end
+                };
+                const cue = _this.createCue(start, end, JSON.stringify(metadata));
+                _this.addVTTCue({
+                    type: 'metadata',
+                    cue,
+                });
+                delete metadata.metadataType;
+                _this.trigger(MEDIA_META_CUE_PARSED, { metadataType, metadata });
+            }
         }
     }
 

--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -33,11 +33,20 @@ const Tracks = {
     addTrackHandler: null,
     addCuesToTrack,
     addCaptionsCue,
+    createCue,
     addVTTCue,
     addVTTCuesToTrack,
     triggerActiveCues,
     renderNatively: false
 };
+
+function createCue(start, end, content) {
+    const MetaCue = window.VTTCue || window.TextTrackCue;
+    // Set a minimum duration for the cue
+    // VTTCues must have a duration for "cuechange" to be dispatched
+    const cueEnd = Math.max(end || 0, start + 0.25);
+    return new MetaCue(start, cueEnd, content);
+}
 
 function setTextTracks(tracks) {
     this._currentTextTrackIndex = -1;


### PR DESCRIPTION
### This PR will...
Add support for Program-Date-Time metadata in Safari

### Why is this Pull Request needed?
For Safari HLS playback with the html5 provider to have API parity with the HLS.js provider. Developers can use the PDT in these metadata events to calculate the running PDT using the start date and currentTime.

```js
{
    autostart: true,
    file: '//hls-stream-with-program-date-time.m3u8',
    events: {
        metadataCueParsed: function(e) {
            if (e.metadataType === 'program-date-time') {
                window.startDateTime = new Date(e.metadata.programDateTime).getTime() - e.metadata.start;
                console.log(e.type, 'program-date-time', e.metadata.programDateTime);
            }
        },
        meta: function(e) {
            if (e.metadataType === 'program-date-time') {
                console.log(e.type, 'program-date-time', e.metadata.programDateTime);
            }
        },
        time: function(e) {
            var fives = Math.floor(e.currentTime / 5);
            if (window.lastFive !== fives) {
                window.lastFive = fives;
                console.log(
                    'currentTime:', e.currentTime,
                    'program-date-time', new Date(e.currentTime + window.startDateTime).toISOString()
                );
            }
        }
    }
}
```

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/6660

#### Addresses Issue(s):
JW8-5650

