### PR TITLE
Create tiny player breakpoint

### DIFF
--- a/src/css/controls/imports/cast.less
+++ b/src/css/controls/imports/cast.less
@@ -21,6 +21,7 @@
     color: #fff;
     font-size: 1.6em;
 
+    .jw-breakpoint--1 &,
     .jw-breakpoint-0 & {
         font-size: 1.15em;
     }

--- a/src/css/controls/imports/controlbar.less
+++ b/src/css/controls/imports/controlbar.less
@@ -118,8 +118,8 @@
 
 &.jw-flag-small-player {
     .jw-display {
-        padding-top: @mobile-touch-target;
-        padding-bottom: (@mobile-touch-target * 1.5);
+        padding-top: 0;
+        padding-bottom: 0;
     }
 }
 
@@ -157,7 +157,10 @@
         .jw-text-countdown {
             display: flex;
         }
+    }
 
+    &.jw-breakpoint--1,
+    &.jw-breakpoint-0 {
         .jw-text-elapsed,
         .jw-text-duration {
             display: none;
@@ -165,7 +168,31 @@
     }
 }
 
-.jwplayer:not(.jw-breakpoint-0) {
+.jwplayer.jw-breakpoint--1&:not(.jw-flag-ads) {
+    .jw-text-countdown,
+    .jw-related-btn,
+    .jw-slider-volume {
+        display: none;
+    }
+
+    .jw-controlbar {
+        flex-direction: column-reverse;
+    }
+
+    .jw-button-container {
+        height: 30px;
+    }
+}
+
+.jw-breakpoint--1.jw-flag-ads {
+    .jw-icon-volume,
+    .jw-icon-fullscreen {
+        display: none;
+    }
+}
+
+.jwplayer:not(.jw-breakpoint-0),
+.jwplayer:not(.jw-breakpoint--1) {
     .jw-text-duration {
         &:before {
             content: "/";

--- a/src/css/controls/imports/controlbar.less
+++ b/src/css/controls/imports/controlbar.less
@@ -168,7 +168,7 @@
     }
 }
 
-.jwplayer.jw-breakpoint--1&:not(.jw-flag-ads) {
+.jwplayer.jw-breakpoint--1&:not(.jw-flag-ads):not(.jw-flag-audio-player) {
     .jw-text-countdown,
     .jw-related-btn,
     .jw-slider-volume {
@@ -184,7 +184,7 @@
     }
 }
 
-.jw-breakpoint--1.jw-flag-ads {
+.jw-breakpoint--1.jw-flag-ads:not(.jw-flag-audio-player) {
     .jw-icon-volume,
     .jw-icon-fullscreen {
         display: none;

--- a/src/css/controls/imports/display.less
+++ b/src/css/controls/imports/display.less
@@ -66,8 +66,13 @@ display icons
     }
 }
 
-// hide next and rewind buttons on extra small player
-.jw-breakpoint-0 {
+.jw-breakpoint--1 .jw-nextup-container {
+    display: none;
+}
+
+// hide next and rewind buttons along with nextup on extra small player
+.jw-breakpoint-0,
+.jw-breakpoint--1 {
     .jw-display-icon-next,
     .jw-display-icon-rewind {
         display: none;

--- a/src/css/controls/imports/icons.less
+++ b/src/css/controls/imports/icons.less
@@ -118,3 +118,24 @@
     }
 }
 // stylelint-enable indentation
+.jwplayer.jw-breakpoint--1 {
+    .jw-icon-cc,
+    .jw-icon-settings,
+    .jw-icon-audio-tracks,
+    .jw-icon-hd,
+    .jw-settings-sharing,
+    .jw-icon-fullscreen,
+    &.jw-flag-cast-available .jw-icon-airplay,
+    &.jw-flag-cast-available .jw-icon-cast {
+        display: none;
+    }
+
+    .jw-icon-volume,
+    .jw-text-live {
+        bottom: 6px;
+    }
+
+    .jw-icon-volume::after {
+        display: none;
+    }
+}

--- a/src/css/controls/imports/icons.less
+++ b/src/css/controls/imports/icons.less
@@ -118,7 +118,7 @@
     }
 }
 // stylelint-enable indentation
-.jwplayer.jw-breakpoint--1 {
+.jwplayer.jw-breakpoint--1:not(.jw-flag-audio-player) {
     .jw-icon-cc,
     .jw-icon-settings,
     .jw-icon-audio-tracks,

--- a/src/css/controls/imports/playback-label.less
+++ b/src/css/controls/imports/playback-label.less
@@ -34,7 +34,8 @@
                 transform: scale(0.7, 0.7);
             }
 
-            .jw-breakpoint-0& {
+            .jw-breakpoint-0&,
+            .jw-breakpoint--1& {
                 font-size: 12px;
             }
         }

--- a/src/css/controls/imports/slider.less
+++ b/src/css/controls/imports/slider.less
@@ -185,3 +185,21 @@
         outline: @ui-focus;
     }
 }
+
+.jw-breakpoint--1 {
+    .jw-slider-time {
+        height: 17px;
+        padding: 0;
+
+        .jw-slider-container {
+            height: 10px;
+        }
+
+        .jw-knob {
+            border-radius: 0;
+            border: 1px solid rgba(0, 0, 0, 0.75);
+            height: 12px;
+            width: 10px;
+        }
+    }
+}

--- a/src/css/controls/imports/slider.less
+++ b/src/css/controls/imports/slider.less
@@ -186,7 +186,7 @@
     }
 }
 
