### PR TITLE
[JW8-10558] Move VT LESS to OS, clean up edge case styles

### DIFF
--- a/src/css/controls.less
+++ b/src/css/controls.less
@@ -17,6 +17,7 @@
 @import "controls/imports/playback-label.less";
 @import "controls/imports/info-overlay.less";
 @import "controls/imports/drop-shadow-variants.less";
+@import "controls/imports/videoThumbnail.less";
 
 // State specific
 @import "controls/states.less";

--- a/src/css/controls/imports/videoThumbnail.less
+++ b/src/css/controls/imports/videoThumbnail.less
@@ -1,4 +1,9 @@
 .jw-video-thumbnail-container {
+    position: relative;
+    height: 100%;
+    width: 100%;
+    overflow: hidden;
+
     &:hover,
     .jw-related-item-content:hover &,
     .jw-related-shelf-item:hover & {
@@ -7,7 +12,6 @@
         .jw-video-thumbnail:not(.jw-video-thumbnail-completed) {
             opacity: 1;
         }
-        overflow: hidden;
     }
 
     .jw-video-thumbnail {

--- a/src/css/controls/imports/videoThumbnail.less
+++ b/src/css/controls/imports/videoThumbnail.less
@@ -1,0 +1,51 @@
+.jw-video-thumbnail-container {
+    &:hover,
+    .jw-related-item-content:hover &,
+    .jw-related-shelf-item:hover & {
+        cursor: pointer;
+
+        .jw-video-thumbnail:not(.jw-video-thumbnail-completed) {
+            opacity: 1;
+        }
+        overflow: hidden;
+    }
+
+    .jw-video-thumbnail {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        bottom: unset;
+        transform: translate(-50%, -50%);
+        width: 100%;
+        height: auto;
+        min-width: 100%;
+        min-height: 100%;
+        opacity: 0;
+        transition: opacity 0.3s ease;
+
+        .jw-related-item-next-up & {
+            height: 100%;
+            width: auto;
+        }
+
+        &.jw-video-thumbnail-visible:not(.jw-video-thumbnail-completed) {
+            opacity: 1;
+        }
+
+        &.jw-video-thumbnail-completed {
+            opacity: 0;
+        }
+
+        ~ .jw-svg-icon-play {
+            display: none;
+        }
+
+        + .jw-related-shelf-item-aspect {
+            pointer-events: none;
+        }
+
+        + .jw-related-item-poster-content {
+            pointer-events: none;
+        }
+    }
+}


### PR DESCRIPTION
### This PR will...
- Move Video Thumbnails LESS to open source.
- Provide improved styling for vertically formatted preview videos in horizontal players.

### Why is this Pull Request needed?
- To ensure video thumbnail poster previews still work when related is disabled.
- To prevent edge-case visual bugs

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/7072

#### Addresses Issue(s):

JW8-10558

