### PR TITLE
Timer test fix

### DIFF
--- a/test/unit/timer-test.js
+++ b/test/unit/timer-test.js
@@ -1,14 +1,15 @@
 import Timer from 'api/timer';
 import { dateTime } from 'utils/clock';
-import { now } from 'utils/date';
 
 describe('clock', function() {
     it('provides date time equal or close to Date.now()', function() {
+        const before = Date.now() - 2;
         const clockTime = dateTime();
-        const dateGetTime = now();
+        const after = Date.now() + 2;
         // With rounding differences between Date.now() and performance.now(),
         // and JavaScipt execution, only allow a few milliseconds difference
-        expect(Math.abs(clockTime - dateGetTime)).to.be.below(5);
+        expect(clockTime).to.be.at.least(before);
+        expect(clockTime).to.be.at.most(after);
     });
 });
 


### PR DESCRIPTION
### This PR will...
Verify that utils/clock `dateTime()` returns a value within the Date ranges that the command is called.

### Why is this Pull Request needed?
So that tests don't fail on Jenkins or other environments that take longer than 5ms to run a line of code.

The command being tested, `dateTime()`, returns `performance.timing.navigationStart + performance.now()`. It provides more precision than Date.now() but may be off by 2 ms with rounding errors in some browsers. This test change accounts for that rather than trying to confirm that the command is executed within 3-7 ms of calling `now()`.
