### PR TITLE
[JW8-9168] Polyfill openLink for Firefox

### DIFF
--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -215,5 +215,5 @@ export function openLink(link, target, additionalOptions = {}) {
     a.href = link;
     a.target = target;
     a = Object.assign(a, additionalOptions);
-    a.click();
+    a.dispatchEvent(new MouseEvent(`click`, { bubbles: true, cancelable: true, view: window }));
 }

--- a/test/unit/dom-test.js
+++ b/test/unit/dom-test.js
@@ -395,27 +395,25 @@ describe('dom', function() {
     });
 
     it('opens a link', function() {
-        const oldClick = HTMLElement.prototype.click;
-        const clickSpy = sinon.spy();
+        const _createElement = document.createElement;
+        let result;
 
-        HTMLElement.prototype.click = clickSpy;
-        sinon.spy(document, 'createElement');
-        openLink('http://localhost/', '_blank', { rel: 'noreferrer' });
+        // Wrapper required to test result, it's never appended to document.
+        document.createElement = (args) => {
+            result = _createElement.apply(document, [...args]);
+            result.onclick = sinon.spy();
+            return result;
+        };
 
-        const clickedElement = clickSpy.thisValues[0];
+        openLink('http://localhost/', '_blank', { rel: 'noreferrer', id: 'testLink' });
 
-        //  Anchor is created.
-        expect(document.createElement.calledWith('a'));
-        //  Element is clicked.
-        expect(clickSpy.calledOnce).to.be.true;
-        //  Element has expected href.
-        expect(clickedElement.href).to.equal('http://localhost/');
-        //  Element has expected target.
-        expect(clickedElement.target).to.equal('_blank');
-        //  Element has expected options
-        expect(clickedElement.rel).to.equal('noreferrer');
-        //  Return click prototype to original value.
-        HTMLElement.prototype.click = oldClick;
+        expect(result.tagName).to.equal('A');
+        expect(result.href).to.equal('http://localhost/');
+        expect(result.target).to.equal('_blank');
+        expect(result.rel).to.equal('noreferrer');
+        expect(result.id).to.equal('testLink');
+        expect(result.onclick.calledOnce).to.be.true;
+
+        document.createElement = _createElement;
     });
-
 });


### PR DESCRIPTION
### This PR will...
Replace the .click() functionality of openLink with a new click mouse event.

### Why is this Pull Request needed?
Firefox doesn't support default click event on anchors unless they're appended to the DOM. Using the mouse event constructor allows us to avoid doing this and still have full functionality.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-9178

