### PR TITLE
[JW8-10789] Audio Track Menu: Fix console error when only one track present.

### DIFF
--- a/src/js/view/controls/components/menu/settings-menu.js
+++ b/src/js/view/controls/components/menu/settings-menu.js
@@ -189,7 +189,7 @@ const SettingsMenu = (api, model, controlbar, localization) => {
         onMenuItemSelected(settingsMenu.children.playbackRates, index);
     }, settingsMenu);
     model.on('change:currentAudioTrack', (changedModel, currentAudioTrack) => {
-        settingsMenu.children.audioTracks.items[currentAudioTrack].activate();
+        onMenuItemSelected(settingsMenu.children.audioTracks, currentAudioTrack);
     }, settingsMenu);
     model.on('change:playlistItem', () => {
         // captions.js silently clears captions when the playlist item changes. The reason it silently clear captions


### PR DESCRIPTION
### This PR will...
Update the settings-menu model listener for audio tracks. It will now use the same functions as the other menus to handle programatic activation.

### Why is this Pull Request needed?
The menuItemSelected function runs checks to prevent updates when the menu isn't present or when there's only a single option.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-10789

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
