### PR TITLE
Prevent .getTime() from being called on NaN value

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -340,7 +340,7 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
     function checkStartDateTime() {
         if (_videotag.getStartDate) {
             const startDate = _videotag.getStartDate();
-            const startDateTime = startDate.getTime();
+            const startDateTime = !isNaN(startDate) ? startDate.getTime() : NaN;
             if (startDateTime !== _this.startDateTime && !isNaN(startDateTime)) {
                 _this.startDateTime = startDateTime;
                 const programDateTime = startDate.toISOString();

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -340,7 +340,7 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
     function checkStartDateTime() {
         if (_videotag.getStartDate) {
             const startDate = _videotag.getStartDate();
-            const startDateTime = !isNaN(startDate) ? startDate.getTime() : NaN;
+            const startDateTime = startDate.getTime ? startDate.getTime() : NaN;
             if (startDateTime !== _this.startDateTime && !isNaN(startDateTime)) {
                 _this.startDateTime = startDateTime;
                 const programDateTime = startDate.toISOString();


### PR DESCRIPTION
### This PR will...
Prevent `e.getTime is not a function` error from being generated for < iOS 11 when calling `.getTime()` on a NaN value

### Why is this Pull Request needed?
While this issue seemingly doesn't affect performance or usability, the purpose of this PR is to prevent generating spurious errors in an effort to reduce logging in error reporting systems.

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
Not that we know of

#### Addresses Issue(s):
Fixes: https://github.com/jwplayer/jwplayer/issues/3440