### PR TITLE
[JW8-10756] Prevent Live text from wrapping at breakpoint 7 

### DIFF
--- a/src/css/controls/imports/controlbar.less
+++ b/src/css/controls/imports/controlbar.less
@@ -43,7 +43,7 @@
                 }
             }
 
-            .jw-icon-inline,
+            .jw-icon-inline:not(.jw-text-live),
             .jw-icon-volume {
                 .square(60px);
 


### PR DESCRIPTION
### This PR will...
Prevent Live text from wrapping at breakpoint 7

### Why is this Pull Request needed?
`.jw-text-live` is created using the controlbar `button` module, so it gets the `.jw-icon-inline` class. At breakpoint-7 all elements in the controlbar are assigned a width and height of 60px. This should not apply to `.jw-text-live`, only to square buttons.

#### Addresses Issue(s):
JW8-10756

### Checklist
- [x] Jenkins builds and unit tests are passing
- [x] I have reviewed the automated results
