### PR TITLE
[JW8-10816] Reset button re-render issue fix

### DIFF
--- a/src/js/view/controls/components/menu/settings-menu.js
+++ b/src/js/view/controls/components/menu/settings-menu.js
@@ -1,5 +1,5 @@
 import Menu from 'view/controls/components/menu/menu';
-import { MenuItem, RadioMenuItem } from 'view/controls/components/menu/menu-item';
+import { MenuItem } from 'view/controls/components/menu/menu-item';
 import { itemMenuTemplate } from 'view/controls/templates/menu/menu-item';
 import { _defaults as CaptionsDefaults } from 'view/captionsrenderer';
 import { captionStyleItems } from './utils';

--- a/src/js/view/controls/components/menu/settings-menu.js
+++ b/src/js/view/controls/components/menu/settings-menu.js
@@ -138,13 +138,13 @@ const SettingsMenu = (api, model, controlbar, localization) => {
                 newStyles[propertyName] = newValue;
                 model.set('captions', newStyles);
             };
-            const resetItem = new RadioMenuItem('Reset', () => {
-                model.set('captions', CaptionsDefaults);
-                renderCaptionsSettings();
-            });
-            resetItem.el.classList.add('jw-settings-reset');
             const persistedOptions = model.get('captions');
             const renderCaptionsSettings = () => {
+                const resetItem = new MenuItem('Reset', () => {
+                    model.set('captions', CaptionsDefaults);
+                    renderCaptionsSettings();
+                });
+                resetItem.el.classList.add('jw-settings-reset');
                 const captionsSettingsItems = [];
                 captionStyleItems.forEach(captionItem => {
                     if (persistedOptions && persistedOptions[captionItem.propertyName]) {


### PR DESCRIPTION
### This PR will...
Resolve an exception caused by an issue with the captions settings menu reset button.

### Why is this Pull Request needed?
This exception would be triggered whenever reset was used after the menu was destroyed, and would block several other functionalities as a result.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-###

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
