### PR TITLE
[JW8-10237] Await Shaka destroy

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -813,7 +813,7 @@ Object.assign(Controller.prototype, {
             if (_backgroundLoading) {
                 _programController.backgroundActiveMedia();
             } else {
-                _programController.attached = false;
+                return _programController.setAttached(false);
             }
         }
 
@@ -823,7 +823,7 @@ Object.assign(Controller.prototype, {
             if (_backgroundLoading) {
                 _programController.restoreBackgroundMedia();
             } else {
-                _programController.attached = true;
+                _programController.setAttached(true);
             }
 
             if (typeof _actionOnAttach === 'function') {

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -32,7 +32,7 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
     let _arrayOptions;
     let _arrayIndex = 0;
     let _data = {};
-    let _destroyPromise = Promise.resolve();
+    let _destroyPromise = null;
     let _options = {};
     let _skipAd = _instreamItemNext;
     let _backgroundLoadTriggered = false;
@@ -102,7 +102,7 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
         // Shaka cleans the videotag async, so wait until its destroy promise fulfills.
         const provider = _model.get('provider');
         if (!_model.get('backgroundLoading') && provider && provider.name === 'shaka') {
-            _destroyPromise = Promise.resolve(_model._provider.destroy());
+            _destroyPromise = _model._provider.destroy();
         }
 
         const mediaElement = _adProgram.primedElement;
@@ -335,7 +335,9 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
 
         adModel.set('skipButton', false);
 
-        const playPromise = _destroyPromise.then(() => _adProgram.setActiveItem(_arrayIndex));
+        const playPromise = _destroyPromise
+            ? _destroyPromise.then(() => _adProgram.setActiveItem(_arrayIndex))
+            : _adProgram.setActiveItem(_arrayIndex);
 
         _backgroundLoadTriggered = false;
         _skipOffset = item.skipoffset || _options.skipoffset;
@@ -477,6 +479,7 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
 
         _adProgram = null;
         _data = { };
+        _destroyPromise = null;
 
         if (!_inited || _model.attributes._destroyed) {
             return;

--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -106,8 +106,9 @@ export default class MediaController extends Events {
     detach() {
         const { provider } = this;
         this.thenPlayPromise.cancel();
-        provider.detachMedia();
+        const result = provider.detachMedia();
         this.attached = false;
+        return result;
     }
 
     // Extends the playPromise

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -98,6 +98,38 @@ class ProgramController extends Events {
         return this.loadPromise;
     }
 
+
+    /**
+     * Attaches or detaches the current media
+     * @param {boolean} shouldAttach - Attach or detach?
+     * @returns {Promise|void} A detach promise. Resolves when media is detached.
+     */
+    setAttached(shouldAttach) {
+        const { mediaController } = this;
+
+        this.attached = shouldAttach;
+
+        if (!mediaController) {
+            return;
+        }
+
+        if (shouldAttach) {
+            mediaController.attach();
+        } else {
+            const result = mediaController.detach();
+
+            const { item, mediaModel } = mediaController;
+
+            // If detaching to play a midroll (pos > 0), ensure that the player resumes at the detached time by setting starttime
+            // We don't need to do this for prerolls because the player re-attaches at time 0 by default
+            const pos = mediaModel.get('position');
+            if (pos) {
+                item.starttime = pos;
+            }
+            return result;
+        }
+    }
+
     /**
      * Plays the active item.
      * Will wait for the Provider promise to resolve before any play attempt.
@@ -562,34 +594,6 @@ class ProgramController extends Events {
         }
 
         return mediaController.qualities;
-    }
-
-    /**
-     * Attaches or detaches the current media
-     * @param {boolean} shouldAttach - Attach or detach?
-     * @returns {void}
-     */
-    set attached(shouldAttach) {
-        const { mediaController } = this;
-
-        if (!mediaController) {
-            return;
-        }
-
-        if (shouldAttach) {
-            mediaController.attach();
-        } else {
-            mediaController.detach();
-
-            const { item, mediaModel } = mediaController;
-
-            // If detaching to play a midroll (pos > 0), ensure that the player resumes at the detached time by setting starttime
-            // We don't need to do this for prerolls because the player re-attaches at time 0 by default
-            const pos = mediaModel.get('position');
-            if (pos) {
-                item.starttime = pos;
-            }
-        }
     }
 
     /**

--- a/src/js/providers/video-attached-mixin.js
+++ b/src/js/providers/video-attached-mixin.js
@@ -6,9 +6,7 @@ const VideoAttachedMixin = {
     },
 
     detachMedia() {
-        this.eventsOff_();
-
-        return this.video;
+        return this.eventsOff_();
     }
 };
 

--- a/test/unit/program-controller-test.js
+++ b/test/unit/program-controller-test.js
@@ -165,7 +165,7 @@ describe('ProgramController', function () {
             .then(function () {
                 const provider = programController.mediaController.provider;
 
-                programController.attached = false;
+                programController.setAttached(false);
                 providerEvents.forEach(event => {
                     provider.trigger(event.type, event);
                 });
@@ -215,12 +215,12 @@ describe('ProgramController', function () {
             .then(function () {
                 const provider = programController.mediaController.provider;
 
-                programController.attached = false;
+                programController.setAttached(false);
                 providerEvents.forEach(event => {
                     provider.trigger(event.type, event);
                 });
                 expect(callback).to.have.callCount(0);
-                programController.attached = true;
+                programController.setAttached(true);
                 expectAllEventsTriggered(callback);
             });
     });
@@ -318,7 +318,7 @@ describe('ProgramController', function () {
             .then(function () {
                 const provider = programController.mediaController.provider;
 
-                programController.attached = false;
+                programController.setAttached(false);
                 sandbox.spy(model, 'set');
                 sandbox.spy(model, 'trigger');
                 sandbox.spy(model, 'persistQualityLevel');
@@ -366,7 +366,7 @@ describe('ProgramController', function () {
             .then(function () {
                 const provider = programController.mediaController.provider;
 
-                programController.attached = false;
+                programController.setAttached(false);
                 sandbox.spy(model, 'set');
                 sandbox.spy(model, 'trigger');
                 sandbox.spy(model, 'persistQualityLevel');
@@ -378,7 +378,7 @@ describe('ProgramController', function () {
                 expect(model.trigger).to.have.callCount(0);
                 expect(model.persistQualityLevel).to.have.callCount(0);
                 expect(model.persistVideoSubtitleTrack).to.have.callCount(0);
-                programController.attached = true;
+                programController.setAttached(true);
                 expect(model.set).to.have.callCount(5);
                 expect(model.trigger).to.have.callCount(6);
                 expect(model.persistQualityLevel).to.have.callCount(1);


### PR DESCRIPTION
### This PR will...
Wait for Shaka's destroy handler before starting ad playback.

### Why is this Pull Request needed?
Shaka was manipulating the shared videotag at the same time as the HTML5 provider, causing ads not to play.

### Are there any points in the code the reviewer needs to double check?
N/A

### Are there any Pull Requests open in other repos which need to be merged with this?
jwplayer/jwplayer-commercial#7028

#### Addresses Issue(s):
JW8-10237