### PR TITLE
[JW8-10018] Remove playlist from feedData

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -240,9 +240,7 @@ Object.assign(Controller.prototype, {
                     };
                     const feedData = _model.get('feedData');
                     if (feedData) {
-                        const eventFeedData = Object.assign({}, feedData);
-                        delete eventFeedData.playlist;
-                        eventData.feedData = eventFeedData;
+                        eventData.feedData = Object.assign({}, feedData);
                     }
                     _this.trigger(PLAYLIST_LOADED, eventData);
                 }
@@ -1023,7 +1021,10 @@ Object.assign(Controller.prototype, {
                 // Throw exception if playlist is empty
                 validatePlaylist(filteredPlaylist);
 
-                _model.set('feedData', feedData);
+                const sanitizedFeedData = Object.assign({}, feedData);
+                delete sanitizedFeedData.playlist;
+
+                _model.set('feedData', sanitizedFeedData);
                 _model.set('playlist', filteredPlaylist);
             } catch (error) {
                 return Promise.reject(error);

--- a/src/js/playlist/playlist.js
+++ b/src/js/playlist/playlist.js
@@ -14,7 +14,7 @@ export function filterPlaylist(playlist, model, feedData) {
     const itemFeedData = Object.assign({}, feedData);
     delete itemFeedData.playlist;
 
-    return playlist.map((item) => normalizePlaylistItem(model, item, feedData)).filter((item) => !!item);
+    return playlist.map((item) => normalizePlaylistItem(model, item, itemFeedData)).filter((item) => !!item);
 
 }
 


### PR DESCRIPTION
### This PR will...
Revert part of an unintended change that caused the `playlist` property get  passed into `feedData`.

### Why is this Pull Request needed?
related events include `feedData` which should not contain a `playlist` property.

This bug causes automated tests to fail:

```gherkin
    Scenario: feedShown event should be triggered when opening the playlist overlay
      enterprise player is ready after recommendations/recommendations-feed-events.json setup
      I click on the centered play button to start playback
      playback has started
      the playlist_button in the control-bar is selected
      on('relatedfeedShown') was fired once
test/cucumber-features/recommendations/recommendations_feedshown_api_events.feature:16:5

      on('relatedfeedShown') object matches JSON feedshown-open-playlist
ERROR: Expected event object to deeply equal JSON:

      [ DiffDeleted {
    kind: 'D',
    path: [ 'feedData', 'playlist' ],
    lhs: [ [Object], [Object], [Object] ] },
```

### Are there any points in the code the reviewer needs to double check?

It looks like there was a fix, followed by a change that undid the fix roughly a year ago, released with 8.5.0:
https://github.com/jwplayer/jwplayer/commit/6ed22f5a06c5d3b3c8754a17e1dbb62440c558e5
https://github.com/jwplayer/jwplayer/commit/c740748bf5d6a9ee134d38778c0e8081fc526a61
But in addition to this, related is pulling feedData from the player model where it has not been sanitized.

### Are there any Pull Requests open in other repos which need to be merged with this?
Our unit tests were asserting that parsed feed JSON was copied directly to the model which it should not. Using `deep.equal` asserts that all the object property values are equal:
https://github.com/jwplayer/jwplayer-commercial/pull/6881