### PR TITLE
[JW8-10370] Catch addcue exceptions caused by vtt.js

### DIFF
--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -538,7 +538,11 @@ function _addCueToTrack(renderNatively, track, vttCue) {
         }
         insertCueInOrder(track, cue);
     } else {
-        track.addCue(vttCue);
+        try {
+            track.addCue(vttCue);
+        } catch (error) {
+            console.error(error);
+        }
     }
 }
 
@@ -556,8 +560,12 @@ function insertCueInOrder(track, vttCue) {
             break;
         }
     }
-    track.addCue(vttCue);
-    temp.forEach(cue => track.addCue(cue));
+    try {
+        track.addCue(vttCue);
+        temp.forEach(cue => track.addCue(cue));
+    } catch (error) {
+        console.error(error);
+    }
     // Restore the original track state
     track.mode = mode;
 }


### PR DESCRIPTION
### This PR will...
Wrap calls to `TextTrack.addCue(vttCue)` in try-catch blocks.

### Why is this Pull Request needed?
I found an issue causing problems on sites using [vtt.js](https://github.com/mozilla/vtt.js/).

vtt.js replaces `window.VTTCue` with a function which when instantiated creates objects that are not valid cues and cannot be added to a TextTrack. When we try to add metadata cues to a video element's TextTrack an exception is thrown:

`Uncaught TypeError: Failed to execute 'addCue' on 'TextTrack': parameter 1 is not of type 'TextTrackCue'.`

I've filed an issue with vtt.js because I don't think they should replace existing globals that other libraries and browser APIs depend on https://github.com/mozilla/vtt.js/issues/385

For now this will prevent the exception from short circuiting other player functionality in the same event loop.

#### Addresses Issue(s):
JW8-10370

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
