### PR TITLE
[JW8-10218] Fix iOS float close button interacting with element below it

### DIFF
--- a/src/js/view/floating-close-button.js
+++ b/src/js/view/floating-close-button.js
@@ -1,4 +1,5 @@
 import { createElement } from 'utils/dom';
+import UI from 'utils/ui';
 import floatingCloseButton from 'templates/floating-close-button';
 import { cloneIcon } from 'view/controls/icons';
 import Events from 'utils/backbone.events';
@@ -10,24 +11,16 @@ export default class FloatingCloseButton extends Events {
         this.element = createElement(floatingCloseButton(ariaLabel));
 
         this.element.appendChild(cloneIcon('close'));
-
-        this.interactionHandler = this.userActionHandler.bind(this);
-        this.element.addEventListener('click', this.interactionHandler);
-        this.element.addEventListener('tap', this.interactionHandler);
-        this.element.addEventListener('enter', this.interactionHandler);
+        this.ui = new UI(this.element, { directSelect: true }).on('click tap enter', () => {
+            this.trigger(USER_ACTION);
+        });
 
         container.appendChild(this.element);
     }
 
-    userActionHandler() {
-        this.trigger(USER_ACTION);
-    }
-
     destroy() {
         if (this.element) {
-            this.element.removeEventListener('click', this.interactionHandler);
-            this.element.removeEventListener('tap', this.interactionHandler);
-            this.element.removeEventListener('enter', this.interactionHandler);
+            this.ui.destroy();
             this.element.parentNode.removeChild(this.element);
             this.element = null;
         }

--- a/src/js/view/floating-close-button.js
+++ b/src/js/view/floating-close-button.js
@@ -1,5 +1,4 @@
 import { createElement } from 'utils/dom';
-import UI from 'utils/ui';
 import floatingCloseButton from 'templates/floating-close-button';
 import { cloneIcon } from 'view/controls/icons';
 import Events from 'utils/backbone.events';
@@ -11,16 +10,24 @@ export default class FloatingCloseButton extends Events {
         this.element = createElement(floatingCloseButton(ariaLabel));
 
         this.element.appendChild(cloneIcon('close'));
-        this.ui = new UI(this.element).on('click tap enter', () => {
-            this.trigger(USER_ACTION);
-        });
+
+        this.interactionHandler = this.userActionHandler.bind(this);
+        this.element.addEventListener('click', this.interactionHandler);
+        this.element.addEventListener('tap', this.interactionHandler);
+        this.element.addEventListener('enter', this.interactionHandler);
 
         container.appendChild(this.element);
     }
 
+    userActionHandler() {
+        this.trigger(USER_ACTION);
+    }
+
     destroy() {
         if (this.element) {
-            this.ui.destroy();
+            this.element.removeEventListener('click', this.interactionHandler);
+            this.element.removeEventListener('tap', this.interactionHandler);
+            this.element.removeEventListener('enter', this.interactionHandler);
             this.element.parentNode.removeChild(this.element);
             this.element = null;
         }


### PR DESCRIPTION
### This PR will...
- Use `addEventListener` function rather than using `UI` class to handle the click

### Why is this Pull Request needed?
- On iOS Safari, there is an intermittent timing issue where the `click` event applies to the element below the player as the player is removed from the position when the float close icon is being clicked
- `UI` tries to see if there is any dragging activity when `click` is detected, and we suspect that is causing the `click` to be applied to the element below after the floating player is removed

### Are there any points in the code the reviewer needs to double check?
- I could not really pin down at where the timing issue is happening. I came up with the solution after creating a test page with two divs one on top of the other, with `addEventListener` - it never had any issues with the event being applied to the bottom div.
- If there is a better solution, please let me know, but I still think this is good because we do not have to register `UI` for simple click handlers that just triggers an event

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):
JW8-10218

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
