### PR TITLE
[JW8-10723] Fix progress bar overlapping with play button on mobile bug

### DIFF
--- a/src/css/controls/imports/controlbar.less
+++ b/src/css/controls/imports/controlbar.less
@@ -19,6 +19,12 @@
     transition-property: opacity, visibility;
     transition-delay: 0s;
 
+    .jw-flag-touch.jw-breakpoint-0 & {
+        .jw-icon-inline {
+            height: 40px;
+        }
+    }
+
     .jw-breakpoint-7 & {
         max-height: 140px;
 

--- a/src/css/controls/imports/display.less
+++ b/src/css/controls/imports/display.less
@@ -83,6 +83,12 @@ display icons
         display: none;
     }
 
+    &.jw-flag-touch .jw-display .jw-icon,
+    &.jw-flag-touch .jw-display .jw-svg-icon {
+        z-index: 100;
+        position: relative;
+    }
+
     .jw-display .jw-icon,
     .jw-display .jw-svg-icon {
         width: @mobile-touch-target;

--- a/src/css/controls/imports/slider.less
+++ b/src/css/controls/imports/slider.less
@@ -181,6 +181,10 @@
         left: 0;
     }
 
+    .jw-breakpoint-0.jw-flag-touch &::before {
+        height: 34px;
+    }
+
     &.jw-tab-focus:focus .jw-rail {
         outline: @ui-focus;
     }
@@ -201,5 +205,11 @@
             height: 12px;
             width: 10px;
         }
+    }
+}
+
+.jw-breakpoint-0 {
+    .jw-slider-time {
+        height: 11px;
     }
 }


### PR DESCRIPTION
### This PR will...
- Fix the progress bar overlapping with the play button on mobile making it so that you cannot click on it.

### Why is this Pull Request needed?
- Bugfix

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

[JW8-10723](https://jwplayer.atlassian.net/browse/JW8-10723)

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
