### PR TITLE
[JW8-9483] Check if quality exists before changing auto label

### DIFF
--- a/src/js/view/controls/settings-menu.js
+++ b/src/js/view/controls/settings-menu.js
@@ -46,7 +46,7 @@ export function createSettingsMenu(controlbar, onVisibility, localization) {
                 // Activate the first submenu if clicking the default button
                 settingsMenu.activateFirstSubmenu(nonKeyboardInteraction);
             }
-        
+
             delayedOpen(isDefault, event);
         }
     });
@@ -215,7 +215,7 @@ export function setupSubmenuListeners(settingsMenu, controlbar, viewModel, api) 
     // Visual Quality
     model.on('change:visualQuality', (changedModel, quality) => {
         const qualitySubMenu = settingsMenu.getSubmenu('quality');
-        if (qualitySubMenu) {
+        if (quality && qualitySubMenu) {
             changeAutoLabel(quality.level, qualitySubMenu, model.get('currentLevel'));
         }
     });


### PR DESCRIPTION
JW8-9483

### This PR will...

* Add a check to make sure `quality` exists before checking for `quality.level` in `change:visualQuality` event handler

### Why is this Pull Request needed?

* When casting, the `visualQuality` event will fire but `quality === null`, causing an exception and the content not to cast successfully.

### Are there any points in the code the reviewer needs to double check?

n/a

### Are there any Pull Requests open in other repos which need to be merged with this?

n/a

#### Addresses Issue(s):

JW8-9483

