### PR TITLE
[JW8-10019] Fix styling on captions for players with controls hidden

### DIFF
--- a/src/css/jwplayer/imports/captions.less
+++ b/src/css/jwplayer/imports/captions.less
@@ -77,7 +77,7 @@
     }
 }
 
-.jwplayer:not(.jw-state-playing),
+.jwplayer:not(.jw-flag-controls-hidden):not(.jw-state-playing),
 .jwplayer.jw-flag-media-audio.jw-state-playing,
 .jwplayer.jw-state-playing:not(.jw-flag-user-inactive):not(.jw-flag-controls-hidden) {
     // Style duplication below prevents compiler bug resulting in lost styles.


### PR DESCRIPTION
### This PR will...
Fix captions styling for players with controls disabled.

### Why is this Pull Request needed?
When controls are disabled, and there are multiline captions being used, everything after the first line is cut off when the player is paused.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-10019

