### PR TITLE
[JW8-10119] Handle cases where skipoffset is set to 0

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -331,9 +331,8 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
         const playPromise = _adProgram.setActiveItem(_arrayIndex);
 
         _backgroundLoadTriggered = false;
-        _skipOffset = item.skipoffset || _options.skipoffset;
-        if (_skipOffset !== undefined) {
-            _this.setupSkipButton(_skipOffset, _options);
+        if (_options.skipoffset !== undefined) {
+            _this.setupSkipButton(_options.skipoffset, _options);
         }
         return playPromise;
     };

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -331,8 +331,9 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
         const playPromise = _adProgram.setActiveItem(_arrayIndex);
 
         _backgroundLoadTriggered = false;
-        if (_options.skipoffset !== undefined) {
-            _this.setupSkipButton(_options.skipoffset, _options);
+        _skipOffset = _options.skipoffset;
+        if (_skipOffset !== undefined) {
+            _this.setupSkipButton(_skipOffset, _options);
         }
         return playPromise;
     };

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -332,7 +332,7 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
 
         _backgroundLoadTriggered = false;
         _skipOffset = item.skipoffset || _options.skipoffset;
-        if (_skipOffset) {
+        if (_skipOffset !== undefined) {
             _this.setupSkipButton(_skipOffset, _options);
         }
         return playPromise;


### PR DESCRIPTION
JW8-10119

### This PR will...

- Change the conditional for determine whether or not to setup the skip button to see if it's not undefined.

### Why is this Pull Request needed?

- Before this change, the conditional would evaluate to `false` when `skipoffset: 0` was set in the config, thus not running `setupSkipButton()`.

### Are there any points in the code the reviewer needs to double check?

n/a

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-ads-vast/pull/583

#### Addresses Issue(s):

JW8-10119

