### PR TITLE
Ensure time slider thumbs do no overlap settings menus

### DIFF
--- a/src/css/controls/imports/tooltip.less
+++ b/src/css/controls/imports/tooltip.less
@@ -14,9 +14,15 @@
     }
 }
 
-.jw-slider-time .jw-overlay:before {
-    height: 1em;
-    top: auto;
+.jw-slider-time {
+    .jw-overlay:before {
+        height: 1em;
+        top: auto;
+    }
+
+    .jw-icon-tooltip.jw-open .jw-overlay {
+        pointer-events: none;
+    }
 }
 
 .jw-volume-tip {


### PR DESCRIPTION
### This PR will...
Update the CSS so time slider thumbs are no longer hoverable

### Why is this Pull Request needed?
Changes made to the volume slider crept into the time slider and caused a bug

### Are there any points in the code the reviewer needs to double check?
Nah

### Are there any Pull Requests open in other repos which need to be merged with this?
Nah

#### Addresses Issue(s):

JW8-9426

