### PR TITLE
[JW8-10821] Allow styling on native captions

### DIFF
--- a/src/js/view/captionsrenderer.js
+++ b/src/js/view/captionsrenderer.js
@@ -132,9 +132,6 @@ const CaptionsRenderer = function (viewModel) {
         _fontScale = _defaults.fontScale;
 
         const styleCaptions = () => {
-            if (_model.get('renderCaptionsNatively')) {
-                return;
-            }
             _setFontScale(_options.fontSize);
     
             const windowColor = _options.windowColor;


### PR DESCRIPTION
### This PR will...
Revert a change that prevented styling on native captions.

### Why is this Pull Request needed?
As we support styling on native captions, the base-case being removed in this PR is unnecessary and causes a a bug that prevents setup if native captions enabled.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-10821

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
