### PR TITLE
[JW8-9245] Catch playPromise.

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -174,7 +174,7 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
 
     function _loadNextItem() {
         _arrayIndex++;
-        _this.loadItem(_array);
+        _this.loadItem(_array).catch(function() { });
     }
 
     function _instreamForward(type, data) {


### PR DESCRIPTION
### This PR will...
Catch the `playPromise` for subsequent ad pod items.

### Why is this Pull Request needed?
Subsequent ad pod items might error (e.g. mediaError), which right now logs an uncaught exception in the console. This PR fixes that.

### Are there any points in the code the reviewer needs to double check?
Note the actual error is handled by the plugins `playbackErrorHandler`, so we're not ignoring the error altogether.

### Are there any Pull Requests open in other repos which need to be merged with this?
jwplayer/jwplayer-ads-vast#541

#### Addresses Issue(s):
JW8-9245