### PR TITLE
[JW8-10170] Resolve pauseAds issues

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -403,6 +403,15 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
      * @return {void}
      */
     this.skipAd = function(event) {
+        const autoPauseAds = _model.get('autoPause').pauseAds;
+        const didNotAutostart = _model.get('playReason') !== 'autostart';
+        const viewable = _model.get('viewable');
+        if (autoPauseAds && didNotAutostart && !viewable) {
+            // If autoPause.pauseAds is enabled and player is not viewable
+            // when skipAd() is called, do not resume playback
+            this.noResume = true;
+        }
+
         const skipAdType = AD_SKIPPED;
         this.trigger(skipAdType, event);
         _skipAd.call(this, {
@@ -469,9 +478,7 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
         // when instream was inited and the player was not destroyed\
         _controller.attachMedia();
 
-        const autoPauseAds = _model.get('autoPause').pauseAds;
-        const playerState = _model.get('state');
-        if (this.noResume || (playerState === STATE_PAUSED) && autoPauseAds) {
+        if (this.noResume) {
             return;
         }
 

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -404,9 +404,9 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
      */
     this.skipAd = function(event) {
         const autoPauseAds = _model.get('autoPause').pauseAds;
-        const didNotAutostart = _model.get('playReason') !== 'autostart';
+        const didAutostart = _model.get('playReason') === 'autostart';
         const viewable = _model.get('viewable');
-        if (autoPauseAds && didNotAutostart && !viewable) {
+        if (autoPauseAds && !didAutostart && !viewable) {
             // If autoPause.pauseAds is enabled and player is not viewable
             // when skipAd() is called, do not resume playback unless player
             // was autostarted out of view and never came in to view

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -408,7 +408,8 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
         const viewable = _model.get('viewable');
         if (autoPauseAds && didNotAutostart && !viewable) {
             // If autoPause.pauseAds is enabled and player is not viewable
-            // when skipAd() is called, do not resume playback
+            // when skipAd() is called, do not resume playback unless player
+            // was autostarted out of view and never came in to view
             this.noResume = true;
         }
 


### PR DESCRIPTION
This PR supercedes #3465 .

JW8-10170

### This PR will...

- Make it so we are not checking for the player state when destroying instream. The check was previously put in for the `pauseAds` work but caused issues (see next section).
- Check whether or not we should resume when calling `skipAd()`, either via the skip button or the API.
  - If player autostarted and was never viewable and `skipAd()` is called, resume playback.
  - If player autostarted, was viewable and then paused due to viewability and `skipAd()` is called, do not resume playback.

### Why is this Pull Request needed?

- The logic for when deciding whether or not to resume content playback when destroying the instream adapter was flawed as it checked for when the player state was paused. This is not good because we destroy instream on setup and, when doing so, set the player's state to paused. This would cause instream to not call to play the content once destroyed.
- The `pauseAds` logic was also incorrectly implemented so that the player would be paused, whether in ads mode or not, if it was autostarting out of view and `pauseAds: true`.

### Are there any points in the code the reviewer needs to double check?

- I checked everything I can think of but the one edge case that I'm not sure if we need to worry about is the following:
  - Autostarting in view
  - Skippable ad playback is paused by going out of view
  - Skipping an ad within an ad pod

In this scenario, the next pod item will play, even though the player is out of view. Once the entire pod is finished, playback will not resume. The issue is that subsequent pod items will play even though the player was auto-paused due to viewability. I don't think this is a widely used use case, however.

(cc @egreaves )

### Are there any Pull Requests open in other repos which need to be merged with this?

n/a

#### Addresses Issue(s):

JW8-10170

