### PR TITLE
[JW8-10642] Visibility Change listener focuses player if triggered by click

### DIFF
--- a/src/js/view/controls/components/settings/menu.js
+++ b/src/js/view/controls/components/settings/menu.js
@@ -40,7 +40,7 @@ export function SettingsMenu(onVisibility, buttonVisibilityChanges, localization
 
         switch (key) {
             case 'Esc':
-                instance.close();
+                instance.close(e);
                 break;
             case 'Left':
                 if (prev) {
@@ -63,15 +63,15 @@ export function SettingsMenu(onVisibility, buttonVisibilityChanges, localization
                 break;
         }
         sourceEvent.stopPropagation();
-        if (/13|32|37|38|39|40/.test(sourceEvent.keyCode)) {
+        if (/13|27|32|37|38|39|40/.test(sourceEvent.keyCode)) {
             // Prevent keypresses from scrolling the screen
             sourceEvent.preventDefault();
             return false;
         }
     });
 
-    const closeButton = button('jw-settings-close', () => {
-        instance.close();
+    const closeButton = button('jw-settings-close', (evt) => {
+        instance.close(evt);
     }, localization.close, [cloneIcon('close')]);
 
     closeButton.ui.on('keydown', function(e) {

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -206,8 +206,9 @@ export default class Controls extends Events {
             if (!visible && settingsButton) {
                 if (isKeyEvent) {
                     settingsButton.element().focus();
-                } else {
-                    this.playerContainer.focus();
+                } else if (evt) {
+                    const focusElement = model.get('isFloating') ? this.wrapperElement : this.playerContainer; 
+                    focusElement.focus();
                 }   
             }
         };

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -202,8 +202,13 @@ export default class Controls extends Events {
             lastState = state;
 
             const settingsButton = this.controlbar.elements.settingsButton;
-            if (!visible && isKeyEvent && settingsButton) {
-                settingsButton.element().focus();
+
+            if (!visible && settingsButton) {
+                if (isKeyEvent) {
+                    settingsButton.element().focus();
+                } else {
+                    this.playerContainer.focus();
+                }   
             }
         };
         const settingsMenu = this.settingsMenu = createSettingsMenu(


### PR DESCRIPTION
Please DNM until 8.11.6 is cut.

### This PR will...
Extend visibility change handler in controls to add functionality for non 'key' events.

### Why is this Pull Request needed?
Currently, player is only refocused when visibility change is triggered by a keypress.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-10642

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
