### PR TITLE
Focus the container explicitly on display play

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -448,6 +448,8 @@ function View(_api, _model) {
         clickHandler.on({
             click: () => {
                 _this.trigger(DISPLAY_CLICK);
+                // Ensures that Firefox focuses the container not the video tag for aria compatibility
+                _getCurrentElement().focus();
 
                 if (_controls) {
                     if (settingsMenuVisible()) {
@@ -496,7 +498,7 @@ function View(_api, _model) {
             },
             doubleClick: () => _controls && api.setFullscreen()
         });
-        
+
         if (!_isMobile) {
             _playerElement.addEventListener('mousemove', moveHandler);
             _playerElement.addEventListener('mouseover', overHandler);


### PR DESCRIPTION
### This PR will...
Change behavior on display (non-play button) click to focus the player element explicitly.

### Why is this Pull Request needed?
In firefox, the default behavior focuses the `video` tag which stops any aria attributes from being read and as a result has a degraded experience for screen reads

### Are there any points in the code the reviewer needs to double check?
Nope!

### Are there any Pull Requests open in other repos which need to be merged with this?
Nah

#### Addresses Issue(s):

JW8-5617

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
