### PR TITLE
Always pass the captions tracks to the captions renderer live restart rendering

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -779,10 +779,10 @@ Object.assign(Controller.prototype, {
             return _programController.audioTracks;
         }
 
-        function _setCurrentCaptions(index) {
+        function _setCurrentCaptions(index, tracks) {
             index = parseInt(index, 10) || 0;
 
-            _model.persistVideoSubtitleTrack(index);
+            _model.persistVideoSubtitleTrack(index, tracks);
             _programController.subtitles = index;
 
             _this.trigger(CAPTIONS_CHANGED, {
@@ -850,7 +850,7 @@ Object.assign(Controller.prototype, {
 
                     // set the current captions if the default index isn't 0 or "Off"
                     if (defaultCaptionsIndex > 0) {
-                        _setCurrentCaptions(defaultCaptionsIndex);
+                        _setCurrentCaptions(defaultCaptionsIndex, e.tracks);
                     }
                 }, _this)
                 .on(MEDIA_COMPLETE, () => {


### PR DESCRIPTION
### This PR will...
Ensure that captions tracks are always passed to the renderer

### Why is this Pull Request needed?
We destroy and recreate the hlsjs instance when live is stopped and resumed. Since the caption tracks were not always passed, when we were to clear them on destroy the renderer would not have access to them when spinning back up, requiring the user to turn them off and then on again

### Are there any points in the code the reviewer needs to double check?
Nah

### Are there any Pull Requests open in other repos which need to be merged with this?
Nah
#### Addresses Issue(s):

JW8-9105

