### PR TITLE
[JW8-10550] Always show float close button when floating and dismissible is true

### DIFF
--- a/src/css/jwplayer/flags/floatingplayer.less
+++ b/src/css/jwplayer/flags/floatingplayer.less
@@ -61,6 +61,7 @@
         .jw-logo {
             display: none;
         }
+
         .jw-float-icon {
             display: flex;
         }

--- a/src/css/jwplayer/flags/floatingplayer.less
+++ b/src/css/jwplayer/flags/floatingplayer.less
@@ -52,12 +52,12 @@
 }
 
 .jw-flag-floating.jw-floating-dismissible {
+    .jw-float-icon {
+        display: flex;
+    }
+
     &.jw-state-paused,
     &:not(.jw-flag-user-inactive) {
-        .jw-float-icon {
-            display: flex;
-        }
-
         .jw-logo {
             display: none;
         }

--- a/src/css/jwplayer/flags/floatingplayer.less
+++ b/src/css/jwplayer/flags/floatingplayer.less
@@ -52,7 +52,7 @@
 }
 
 .jw-flag-floating.jw-floating-dismissible {
-    .jw-float-icon {
+    &.jw-flag-ads .jw-float-icon {
         display: flex;
     }
 
@@ -60,6 +60,9 @@
     &:not(.jw-flag-user-inactive) {
         .jw-logo {
             display: none;
+        }
+        .jw-float-icon {
+            display: flex;
         }
     }
 }


### PR DESCRIPTION
### This PR will...
- Make float close button always visible even when the controls are hidden from inactivity
- If the controls are set to false by the api `jwplayer().setControls(false)`, the close button is also hidden

### Why is this Pull Request needed?
- AdExchange requirements

### Are there any points in the code the reviewer needs to double check?
- For TE: please test on different scenarios
-- Outstream, when `dismissible` for outstream is set to `true`/ `false`
-- Floating when `dismissible` is set to false, the icon should not appear

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):
JW8-10550

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
