### PR TITLE
[JW8-10618] Fix float dragging issue in iOS 13

### DIFF
--- a/src/css/jwplayer/flags/floatingplayer.less
+++ b/src/css/jwplayer/flags/floatingplayer.less
@@ -23,6 +23,10 @@
             right: 0;
         }
 
+        .jw-media {
+            touch-action: none;
+        }
+
         .jw-flag-touch& {
             @media screen and (max-device-width : 480px) and (orientation: portrait) {
                 animation: none;


### PR DESCRIPTION
### This PR will...
- Fix float dragging issue for iOS 13 by not allowing browser to handle any touch event when floating

### Why is this Pull Request needed?
- iOS 13 fires `pointercancel` event whenever there is a vertical drag movement to handle the scrolling, which prevents our floating player to be dragged vertically at all

### Are there any points in the code the reviewer needs to double check?
- Is there a better solution?
- Do you see any side effects by adding this? (although we are only doing it on the floating player)

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-10618

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
