### PR TITLE
Implement latency getter in default provider, mixin 

### DIFF
--- a/src/js/providers/default.js
+++ b/src/js/providers/default.js
@@ -78,6 +78,9 @@ const DefaultProvider = {
     getBandwidthEstimate() {
         return null;
     },
+    getLiveLatency() {
+        return null;
+    },
 
     // TODO: Deprecate provider.setControls(bool) with Flash. It's used to toggle the cursor when the swf is in focus.
     setControls: noop,

--- a/src/js/providers/video-listener-mixin.js
+++ b/src/js/providers/video-listener-mixin.js
@@ -54,6 +54,7 @@ const VideoListenerMixin = {
             this.trigger(PROVIDER_FIRST_FRAME);
         }
 
+
         const timeEventObject = {
             position,
             duration,
@@ -68,6 +69,11 @@ const VideoListenerMixin = {
             if (ptsOffset >= 0) {
                 timeEventObject.metadata.mpegts = ptsOffset + position;
             }
+        }
+
+        const latency = this.getLiveLatency();
+        if (latency !== null) {
+            timeEventObject.latency = latency;
         }
 
         // only emit time events when playing or seeking


### PR DESCRIPTION
### This PR will...
Call `getLiveLatency` on the `timeupdate` video event

### Why is this Pull Request needed?
So that we can ping live latency for A/B testing

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/6747

#### Addresses Issue(s):

JW8-9325

