### PR TITLE
[JW8-8986] Add rtl support to info-overlay and rightclick menu

### DIFF
--- a/src/css/controls/imports/info-overlay.less
+++ b/src/css/controls/imports/info-overlay.less
@@ -37,13 +37,19 @@
 
     .jw-info-description {
         margin-bottom: 30px;
+        text-align: start;
 
         &:empty {
             display: none;
         }
     }
 
+    .jw-info-duration {
+        text-align: start;
+    }
+
     .jw-info-title {
+        text-align: start;
         font-size: 12px;
         font-weight: bold;
     }

--- a/src/css/controls/imports/rightclick.less
+++ b/src/css/controls/imports/rightclick.less
@@ -42,7 +42,9 @@
                 font-size: 11px;
                 line-height: 1em;
                 padding: 15px 23px;
+                text-align: start;
                 text-decoration: none;
+                width: 100%;
             }
 
             &:last-child {

--- a/src/js/view/controls/templates/info-overlay.js
+++ b/src/js/view/controls/templates/info-overlay.js
@@ -1,9 +1,9 @@
 export default () => (
     `<div class="jw-reset jw-info-overlay jw-modal">` +
         `<div class="jw-reset jw-info-container">` +
-            `<div class="jw-reset jw-info-title"></div>` +
-            `<div class="jw-reset jw-info-duration"></div>` +
-            `<div class="jw-reset jw-info-description"></div>` +
+            `<div class="jw-reset-text jw-info-title" dir="auto"></div>` +
+            `<div class="jw-reset-text jw-info-duration" dir="auto"></div>` +
+            `<div class="jw-reset-text jw-info-description" dir="auto"></div>` +
         `</div>` +
         `<div class="jw-reset jw-info-clientid"></div>` +
     `</div>`

--- a/src/js/view/controls/templates/rightclick.js
+++ b/src/js/view/controls/templates/rightclick.js
@@ -16,10 +16,10 @@ const rightClickItem = (item, localization) => {
 };
 
 const itemContentTypes = {
-    link: ({ link, title, logo }) => `<a href="${link || ''}" class="jw-rightclick-link jw-reset" target="_blank" rel="noreferrer">${logo}${title || ''}</a>`,
-    info: (item, localization) => `<button type="button" class="jw-reset jw-rightclick-link jw-info-overlay-item">${localization.videoInfo}</button>`,
-    share: (item, localization) => `<button type="button" class="jw-reset jw-rightclick-link jw-share-item">${localization.sharing.heading}</button>`,
-    keyboardShortcuts: () => `<button type="button" class="jw-reset jw-rightclick-link jw-shortcuts-item">Keyboard Shortcuts</button>`,
+    link: ({ link, title, logo }) => `<a href="${link || ''}" class="jw-rightclick-link jw-reset-text" target="_blank" rel="noreferrer" dir="auto">${logo}${title || ''}</a>`,
+    info: (item, localization) => `<button type="button" class="jw-reset-text jw-rightclick-link jw-info-overlay-item" dir="auto">${localization.videoInfo}</button>`,
+    share: (item, localization) => `<button type="button" class="jw-reset-text jw-rightclick-link jw-share-item" dir="auto">${localization.sharing.heading}</button>`,
+    keyboardShortcuts: () => `<button type="button" class="jw-reset-text jw-rightclick-link jw-shortcuts-item" dir="auto">Keyboard Shortcuts</button>`,
 };
 
 


### PR DESCRIPTION
### This PR will...
Switch right-click items and about overlay items from .jw-reset to .jw-reset-text, as well as add dir="auto" attribute to said elements. Styles then modified to include text-align: start.

### Why is this Pull Request needed?
To improve support for right-to-left languages.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-8986

