### PR TITLE
[JW8-9359] Do not retry loading ads

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -615,6 +615,7 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
     };
 
     this.init = function(item) {
+        _this.retries = 0;
         _this.maxRetries = item.adType ? 0 : 3;
         setPlaylistItem(item);
         const source = _levels[_currentQuality];

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -68,6 +68,7 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
 
     // Attempt to reload video on error
     this.retries = 0;
+    this.maxRetries = 3;
 
     // Always render natively in iOS and Safari, where HLS is supported.
     // Otherwise, use native rendering when set in the config for browsers that have adequate support.
@@ -205,7 +206,7 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
             const error = video.error;
             const errorCode = (error && error.code) || -1;
 
-            if ((errorCode === 3 || errorCode === 4) && _this.retries < 3) {
+            if ((errorCode === 3 || errorCode === 4) && _this.retries < _this.maxRetries) {
                 // Workaround Safari bug https://bugs.webkit.org/show_bug.cgi?id=195452
                 //  and stale manifests
                 _this.trigger(WARNING, new PlayerError(null, HTML5_BASE_WARNING + errorCode - 1, error));
@@ -614,7 +615,7 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
     };
 
     this.init = function(item) {
-        _this.retries = 0;
+        _this.maxRetries = item.adType ? 0 : 3;
         setPlaylistItem(item);
         const source = _levels[_currentQuality];
         _androidHls = isAndroidHls(source);


### PR DESCRIPTION
### This PR will...
- Prevent ads from retrying to load when the ad 404s

### Why is this Pull Request needed?
- Retry logic was added for hls contents, not for ads. We want to prevent ads from retrying.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-9359

