### PR TITLE
[JW8-8949] Add temporary _hlsjsProgressive config

### DIFF
--- a/src/js/playlist/playlist.js
+++ b/src/js/playlist/playlist.js
@@ -63,6 +63,9 @@ function formatSources(item, model) {
         copyAttribute(originalSource, attributes, 'androidhls');
         copyAttribute(originalSource, attributes, 'hlsjsdefault');
         copyAttribute(originalSource, attributes, 'safarihlsjs');
+        // Set in order to force the progressive Hls.js provider; used for A/B testing
+        // TODO: Remove after A/B testing concludes
+        copyAttribute(originalSource, attributes, '_hlsjsProgressive');
 
         originalSource.preload = getPreload(originalSource.preload, preload);
 


### PR DESCRIPTION
### This PR will...
- Adds a new top-level `_hlsjsProgressive` config
- Propagates the config to the source level

### Why is this Pull Request needed?
So that we can force the progressive Hls.js provider to load

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/6711

#### Addresses Issue(s):

JW8-8949

