### PR TITLE
Focus the player container on play btn click

### DIFF
--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -108,6 +108,7 @@ export default class Controls extends Events {
                 this.trigger(DISPLAY_CLICK);
                 this.userActive(1000);
                 api.playToggle(reasonInteraction());
+                this.playerContainer.focus();
             });
 
             this.div.appendChild(displayContainer.element());


### PR DESCRIPTION
### This PR will...
Add a focus call which ensures the player container remains focused as the idle state ui disappears after a play button click

### Why is this Pull Request needed?
The player did not remain focused after clicking on the play button in idle state

### Are there any points in the code the reviewer needs to double check?
Looking at how [the display background](https://github.com/jwplayer/jwplayer/blob/master/src/js/view/view.js#L449-L461) accomplishes this, there is no difference other than the `userActive` call present when clicking the play button. I tried to remove this to no avail so landed on a new `focus()` call. Any other ideas welcome!

### Are there any Pull Requests open in other repos which need to be merged with this?
Nah

#### Addresses Issue(s):

JW8-10349

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
