### PR TITLE
Remove the focus ring that exists on the video element in android chrome

### DIFF
--- a/src/css/jwplayer/imports/video.less
+++ b/src/css/jwplayer/imports/video.less
@@ -9,6 +9,9 @@
         height: 100%;
         margin: auto;
         background: transparent;
+        -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+        -webkit-focus-ring-color: rgba(0, 0, 0, 0);
+        outline: none;
 
         // Hides the native play button pseudoelement in iOS
         &::-webkit-media-controls-start-playback-button {


### PR DESCRIPTION
### This PR will...
Add additional styling rules to the video tag which disable an orange ring around that tag.

### Why is this Pull Request needed?
When you enter fullscreen in android chrome the video tag focuses and creates an orange focus ring

### Are there any points in the code the reviewer needs to double check?
None I can think of

### Are there any Pull Requests open in other repos which need to be merged with this?
Nah 

#### Addresses Issue(s):

JW8-10814

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
