### PR TITLE
[DNM] Use babel plugin transform runtime to reduce bundle size by 100kb

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
   "devDependencies": {
     "@babel/core": "7.2.2",
     "@babel/helper-module-imports": "7.0.0",
+    "@babel/plugin-transform-runtime": "^7.4.4",
     "@babel/preset-env": "7.3.1",
+    "@babel/runtime": "^7.4.5",
     "async": "2.6.0",
     "babel-loader": "8.0.5",
     "chai": "4.1.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -77,6 +77,7 @@ const webpackConfig = {
                         babelrc: false,
                         presets: ['@babel/preset-env'],
                         plugins: [
+                            '@babel/plugin-transform-runtime',
                             {
                                 visitor: {
                                     CallExpression: function(path) {


### PR DESCRIPTION
### This PR will...
Reduce the total size of bin-debug/bin-release by 100kb each by removing redundant imports/duplicated polyfills.

### Why is this Pull Request needed?
Removes redundant imports. On commercial, will allow use of spread operators without breaking karma tests.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-###

