### PR TITLE
[JW8-9323] Expose `genId` function in utils

### DIFF
--- a/src/js/utils/helpers.js
+++ b/src/js/utils/helpers.js
@@ -38,6 +38,7 @@ import {
 import { ajax } from 'utils/ajax';
 import { between } from 'utils/math';
 import { log } from 'utils/log';
+import { genId } from 'utils/random-id-generator';
 
 // TODO: deprecate (jwplayer-ads-vast uses utils.crossdomain(url))
 function crossdomain(uri) {
@@ -87,6 +88,7 @@ const helpers = Object.assign({}, parser, validator, playerutils, {
     Error,
     Timer,
     log,
+    genId,
     between,
     foreach,
     flashVersion,


### PR DESCRIPTION
### This PR will...
Expose `genId` function in utils

### Why is this Pull Request needed?
We want to use `genId` function in ads plugins, as ads plugin currently uses `Math.random` to generate ids. Using `Math.random` to generate IDs create collisions once every 10^5 times.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-ads-vast/pull/542
https://github.com/jwplayer/jwplayer-ads-googima/pull/500

#### Addresses Issue(s):

JW8-9323

