### PR TITLE
[JW8-9533] Add autoPause option to pause ads

### DIFF
--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -10,8 +10,11 @@ import { getLanguage, getCustomLocalization, applyTranslation, normalizeIntl } f
 /* eslint camelcase: 0 */
 // Defaults
 // Alphabetical order
-export const Defaults = {
-    autoPause: { viewability: false },
+const Defaults = {
+    autoPause: {
+        viewability: false,
+        pauseAds: false
+    },
     autostart: false,
     bandwidthEstimate: null,
     bitrateSelection: null,

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -10,7 +10,7 @@ import { getLanguage, getCustomLocalization, applyTranslation, normalizeIntl } f
 /* eslint camelcase: 0 */
 // Defaults
 // Alphabetical order
-const Defaults = {
+export const Defaults = {
     autoPause: {
         viewability: false,
         pauseAds: false

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -364,7 +364,7 @@ Object.assign(Controller.prototype, {
             if (model.get('playOnViewable')) {
                 if (viewable) {
                     const reason = 'viewable';
-                    if (model.get('state') === STATE_IDLE) {
+                    if (model.get('state') === STATE_IDLE && !(model.get('autoPause').pauseAds && adState)) {
                         _autoStart(reason);
                     } else {
                         _play({ reason });
@@ -388,7 +388,11 @@ Object.assign(Controller.prototype, {
             const playReason = model.get('playReason');
 
             if (adState) {
-                _pauseAfterAd(viewable);
+                if (model.get('autoPause').pauseAds) {
+                    _pauseWhenNotViewable(viewable);
+                } else {
+                    _pauseAfterAd(viewable);
+                }
             } else if (playerState === STATE_PLAYING || playerState === STATE_BUFFERING) {
                 _pauseWhenNotViewable(viewable);
             } else if (playerState === STATE_IDLE && playReason === 'playlist') {
@@ -487,7 +491,8 @@ Object.assign(Controller.prototype, {
 
             const adState = _getAdState();
             const pauseReason = _model.get('pauseReason');
-            if (adState && pauseReason === 'viewable' && playReason !== 'interaction') {
+            const autoPauseAds = _model.get('autoPause').pauseAds;
+            if (adState && !autoPauseAds && pauseReason === 'viewable' && playReason !== 'interaction') {
                 return;
             }
 

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -364,9 +364,11 @@ Object.assign(Controller.prototype, {
             if (model.get('playOnViewable')) {
                 if (viewable) {
                     const reason = 'viewable';
-                    if (model.get('state') === STATE_IDLE) {
+                    const autoPauseAds = model.get('autoPause').pauseAds;
+                    const pauseReason = model.get('pauseReason');
+                    if (_getState() === STATE_IDLE) {
                         _autoStart(reason);
-                    } else if (!adState || model.get('autoPause').pauseAds) {
+                    } else if ((!adState || autoPauseAds) && pauseReason !== 'interaction') {
                         // resume normal playback or ads if pauseAds is true
                         _play({ reason });
                     }
@@ -491,11 +493,6 @@ Object.assign(Controller.prototype, {
             _model.set('playReason', playReason);
 
             const adState = _getAdState();
-            const pauseReason = _model.get('pauseReason');
-            const autoPauseAds = _model.get('autoPause').pauseAds;
-            if (adState && !autoPauseAds && pauseReason === 'viewable' && playReason !== 'interaction') {
-                return;
-            }
 
             if (adState) {
                 // this will resume the ad. _api.playAd would load a new ad

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -364,9 +364,10 @@ Object.assign(Controller.prototype, {
             if (model.get('playOnViewable')) {
                 if (viewable) {
                     const reason = 'viewable';
-                    if (model.get('state') === STATE_IDLE && !(model.get('autoPause').pauseAds && adState)) {
+                    if (model.get('state') === STATE_IDLE) {
                         _autoStart(reason);
-                    } else {
+                    } else if (!adState || model.get('autoPause').pauseAds) {
+                        // resume normal playback or ads if pauseAds is true
                         _play({ reason });
                     }
                 } else if (OS.mobile && !adState) {

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -469,7 +469,9 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
         // when instream was inited and the player was not destroyed\
         _controller.attachMedia();
 
-        if (this.noResume) {
+        const autoPauseAds = _model.get('autoPause').pauseAds;
+        const playerState = _model.get('state');
+        if (this.noResume || (playerState === STATE_PAUSED) && autoPauseAds) {
             return;
         }
 

--- a/test/data/model-properties.js
+++ b/test/data/model-properties.js
@@ -69,7 +69,10 @@ export const addedProperties = {
 
 export default {
     id: '',
-    autoPause: { viewability: false },
+    autoPause: {
+        viewability: false,
+        pauseAds: false
+    },
     autostart: false,
     base: '',
     controls: true,


### PR DESCRIPTION
JW8-9533

### This PR will...

- Cause the player to automatically pause during ad playback when player becomes not viewable, if `autoPause.viewability` and `autoPause.pauseAds` configuration options are both `true`
- If ads are paused due to the player becoming not viewable, they should resume when the player becomes viewable.

### Why is this Pull Request needed?

- Previously, ad playback would continue and then pause afterwards if player becomes not viewable.
- Customers have requested the ability to automatically pause ad playback in outstream players.

### Are there any points in the code the reviewer needs to double check?

n/a

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-commercial/pull/6890

#### Addresses Issue(s):

JW8-9533

