### PR TITLE
[JW8-10119] Handle when skipoffset is 0

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -331,6 +331,7 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
         const playPromise = _adProgram.setActiveItem(_arrayIndex);
 
         _backgroundLoadTriggered = false;
+        // Need to use item.skipoffset since _options is undefined for subsequent ads in pods
         _skipOffset = item.skipoffset || _options.skipoffset;
         if (_skipOffset !== undefined) {
             _this.setupSkipButton(_skipOffset, _options);

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -332,7 +332,7 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
 
         _backgroundLoadTriggered = false;
         _skipOffset = item.skipoffset || _options.skipoffset;
-        if (_skipOffset) {
+        if (_skipOffset !== undefined) {
             _this.setupSkipButton(_skipOffset, _options);
         }
         return playPromise;


### PR DESCRIPTION
JW8-10119

### This PR will...

- Change the conditional for determine whether or not to setup the skip button to see if it's not undefined.

### Why is this Pull Request needed?

- Before this change, the conditional would evaluate to `false` when `skipoffset: 0` was set in the config, thus not running `setupSkipButton()`.

### Are there any points in the code the reviewer needs to double check?

n/a

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-ads-vast/pull/584

#### Addresses Issue(s):

JW8-10119

