### PR TITLE
[JW8-9502] Open Source Changes for Motion Thumbnails

### DIFF
--- a/src/css/jwplayer/imports/video.less
+++ b/src/css/jwplayer/imports/video.less
@@ -1,5 +1,5 @@
 .jwplayer {
-    video {
+    .jw-media video {
         position: absolute;
         top: 0;
         right: 0;
@@ -17,25 +17,25 @@
     }
 
     &.jw-stretch-uniform {
-        video {
+        .jw-media video {
             object-fit: contain;
         }
     }
 
     &.jw-stretch-none {
-        video {
+        .jw-media video {
             object-fit: none;
         }
     }
 
     &.jw-stretch-fill {
-        video {
+        .jw-media video {
             object-fit: cover;
         }
     }
 
     &.jw-stretch-exactfit {
-        video {
+        .jw-media video {
             object-fit: fill;
         }
     }

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -63,7 +63,7 @@ function View(_api, _model) {
     const _videoLayer = _playerElement.querySelector('.jw-media');
     const _floatingUI = new FloatingDragUI(_wrapperElement);
 
-    const _preview = new Preview(_model);
+    const _preview = new Preview(_model, _api);
     const _title = new Title(_model);
 
     const _captionsRenderer = new CaptionsRenderer(_model);

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -337,7 +337,7 @@ function View(_api, _model) {
         playerViewModel.change('controls', changeControls);
         _model.change('streamType', _setLiveMode);
         _model.change('mediaType', _onMediaTypeChange);
-        playerViewModel.change('playlistItem', onPlaylistItem);
+        playerViewModel.change('playlistItem', onPlaylistItem.bind(this));
         // Triggering 'resize' resulting in player 'ready'
         _lastWidth = _lastHeight = null;
         this.checkResized();
@@ -771,17 +771,17 @@ function View(_api, _model) {
         videotag.setAttribute('title', body.textContent);
     }
 
-    function setPosterImage(item) {
-        _preview.setImage(item && item.image);
-    }
+    this.setPosterImage = function(item, preview) {
+        preview.setImage(item && item.image);
+    };
 
-    function onPlaylistItem(model, item) {
-        setPosterImage(item);
+    const onPlaylistItem = (model, item) => {
+        this.setPosterImage(item, _preview);
         // Set the title attribute of the video tag to display background media information on mobile devices
         if (_isMobile) {
             setMediaTitleAttribute(model, item);
         }
-    }
+    };
 
     const settingsMenuVisible = () => {
         const settingsMenu = _controls && _controls.settingsMenu;

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -337,7 +337,9 @@ function View(_api, _model) {
         playerViewModel.change('controls', changeControls);
         _model.change('streamType', _setLiveMode);
         _model.change('mediaType', _onMediaTypeChange);
-        playerViewModel.change('playlistItem', onPlaylistItem.bind(this));
+        playerViewModel.change('playlistItem', (model, item) => { 
+            onPlaylistItem(model, item);
+        });
         // Triggering 'resize' resulting in player 'ready'
         _lastWidth = _lastHeight = null;
         this.checkResized();


### PR DESCRIPTION
### This PR will...
Make setPosterImage a property of view object so extended preview can be procedurally selected for commercial motion thumbs changes

### Why is this Pull Request needed?
For commercial changes to work

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/6958

#### Addresses Issue(s):

JW8-9502
