### PR TITLE
Only assert recovery when current time is 0 or positive

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -93,7 +93,7 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
         },
 
         timeupdate() {
-            if (_this.currentTime) {
+            if (_this.currentTime >= 0) {
                 // Reset error retries after concurrent timeupdate events
                 _this.retries = 0;
             }


### PR DESCRIPTION
### This PR will...
Update our retry logic so we only truly reset when we have recovered

### Why is this Pull Request needed?
Chrome for whatever reason calls timeupdate but when the playback manifest is 404'ing we get a `currentTime` value of `-1` this change ensures it's a reliable current time before we assume recovery

### Are there any points in the code the reviewer needs to double check?
Nah

### Are there any Pull Requests open in other repos which need to be merged with this?
Nah

#### Addresses Issue(s):

JW8-9327 

