### PR TITLE
[JW8-9168] openLink FF fix with IE support

### DIFF
--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -217,7 +217,7 @@ export function openLink(link, target, additionalOptions = {}) {
     a.target = target;
     a = Object.assign(a, additionalOptions);
 
-    // Must support all browsers.
+    // Firefox is the only modern browser that doesn't support clicking orphaned anchors.
     if (Browser.firefox) {
         a.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }));
     } else {

--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -215,5 +215,11 @@ export function openLink(link, target, additionalOptions = {}) {
     a.href = link;
     a.target = target;
     a = Object.assign(a, additionalOptions);
-    a.dispatchEvent(new MouseEvent(`click`, { bubbles: true, cancelable: true, view: window }));
+
+    // Must support all browsers.
+    try {
+        a.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }));
+    } catch (e) {
+        a.click();
+    }
 }

--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -1,5 +1,6 @@
 import { trim } from 'utils/strings';
 import { isString, contains, difference, isBoolean } from 'utils/underscore';
+import { Browser } from '../environment/environment';
 
 let parser;
 
@@ -217,9 +218,9 @@ export function openLink(link, target, additionalOptions = {}) {
     a = Object.assign(a, additionalOptions);
 
     // Must support all browsers.
-    try {
+    if (Browser.firefox) {
         a.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }));
-    } catch (e) {
+    } else {
         a.click();
     }
 }


### PR DESCRIPTION
### This PR will...
Extend the new openLink method to work on IE.

### Why is this Pull Request needed?
IE doesn't support custom events. The new method uses custom events in order to work on FF without causing reflows.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-9168

