### PR TITLE
Utilize internal audio/video determination in html5 provider

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -524,7 +524,7 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
             });
         }
         if (_levels.length && _levels[0].type !== 'hls') {
-            _this.sendMediaType(_levels);
+            _setMediaType();
         }
     }
 
@@ -897,11 +897,8 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
     }
 
     function _setMediaType() {
-        // Send mediaType when format is HLS. Other types are handled earlier by default.js.
-        if (_levels[0].type === 'hls') {
-            const mediaType = isAudioStream() ? 'audio' : 'video';
-            _this.trigger(MEDIA_TYPE, { mediaType });
-        }
+        const mediaType = isAudioStream() ? 'audio' : 'video';
+        _this.trigger(MEDIA_TYPE, { mediaType });
     }
 
     // If we're live and the buffer end has remained the same for some time, mark the stream as stale and check if the stream is over


### PR DESCRIPTION
### This PR will...
Fix an issue where audio only mp4s were displaying a big black box instead of the poster image

### Why is this Pull Request needed?
We should certainly display the poster image for any audio only case - also important for tracking to ensure we have the media type correct

### Are there any points in the code the reviewer needs to double check?
None I can think of, events test page looks good (single `mediaType` evt)

### Are there any Pull Requests open in other repos which need to be merged with this?
Nah

#### Addresses Issue(s):

JW8-10172

