### PR TITLE
[JW8-9936] Sanitize Right Click Menu links before appending to DOM.

### DIFF
--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -25,7 +25,7 @@ function appendHtml(element, html) {
     const fragment = document.createDocumentFragment();
     const nodes = htmlToParentElement(html).childNodes;
     for (let i = 0; i < nodes.length; i++) {
-        fragment.appendChild(nodes[i].cloneNode());
+        fragment.appendChild(nodes[i].cloneNode(true));
     }
     element.appendChild(fragment);
 }
@@ -39,7 +39,7 @@ export function htmlToParentElement(html) {
     // Delete script nodes
     sanitizeScriptNodes(parsedElement);
     // Delete event handler attributes that could execute XSS JavaScript
-    const insecureElements = parsedElement.querySelectorAll('img,svg');
+    const insecureElements = parsedElement.querySelectorAll('*');
 
     for (let i = insecureElements.length; i--;) {
         const element = insecureElements[i];

--- a/test/unit/sanitize-html-test.js
+++ b/test/unit/sanitize-html-test.js
@@ -25,7 +25,7 @@ describe('Sanitize HTML', function () {
             expect(element.firstChild.getAttribute('onerror')).to.equal(null);
         });
 
-        it('should sanitizea and add svg tags', function () {
+        it('should sanitize and add svg tags', function () {
             const svgHtml = '<svg xmlns="http://www.w3.org/2000/svg" onload="console.log(\'baz\')"/>';
             replaceInnerHtml(element, svgHtml);
             expect(console.log).to.have.callCount(0);
@@ -51,6 +51,14 @@ describe('Sanitize HTML', function () {
             expect(console.log).to.have.callCount(0);
             expect(nestedElement.getAttribute('onload')).to.equal(null);
             expect(nestedElement.firstChild).to.equal(null);
+        });
+
+        it('should sanitize any html element', function () {
+            const divHtml = '<div onmouseover=console.log(document.domain)>foo</div>';
+            replaceInnerHtml(element, divHtml);
+            expect(console.log).to.have.callCount(0);
+            expect(element.firstChild.getAttribute('onmouseover')).to.equal(null);
+            expect(element.firstChild.textContent).to.equal('foo');
         });
     });
 


### PR DESCRIPTION
### This PR will...

- Sanitize attributes of all elements instead of just ```img``` and ```svg``` tags.
- Pass ```true```  when calling```cloneNode```. 

### Why is this Pull Request needed?

- To prevent injecting JavaScript in the right click menu through config options.
- To make sure the text of an html element is copied over when calling ```appendHtml```. We currently don't do that if you pass in html that has text in it. (ex: the description of a video is ```<div>foobar</div>```. Foobar would get stripped out but the empty div would still be appended to the DOM as the description.

### Are there any points in the code the reviewer needs to double check?

- Could looping through every node, slow down setup time?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-9936

