### PR TITLE
Only disable track on detach for HTML with sideload

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -265,8 +265,12 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
             clearTimeouts();
             // Stop listening to track changes so disabling the current track doesn't update the model
             this.removeTracksListener(_videotag.textTracks, 'change', this.textTrackChangeHandler);
-            // Prevent tracks from showing during ad playback
-            this.disableTextTrack();
+
+            const currTrack = this.getCurrentTextTrack();
+            // Prevent sideloaded tracks from showing during ad playback
+            if (currTrack && currTrack.sideloaded) {
+                this.disableTextTrack();
+            }
         },
         attachMedia() {
             VideoAttached.attachMedia.call(_this);
@@ -275,8 +279,13 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
             this.seeking = false;
             // In case the video tag was modified while we shared it
             _videotag.loop = false;
-            // If there was a showing track, re-enable it
-            this.enableTextTrack();
+
+            const currTrack = this.getCurrentTextTrack();
+            // If there was a showing sideloaded track disabled in detached, re-enable it
+            if (currTrack && currTrack.sideloaded) {
+                this.enableTextTrack();
+            }
+
             if (this.renderNatively) {
                 this.setTextTracks(this.video.textTracks);
             }

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -266,9 +266,8 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
             // Stop listening to track changes so disabling the current track doesn't update the model
             this.removeTracksListener(_videotag.textTracks, 'change', this.textTrackChangeHandler);
 
-            const currTrack = this.getCurrentTextTrack();
             // Prevent sideloaded tracks from showing during ad playback
-            if (currTrack && currTrack.sideloaded) {
+            if (_shouldToggleTrackOnDetach()) {
                 this.disableTextTrack();
             }
         },
@@ -280,9 +279,8 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
             // In case the video tag was modified while we shared it
             _videotag.loop = false;
 
-            const currTrack = this.getCurrentTextTrack();
             // If there was a showing sideloaded track disabled in detached, re-enable it
-            if (currTrack && currTrack.sideloaded) {
+            if (_shouldToggleTrackOnDetach()) {
                 this.enableTextTrack();
             }
 
@@ -545,6 +543,18 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
         if (_levels.length && _levels[0].type !== 'hls') {
             _setMediaType();
         }
+    }
+
+    // Safari has a bug where our disable of an embedded rendered track causes
+    //  the track to not display when we re-attach the media. We can avoid this
+    //  by only disabling the track if sideloaded in safari
+    function _shouldToggleTrackOnDetach() {
+        if (!Browser.safari) {
+            return true;
+        }
+
+        const track = _this.getCurrentTextTrack();
+        return track && track.sideloaded;
     }
 
     function _setVideotagSource(source) {

--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -23,6 +23,7 @@ const Tracks = {
     clearCueData,
     disableTextTrack,
     enableTextTrack,
+    getCurrentTextTrack,
     getSubtitlesTrack,
     removeTracksListener,
     addTextTracks,
@@ -158,7 +159,6 @@ function setTextTracks(tracks) {
 
 function setupSideloadedTracks(itemTracks) {
     // Add tracks if we're starting playback or resuming after a midroll
-
     if (!this.renderNatively) {
         return;
     }
@@ -167,7 +167,9 @@ function setupSideloadedTracks(itemTracks) {
     if (!alreadyLoaded) {
         cancelXhr(this._itemTracks);
     }
+
     this._itemTracks = itemTracks;
+
     if (!itemTracks) {
         return;
     }
@@ -423,6 +425,10 @@ function disableTextTrack() {
     }
 }
 
+function getCurrentTextTrack() {
+    return this._textTracks && this._textTracks[this._currentTextTrackIndex];
+}
+
 function enableTextTrack() {
     if (this._textTracks) {
         const track = this._textTracks[this._currentTextTrackIndex];
@@ -481,6 +487,7 @@ function addTextTracks(tracksArray) {
             itemTrack.data = [];
             loadFile(itemTrack,
                 (vttCues) => {
+                    textTrackAny.sideloaded = true;
                     this.addVTTCuesToTrack(textTrackAny, vttCues);
                 },
                 error => {

--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -216,8 +216,9 @@ function setSubtitlesTrack(menuIndex) {
     // Set the provider's index to the model's index, then show the selected track if it exists
     this._currentTextTrackIndex = menuIndex - 1;
 
-    if (this._textTracks[this._currentTextTrackIndex]) {
-        this._textTracks[this._currentTextTrackIndex].mode = 'showing';
+    const track = this.getCurrentTextTrack();
+    if (track) {
+        track.mode = 'showing';
     }
 
     // Update the model index since the track change may have come from a browser event
@@ -412,15 +413,13 @@ function clearCueData(trackId) {
 }
 
 function disableTextTrack() {
-    if (this._textTracks) {
-        const track = this._textTracks[this._currentTextTrackIndex];
-        if (track) {
-            // FF does not remove the active cue from the dom when the track is hidden, so we must disable it
-            track.mode = 'disabled';
-            const trackId = track._id;
-            if (trackId && trackId.indexOf('nativecaptions') === 0) {
-                track.mode = 'hidden';
-            }
+    const track = this.getCurrentTextTrack();
+    if (track) {
+        // FF does not remove the active cue from the dom when the track is hidden, so we must disable it
+        track.mode = 'disabled';
+        const trackId = track._id;
+        if (trackId && trackId.indexOf('nativecaptions') === 0) {
+            track.mode = 'hidden';
         }
     }
 }
@@ -430,11 +429,9 @@ function getCurrentTextTrack() {
 }
 
 function enableTextTrack() {
-    if (this._textTracks) {
-        const track = this._textTracks[this._currentTextTrackIndex];
-        if (track) {
-            track.mode = 'showing';
-        }
+    const track = this.getCurrentTextTrack();
+    if (track) {
+        track.mode = 'showing';
     }
 }
 


### PR DESCRIPTION
### This PR will...
Update our html 5 provider so that when the media is detached it only disables the running track if it has been sideloaded.

### Why is this Pull Request needed?
There is an issue with safari that is potentially related to this [webkit bug report](https://bugs.webkit.org/show_bug.cgi?id=184443) in which after the media is detached and reattached the disabled track (despite being reenabled) never shows in the viewport.

It appears to be a Safari issue but this change works around it

### Are there any points in the code the reviewer needs to double check?
Nah

### Are there any Pull Requests open in other repos which need to be merged with this?
None 

#### Addresses Issue(s):

JW8-10239

### Checklist
- [x] Jenkins builds and unit tests are passing
- [x] I have reviewed the automated results
