### PR TITLE
[JW8-9901] Use -1 instead of 0 on default bitrate, so we can detect when it's be…

### DIFF
--- a/src/js/providers/video-listener-mixin.js
+++ b/src/js/providers/video-listener-mixin.js
@@ -160,7 +160,7 @@ const VideoListenerMixin = {
 
     ended() {
         this.videoHeight = 0;
-        this.streamBitrate = 0;
+        this.streamBitrate = -1;
         if (this.state !== STATE_IDLE && this.state !== STATE_COMPLETE) {
             this.trigger(MEDIA_COMPLETE);
         }


### PR DESCRIPTION
…en updated

### This PR will...
Set stream bitrate to -1 on end.

### Why is this Pull Request needed?
A PR on commercial for the same ticket updates this value, should be changed here to stay uniform.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/6868

#### Addresses Issue(s):

JW8-9901

