### PR TITLE
[JW8-10559] Remove videotag return.

### DIFF
--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -262,9 +262,7 @@ Object.assign(CoreShim.prototype, {
     },
     skipAd() {},
     attachMedia() {},
-    detachMedia() {
-        return null; // video tag;
-    }
+    detachMedia() {}
 });
 
 function setupError(core, api, error) {

--- a/src/js/providers/default.js
+++ b/src/js/providers/default.js
@@ -38,8 +38,6 @@ const DefaultProvider = {
     resize: noop,
     remove: noop, // removes from page
     destroy: noop, // frees memory
-    eventsOn_: noop,
-    eventsOff_: noop,
 
     setVisibility: noop,
     setFullscreen: noop,

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -267,7 +267,6 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
             this.removeTracksListener(_videotag.textTracks, 'change', this.textTrackChangeHandler);
             // Prevent tracks from showing during ad playback
             this.disableTextTrack();
-            return _videotag;
         },
         attachMedia() {
             VideoAttached.attachMedia.call(_this);

--- a/src/js/providers/video-attached-mixin.js
+++ b/src/js/providers/video-attached-mixin.js
@@ -1,6 +1,9 @@
 
 const VideoAttachedMixin = {
 
+    eventsOn_() {},
+    eventsOff_() {},
+
     attachMedia() {
         this.eventsOn_();
     },


### PR DESCRIPTION
### This PR will...
Make sure all calls to `detachMedia` either return `undefined`, or a detach `Promise`.

### Why is this Pull Request needed?
The videotag return was interpreted as a detach `Promise`, leading to exceptions.

### Are there any points in the code the reviewer needs to double check?
As far as I can see, the public API `detachMedia` method would already never return anything, so this PR shouldn't break anything in that regard.

### Are there any Pull Requests open in other repos which need to be merged with this?
N/A

#### Addresses Issue(s):
JW8-10559