### PR TITLE
Early exit from best pos find if none found

### DIFF
--- a/src/js/polyfills/webvtt.js
+++ b/src/js/polyfills/webvtt.js
@@ -719,7 +719,7 @@ function moveBoxToLinePosition(window, styleBox, containerBox, boxPositions, num
         // If we detect a best position based on one axis, oftentimes combining with the other axis
         // results in a much better position.
         // TODO: Make more performant by checking axis permutations above
-        if (posFindRecursiveCount === 0) {
+        if (bestAxis && posFindRecursiveCount === 0) {
             let otherAxis = bestAxis.indexOf('y') === -1 ? ['-y', '+y'] : ['-x', '+x'];
             return findBestPosition(finalPos, otherAxis, posFindRecursiveCount+1);
         }


### PR DESCRIPTION
### This PR will...
Fix a bug where the new VTT code was causing an exception. When transitioning to ads playback the player attempts to position captions until the ad is loaded

### Why is this Pull Request needed?
The bug prevents ad playback

### Are there any points in the code the reviewer needs to double check?
None I can think of

### Are there any Pull Requests open in other repos which need to be merged with this?
None

#### Addresses Issue(s):

JW8-10683

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
