### PR TITLE
[JW8-10140] Don't update size on aspect ratio change when floating

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -481,7 +481,7 @@ function View(_api, _model) {
         style(aspectRatioContainer, {
             paddingTop: aspectratio || null
         });
-        if (_this.isSetup && aspectratio) {
+        if (_this.isSetup && aspectratio && !_model.get('isFloating')) {
             style(_playerElement, getPlayerSizeStyles(model.get('width')));
             _responsiveUpdate();
         }


### PR DESCRIPTION
### Why is this Pull Request needed?
To prevent the player from being resized when floating. This could lead to a loop where the player floats, resizes, goes in to view, stop floating, resizes, goes out of view and repeats.

#### Addresses Issue(s):
JW8-10140
