### PR TITLE
[JW8-9161] Debounce submenu open to prevent duplicate tap events

### DIFF
--- a/src/js/utils/underscore.js
+++ b/src/js/utils/underscore.js
@@ -753,6 +753,16 @@ const result = function (object, prop) {
 
 export const isValidNumber = (val) => isNumber(val) && !isNaN(val);
 
+export const debounce = (func, wait = 100) => {
+    let timeout;
+    return function(...args) {
+        clearTimeout(timeout);
+        timeout = setTimeout(() => {
+            func.apply(this, args);
+        }, wait);
+    };
+};
+
 export default {
     after,
     all,
@@ -764,6 +774,7 @@ export default {
     compact,
     constant,
     contains,
+    debounce,
     defaults,
     defer,
     delay,

--- a/src/js/view/controls/settings-menu.js
+++ b/src/js/view/controls/settings-menu.js
@@ -1,3 +1,4 @@
+import { debounce } from '../../utils/underscore';
 import { SettingsMenu } from 'view/controls/components/settings/menu';
 import {
     addCaptionsSubmenu,
@@ -20,6 +21,8 @@ export function createSettingsMenu(controlbar, onVisibility, localization) {
     controlbar.on('settingsInteraction', (submenuName, isDefault, event) => {
         const submenu = settingsMenu.getSubmenu(submenuName);
         const nonKeyboardInteraction = event && event.type !== 'enter';
+        const delayedOpen = debounce(settingsMenu.open, 10);
+
         if (!submenu && !isDefault) {
             // Do nothing if activating an invalid submenu
             // An invalid submenu is one which does not exist
@@ -43,7 +46,8 @@ export function createSettingsMenu(controlbar, onVisibility, localization) {
                 // Activate the first submenu if clicking the default button
                 settingsMenu.activateFirstSubmenu(nonKeyboardInteraction);
             }
-            settingsMenu.open(isDefault, event);
+        
+            delayedOpen(isDefault, event);
         }
     });
 


### PR DESCRIPTION
### This PR will...
Debounce the submenu open call, preventing the duplicate tap event from focusing an un-clicked menu option.

### Why is this Pull Request needed?
For a currently unknown reason, clicking a button that opens a submenu triggers 2-3 tap events.

### Are there any points in the code the reviewer needs to double check?
Do you know where the additional taps are dispatched? If so, let me know as I'd prefer to take a more holistic approach.

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-9161
