### PR TITLE
[JW8-10170] Resolve issues with pauseAds in autostart players

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -346,7 +346,6 @@ Object.assign(Controller.prototype, {
         }
 
         function _pauseAfterAd(viewable) {
-            _this._instreamAdapter.noResume = !viewable;
             if (!viewable) {
                 _updatePauseReason({ reason: 'viewable' });
             }
@@ -389,9 +388,10 @@ Object.assign(Controller.prototype, {
             const playerState = model.get('state');
             const adState = _getAdState();
             const playReason = model.get('playReason');
+            const autoPauseAds = model.get('autoPause').pauseAds;
 
             if (adState) {
-                if (model.get('autoPause').pauseAds) {
+                if (autoPauseAds) {
                     _pauseWhenNotViewable(viewable);
                 } else {
                     _pauseAfterAd(viewable);
@@ -403,6 +403,10 @@ Object.assign(Controller.prototype, {
                 model.once('change:state', () => {
                     _pauseWhenNotViewable(viewable);
                 });
+            } else if (autoPauseAds && playerState === STATE_IDLE && !viewable) {
+                // When autostarting ads, instream may not be initialized
+                // so we need to check if we should pause for pauseAds
+                _pauseWhenNotViewable(viewable);
             }
         }
 

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -470,8 +470,8 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
         _controller.attachMedia();
 
         const autoPauseAds = _model.get('autoPause').pauseAds;
-        const playerState = _model.get('state');
-        if (this.noResume || (playerState === STATE_PAUSED) && autoPauseAds) {
+        const viewable = _model.get('viewable');
+        if (this.noResume || (autoPauseAds && !viewable)) {
             return;
         }
 


### PR DESCRIPTION
### This PR will...

- Check for viewability in instream adapter (instead of player state) when deciding whether or not to resume after destroying instream
- Add case in `_checkPauseWhenViewable()` for when we are autostarting with ads

### Why is this Pull Request needed?

- The logic for when deciding whether or not to resume content playback when destroying the instream adapter was flawed as it checked for when the player state was paused. This is not good because we destroy instream on setup and, when doing so, set the player's state to paused.

### Are there any points in the code the reviewer needs to double check?

n/a

### Are there any Pull Requests open in other repos which need to be merged with this?

n/a

#### Addresses Issue(s):

JW8-10170

