### PR TITLE
[JW8-10600] Implement consistent latency property in time events

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -381,12 +381,14 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
 
     function getPosition(currentTime) {
         const seekRange = _this.getSeekRange();
-        if (_this.isLive() && isDvr(seekRange.end - seekRange.start, minDvrWindow)) {
+        if (_this.isLive()) {
             const rangeUpdated = !dvrPosition || Math.abs(dvrEnd - seekRange.end) > 1;
             if (rangeUpdated) {
                 updateDvrPosition(seekRange);
             }
-            return dvrPosition;
+            if (isDvr(seekRange.end - seekRange.start, minDvrWindow)) {
+                return dvrPosition;
+            }
         }
         return currentTime;
     }
@@ -428,6 +430,15 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
         }
 
         return seekRange;
+    };
+
+    _this.getLiveLatency = function() {
+        let latency = null;
+        const end = _getSeekableEnd();
+        if (_this.isLive() && end) {
+            latency = end + (now() - dvrUpdatedTime) / 1000 - _videotag.currentTime;
+        }
+        return latency;
     };
 
     function _checkDelayedSeek(duration) {


### PR DESCRIPTION
### This PR will...
- Implement latency property on "time" events for live and DVR streams in html5 provider (HLS in Safari and iOS)

### Why is this Pull Request needed?
So that developers can get an estimate of live stream latency in when playing HLS streams in Safari and iOS browsers.

### Are there any points in the code the reviewer needs to double check?
No.

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/7134

#### Addresses Issue(s):
JW8-10600

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
