### PR TITLE
VTT Caption Positioning Fixes

### DIFF
--- a/src/js/polyfills/webvtt.js
+++ b/src/js/polyfills/webvtt.js
@@ -674,23 +674,6 @@ BoxPosition.getSimpleBoxPosition = function (obj) {
     return ret;
 };
 
-// Helper function for visualizing box position
-// Helpful when debugging
-function drawBox(b, container, color) { // eslint-disable-line no-unused-vars
-    let pos = b.toCSSCompatValues(container);
-    let el = document.createElement('div');
-    el.style.top = pos.top + 'px';
-    el.style.bottom = pos.bottom + 'px';
-    el.style.left = pos.left + 'px';
-    el.style.right = pos.right + 'px';
-    el.style.width = pos.width + 'px';
-    el.style.height = pos.height + 'px';
-    el.style.border = '2px solid ' + color;
-    el.style.position = 'absolute';
-    document.querySelector('.jw-text-track-container').appendChild(el);
-}
-
-
 // Move a StyleBox to its specified, or next best, position. The containerBox
 // is the box that contains the StyleBox, such as a div. boxPositions are
 // a list of other boxes that the styleBox can't overlap with.
@@ -740,7 +723,6 @@ function moveBoxToLinePosition(window, styleBox, containerBox, boxPositions, num
             let otherAxis = bestAxis.indexOf('y') === -1 ? ['-y', '+y'] : ['-x', '+x'];
             return findBestPosition(finalPos, otherAxis, posFindRecursiveCount+1);
         }
-
         return finalPos;
     }
     let boxPosition = new BoxPosition(styleBox);

--- a/src/js/polyfills/webvtt.js
+++ b/src/js/polyfills/webvtt.js
@@ -420,6 +420,7 @@ function CueStyleBox(window, cue) {
         top: 0,
         bottom: 0,
         display: 'inline',
+        'white-space': 'pre',
         writingMode,
         unicodeBidi: 'plaintext',
     };
@@ -480,8 +481,7 @@ function CueStyleBox(window, cue) {
     // the right from there.
     if (!cue.vertical) {
         this.applyStyles({
-            left: this.formatStyle(textPos, '%'),
-            width: this.formatStyle(cue.size, '%')
+            left: this.formatStyle(textPos, '%')
         });
         // Vertical box orientation; textPos is the distance from the top edge of the
         // area to the top edge of the box and cue.size is the height extending
@@ -499,8 +499,7 @@ function CueStyleBox(window, cue) {
             bottom: this.formatStyle(box.bottom, 'px'),
             left: this.formatStyle(box.left, 'px'),
             paddingRight: this.formatStyle(box.right, 'px'),
-            height: 'auto',
-            width: this.formatStyle(box.width, 'px')
+            height: 'auto'
         });
     };
 }
@@ -641,8 +640,7 @@ BoxPosition.prototype.toCSSCompatValues = function (reference) {
         bottom: reference.bottom - this.bottom,
         left: this.left - reference.left,
         paddingRight: reference.right - this.right,
-        height: this.height,
-        width: this.width
+        height: this.height
     };
 };
 
@@ -681,13 +679,14 @@ function moveBoxToLinePosition(window, styleBox, containerBox, boxPositions, num
     function findBestPosition(b, axis) {
         let bestPosition;
         const specifiedPosition = new BoxPosition(b);
-        let percentage = 1; // Highest possible so the first thing we get is better.
+        let percentage = 0; // Highest possible so the first thing we get is better.
 
         for (let i = 0; i < axis.length; i++) {
             while (b.overlapsOppositeAxis(containerBox, axis[i]) ||
             (b.within(containerBox) && b.overlapsAny(boxPositions))) {
                 b.move(axis[i]);
             }
+
             // We found a spot where we aren't overlapping anything. This is our
             // best position.
             if (b.within(containerBox)) {
@@ -696,7 +695,7 @@ function moveBoxToLinePosition(window, styleBox, containerBox, boxPositions, num
             const p = b.intersectPercentage(containerBox);
             // If we're outside the container box less then we were on our last try
             // then remember this position as the best position.
-            if (percentage > p) {
+            if (percentage <= p) {
                 bestPosition = new BoxPosition(b);
                 percentage = p;
             }
@@ -775,9 +774,7 @@ function moveBoxToLinePosition(window, styleBox, containerBox, boxPositions, num
         // position.
         boxPosition.move(initialAxis, position);
     } else {
-        // If we have a percentage line value for the cue.
         const calculatedPercentage = (boxPosition.lineHeight / containerBox.height) * 100;
-
         switch (cue.lineAlign) {
             case 'middle':
                 linePos -= (calculatedPercentage / 2);

--- a/src/js/polyfills/webvtt.js
+++ b/src/js/polyfills/webvtt.js
@@ -455,16 +455,21 @@ function CueStyleBox(window, cue) {
     // https://w3c.github.io/webvtt/#ref-for-enumdef-positionalignsetting-1
     // The cue.align property is settable and other browsers use it as the offset from which the cue.position
     // value is applied.
+    let transform = '';
     switch (cue.align) {
         case 'start':
         case 'left':
-        case 'end':
-        case 'right':
             textPos = cue.position;
             break;
         case 'middle':
         case 'center':
-            textPos = (cue.position === 'auto' ? 0 : cue.position);
+            textPos = (cue.position === 'auto' ? 50 : cue.position);
+            transform = cue.vertical ? 'translateY(-50%)' : 'translateX(-50%)';
+            break;
+        case 'end':
+        case 'right':
+            textPos = (cue.position === 'auto' ? 100 : cue.position);
+            transform = cue.vertical ? 'translateY(-100%)' : 'translateX(-100%)';
             break;
         default:
             break;
@@ -479,7 +484,8 @@ function CueStyleBox(window, cue) {
     // the right from there.
     if (!cue.vertical) {
         this.applyStyles({
-            left: this.formatStyle(textPos, '%')
+            left: this.formatStyle(textPos, '%'),
+            transform
         });
         // Vertical box orientation; textPos is the distance from the top edge of the
         // area to the top edge of the box and cue.size is the height extending
@@ -487,7 +493,8 @@ function CueStyleBox(window, cue) {
     } else {
         this.applyStyles({
             top: this.formatStyle(textPos, '%'),
-            height: this.formatStyle(cue.size, '%')
+            height: this.formatStyle(cue.size, '%'),
+            transform
         });
     }
 
@@ -497,7 +504,8 @@ function CueStyleBox(window, cue) {
             bottom: this.formatStyle(box.bottom, 'px'),
             left: this.formatStyle(box.left, 'px'),
             paddingRight: this.formatStyle(box.right, 'px'),
-            height: this.formatStyle(box.height, 'px')
+            height: this.formatStyle(box.height, 'px'),
+            transform: ''
         });
     };
 


### PR DESCRIPTION
### This PR will...
Fix positioning in the following ways:
* Ensure caption width only extends as far as the words, not the full caption container
* Fix the position finding algorithm such that it correct calculates the best place for the caption (previously was selecting the worst)
* Fix the position finding algorithm by ensuring it combines both horizontal and vertical axis to position in the true best position

### Why is this Pull Request needed?
Using `line` attribute screws with all the above issues and surfaced quite a few bugs in our caption rendering

### Are there any points in the code the reviewer needs to double check?
All of it - this took a lot of research and trial and error to get right. want to be sure i'm not missing something

### Are there any Pull Requests open in other repos which need to be merged with this?
Nope

#### Addresses Issue(s):

JW8-10682

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
