### PR TITLE
[JW8-10824][JW8-10822] Menus: Fix gear icon visibility edge-case, remove caption settings menu when casting

### DIFF
--- a/src/js/view/controls/components/menu/menu.js
+++ b/src/js/view/controls/components/menu/menu.js
@@ -313,6 +313,7 @@ export default class Menu extends Events {
             );
         }
         this.mainMenu.el.appendChild(el);
+        this.trigger('menuAppended', name);
     }
     removeMenu(name) {
         if (!name) {
@@ -325,6 +326,7 @@ export default class Menu extends Events {
         }
         delete this.children[name];
         menu.destroy();
+        this.trigger('menuRemoved', name);
     }
     open(evt) {
         const mainMenuVisible = this.mainMenu.visible;

--- a/src/js/view/controls/components/menu/menu.js
+++ b/src/js/view/controls/components/menu/menu.js
@@ -484,6 +484,7 @@ export default class Menu extends Events {
         if (this.el.parentNode) {
             this.el.parentNode.removeChild(this.el);
         }
+        this.off();
     }
 }
 

--- a/src/js/view/controls/components/menu/settings-menu.js
+++ b/src/js/view/controls/components/menu/settings-menu.js
@@ -4,7 +4,7 @@ import { itemMenuTemplate } from 'view/controls/templates/menu/menu-item';
 import { _defaults as CaptionsDefaults } from 'view/captionsrenderer';
 import { captionStyleItems } from './utils';
 
-const SettingsMenu = (api, model, controlbar, localization) => {
+const SettingsMenu = (api, model, localization) => {
     const settingsMenu = new Menu('settings', null, localization);
     const changeMenuItems = (menuName, items, onItemSelect, defaultItemIndex, itemOptions) => {
         if (!items || items.length <= 1) {
@@ -42,7 +42,7 @@ const SettingsMenu = (api, model, controlbar, localization) => {
     // Quality Tracks
     model.change('levels', (changedModel, levels) => {
         setLevelsMenu(levels);
-    }, settingsMenu);
+    });
     const changeAutoLabel = function (qualityLevel, qualityMenu, currentIndex) {
         const levels = model.get('levels');
         // Return early if the label isn't "Auto" (html5 provider with multiple mp4 sources)
@@ -63,7 +63,7 @@ const SettingsMenu = (api, model, controlbar, localization) => {
         if (!qualityMenu.items[currentIndex].active) {
             onMenuItemSelected(qualityMenu, currentIndex);
         }
-    }, settingsMenu);
+    });
 
     // Visual Quality
     model.on('change:visualQuality', (changedModel, quality) => {
@@ -84,23 +84,22 @@ const SettingsMenu = (api, model, controlbar, localization) => {
     };
     model.change('audioTracks', (changedModel, audioTracks) => {
         setAudioTracksMenu(audioTracks);
-    }, settingsMenu);
+    });
     model.on('change:currentAudioTrack', (changedModel, currentAudioTrack) => {
         onMenuItemSelected(settingsMenu.children.audioTracks, currentAudioTrack);
-    }, settingsMenu);
+    });
 
     // Captions
     model.on('change:playlistItem', () => {
         // captions.js silently clears captions when the playlist item changes. The reason it silently clear captions
         // instead of dispatching an event is because we don't want to emit 'captionsList' if the new list is empty.
         settingsMenu.removeMenu('captions');
-        controlbar.elements.captionsButton.hide();
 
         // Settings menu should not be visible when switching playlist items via controls or .load()
         if (settingsMenu.visible) {
             settingsMenu.close();
         }
-    }, settingsMenu);
+    });
     model.change('captionsList', (changedModel, captionsList) => {
         const menuItemOptions = { defaultText: localization.off };
         const initialIndex = model.get('captionsIndex');
@@ -181,8 +180,7 @@ const SettingsMenu = (api, model, controlbar, localization) => {
         if (captionsSubmenu) {
             onMenuItemSelected(captionsSubmenu, index);
         }
-        controlbar.toggleCaptionsButtonState(!!index);
-    }, settingsMenu);
+    });
 
     // Playback Rates
     const setPlaybackRatesMenu = (playbackRates) => {
@@ -209,7 +207,7 @@ const SettingsMenu = (api, model, controlbar, localization) => {
     };
     model.change('playbackRates', (changedModel, playbackRates) => {
         setPlaybackRatesMenu(playbackRates);
-    }, settingsMenu);
+    });
     model.change('playbackRate', (changedModel, playbackRate) => {
         const rates = model.get('playbackRates');
         let index = -1;
@@ -217,7 +215,7 @@ const SettingsMenu = (api, model, controlbar, localization) => {
             index = rates.indexOf(playbackRate);
         }
         onMenuItemSelected(settingsMenu.children.playbackRates, index);
-    }, settingsMenu);
+    });
 
     model.on('change:playbackRateControls', () => {
         setPlaybackRatesMenu(model.get('playbackRates'));
@@ -238,12 +236,12 @@ const SettingsMenu = (api, model, controlbar, localization) => {
             setLevelsMenu(model.get('levels'));
             setPlaybackRatesMenu(model.get('playbackRates'));
         }
-    }, settingsMenu);
+    });
 
     // Update playback rates when stream type changes
     model.on('change:streamType', () => {
         setPlaybackRatesMenu(model.get('playbackRates'));
-    }, settingsMenu);
+    });
 
     return settingsMenu;
 };

