### PR TITLE
[JW8-9895] Expose replaceInnerHtml function for ads plugins

### DIFF
--- a/src/js/utils/helpers.js
+++ b/src/js/utils/helpers.js
@@ -27,6 +27,7 @@ import {
     addStyleSheet,
     bounds,
     openLink,
+    replaceInnerHtml
 } from 'utils/dom';
 import {
     css,
@@ -77,6 +78,7 @@ const helpers = Object.assign({}, parser, validator, playerutils, {
     addStyleSheet,
     bounds,
     openLink,
+    replaceInnerHtml,
     css,
     clearCss,
     style,


### PR DESCRIPTION
### This PR will...
- Expose `replaceInnerHtml` function

### Why is this Pull Request needed?
- Vast plugin wants to use it for sanitizing icon innerHTML

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-ads-vast/pull/567

#### Addresses Issue(s):

JW8-9895

