### PR TITLE
[JW8-9807] Reset custom font-size after exiting fullscreen on iOS

### DIFF
--- a/src/js/view/captionsrenderer.js
+++ b/src/js/view/captionsrenderer.js
@@ -273,12 +273,15 @@ const CaptionsRenderer = function (viewModel) {
 
     function _setShadowDOMFontSize(playerId, fontSize) {
         // Set Shadow DOM font size (needs to be important to override browser's in line style)
-        _windowStyle.fontSize = fontSize;
         const selector = `#${playerId} .jw-video::-webkit-media-text-track-display`;
-        if (fontSize && OS.iOS) {
-            // Force layout after exiting fullscreen
-            css(selector, { fontSize: 'inherit' }, playerId, true);
+        if (fontSize) {
+            fontSize += 'px';
+            if (OS.iOS) {
+                // Force layout after exiting fullscreen
+                css(selector, { fontSize: 'inherit' }, playerId, true);
+            }
         }
+        _windowStyle.fontSize = fontSize;
         css(selector, _windowStyle, playerId, true);
     }
 

--- a/src/js/view/captionsrenderer.js
+++ b/src/js/view/captionsrenderer.js
@@ -200,7 +200,7 @@ const CaptionsRenderer = function (viewModel) {
 
         let fontSize;
         if (_model.get('fullscreen') && OS.iOS) {
-            fontSize = 'inherit';
+            fontSize = null;
         } else {
             // round to 1dp to match browser precision
             const containerFontSize = height * _fontScale;
@@ -273,8 +273,13 @@ const CaptionsRenderer = function (viewModel) {
 
     function _setShadowDOMFontSize(playerId, fontSize) {
         // Set Shadow DOM font size (needs to be important to override browser's in line style)
-        _windowStyle.fontSize = fontSize + 'px';
-        css('#' + playerId + ' .jw-video::-webkit-media-text-track-display', _windowStyle, playerId, true);
+        _windowStyle.fontSize = fontSize;
+        const selector = `#${playerId} .jw-video::-webkit-media-text-track-display`;
+        if (fontSize && OS.iOS) {
+            // Force layout after exiting fullscreen
+            css(selector, { fontSize: 'inherit' }, playerId, true);
+        }
+        css(selector, _windowStyle, playerId, true);
     }
 
     function _addTextStyle(textStyle, options) {


### PR DESCRIPTION
### This PR will...
Force iOS to resize captions shadow-dom elements when setting a custom font-size.

### Why is this Pull Request needed?
When exiting fullscreen on iOS, the browser ignores the important font-size rules that we attempt to restore. Setting a rule to inherit font-size first, forces the browser to update layout.

#### Addresses Issue(s):
JW8-9807

