### PR TITLE
[DNM] [JW8-9133] Add skipAd to api prototype, remove from controller

### DIFF
--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -843,15 +843,6 @@ export default function Api(element) {
         },
 
         /**
-         * Calls `skipAd` on the active instream adapter instance if present.
-         * @returns {Api} The Player API instance.
-         */
-        skipAd() {
-            core.skipAd();
-            return this;
-        },
-
-        /**
          * Stops any active playback.
          * @returns {Api} The Player API instance.
          */
@@ -1053,4 +1044,10 @@ Object.assign(Api.prototype, /** @lends Api.prototype */ {
      * @returns {void}
      */
     pauseAd(toggle) {}, // eslint-disable-line
+
+    /**
+     * Skips the currently playing ad, if skippable. Implemented by ad plugins.
+     * @returns {Api} The Player API instance.
+     */
+    skipAd() {},
 });

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -1074,12 +1074,6 @@ Object.assign(Controller.prototype, {
             return this._instreamAdapter;
         };
 
-        this.skipAd = function() {
-            if (this._instreamAdapter) {
-                this._instreamAdapter.skipAd();
-            }
-        };
-
         this.instreamDestroy = function() {
             if (_this._instreamAdapter) {
                 _this._instreamAdapter.destroy();


### PR DESCRIPTION
JW8-9133

### This PR will...

* Add `skipAd()` to API prototype so that the logic can be handled by the ads plugins themselves instead of the controller
* Removes `skipAd()` logic from the controller

### Why is this Pull Request needed?

* For VPAIDs, we want to be able to call the VPAID creative's own `skipAd()` method and also check to see if the VPAID deems itself as skippable or not.
* This also creates parity with our `skipAd()` works with the IMA plugin

### Are there any points in the code the reviewer needs to double check?

n/a

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-ads-vast/pull/543
https://github.com/jwplayer/jwplayer-ads-freewheel/pull/155

#### Addresses Issue(s):

JW8-9133

