### PR TITLE
[JW8-10654] Expose activeTab function to utils

### DIFF
--- a/src/js/utils/helpers.js
+++ b/src/js/utils/helpers.js
@@ -11,6 +11,7 @@ import {
     suffix,
 } from 'utils/strings';
 import Timer from 'api/timer';
+import activeTab from 'utils/active-tab';
 import { tryCatch, JwError as Error } from 'utils/trycatch';
 import { indexOf } from 'utils/underscore';
 import { isIframe, flashVersion } from 'utils/browser';
@@ -66,6 +67,7 @@ const foreach = function (aData, fnEach) {
 const noop = function () {};
 
 const helpers = Object.assign({}, parser, validator, playerutils, {
+    activeTab,
     addClass,
     hasClass,
     removeClass,


### PR DESCRIPTION
### This PR will...
- Expose `activeTab` function in utils, so that ads plugins can use them

### Why is this Pull Request needed?
- There is a new ad rule to not request for ads when the tab is not active
- Want to re-use this function for the ad rules

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-ads-vast/pull/612

#### Addresses Issue(s):

JW8-10654

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
