### PR TITLE
[JW8-9939] Export config defaults and prevent timeslider active color styling

### DIFF
--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -10,7 +10,7 @@ import { getLanguage, getCustomLocalization, applyTranslation, normalizeIntl } f
 /* eslint camelcase: 0 */
 // Defaults
 // Alphabetical order
-const Defaults = {
+export const Defaults = {
     autoPause: { viewability: false },
     autostart: false,
     bandwidthEstimate: null,

--- a/src/js/view/controls/components/custom-button.js
+++ b/src/js/view/controls/components/custom-button.js
@@ -4,7 +4,7 @@ import svgParse from 'utils/svgParser';
 
 let collection = {};
 
-function getCachedIcon(svg) {
+export function getCachedIcon(svg) {
     if (!collection[svg]) {
         const icons = Object.keys(collection);
         if (icons.length > 10) {

--- a/src/js/view/utils/skin.js
+++ b/src/js/view/utils/skin.js
@@ -176,15 +176,18 @@ export function handleColorOverrides(playerId, skin) {
     }
 
     function styleTimeslider(config) {
+        const { progress } = config;
 
-        addStyle([
-            '.jw-progress',
-            '.jw-knob'
-        ], 'background-color', config.progress);
+        if (progress !== 'none') {
+            addStyle([
+                '.jw-progress',
+                '.jw-knob'
+            ], 'background-color', progress);
 
-        addStyle([
-            '.jw-buffer',
-        ], 'background-color', getRgba(config.progress, 50));
+            addStyle([
+                '.jw-buffer',
+            ], 'background-color', getRgba(progress, 50));
+        }
 
         addStyle([
             '.jw-rail'


### PR DESCRIPTION
### This PR will...
- Export config defaults for use in commercial project
- Accept 'none' as a value for `skin.timeslider.progress` color to prevent the timeslider from having the `skin.active` color applied

### Why is this Pull Request needed?
Improve branding options and allow config defaults to be used in commercial.

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/6916

#### Addresses Issue(s):
JW8-9939
