### PR TITLE
[JW8-10623] Add 'images' to config.playlist

### DIFF
--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -131,6 +131,7 @@ const Config = function(options, persisted) {
             'type',
             'mediaid',
             'image',
+            'images',
             'file',
             'sources',
             'tracks',


### PR DESCRIPTION
### This PR will...
Add `images` block to conflig.playlist.

### Why is this Pull Request needed?
Config.js has a function that converts a single item to a playlist. Currently the new `images` block does not get added when the config item is normalized as a playlist item.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-10623

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
