### PR TITLE
Fix settings menu exception with hlsjs.removeLevel()

### DIFF
--- a/src/js/view/controls/settings-menu.js
+++ b/src/js/view/controls/settings-menu.js
@@ -144,7 +144,7 @@ export function setupSubmenuListeners(settingsMenu, controlbar, viewModel, api) 
         );
     };
 
-    const changeAutoLabel = function (quality, qualitySubMenu, currentQuality) {
+    const changeAutoLabel = function (qualityLevel, qualitySubMenu, currentIndex) {
         const levels = model.get('levels');
         // Return early if the label isn't "Auto" (html5 provider with multiple mp4 sources)
         if (!levels || levels[0].label !== 'Auto') {
@@ -152,19 +152,20 @@ export function setupSubmenuListeners(settingsMenu, controlbar, viewModel, api) 
         }
         const items = qualitySubMenu.getItems();
         const item = items[0].element().querySelector('.jw-auto-label');
+        const level = levels[qualityLevel.index] || { label: '' };
 
-        item.textContent = currentQuality ? '' : levels[quality.level.index].label;
+        item.textContent = currentIndex ? '' : level.label;
     };
 
     // Quality Levels
     model.change('levels', onQualitiesChanged, settingsMenu);
-    model.on('change:currentLevel', (changedModel, currentQuality) => {
+    model.on('change:currentLevel', (changedModel, currentIndex) => {
         const qualitySubMenu = settingsMenu.getSubmenu('quality');
         const visualQuality = model.get('visualQuality');
         if (visualQuality && qualitySubMenu) {
-            changeAutoLabel(visualQuality, qualitySubMenu, currentQuality);
+            changeAutoLabel(visualQuality.level, qualitySubMenu, currentIndex);
         }
-        activateSubmenuItem('quality', currentQuality);
+        activateSubmenuItem('quality', currentIndex);
     }, settingsMenu);
 
     // Audio Tracks
@@ -211,7 +212,7 @@ export function setupSubmenuListeners(settingsMenu, controlbar, viewModel, api) 
     model.on('change:visualQuality', (changedModel, quality) => {
         const qualitySubMenu = settingsMenu.getSubmenu('quality');
         if (qualitySubMenu) {
-            changeAutoLabel(quality, qualitySubMenu, model.get('currentLevel'));
+            changeAutoLabel(quality.level, qualitySubMenu, model.get('currentLevel'));
         }
     });
 


### PR DESCRIPTION
### This PR will...
Fix settings menu exception with hlsjs.removeLevel()

### Why is this Pull Request needed?
The number of levels changes when a provider removes a level because it returned an error. This shouldn't cause an exception.

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/hls.js/pull/218
https://github.com/jwplayer/jwplayer-commercial/pull/6731

#### Addresses Issue(s):
JW8-9327 (TODO: Sub-bug)

