### PR TITLE
[JW8-10896] Reduce Player Asset Size

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -120,8 +120,7 @@ module.exports = function(grunt) {
                 junitReporter: {
                     suite: '<%= grunt.task.current.target %>',
                     outputDir: 'reports/junit'
-                },
-                concurrency: 1
+                }
             },
             headless: {
                 browsers: ['ChromeHeadless']

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -77,7 +77,7 @@ const webpackConfig = {
                     options: {
                         babelrc: false,
                         presets: [
-                            '@babel/preset-env',
+                            ['@babel/preset-env', { loose: true, modules: false }],
                             '@babel/preset-typescript'
                         ],
                         plugins: [


### PR DESCRIPTION
Change babel settings so that we use loose mode and enable treeshaking by disabling the default conversion of modules to commonjs.

Reference https://medium.com/@bluepnume/javascript-tree-shaking-like-a-pro-7bf96e139eb7

As a result the web player release assets will have a smaller footprint which is better for everybody. (Note these sizes are from the commercial project bin-release assets)

```
189K > 170K (-19K) jwplayer.controls.js
339K > 312K (-27K) jwplayer.core.controls.html5.js
310K > 283K (-27K) jwplayer.core.controls.js
346K > 319K (-27K) jwplayer.core.controls.polyfills.html5.js
317K > 290K (-27K) jwplayer.core.controls.polyfills.js
131K > 123K (- 8K) jwplayer.core.js
113K > 108K (- 5K) jwplayer.js
 36K >  36K (   0) provider.html5.js
```

Loose mode differences:

1. Uses `+` operator for string concatenation in transpiled string templates (smaller) 
```js
  var playerId = element.id || "player-".concat(uniqueId);
  // loose:
  var playerId = element.id || "player-" + uniqueId;
```
2. Uses `undefined` check for assigning argument defaults (smaller, and skips assignment when the argument is undefined ). A lot of times I use || as an optimization to avoid this boiler plate, so loose mode is much better.
```js
getSafeRegion: function getSafeRegion() {
      var excludeControlbar = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : true;
// loose:
getSafeRegion: function getSafeRegion(excludeControlbar) {
      if (excludeControlbar === void 0) {
        excludeControlbar = true;
```

3. Removes `_classCallCheck` from all modules with classes and their constructors (not needed and is a huge saving in size and execution of code that we do not need).  You can call Class() as a function without the new keyword in loose, but we’d never do that because the result would not be an instance and would not work.
```js
// Every module with a class (before):
function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
// And if necessry: _possibleConstructorReturn, _assertThisInitialized, _get, _superPropBase, _getPrototypeOf, _inherits, _setPrototypeOf
  function ClassName() {
    _classCallCheck(this, ClassName);
...
  _createClass(ClassName, null, [{
    key: "methodName",
    value: function...
    
 // loose:
   function ClassName() {
...
var _proto = ClassName.prototype;
_proto.methodName = function ...
```

The overhead required to parse and define each class as well as create instances is really concerning. By removing this the player will be more performant. These settings are already being used in hls.js.

4. Use typeof operator instead of ES6 Symbol compatible polyfill in each module using typeof
```js
function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
...
if (_typeof(pluginsConfig) !== 'object') {

// loose (the code is left as we wrote it):
if (typeof pluginsConfig !== 'object') {
```

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/7395

#### Addresses Issue(s):
JW8-10896

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
