### PR TITLE
Ensure data is loaded before deriving media type

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -892,13 +892,19 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
     }
 
     function isAudioStream() {
-        // Safari will report videoHeight as 0 for HLS streams until readyState indicates that the browser has data
-        return _videotag.videoHeight === 0 && !((OS.iOS || Browser.safari) && _videotag.readyState < 2);
+        if (_videotag.readyState < 2) {
+            return;
+        }
+
+        return _videotag.videoHeight === 0;
     }
 
     function _setMediaType() {
-        const mediaType = isAudioStream() ? 'audio' : 'video';
-        _this.trigger(MEDIA_TYPE, { mediaType });
+        let isAudio = isAudioStream();
+        if (typeof isAudio !== 'undefined') {
+            const mediaType = isAudio ? 'audio' : 'video';
+            _this.trigger(MEDIA_TYPE, { mediaType });
+        }
     }
 
     // If we're live and the buffer end has remained the same for some time, mark the stream as stale and check if the stream is over


### PR DESCRIPTION
### This PR will...
Fix a bug when an unloaded video could trigger multiple `mediaType` events (vacillating between audio and video)

### Why is this Pull Request needed?
We want a single determination once the media is ready

### Are there any points in the code the reviewer needs to double check?
Nah

### Are there any Pull Requests open in other repos which need to be merged with this?
Nah

#### Addresses Issue(s):

JW8-10560 

