### PR TITLE
[JW8-2639] Enable/Disable Shortcuts

### DIFF
--- a/src/css/controls.less
+++ b/src/css/controls.less
@@ -14,6 +14,7 @@
 @import "controls/imports/nextup.less";
 @import "controls/imports/autostartmute.less";
 @import "controls/imports/settings-menu.less";
+@import "controls/imports/switch.less";
 @import "controls/imports/playback-label.less";
 @import "controls/imports/info-overlay.less";
 @import "controls/imports/drop-shadow-variants.less";

--- a/src/css/controls/imports/shortcuts-tooltip.less
+++ b/src/css/controls/imports/shortcuts-tooltip.less
@@ -2,10 +2,6 @@
 @import "../../shared-imports/mixins.less";
 
 .jwplayer .jw-shortcuts-tooltip {
-    @rightclick-primary-text: #fefefe;
-    @rightclick-secondary-text: #333;
-    @rightclick-bg: #333;
-    @rightclick-secondary-bg: #fefefe;
     @ui-padding: 0.5em;
     @ui-margin: 20px;
 
@@ -43,67 +39,11 @@
             font-weight: bold;
         }
 
-        .jw-shortcuts-switch {
-            position: relative;
-            left: 25px;
-            display: inline-block;
-            transition: ease-out 0.15s;
-            transition-property: opacity, background;
-            border-radius: 18px;
-            width: 80px;
-            height: 20px;
-            padding: 10px;
-            background: fade(@rightclick-secondary-bg, 80%);
-            cursor: pointer;
-            font-size: inherit;
-            vertical-align: middle;
-
-            .jw-shortcuts-switch-knob {
-                position: absolute;
-                top: 2px;
-                left: 1px;
-                transition: ease-out 0.15s;
-                box-shadow: 0 0 10px rgba(0, 0, 0, 0.4);
-                border-radius: 13px;
-                width: 15px;
-                height: 15px;
-                background: @rightclick-secondary-bg;
-            }
-
-            &:before,
-            &:after {
-                position: absolute;
-                top: 3px;
-                transition: inherit;
-                color: @rightclick-primary-text;
-            }
-
-            &:before {
-                content: attr(data-jw-shortcuts-disabled);
-                right: 8px;
-            }
-
-            &:after {
-                content: attr(data-jw-shortcuts-enabled);
-                left: 8px;
-                opacity: 0;
-            }
-
-            &[aria-checked="true"] {
-                background: @rightclick-bg;
-
-                &:before {
-                    opacity: 0;
-                }
-
-                &:after {
-                    opacity: 1;
-                }
-
-                .jw-shortcuts-switch-knob {
-                    left: 60px;
-                }
-            }
+        .jw-shortcuts-header {
+            align-items: center;
+            display: flex;
+            justify-content: space-between;
+            margin-bottom: 10px;
         }
 
         .jw-shortcuts-tooltip-list {
@@ -111,11 +51,16 @@
             max-width: 340px;
             margin: 0 10px;
 
+            .jw-shortcuts-tooltip-descriptions {
+                width: 100%;
+            }
+
             .jw-shortcuts-row {
                 display: flex;
                 align-items: center;
                 justify-content: space-between;
                 margin: 10px 0;
+                width: 100%;
 
                 .jw-shortcuts-description {
                     margin-right: 10px;
@@ -123,8 +68,8 @@
                 }
 
                 .jw-shortcuts-key {
-                    background: @rightclick-secondary-bg;
-                    color: @rightclick-secondary-text;
+                    background: @rightclick-shortcuts-secondary-bg;
+                    color: @rightclick-shortcuts-secondary-text;
                     overflow: hidden;
                     padding: 7px 10px;
                     text-overflow: ellipsis;

--- a/src/css/controls/imports/shortcuts-tooltip.less
+++ b/src/css/controls/imports/shortcuts-tooltip.less
@@ -38,36 +38,107 @@
         margin: 0 20px 20px;
         overflow-y: auto;
         padding: 5px;
-    }
 
-    .jw-shortcuts-title {
-        font-weight: bold;
-    }
+        .jw-shortcuts-title {
+            font-weight: bold;
+        }
 
-    .jw-shortcuts-tooltip-list {
-        display: flex;
-        max-width: 340px;
-        margin: 0 10px;
+        .jw-shortcuts-switch {
+            position: relative;
+            left: 25px;
+            display: inline-block;
+            transition: ease-out 0.15s;
+            transition-property: opacity, background;
+            border-radius: 18px;
+            width: 80px;
+            height: 20px;
+            padding: 10px;
+            background: fade(@rightclick-secondary-bg, 80%);
+            cursor: pointer;
+            font-size: inherit;
+            vertical-align: middle;
 
+<<<<<<< HEAD
         .jw-shortcuts-row {
             display: flex;
             align-items: center;
             justify-content: space-between;
             margin: 10px 0;
             min-width: 170px;
+=======
+            .jw-shortcuts-switch-knob {
+                position: absolute;
+                top: 2px;
+                left: 1px;
+                transition: ease-out 0.15s;
+                box-shadow: 0 0 10px rgba(0, 0, 0, 0.4);
+                border-radius: 13px;
+                width: 15px;
+                height: 15px;
+                background: @rightclick-secondary-bg;
+            }
+>>>>>>> change checkbox to switch toggle
 
-            .jw-shortcuts-description {
-                margin-right: 10px;
-                max-width: 70%;
+            &:before,
+            &:after {
+                position: absolute;
+                top: 3px;
+                transition: inherit;
+                color: @rightclick-primary-text;
             }
 
-            .jw-shortcuts-key {
-                background: @rightclick-secondary-bg;
-                color: @rightclick-secondary-text;
-                overflow: hidden;
-                padding: 7px 10px;
-                text-overflow: ellipsis;
-                white-space: nowrap;
+            &:before {
+                content: attr(data-jw-shortcuts-disabled);
+                right: 8px;
+            }
+
+            &:after {
+                content: attr(data-jw-shortcuts-enabled);
+                left: 8px;
+                opacity: 0;
+            }
+
+            &[aria-checked="true"] {
+                background: @rightclick-bg;
+
+                &:before {
+                    opacity: 0;
+                }
+
+                &:after {
+                    opacity: 1;
+                }
+
+                .jw-shortcuts-switch-knob {
+                    left: 60px;
+                }
+            }
+        }
+
+        .jw-shortcuts-tooltip-list {
+            display: flex;
+            max-width: 340px;
+            margin: 0 10px;
+
+            .jw-shortcuts-row {
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+                margin: 10px 0;
+
+                .jw-shortcuts-description {
+                    margin-right: 10px;
+                    max-width: 70%;
+                }
+
+                .jw-shortcuts-key {
+                    background: @rightclick-secondary-bg;
+                    color: @rightclick-secondary-text;
+                    overflow: hidden;
+                    padding: 7px 10px;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                }
             }
         }
     }

--- a/src/css/controls/imports/shortcuts-tooltip.less
+++ b/src/css/controls/imports/shortcuts-tooltip.less
@@ -34,20 +34,19 @@
         display: flex;
         flex: 1 1 auto;
         flex-flow: column;
+        font-size: 12px;
         margin: 0 20px 20px;
         overflow-y: auto;
         padding: 5px;
     }
 
     .jw-shortcuts-title {
-        font-size: 12px;
         font-weight: bold;
     }
 
     .jw-shortcuts-tooltip-list {
         display: flex;
         max-width: 340px;
-        font-size: 12px;
         margin: 0 10px;
 
         .jw-shortcuts-row {

--- a/src/css/controls/imports/shortcuts-tooltip.less
+++ b/src/css/controls/imports/shortcuts-tooltip.less
@@ -58,14 +58,6 @@
             font-size: inherit;
             vertical-align: middle;
 
-<<<<<<< HEAD
-        .jw-shortcuts-row {
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            margin: 10px 0;
-            min-width: 170px;
-=======
             .jw-shortcuts-switch-knob {
                 position: absolute;
                 top: 2px;
@@ -77,7 +69,6 @@
                 height: 15px;
                 background: @rightclick-secondary-bg;
             }
->>>>>>> change checkbox to switch toggle
 
             &:before,
             &:after {

--- a/src/css/controls/imports/switch.less
+++ b/src/css/controls/imports/switch.less
@@ -1,0 +1,63 @@
+.jw-shortcuts-container {
+    .jw-switch {
+        position: relative;
+        display: inline-block;
+        transition: ease-out 0.15s;
+        transition-property: opacity, background;
+        border-radius: 18px;
+        width: 80px;
+        height: 20px;
+        padding: 10px;
+        background: fade(#505050, 80%);
+        cursor: pointer;
+        font-size: inherit;
+        vertical-align: middle;
+
+        .jw-switch-knob {
+            position: absolute;
+            top: 2px;
+            left: 1px;
+            transition: ease-out 0.15s;
+            box-shadow: 0 0 10px rgba(0, 0, 0, 0.4);
+            border-radius: 13px;
+            width: 15px;
+            height: 15px;
+            background: @rightclick-shortcuts-secondary-bg;
+        }
+
+        &:before,
+        &:after {
+            position: absolute;
+            top: 3px;
+            transition: inherit;
+            color: @rightclick-shortcuts-primary-text;
+        }
+
+        &:before {
+            content: attr(data-jw-switch-disabled);
+            right: 8px;
+        }
+
+        &:after {
+            content: attr(data-jw-switch-enabled);
+            left: 8px;
+            opacity: 0;
+        }
+
+        &[aria-checked="true"] {
+            background: #475470;
+
+            &:before {
+                opacity: 0;
+            }
+
+            &:after {
+                opacity: 1;
+            }
+
+            .jw-switch-knob {
+                left: 60px;
+            }
+        }
+    }
+}

--- a/src/css/shared-imports/vars.less
+++ b/src/css/shared-imports/vars.less
@@ -114,3 +114,9 @@
 // Settings menu and floating player close buttons
 @dismiss-top-padding: 3px;
 @dismiss-right-padding: 5px;
+
+// Keyboard shortcuts
+@rightclick-shortcuts-primary-text: #fefefe;
+@rightclick-shortcuts-bg: #333;
+@rightclick-shortcuts-secondary-text: #333;
+@rightclick-shortcuts-secondary-bg: #fefefe;

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -25,7 +25,7 @@ export const Defaults = {
     displaydescription: true,
     displaytitle: true,
     displayPlaybackLabel: false,
-    enableShortcuts: true,
+    enableShortcuts: 'true',
     height: 360,
     intl: {},
     language: 'en',

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -25,7 +25,7 @@ export const Defaults = {
     displaydescription: true,
     displaytitle: true,
     displayPlaybackLabel: false,
-    enableShortcuts: 'true',
+    enableShortcuts: true,
     height: 360,
     intl: {},
     language: 'en',

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -25,6 +25,7 @@ export const Defaults = {
     displaydescription: true,
     displaytitle: true,
     displayPlaybackLabel: false,
+    enableShortcuts: true,
     height: 360,
     intl: {},
     language: 'en',

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -25,7 +25,6 @@ export const Defaults = {
     displaydescription: true,
     displaytitle: true,
     displayPlaybackLabel: false,
-    enableShortcuts: true,
     height: 360,
     intl: {},
     language: 'en',

--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -76,7 +76,8 @@ Object.assign(CoreShim.prototype, {
             'captionLabel',
             'bandwidthEstimate',
             'bitrateSelection',
-            'qualityLabel'
+            'qualityLabel',
+            'enableShortcuts'
         ]);
         const persisted = storage && storage.getAllItems();
         model.attributes = model.attributes || {};

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -304,6 +304,10 @@ export default class Controls extends Events {
                     break;
                 case 13: // enter
                 case 32: // space
+                    if (document.activeElement.id === 'jw-enable-shortcuts') {
+                        // Let event bubble up if focused on checbox in shortcuts menu
+                        return true;
+                    }
                     if (shortcutsEnabled) {
                         api.playToggle(reasonInteraction());
                     }

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -21,6 +21,8 @@ import FloatingCloseButton from 'view/floating-close-button';
 require('css/controls.less');
 
 const ACTIVE_TIMEOUT = OS.mobile ? 4000 : 2000;
+// Keys which bypass keyboard shortcuts being off
+const ALWAYS_ALLOWED_KEYS = [27];
 
 ErrorContainer.cloneIcon = cloneIcon;
 instances.forEach(api => {
@@ -276,8 +278,13 @@ export default class Controls extends Events {
                 return true;
             }
             const menuHidden = !this.settingsMenu.visible;
-            const shortcutsEnabled = model.get('enableShortcuts') === 'true';
+            const shortcutsEnabled = model.get('enableShortcuts') === true;
             const adMode = this.instreamState;
+
+            if (!shortcutsEnabled && ALWAYS_ALLOWED_KEYS.indexOf(evt.keyCode) === -1) {
+                return;
+            }
+
             switch (evt.keyCode) {
                 case 27: // Esc
                     if (model.get('fullscreen')) {
@@ -304,54 +311,47 @@ export default class Controls extends Events {
                     break;
                 case 13: // enter
                 case 32: // space
-                    if (document.activeElement.className === 'jw-shortcuts-switch' && evt.keyCode === 32) {
+                    if (document.activeElement.className === 'jw-switch' && evt.keyCode === 32) {
                         // Let event bubble up so the spacebar can control the toggle if focused on
                         return true;
                     }
-                    if (shortcutsEnabled) {
-                        api.playToggle(reasonInteraction());
-                    }
+                    api.playToggle(reasonInteraction());
                     break;
                 case 37: // left-arrow, if shortcuts are enabled, not adMode, and settings menu is hidden
-                    if (shortcutsEnabled && !adMode && menuHidden) {
+                    if (!adMode && menuHidden) {
                         adjustSeek(-5);
                     }
                     break;
                 case 39: // right-arrow, if shortcuts are enabled, not adMode, and settings menu is hidden
-                    if (shortcutsEnabled && !adMode && menuHidden) {
+                    if (!adMode && menuHidden) {
                         adjustSeek(5);
                     }
                     break;
                 case 38: // up-arrow, if shortcuts are enabled and settings menu is hidden
-                    if (shortcutsEnabled && menuHidden) {
+                    if (menuHidden) {
                         adjustVolume(10);
                     }
                     break;
                 case 40: // down-arrow, if shortcuts are enabled and settings menu is hidden
-                    if (shortcutsEnabled && menuHidden) {
+                    if (menuHidden) {
                         adjustVolume(-10);
                     }
                     break;
-                case 67: // c-key, if shortcuts are enabled
-                    if (shortcutsEnabled) {
-                        const captionsList = api.getCaptionsList();
-                        const listLength = captionsList.length;
-                        if (listLength) {
-                            const nextIndex = (api.getCurrentCaptions() + 1) % listLength;
-                            api.setCurrentCaptions(nextIndex);
-                        }
+                case 67: {
+                    // c-key, if shortcuts are enabled
+                    const captionsList = api.getCaptionsList();
+                    const listLength = captionsList.length;
+                    if (listLength) {
+                        const nextIndex = (api.getCurrentCaptions() + 1) % listLength;
+                        api.setCurrentCaptions(nextIndex);
                     }
-
                     break;
+                }
                 case 77: // m-key, if shortcuts are enabled
-                    if (shortcutsEnabled) {
-                        api.setMute();
-                    }
+                    api.setMute();
                     break;
                 case 70: // f-key, if shortcuts are enabled
-                    if (shortcutsEnabled) {
-                        api.setFullscreen();
-                    }
+                    api.setFullscreen();
                     break;
                 case 191: // ? key
                     if (this.shortcutsTooltip) {
@@ -359,8 +359,8 @@ export default class Controls extends Events {
                     }
                     break;
                 default:
-                    if (evt.keyCode >= 48 && evt.keyCode <= 59 && shortcutsEnabled) {
-                        // if 0-9 number key and shortcuts are enabled, move to n/10 of the percentage of the video
+                    if (evt.keyCode >= 48 && evt.keyCode <= 59) {
+                        // if 0-9 number key, move to n/10 of the percentage of the video
                         const number = evt.keyCode - 48;
                         const newSeek = (number / 10) * model.get('duration');
                         api.seek(newSeek, reasonInteraction());

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -276,7 +276,7 @@ export default class Controls extends Events {
                 return true;
             }
             const menuHidden = !this.settingsMenu.visible;
-            const shortcutsEnabled = model.get('enableShortcuts');
+            const shortcutsEnabled = model.get('enableShortcuts') === 'true';
             const adMode = this.instreamState;
             switch (evt.keyCode) {
                 case 27: // Esc
@@ -304,8 +304,8 @@ export default class Controls extends Events {
                     break;
                 case 13: // enter
                 case 32: // space
-                    if (document.activeElement.id === 'jw-enable-shortcuts' && evt.keyCode === 32) {
-                        // Let event bubble up so spacebar can control checkbox if focused on checbox in shortcuts menu
+                    if (document.activeElement.className === 'jw-shortcuts-switch' && evt.keyCode === 32) {
+                        // Let event bubble up so the spacebar can control the toggle if focused on
                         return true;
                     }
                     if (shortcutsEnabled) {

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -304,8 +304,8 @@ export default class Controls extends Events {
                     break;
                 case 13: // enter
                 case 32: // space
-                    if (document.activeElement.id === 'jw-enable-shortcuts') {
-                        // Let event bubble up if focused on checbox in shortcuts menu
+                    if (document.activeElement.id === 'jw-enable-shortcuts' && evt.keyCode === 32) {
+                        // Let event bubble up so spacebar can control checkbox if focused on checbox in shortcuts menu
                         return true;
                     }
                     if (shortcutsEnabled) {

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -276,6 +276,7 @@ export default class Controls extends Events {
                 return true;
             }
             const menuHidden = !this.settingsMenu.visible;
+            const shortcutsEnabled = model.get('enableShortcuts');
             const adMode = this.instreamState;
             switch (evt.keyCode) {
                 case 27: // Esc
@@ -303,30 +304,32 @@ export default class Controls extends Events {
                     break;
                 case 13: // enter
                 case 32: // space
-                    api.playToggle(reasonInteraction());
+                    if (shortcutsEnabled) {
+                        api.playToggle(reasonInteraction());
+                    }
                     break;
-                case 37: // left-arrow, if not adMode and settings menu is hidden
-                    if (!adMode && menuHidden) {
+                case 37: // left-arrow, if shortcuts are enabled, not adMode, and settings menu is hidden
+                    if (shortcutsEnabled && !adMode && menuHidden) {
                         adjustSeek(-5);
                     }
                     break;
-                case 39: // right-arrow, if not adMode and settings menu is hidden
-                    if (!adMode && menuHidden) {
+                case 39: // right-arrow, if shortcuts are enabled, not adMode, and settings menu is hidden
+                    if (shortcutsEnabled && !adMode && menuHidden) {
                         adjustSeek(5);
                     }
                     break;
-                case 38: // up-arrow, if settings menu is hidden
-                    if (menuHidden) {
+                case 38: // up-arrow, if shortcuts are enabled and settings menu is hidden
+                    if (shortcutsEnabled && menuHidden) {
                         adjustVolume(10);
                     }
                     break;
-                case 40: // down-arrow, if settings menu is hidden
-                    if (menuHidden) {
+                case 40: // down-arrow, if shortcuts are enabled and settings menu is hidden
+                    if (shortcutsEnabled && menuHidden) {
                         adjustVolume(-10);
                     }
                     break;
-                case 67: // c-key
-                    {
+                case 67: // c-key, if shortcuts are enabled
+                    if (shortcutsEnabled) {
                         const captionsList = api.getCaptionsList();
                         const listLength = captionsList.length;
                         if (listLength) {
@@ -334,12 +337,17 @@ export default class Controls extends Events {
                             api.setCurrentCaptions(nextIndex);
                         }
                     }
+
                     break;
-                case 77: // m-key
-                    api.setMute();
+                case 77: // m-key, if shortcuts are enabled
+                    if (shortcutsEnabled) {
+                        api.setMute();
+                    }
                     break;
-                case 70: // f-key
-                    api.setFullscreen();
+                case 70: // f-key, if shortcuts are enabled
+                    if (shortcutsEnabled) {
+                        api.setFullscreen();
+                    }
                     break;
                 case 191: // ? key
                     if (this.shortcutsTooltip) {
@@ -347,8 +355,8 @@ export default class Controls extends Events {
                     }
                     break;
                 default:
-                    if (evt.keyCode >= 48 && evt.keyCode <= 59) {
-                        // if 0-9 number key, move to n/10 of the percentage of the video
+                    if (evt.keyCode >= 48 && evt.keyCode <= 59 && shortcutsEnabled) {
+                        // if 0-9 number key and shortcuts are enabled, move to n/10 of the percentage of the video
                         const number = evt.keyCode - 48;
                         const newSeek = (number / 10) * model.get('duration');
                         api.seek(newSeek, reasonInteraction());

--- a/src/js/view/controls/shortcuts-tooltip.js
+++ b/src/js/view/controls/shortcuts-tooltip.js
@@ -68,8 +68,7 @@ export default function (container, api, model) {
     const checkBox = template.querySelector('#jw-enable-shortcuts');
 
     const open = () => {
-        const shortcutsEnabled = model.get('enableShortcuts');
-        checkBox.checked = shortcutsEnabled === undefined || shortcutsEnabled;
+        checkBox.checked = model.get('enableShortcuts');
         checkBox.addEventListener('change', checkboxChangeHandler);
 
         addClass(template, 'jw-open');

--- a/src/js/view/controls/shortcuts-tooltip.js
+++ b/src/js/view/controls/shortcuts-tooltip.js
@@ -68,7 +68,8 @@ export default function (container, api, model) {
     const checkBox = template.querySelector('#jw-enable-shortcuts');
 
     const open = () => {
-        checkBox.checked = model.get('enableShortcuts');
+        const shortcutsEnabled = model.get('enableShortcuts');
+        checkBox.checked = shortcutsEnabled === undefined ? true : shortcutsEnabled;
         checkBox.addEventListener('change', checkboxChangeHandler);
 
         addClass(template, 'jw-open');
@@ -89,11 +90,12 @@ export default function (container, api, model) {
         }
     };
     const documentClickHandler = (e) => {
-        if (!/jw-shortcuts/.test(e.target.className)) {
-            close();
-        }
+        // if (!/jw-shortcuts/.test(e.target.className)) {
+        //     close();
+        // }
     };
     const checkboxChangeHandler = (e) => {
+        console.log('fired');
         model.set('enableShortcuts', e.target.checked);
     };
     const toggleVisibility = () => {

--- a/src/js/view/controls/shortcuts-tooltip.js
+++ b/src/js/view/controls/shortcuts-tooltip.js
@@ -6,17 +6,17 @@ import { STATE_PLAYING } from 'events/events';
 
 
 function getShortcuts(shortcuts) {
-    const { 
-        playPause, 
-        volumeToggle, 
-        fullscreenToggle, 
-        seekPercent, 
-        increaseVolume, 
-        decreaseVolume, 
-        seekForward, 
-        seekBackward, 
-        spacebar, 
-        captionsToggle 
+    const {
+        playPause,
+        volumeToggle,
+        fullscreenToggle,
+        seekPercent,
+        increaseVolume,
+        decreaseVolume,
+        seekForward,
+        seekBackward,
+        spacebar,
+        captionsToggle
     } = shortcuts;
 
     return [
@@ -63,9 +63,11 @@ export default function (container, api, model) {
     let isOpen = false;
     let lastState = null;
     const shortcuts = model.get('localization').shortcuts;
-    const template = createElement(shortcutTooltipTemplate(getShortcuts(shortcuts), shortcuts.keyboardShortcuts));
+    const template = createElement(
+        shortcutTooltipTemplate(getShortcuts(shortcuts), shortcuts.keyboardShortcuts)
+    );
     const settingsInteraction = { reason: 'settingsInteraction' };
-    const shortcutToggle = template.querySelector('.jw-shortcuts-switch');
+    const shortcutToggle = template.querySelector('.jw-switch');
 
     const open = () => {
         shortcutToggle.setAttribute('aria-checked', model.get('enableShortcuts'));
@@ -80,7 +82,7 @@ export default function (container, api, model) {
     };
     const close = () => {
         shortcutToggle.removeEventListener('click', toggleClickHandler);
-        removeClass(template, 'jw-open');     
+        removeClass(template, 'jw-open');
         document.removeEventListener('click', documentClickHandler);
         container.focus();
         isOpen = false;
@@ -89,14 +91,15 @@ export default function (container, api, model) {
         }
     };
     const documentClickHandler = (e) => {
-        if (!/jw-shortcuts/.test(e.target.className)) {
+        if (!/jw-shortcuts|jw-switch/.test(e.target.className)) {
             close();
         }
     };
     const toggleClickHandler = (e) => {
         const toggle = e.currentTarget;
-        toggle.setAttribute('aria-checked', toggle.getAttribute('aria-checked') === 'true' ? 'false' : 'true');
-        model.set('enableShortcuts', toggle.getAttribute('aria-checked'));
+        const isChecked = toggle.getAttribute('aria-checked') === 'true' ? false : true;
+        toggle.setAttribute('aria-checked', isChecked);
+        model.set('enableShortcuts', isChecked);
     };
     const toggleVisibility = () => {
         if (isOpen) {
@@ -113,7 +116,7 @@ export default function (container, api, model) {
         //  Append close button to modal.
         prependChild(template, closeButton.element());
         closeButton.show();
-        
+
         //  Append modal to container
         container.appendChild(template);
     };

--- a/src/js/view/controls/shortcuts-tooltip.js
+++ b/src/js/view/controls/shortcuts-tooltip.js
@@ -65,11 +65,11 @@ export default function (container, api, model) {
     const shortcuts = model.get('localization').shortcuts;
     const template = createElement(shortcutTooltipTemplate(getShortcuts(shortcuts), shortcuts.keyboardShortcuts));
     const settingsInteraction = { reason: 'settingsInteraction' };
-    const checkBox = template.querySelector('#jw-enable-shortcuts');
+    const shortcutToggle = template.querySelector('.jw-shortcuts-switch');
 
     const open = () => {
-        checkBox.checked = model.get('enableShortcuts');
-        checkBox.addEventListener('change', checkboxChangeHandler);
+        shortcutToggle.setAttribute('aria-checked', model.get('enableShortcuts'));
+        shortcutToggle.addEventListener('click', toggleClickHandler);
 
         addClass(template, 'jw-open');
         lastState = model.get('state');
@@ -79,7 +79,7 @@ export default function (container, api, model) {
         api.pause(settingsInteraction);
     };
     const close = () => {
-        checkBox.removeEventListener('change', checkboxChangeHandler);
+        shortcutToggle.removeEventListener('click', toggleClickHandler);
         removeClass(template, 'jw-open');     
         document.removeEventListener('click', documentClickHandler);
         container.focus();
@@ -89,12 +89,14 @@ export default function (container, api, model) {
         }
     };
     const documentClickHandler = (e) => {
-        if (!/jw-shortcuts/.test(e.target.className) && !checkBox.contains(e.target)) {
+        if (!/jw-shortcuts/.test(e.target.className)) {
             close();
         }
     };
-    const checkboxChangeHandler = (e) => {
-        model.set('enableShortcuts', e.target.checked);
+    const toggleClickHandler = (e) => {
+        const toggle = e.currentTarget;
+        toggle.setAttribute('aria-checked', toggle.getAttribute('aria-checked') === 'true' ? 'false' : 'true');
+        model.set('enableShortcuts', toggle.getAttribute('aria-checked'));
     };
     const toggleVisibility = () => {
         if (isOpen) {

--- a/src/js/view/controls/shortcuts-tooltip.js
+++ b/src/js/view/controls/shortcuts-tooltip.js
@@ -65,8 +65,12 @@ export default function (container, api, model) {
     const shortcuts = model.get('localization').shortcuts;
     const template = createElement(shortcutTooltipTemplate(getShortcuts(shortcuts), shortcuts.keyboardShortcuts));
     const settingsInteraction = { reason: 'settingsInteraction' };
+    const checkBox = template.querySelector('#jw-enable-shortcuts');
 
     const open = () => {
+        checkBox.checked = model.get('enableShortcuts');
+        checkBox.addEventListener('change', checkboxChangeHandler);
+
         addClass(template, 'jw-open');
         lastState = model.get('state');
         template.querySelector('.jw-shortcuts-close').focus();
@@ -75,6 +79,7 @@ export default function (container, api, model) {
         api.pause(settingsInteraction);
     };
     const close = () => {
+        checkBox.removeEventListener('change', checkboxChangeHandler);
         removeClass(template, 'jw-open');     
         document.removeEventListener('click', documentClickHandler);
         container.focus();
@@ -87,6 +92,9 @@ export default function (container, api, model) {
         if (!/jw-shortcuts/.test(e.target.className)) {
             close();
         }
+    };
+    const checkboxChangeHandler = (e) => {
+        model.set('enableShortcuts', e.target.checked);
     };
     const toggleVisibility = () => {
         if (isOpen) {

--- a/src/js/view/controls/shortcuts-tooltip.js
+++ b/src/js/view/controls/shortcuts-tooltip.js
@@ -94,7 +94,6 @@ export default function (container, api, model) {
         }
     };
     const checkboxChangeHandler = (e) => {
-        console.log('fired');
         model.set('enableShortcuts', e.target.checked);
     };
     const toggleVisibility = () => {

--- a/src/js/view/controls/shortcuts-tooltip.js
+++ b/src/js/view/controls/shortcuts-tooltip.js
@@ -69,7 +69,7 @@ export default function (container, api, model) {
 
     const open = () => {
         const shortcutsEnabled = model.get('enableShortcuts');
-        checkBox.checked = shortcutsEnabled === undefined ? true : shortcutsEnabled;
+        checkBox.checked = shortcutsEnabled === undefined || shortcutsEnabled;
         checkBox.addEventListener('change', checkboxChangeHandler);
 
         addClass(template, 'jw-open');
@@ -90,9 +90,9 @@ export default function (container, api, model) {
         }
     };
     const documentClickHandler = (e) => {
-        // if (!/jw-shortcuts/.test(e.target.className)) {
-        //     close();
-        // }
+        if (!/jw-shortcuts/.test(e.target.className) && !checkBox.contains(e.target)) {
+            close();
+        }
     };
     const checkboxChangeHandler = (e) => {
         console.log('fired');

--- a/src/js/view/controls/templates/shortcuts-tooltip.js
+++ b/src/js/view/controls/templates/shortcuts-tooltip.js
@@ -18,10 +18,9 @@ export default (shortcuts, title) => {
             `<div class="jw-reset jw-shortcuts-container">` +
                 `<div class="jw-shortcuts-header">` +
                     `<span class="jw-reset jw-shortcuts-title">${title}</span>` +
-                    '<span class="jw-shortcuts-checkbox">' +
-                        `<input type="checkbox" id="jw-enable-shortcuts" name="jw-enable-shortcuts">` +
-                        `<label for="jw-enable-shortcuts">enabled</label>` +
-                    `</span>` +
+                    `<button role="switch" class="jw-shortcuts-switch" data-jw-shortcuts-enabled="Enabled" data-jw-shortcuts-disabled="Disabled">` +
+                        `<span class="jw-shortcuts-switch-knob"></span>` +
+                    `</button>` +
                 `</div>` +
                 `<div class="jw-reset jw-shortcuts-tooltip-list">` +
                     `<div class="jw-shortcuts-tooltip-descriptions jw-reset">` +

--- a/src/js/view/controls/templates/shortcuts-tooltip.js
+++ b/src/js/view/controls/templates/shortcuts-tooltip.js
@@ -18,8 +18,8 @@ export default (shortcuts, title) => {
             `<div class="jw-reset jw-shortcuts-container">` +
                 `<div class="jw-shortcuts-header">` +
                     `<span class="jw-reset jw-shortcuts-title">${title}</span>` +
-                    `<button role="switch" class="jw-shortcuts-switch" data-jw-shortcuts-enabled="Enabled" data-jw-shortcuts-disabled="Disabled">` +
-                        `<span class="jw-shortcuts-switch-knob"></span>` +
+                    `<button role="switch" class="jw-switch" data-jw-switch-enabled="Enabled" data-jw-switch-disabled="Disabled">` +
+                        `<span class="jw-switch-knob"></span>` +
                     `</button>` +
                 `</div>` +
                 `<div class="jw-reset jw-shortcuts-tooltip-list">` +

--- a/src/js/view/controls/templates/shortcuts-tooltip.js
+++ b/src/js/view/controls/templates/shortcuts-tooltip.js
@@ -16,7 +16,13 @@ export default (shortcuts, title) => {
                 `Press shift question mark to access a list of keyboard shortcuts` +
             `</span>` +
             `<div class="jw-reset jw-shortcuts-container">` +
-                `<div class="jw-reset jw-shortcuts-title">${title}</div>` +
+                `<div class="jw-shortcuts-header">` +
+                    `<span class="jw-reset jw-shortcuts-title">${title}</span>` +
+                    '<span class="jw-shortcuts-checkbox">' +
+                        `<input type="checkbox" id="jw-enable-shortcuts" name="jw-enable-shortcuts">` +
+                        `<label for="jw-enable-shortcuts">enabled</label>` +
+                    `</span>` +
+                `</div>` +
                 `<div class="jw-reset jw-shortcuts-tooltip-list">` +
                     `<div class="jw-shortcuts-tooltip-descriptions jw-reset">` +
                         `${list}` +

--- a/test/data/model-properties.js
+++ b/test/data/model-properties.js
@@ -83,6 +83,7 @@ export default {
     displaytitle: true,
     displaydescription: true,
     displayPlaybackLabel: false,
+    enableShortcuts: true,
     playbackRateControls: true,
     playbackRates: [1.0],
     playbackRate: 1,

--- a/test/data/model-properties.js
+++ b/test/data/model-properties.js
@@ -83,7 +83,7 @@ export default {
     displaytitle: true,
     displaydescription: true,
     displayPlaybackLabel: false,
-    enableShortcuts: true,
+    enableShortcuts: 'true',
     playbackRateControls: true,
     playbackRates: [1.0],
     playbackRate: 1,

--- a/test/data/model-properties.js
+++ b/test/data/model-properties.js
@@ -83,7 +83,7 @@ export default {
     displaytitle: true,
     displaydescription: true,
     displayPlaybackLabel: false,
-    enableShortcuts: 'true',
+    enableShortcuts: true,
     playbackRateControls: true,
     playbackRates: [1.0],
     playbackRate: 1,


### PR DESCRIPTION
### This PR will...

- Add a button toggle to the shortcuts menu to enable/disable the shortcuts listed in the menu.
- Persist the users choice to the model and local storage

### Why is this Pull Request needed?

Feature to allow users to disable shortcuts and use their screen readers as designed.

### Are there any points in the code the reviewer needs to double check?

- Hover/Focus styles for the toggle
- Making the css cleaner if needed

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-2639

