### PR TITLE
[JW8-10805] Opening/closing the menu properly sets the state when it's supposed to

### DIFF
--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -195,7 +195,6 @@ export default class Controls extends Events {
             const activeTimeout = (visible || isKeyEvent) ? 0 : ACTIVE_TIMEOUT;
             // Trigger userActive so that a dismissive click outside the player can hide the controlbar
             this.userActive(activeTimeout);
-            lastState = state;
             if (getBreakpoint(model.get('containerWidth')) < 2) {
                 if (visible && state === STATE_PLAYING) {
                     // Pause playback on open if we're currently playing
@@ -205,6 +204,7 @@ export default class Controls extends Events {
                     api.play(settingsInteraction);
                 }
             }
+            lastState = state;
             if (!visible && isKeyEvent && settingsButton) {
                 settingsButton.element().focus();
             } else if (evt) {


### PR DESCRIPTION
### This PR will...
Properly play/pause video when closing/opening the menu at containerWidth < 2.

### Why is this Pull Request needed?
Re-ordering of setting lastState broke this functionality.

### Are there any points in the code the reviewer needs to double check?
Please ensure the PR below is merged before this is, as it has fixes this fix is dependent on.

### Are there any Pull Requests open in other repos which need to be merged with this?
Dependent on changes made in this PR: https://github.com/jwplayer/jwplayer/pull/3548

#### Addresses Issue(s):

JW8-10805

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