-.jw-breakpoint--1 {
+.jw-breakpoint--1:not(.jw-flag-audio-player) {
     .jw-slider-time {
         height: 17px;
         padding: 0;

--- a/src/css/shared-imports/vars.less
+++ b/src/css/shared-imports/vars.less
@@ -19,7 +19,7 @@
 @max-breakpoint-1-width: 419px;
 @min-breakpoint-1-width: 320px;
 @max-breakpoint-0-width: 319px;
-@min-breakpoint-0-width: 280px;
+@min-breakpoint-0-width: 250px;
 @max-breakpoint--1-width: 249px;
 @min-breakpoint--1-width: 0;
 

--- a/src/css/shared-imports/vars.less
+++ b/src/css/shared-imports/vars.less
@@ -19,7 +19,9 @@
 @max-breakpoint-1-width: 419px;
 @min-breakpoint-1-width: 320px;
 @max-breakpoint-0-width: 319px;
-@min-breakpoint-0-width: 0;
+@min-breakpoint-0-width: 280px;
+@max-breakpoint--1-width: 249px;
+@min-breakpoint--1-width: 0;
 
 // Colors
 @black: #000;

--- a/src/js/view/utils/breakpoint.js
+++ b/src/js/view/utils/breakpoint.js
@@ -1,7 +1,7 @@
 import { replaceClass } from 'utils/dom';
 
 export function getBreakpoint(width) {
-    let breakpoint = 0;
+    let breakpoint = -1;
 
     if (width >= 1280) {
         breakpoint = 7;
@@ -17,6 +17,8 @@ export function getBreakpoint(width) {
         breakpoint = 2;
     } else if (width >= 320) {
         breakpoint = 1;
+    } else if (width >= 250) {
+        breakpoint = 0;
     }
 
     return breakpoint;
@@ -24,5 +26,5 @@ export function getBreakpoint(width) {
 
 export function setBreakpoint(playerElement, breakpointNumber) {
     const breakpointClass = 'jw-breakpoint-' + breakpointNumber;
-    replaceClass(playerElement, /jw-breakpoint-\d+/, breakpointClass);
+    replaceClass(playerElement, /jw-breakpoint--?\d+/, breakpointClass);
 }


### PR DESCRIPTION
### This PR will...
Create styling required for a `breakpoint: -1`

Ads UI:
* Countdown
* Skip button
* Play/pause

Playback UI:
* Volume Toggle
* Seek bar
* Play/Pause

#### Tested In:
* [x] IE
* [x] Chrome
* [x] Safari
* [x] Edge
* [x] Firefox

### Why is this Pull Request needed?
We want to have better support for very tiny JW Players

### Are there any points in the code the reviewer needs to double check?
Do my CSS changes break with convention in any way?

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/6670

#### Addresses Issue(s):

JW8-2535

