### PR TITLE
[JW8-10791] Bugfix/menu accessability order fix

### DIFF
--- a/src/js/view/controls/components/menu/utils.js
+++ b/src/js/view/controls/components/menu/utils.js
@@ -121,3 +121,5 @@ const colorTable = {
     Magenta: 'ff00ff',
     Cyan: '#00ffff'
 };
+
+export const normalizeKey = (sourceEventKey) => sourceEventKey.replace(/(Arrow|ape)/, '');


### PR DESCRIPTION
### This PR will...
Re-implement the old accessibility order.

### Why is this Pull Request needed?
WCAG/ARIA spec is to select first menu item on open, however this would prevent accessibility users from knowing about other submenus. As a result the category button row can be seen as a menu itself, so focus should go to the default menu's category button when main menu is opened. This was the behavior prior to refactor, so this PR simply reverts it to how it was before.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-10791

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
