### PR TITLE
Stop scroll handler when we stop floating forever

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -347,7 +347,7 @@ function View(_api, _model) {
         playerViewModel.change('controls', changeControls);
         _model.change('streamType', _setLiveMode);
         _model.change('mediaType', _onMediaTypeChange);
-        playerViewModel.change('playlistItem', (model, item) => { 
+        playerViewModel.change('playlistItem', (model, item) => {
             onPlaylistItem(model, item);
         });
         // Triggering 'resize' resulting in player 'ready'
@@ -1020,6 +1020,7 @@ function View(_api, _model) {
     this.stopFloating = function(forever, mobileFloatIntoPlace) {
         if (forever) {
             _floatingConfig = null;
+            viewsManager.removeScrollHandler(throttledMobileFloatScrollHandler);
         }
         if (floatingPlayer === _playerElement) {
             floatingPlayer = null;


### PR DESCRIPTION
### This PR will...
Ensure that the dismiss button stops the player from floating forever

### Why is this Pull Request needed?
There is a bug where on mobile any scrolling after dismissal will pop the player back into place

### Are there any points in the code the reviewer needs to double check?
None I can think of

### Are there any Pull Requests open in other repos which need to be merged with this?
Nah

#### Addresses Issue(s):

JW8-10615

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
