### PR TITLE
[JW8-10686] Use event.oldstate when available in instream

### DIFF
--- a/src/js/program/ad-program-controller.js
+++ b/src/js/program/ad-program-controller.js
@@ -110,7 +110,7 @@ export default class AdProgramController extends ProgramController {
 
         const adMediaModelContext = model.mediaModel;
         provider.on(PLAYER_STATE, (event) => {
-            event.oldstate = model.get(PLAYER_STATE);
+            event.oldstate = event.oldstate || model.get(PLAYER_STATE);
             adMediaModelContext.set('mediaState', event.newstate);
         });
         provider.on(NATIVE_FULLSCREEN, this._nativeFullscreenHandler, this);


### PR DESCRIPTION
JW8-10686

### This PR will...

- Use `event.oldstate` when triggering the `adPlay` and `adPause` events, if it exists. If not, it will fallback to the current player state.

### Why is this Pull Request needed?

- `adPlay` was not being fired for subsequent VPAID ads in ad pods because the player state remained `"playing"` throughout.

### Are there any points in the code the reviewer needs to double check?

n/a

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-ads-vast/pull/617
https://github.com/jwplayer/jwplayer-ads-googima/pull/532

#### Addresses Issue(s):

JW8-10686

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
