### PR TITLE
[JW8-10688] Fix blue ring and keyboard shortcut on shortcutsToggle

### DIFF
--- a/src/css/controls/imports/switch.less
+++ b/src/css/controls/imports/switch.less
@@ -16,7 +16,7 @@
         &.jw-tab-focus {
             outline: @ui-focus;
         }
-        
+
         .jw-switch-knob {
             position: absolute;
             top: 2px;

--- a/src/css/controls/imports/switch.less
+++ b/src/css/controls/imports/switch.less
@@ -13,6 +13,10 @@
         font-size: inherit;
         vertical-align: middle;
 
+        &.jw-tab-focus {
+            outline: @ui-focus;
+        }
+        
         .jw-switch-knob {
             position: absolute;
             top: 2px;

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -317,7 +317,7 @@ export default class Controls extends Events {
                     break;
                 case 13: // enter
                 case 32: // space
-                    if (document.activeElement.classList.contains('jw-switch') && evt.keyCode === 32) {
+                    if (document.activeElement.classList.contains('jw-switch') && evt.keyCode === 13) {
                         // Let event bubble up so the spacebar can control the toggle if focused on
                         return true;
                     }
@@ -382,13 +382,20 @@ export default class Controls extends Events {
         this.playerContainer.addEventListener('keydown', handleKeydown);
         this.keydownCallback = handleKeydown;
 
-        // keep controls active when navigating inside the player
         const handleKeyup = (evt) => {
-            const isTab = evt.keyCode === 9;
-            if (isTab) {
-                const insideContainer = this.playerContainer.contains(evt.target);
-                const activeTimeout = insideContainer ? 0 : ACTIVE_TIMEOUT;
-                this.userActive(activeTimeout);
+            switch (evt.keyCode) {
+                case 9: {
+                    // tab, keep controls active when navigating inside the player
+                    const insideContainer = this.playerContainer.contains(evt.target);
+                    const activeTimeout = insideContainer ? 0 : ACTIVE_TIMEOUT;
+                    this.userActive(activeTimeout);
+                    break;
+                }
+                case 32: // space
+                    evt.preventDefault();
+                    break;
+                default:
+                    break;
             }
         };
         this.playerContainer.addEventListener('keyup', handleKeyup);

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -446,7 +446,16 @@ export default class Controls extends Events {
     }
 
     disable(model) {
-        const { nextUpToolTip, settingsMenu, infoOverlay, controlbar, rightClickMenu, playerContainer, div } = this;
+        const { 
+            nextUpToolTip,
+            settingsMenu,
+            infoOverlay,
+            controlbar,
+            rightClickMenu,
+            shortcutsTooltip,
+            playerContainer,
+            div
+        } = this;
 
         clearTimeout(this.activeTimeout);
         this.activeTimeout = -1;
@@ -500,6 +509,10 @@ export default class Controls extends Events {
 
         if (infoOverlay) {
             infoOverlay.destroy();
+        }
+
+        if (shortcutsTooltip) {
+            shortcutsTooltip.destroy();
         }
 
         this.removeBackdrop();

--- a/src/js/view/controls/shortcuts-tooltip.js
+++ b/src/js/view/controls/shortcuts-tooltip.js
@@ -81,8 +81,9 @@ export default function (container, api, model) {
         isOpen = true;
         api.pause(settingsInteraction);
     };
+
     const close = () => {
-        shortcutToggleUi.off('click tap enter', toggleClickHandler);
+        shortcutToggleUi.off();
         removeClass(template, 'jw-open');
         document.removeEventListener('click', documentClickHandler);
         container.focus();
@@ -91,17 +92,24 @@ export default function (container, api, model) {
             api.play(settingsInteraction);
         }
     };
+
+    const destroy = () => {
+        close();
+    };
+
     const documentClickHandler = (e) => {
         if (!/jw-shortcuts|jw-switch/.test(e.target.className)) {
             close();
         }
     };
+
     const toggleClickHandler = (e) => {
         const toggle = e.currentTarget;
         const isChecked = toggle.getAttribute('aria-checked') === 'true' ? false : true;
         toggle.setAttribute('aria-checked', isChecked);
         model.set('enableShortcuts', isChecked);
     };
+
     const toggleVisibility = () => {
         if (isOpen) {
             close();
@@ -109,6 +117,7 @@ export default function (container, api, model) {
             open();
         }
     };
+    
     const render = () => {
         const closeButton = button('jw-shortcuts-close', close, model.get('localization').close, [cloneIcon('close')]);
 
@@ -124,8 +133,9 @@ export default function (container, api, model) {
 
     return {
         el: template,
-        close,
         open,
-        toggleVisibility,
+        close,
+        destroy,
+        toggleVisibility
     };
 }

--- a/src/js/view/controls/shortcuts-tooltip.js
+++ b/src/js/view/controls/shortcuts-tooltip.js
@@ -93,7 +93,6 @@ export default function (container, api, model) {
 
     const destroy = () => {
         close();
-        shortcutToggleUi.off();
         shortcutToggleUi.destroy();
     };
 

--- a/src/js/view/controls/shortcuts-tooltip.js
+++ b/src/js/view/controls/shortcuts-tooltip.js
@@ -1,5 +1,6 @@
 import shortcutTooltipTemplate from 'view/controls/templates/shortcuts-tooltip';
 import { createElement, removeClass, addClass, prependChild } from 'utils/dom';
+import UI from 'utils/ui';
 import button from 'view/controls/components/button';
 import { cloneIcon } from 'view/controls/icons';
 import { STATE_PLAYING } from 'events/events';
@@ -67,11 +68,11 @@ export default function (container, api, model) {
         shortcutTooltipTemplate(getShortcuts(shortcuts), shortcuts.keyboardShortcuts)
     );
     const settingsInteraction = { reason: 'settingsInteraction' };
-    const shortcutToggle = template.querySelector('.jw-switch');
+    const shortcutToggleUi = new UI(template.querySelector('.jw-switch'));
 
     const open = () => {
-        shortcutToggle.setAttribute('aria-checked', model.get('enableShortcuts'));
-        shortcutToggle.addEventListener('click', toggleClickHandler);
+        shortcutToggleUi.el.setAttribute('aria-checked', model.get('enableShortcuts'));
+        shortcutToggleUi.on('click tap enter', toggleClickHandler);
 
         addClass(template, 'jw-open');
         lastState = model.get('state');
@@ -81,7 +82,7 @@ export default function (container, api, model) {
         api.pause(settingsInteraction);
     };
     const close = () => {
-        shortcutToggle.removeEventListener('click', toggleClickHandler);
+        shortcutToggleUi.off('click tap enter', toggleClickHandler);
         removeClass(template, 'jw-open');
         document.removeEventListener('click', documentClickHandler);
         container.focus();
@@ -109,9 +110,7 @@ export default function (container, api, model) {
         }
     };
     const render = () => {
-        const closeButton = button('jw-shortcuts-close', () => {
-            close();
-        }, model.get('localization').close, [cloneIcon('close')]);
+        const closeButton = button('jw-shortcuts-close', close, model.get('localization').close, [cloneIcon('close')]);
 
         //  Append close button to modal.
         prependChild(template, closeButton.element());

--- a/src/js/view/controls/shortcuts-tooltip.js
+++ b/src/js/view/controls/shortcuts-tooltip.js
@@ -95,6 +95,7 @@ export default function (container, api, model) {
 
     const destroy = () => {
         close();
+        shortcutToggleUi.destroy();
     };
 
     const documentClickHandler = (e) => {

--- a/src/js/view/controls/shortcuts-tooltip.js
+++ b/src/js/view/controls/shortcuts-tooltip.js
@@ -72,7 +72,6 @@ export default function (container, api, model) {
 
     const open = () => {
         shortcutToggleUi.el.setAttribute('aria-checked', model.get('enableShortcuts'));
-        shortcutToggleUi.on('click tap enter', toggleClickHandler);
 
         addClass(template, 'jw-open');
         lastState = model.get('state');
@@ -83,7 +82,6 @@ export default function (container, api, model) {
     };
 
     const close = () => {
-        shortcutToggleUi.off();
         removeClass(template, 'jw-open');
         document.removeEventListener('click', documentClickHandler);
         container.focus();
@@ -95,6 +93,7 @@ export default function (container, api, model) {
 
     const destroy = () => {
         close();
+        shortcutToggleUi.off();
         shortcutToggleUi.destroy();
     };
 
@@ -128,6 +127,8 @@ export default function (container, api, model) {
 
         //  Append modal to container
         container.appendChild(template);
+        
+        shortcutToggleUi.on('click tap enter', toggleClickHandler);
     };
 
     render();


### PR DESCRIPTION
### This PR will...

- Make a blue ring is displayed around the shortcutsToggle across all browsers when it is tabbed to.
- Allow the shortcuts to be enabled/disabled with the enter key as opposed to the space bar.

### Why is this Pull Request needed?

- Update the shortcuts menu to make sure it is functioning as expected

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

[JW8-10688](https://jwplayer.atlassian.net/browse/JW8-10688)

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
