### PR TITLE
[JW8-6089] Allow multiline titles in A/B variant

### DIFF
--- a/src/css/jwplayer/imports/title.less
+++ b/src/css/jwplayer/imports/title.less
@@ -32,6 +32,7 @@
     .jw-flag-small-player & {
         font-size: 1.25em;
     }
+
     .jw-breakpoint-0 .jw-ab-truncated &,
     .jw-breakpoint-1 .jw-ab-truncated &,
     .jw-breakpoint-2 .jw-ab-truncated & {
@@ -44,9 +45,11 @@
         white-space: pre-wrap;
         line-height: 1.2;
     }
+
     .jw-breakpoint-1 .jw-ab-truncated & {
         font-size: 1.25em;
     }
+
     .jw-breakpoint-0 .jw-ab-truncated & {
         font-size: 1em;
     }

--- a/src/css/jwplayer/imports/title.less
+++ b/src/css/jwplayer/imports/title.less
@@ -32,10 +32,31 @@
     .jw-flag-small-player & {
         font-size: 1.25em;
     }
+    .jw-breakpoint-0 .jw-ab-truncated &,
+    .jw-breakpoint-1 .jw-ab-truncated &,
+    .jw-breakpoint-2 .jw-ab-truncated & {
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+        padding-bottom: 0;
+        margin-bottom: 0.5em;
+        white-space: pre-wrap;
+        line-height: 1.2;
+    }
+    .jw-breakpoint-1 .jw-ab-truncated & {
+        font-size: 1.25em;
+    }
+    .jw-breakpoint-0 .jw-ab-truncated & {
+        font-size: 1em;
+    }
 }
 
 .jw-title-secondary {
     .jw-flag-small-player &,
+    .jw-breakpoint-0 .jw-ab-truncated &,
+    .jw-breakpoint-1 .jw-ab-truncated &,
+    .jw-breakpoint-2 .jw-ab-truncated &,
     &:empty {
         display: none;
     }

--- a/src/js/view/title.js
+++ b/src/js/view/title.js
@@ -5,6 +5,7 @@ import {
 
 const Title = function(_model) {
     this.model = _model.player;
+    this.truncated = _model.get('__ab_truncated');
 };
 
 Object.assign(Title.prototype, {
@@ -24,7 +25,9 @@ Object.assign(Title.prototype, {
         const arr = this.el.getElementsByTagName('div');
         this.title = arr[0];
         this.description = arr[1];
-
+        if (this.truncated) {
+            this.el.classList.add('jw-ab-truncated');
+        }
         this.model.on('change:logoWidth', this.update, this);
         this.model.change('playlistItem', this.playlistItem, this);
     },

--- a/src/js/view/title.js
+++ b/src/js/view/title.js
@@ -2,10 +2,11 @@ import { style } from 'utils/css';
 import {
     replaceInnerHtml
 } from 'utils/dom';
+import { Browser } from 'environment/environment';
 
 const Title = function(_model) {
     this.model = _model.player;
-    this.truncated = _model.get('__ab_truncated');
+    this.truncated = _model.get('__ab_truncated') && !Browser.ie;
 };
 
 Object.assign(Title.prototype, {


### PR DESCRIPTION
### This PR will...
Create a configurable option to allow two lines of text before title truncation, and use a smaller font size for breakpoints 0 and 1 when this option is enabled.

### Why is this Pull Request needed?
A/B Test

### Are there any points in the code the reviewer needs to double check?
The CSS -webkit-line-clamp property isn't IE compatible, but without control of the player width, font family, font size etc, I can't immediately think of an efficient way to calculate via JS

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-6089

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
