### PR TITLE
add language to captions returned by _captionsMenu

### DIFF
--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -103,7 +103,8 @@ const Captions = function(_model) {
         for (let i = 0; i < _tracks.length; i++) {
             list.push({
                 id: _tracks[i]._id,
-                label: _tracks[i].name || 'Unknown CC'
+                label: _tracks[i].name || 'Unknown CC',
+                language: _tracks[i].language,
             });
         }
         return list;


### PR DESCRIPTION
### This PR will...

Address #3474 and add the `language` property to tracks returned by `_captionsMenu()` (and, by extension, `getCaptionsList()`).

### Why is this Pull Request needed?

`LANGUAGE` is [part of the HLS specification for alternate media](https://developer.apple.com/documentation/http_live_streaming/example_playlists_for_http_live_streaming/adding_alternate_media_to_a_playlist) as an optional attribute used to "[identify] the primary language used in the media selection." This differs from `NAME` (returned as `label` by JWPlayer), which the HLS specification indicates is a "[description of] the primary language used in the media selection."

It’s generally good practice to be distinguish a display name (for user presentation) from a programatic identifier, so as to be able to vary these independently. The ability to do so via separate `name` (`label`) and `language` attributes corresponding to the HLS spec is common in video players (examples of some are provided below).

User presentation makes the `NAME` attribute an especially poor candidate for unique language identifiers (like locales) because even in instances where JWPlayer's default UI is being overridden, the `name` attribute will still be exposed to users when the media is played on devices not controlled by JWPlayer (e.g. iOS Safari's web player, Chromecast, AppleTV) where `NAME` is assumed to be user-facing (as the HLS specification suggests). 

### Are there any points in the code the reviewer needs to double check?

None that I know of.

### Are there any Pull Requests open in other repos which need to be merged with this?

No.

