### PR TITLE
Avoid disabling a track if it is already disabled JW8-2590

### DIFF
--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -573,7 +573,7 @@ function _removeCues(renderNatively, tracks) {
             // Cues are inaccessible if the track is disabled. While hidden,
             // we can remove cues while the track is in a non-visible state
             // Set to disabled before hidden to ensure active cues disappear
-            if (track.mode !== 'disabled') {
+            if (!Browser.ie || track.mode !== 'disabled') {
                 // Avoid setting the track to disabled if it is already so. This prevents an exception when trying
                 // to set the mode on Edge
                 track.mode = 'disabled';

--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -573,8 +573,12 @@ function _removeCues(renderNatively, tracks) {
             // Cues are inaccessible if the track is disabled. While hidden,
             // we can remove cues while the track is in a non-visible state
             // Set to disabled before hidden to ensure active cues disappear
-            track.mode = 'disabled';
-            track.mode = 'hidden';
+            if (track.mode !== 'disabled') {
+                // Avoid setting the track to disabled if it is already so. This prevents an exception when trying
+                // to set the mode on Edge
+                track.mode = 'disabled';
+                track.mode = 'hidden';
+            }
             for (let i = track.cues.length; i--;) {
                 track.removeCue(track.cues[i]);
             }


### PR DESCRIPTION
### Why is this Pull Request needed?
For an unknown reason, Edge will throw an exception if trying to set track modes if it is already disabled. This prevents Hls.js from switching live streams; cues are cleared on `stop` and `play`, and on the second call to remove cues, an exception is thrown.

### Are there any points in the code the reviewer needs to double check?
Try/catch also works. Maybe that's better than the guard?

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-2590

