### PR TITLE
[JW8-10878] Add any missing aria labels

### DIFF
--- a/src/js/view/controls/templates/menu/menu-item.js
+++ b/src/js/view/controls/templates/menu/menu-item.js
@@ -1,5 +1,5 @@
 import ARROW_RIGHT_ICON from 'assets/SVG/arrow-right.svg';
-export const itemTemplate = (content) => `<button type="button" class="jw-reset-text jw-settings-content-item" dir="auto">${content}</button>`;
+export const itemTemplate = (content) => `<button type="button" class="jw-reset-text jw-settings-content-item" aria-label="${content}" dir="auto">${content}</button>`;
 
 export const itemMenuTemplate = ({ name, label, currentSelection }) => {
     return (
@@ -15,7 +15,7 @@ export const itemMenuTemplate = ({ name, label, currentSelection }) => {
 
 export const itemRadioButtonTemplate = (content) => {
     return (
-        `<button type="button" class="jw-reset-text jw-settings-content-item" aria-label="${content.label}" role="menuitemradio" aria-checked="false" dir="auto">` +
+        `<button type="button" class="jw-reset-text jw-settings-content-item" aria-label="${content}" role="menuitemradio" aria-checked="false" dir="auto">` +
             `${content}` +
         `</button>`
     );


### PR DESCRIPTION
### This PR will...
Fix an issue where certain items still missing aria labels.

### Why is this Pull Request needed?
Menus aren't revealed until an interaction or API event. Labels help to distinguish between elements when text is not visible.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-10848

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
