### PR TITLE
[JW8-9349] Implement compiler-friendly captions styles

### DIFF
--- a/src/css/jwplayer/imports/captions.less
+++ b/src/css/jwplayer/imports/captions.less
@@ -80,7 +80,11 @@
 .jwplayer:not(.jw-state-playing),
 .jwplayer.jw-flag-media-audio.jw-state-playing,
 .jwplayer.jw-state-playing:not(.jw-flag-user-inactive):not(.jw-flag-controls-hidden) {
-    .jw-captions,
+    // Style duplication below prevents compiler bug resulting in lost styles.
+    .jw-captions {
+        max-height: calc(100% - 60px);
+    }
+
     &:not(.jw-flag-ios-fullscreen) video::-webkit-media-text-track-container {
         max-height: calc(100% - 60px);
     }


### PR DESCRIPTION
### This PR will...
make a syntax change to the LESS as a work-around to a bug with style-loader. This will fix the IE/Edge VTT captions bug.

### Why is this Pull Request needed?
Currently captions are displaying under the bar on IE/Edge

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-9349