--- a/src/js/view/controls/components/menu/settings-menu.js
+++ b/src/js/view/controls/components/menu/settings-menu.js
@@ -7,12 +7,8 @@ import { captionStyleItems } from './utils';
 const SettingsMenu = (api, model, controlbar, localization) => {
     const settingsMenu = new Menu('settings', null, localization);
     const changeMenuItems = (menuName, items, onItemSelect, defaultItemIndex, itemOptions) => {
-        const controlBarButton = controlbar.elements[`${menuName}Button`];
         if (!items || items.length <= 1) {
             settingsMenu.removeMenu(menuName);
-            if (controlBarButton) {
-                controlBarButton.hide();
-            }
             return;
         }
         let menu = settingsMenu.children[menuName];
@@ -23,9 +19,6 @@ const SettingsMenu = (api, model, controlbar, localization) => {
             menu.createItems(items, onItemSelect, itemOptions), 
             defaultItemIndex
         );
-        if (controlBarButton) {
-            controlBarButton.show();
-        }
     };
     const setLevelsMenu = (levels) => {
         const menuItemOptions = { defaultText: localization.auto };
@@ -36,9 +29,6 @@ const SettingsMenu = (api, model, controlbar, localization) => {
             model.get('currentLevel') || 0, 
             menuItemOptions
         );
-        const childMenus = settingsMenu.children;
-        const shouldShowGear = !!childMenus.quality || childMenus.playbackRates || Object.keys(childMenus).length > 1;
-        controlbar.elements.settingsButton.toggle(shouldShowGear);
     };
     const onMenuItemSelected = (menu, itemIndex) => {
         if (menu && itemIndex > -1) {
@@ -184,7 +174,6 @@ const SettingsMenu = (api, model, controlbar, localization) => {
                 captionsSettingsMenu.setMenuItems(captionsSettingsItems);
             };
             renderCaptionsSettings();
-            controlbar.toggleCaptionsButtonState(!!model.get('captionsIndex'));
         }
     });
     model.change('captionsIndex', (changedModel, index) => {

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -225,10 +225,11 @@ export default class Controls extends Events {
         });
         const updateControlbarButtons = (menuName) => {
             const childMenus = settingsMenu.children;
+            const menuCount = Object.keys(childMenus).length;
             const shouldShowGear = 
                 !!childMenus.quality || 
                 !!childMenus.playbackRates || 
-                Object.keys(childMenus).length > 1;
+                menuCount > 1;
 
             controlbar.elements.settingsButton.toggle(shouldShowGear);
             if (childMenus.captions) {
@@ -236,13 +237,14 @@ export default class Controls extends Events {
             }
             const controlBarButton = controlbar.elements[`${menuName}Button`];
             if (controlBarButton) {
-                const isVisible = !!childMenus[menuName];
+                const isVisible = !!childMenus[menuName] && !shouldShowGear || menuCount > 1;
                 controlBarButton.toggle(isVisible);
             }
         };
         settingsMenu.on('menuRemoved menuAppended', (menuName) => { 
             updateControlbarButtons(menuName);
         });
+        updateControlbarButtons('captions');
         if (OS.mobile) {
             this.div.appendChild(settingsMenu.el);
         } else {

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -184,7 +184,9 @@ export default class Controls extends Events {
         this.div.appendChild(controlbar.element());
 
         const localization = model.get('localization');
-        const settingsMenu = this.settingsMenu = SettingsMenu(api, model.player, this.controlbar, localization);
+
+        // Settings Menu
+        const settingsMenu = this.settingsMenu = SettingsMenu(api, model.player, localization);
         let lastState = null;
 
         settingsMenu.on('menuVisibility', ({ visible, evt }) => {
@@ -211,6 +213,9 @@ export default class Controls extends Events {
                 focusPlayerElement();
             }
         });
+        model.change('captionsIndex', (changedModel, index) => {
+            controlbar.toggleCaptionsButtonState(!!index);
+        });
         settingsMenu.on('captionStylesOpened', () => this.trigger('captionStylesOpened'));
         controlbar.on('settingsInteraction', (submenuName, isDefault, event) => {
             if (isDefault) {
@@ -220,7 +225,11 @@ export default class Controls extends Events {
         });
         const updateControlbarButtons = (menuName) => {
             const childMenus = settingsMenu.children;
-            const shouldShowGear = !!childMenus.quality || !!childMenus.playbackRates || Object.keys(childMenus).length > 1;
+            const shouldShowGear = 
+                !!childMenus.quality || 
+                !!childMenus.playbackRates || 
+                Object.keys(childMenus).length > 1;
+
             controlbar.elements.settingsButton.toggle(shouldShowGear);
             if (childMenus.captions) {
                 controlbar.toggleCaptionsButtonState(!!model.get('captionsIndex'));

--- a/test/unit/menu-test.js
+++ b/test/unit/menu-test.js
@@ -4,7 +4,6 @@ import SimpleModel from 'model/simplemodel';
 import MockApi from 'mock/mock-api';
 
 const localization = { close: 'close', hd: 'quality', playbackRates: 'rates' };
-const createMockMenu = (name, parent) => new Menu(name, parent, localization);
 
 describe('Menu', () => {
     let settingsMenu;
@@ -85,61 +84,21 @@ describe('Settings Menu', () => {
     let viewModel;
     let settingsMenu;
     let api;
-    let controlbar;
     
     beforeEach(function() {
         viewModel = new SimpleModel();
         api = MockApi;
-        controlbar = {};
-        controlbar.on = sinon.stub();
-        controlbar.elements = {
-            hd: { selectItem: sinon.spy() },
-            settingsButton: {
-                toggle: function(bool) { 
-                    if (bool) {
-                        return this.show();
-                    }
-                    return this.hide();
-                },
-                show: sinon.spy(),
-                hide: sinon.spy()
-            }
-        };
-        controlbar.toggleCaptionsButtonState = sinon.spy();
     });
 
-    it('properly toggles visibility of settings button on quality levels', () => {
-        viewModel.set('levels', [{ label: 'Auto' }, { label: '1080p' }]);
-        // Should show settings button and create quality menu if levels present.
-        settingsMenu = SettingsMenu(api, viewModel, controlbar, localization);
-        expect(controlbar.elements.settingsButton.show.called).to.be.true;
-        expect(controlbar.elements.settingsButton.hide.called).to.be.false;
-        expect(!!settingsMenu.children.quality).to.be.true;
-        // If only one level, should hide settings button and remove quality menu.
-        viewModel.set('levels', [{ label: 'Auto' }]);
-        expect(controlbar.elements.settingsButton.hide.called).to.be.true;
-        expect(!!settingsMenu.children.quality).to.be.false;
-
-        controlbar.elements.settingsButton.show.resetHistory();
-        controlbar.elements.settingsButton.hide.resetHistory();
-
-        // Should hide settings button if less than two menus are present
-        createMockMenu('captions', settingsMenu);
-        expect(controlbar.elements.settingsButton.show.called).to.be.false;
-        createMockMenu('audioTracks', settingsMenu);
-        viewModel.set('levels', [{ label: 'Auto' }]);
-        expect(controlbar.elements.settingsButton.show.called).to.be.true;
-    });
-    
     it('should setup quality menu on levels change', function() {
-        settingsMenu = SettingsMenu(api, viewModel, controlbar, localization);
+        settingsMenu = SettingsMenu(api, viewModel, localization);
         expect(!!settingsMenu.children.quality).to.be.false;
         viewModel.set('levels', [{ label: 'Auto' }, { label: '1080p' }]);
         expect(!!settingsMenu.children.quality).to.be.true;
     });
 
     it('should setup captions menu on captions change', function() {
-        settingsMenu = SettingsMenu(api, viewModel, controlbar, localization);
+        settingsMenu = SettingsMenu(api, viewModel, localization);
         expect(!!settingsMenu.children.captions).to.be.false;
         viewModel.set('captionsList', [
             { id: 'off', label: 'Off' },
@@ -149,7 +108,7 @@ describe('Settings Menu', () => {
     });
 
     it('should setup playback rates menu on playback rates if configured', () => {
-        settingsMenu = SettingsMenu(api, viewModel, controlbar, localization);
+        settingsMenu = SettingsMenu(api, viewModel, localization);
         viewModel.set('playbackRates', [0.5, 1, 1.25, 1.5, 2]);
         expect(!!settingsMenu.children.playbackRates).to.be.false;
         viewModel.set('supportsPlaybackRate', true);
@@ -167,10 +126,25 @@ describe('Settings Menu', () => {
             shakaIndex: 0,
             shakaId: 32
         };
-        settingsMenu = SettingsMenu(api, viewModel, controlbar, localization);
+        settingsMenu = SettingsMenu(api, viewModel, localization);
         viewModel.set('audioTracks', [track]);
         expect(!!settingsMenu.children.audioTracks).to.be.false;
         viewModel.set('audioTracks', [track, track]);
         expect(!!settingsMenu.children.audioTracks).to.be.true;
+    });
+
+    it('Emits an event when a submenu is added', () => {
+        settingsMenu = SettingsMenu(api, viewModel, localization);
+        settingsMenu.trigger = sinon.spy();
+        viewModel.set('levels', [{ label: 'Auto' }, { label: '1080p' }]);
+        expect(settingsMenu.trigger.calledWith('menuAppended')).to.equal(true);
+    });
+
+    it('Emits an event when a submenu is removed', () => {
+        settingsMenu = SettingsMenu(api, viewModel, localization);
+        settingsMenu.trigger = sinon.spy();
+        viewModel.set('levels', [{ label: 'Auto' }, { label: '1080p' }]);
+        viewModel.set('levels', [{ label: 'Auto' }]);
+        expect(settingsMenu.trigger.calledWith('menuRemoved')).to.equal(true);
     });
 });


### PR DESCRIPTION
### This PR will...
Fix a bug where the gear icon is visible when playBackRateControls is set to true on a live stream.

Also makes the following improvements:
- Separates controlbar logic from settings menu.
- Consolidates controlbar button updating based on menu availability to a single function.
- Removes listeners from settings menu when destroyed via model.off
- Removes the redundancy from menuVisibility listener pattern in controls.js, as per @robwalch's prior suggestion.
- Removes Subtitle Settings when casting.

### Why is this Pull Request needed?
Fixes a bug, makes a memory optimization.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-10824
JW8-10822

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
