### PR TITLE
[JW8-10808] Implement directSelect on menuItem and categoryButton UIs.

### DIFF
--- a/src/js/view/controls/components/menu/category-button.js
+++ b/src/js/view/controls/components/menu/category-button.js
@@ -33,6 +33,7 @@ const categoryButton = (menu, localizedName) => {
     if (!('ontouchstart' in window)) {
         menuCategoryButton.tooltip = SimpleTooltip(buttonElement, name, localizedName);
     }
+    menuCategoryButton.ui.directSelect = true;
     return menuCategoryButton;
 };
 

--- a/src/js/view/controls/components/menu/menu-item.js
+++ b/src/js/view/controls/components/menu/menu-item.js
@@ -6,6 +6,7 @@ export class MenuItem {
     constructor(_content, _action, _template = itemTemplate) {
         this.el = createElement(_template(_content));
         this.ui = new UI(this.el).on('click tap enter', _action, this);
+        this.ui.directSelect = true;
     }
     destroy() {
         this.ui.destroy();

--- a/src/js/view/controls/components/menu/menu-item.js
+++ b/src/js/view/controls/components/menu/menu-item.js
@@ -5,8 +5,7 @@ import { itemRadioButtonTemplate, itemTemplate } from 'view/controls/templates/m
 export class MenuItem {
     constructor(_content, _action, _template = itemTemplate) {
         this.el = createElement(_template(_content));
-        this.ui = new UI(this.el).on('click tap enter', _action, this);
-        this.ui.directSelect = true;
+        this.ui = new UI(this.el, { directSelect: true }).on('click tap enter', _action, this);
     }
     destroy() {
         this.ui.destroy();


### PR DESCRIPTION
### This PR will...
Implement directSelect on UI instances for menuItem and categoryButton

### Why is this Pull Request needed?
Otherwise end events (touchend, pointerup) will trigger after UI's touch/tap/enter handler fires, bleeding through to the new target.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-10808

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
