### PR TITLE
[JW8-10889] Fix issue where template breaks for auto option

### DIFF
--- a/src/js/view/controls/components/menu/menu.js
+++ b/src/js/view/controls/components/menu/menu.js
@@ -180,10 +180,12 @@ export default class Menu extends Events {
         const menuItems = genericItems.map((item, index) => {
             let content;
             let argument;
+            let additionalHTML;
             switch (itemType) {
                 case 'quality':
                     if (item.label === 'Auto' && index === 0) {
-                        content = `${options.defaultText}&nbsp;<span class="jw-reset jw-auto-label"></span>`;
+                        content = `${options.defaultText}`;
+                        additionalHTML = ' <span class="jw-reset jw-auto-label"></span>';
                     } else {
                         content = item.label;
                     }
@@ -237,7 +239,9 @@ export default class Menu extends Events {
             };
 
             const menuItem = new Item(content, menuItemClick.bind(this));
-
+            if (additionalHTML) {
+                menuItem.el.appendChild(createElement(additionalHTML));
+            }
             return menuItem;
         });
 


### PR DESCRIPTION
### This PR will...
Update behavior around templating the auto quality label.

### Why is this Pull Request needed?
When radio item content types were normalized, there was an issue where html was part of the label. In order to limit the need for a single use template, we will instead just append the extra html when it renders.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-10889

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
