### PR TITLE
[JW8-9256] Correct height on non-linear static ads at breakpoint 7

### DIFF
--- a/src/css/jwplayer/imports/jwplayerlayout.less
+++ b/src/css/jwplayer/imports/jwplayerlayout.less
@@ -64,6 +64,10 @@
     position: absolute;
     bottom: (@mobile-touch-target * 1.5);
 
+    .jw-breakpoint-7 & {
+        bottom: (@mobile-touch-target * 3);
+    }
+
     .jw-banner {
         max-width: 100%;
         opacity: 0;


### PR DESCRIPTION
### This PR will...
Change the "bottom" style for non-linear ads at breakpoint 7.

### Why is this Pull Request needed?
Currently, non-linear ads intersect with time slider at breakpoint 7.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-9256

