### PR TITLE
Add redundant label checking to OSS utils

### DIFF
--- a/src/js/providers/utils/quality-labels.js
+++ b/src/js/providers/utils/quality-labels.js
@@ -74,8 +74,31 @@ export function hasRedundantLevels(levels) {
     if (!Array.isArray(levels)) {
         return false;
     }
+    return checkForLevelDuplicates(levels, ['height', 'bitrate', 'bandwidth']);
+}
+
+export function hasRedundantLabels(levels) {
+    if (!Array.isArray(levels)) {
+        return false;
+    }
+    return checkForLevelDuplicates(levels, ['label']);
+}
+
+function checkForLevelDuplicates(levels, dupKeys) {
     return levels.some(function (level) {
-        const key = level.height || level.bitrate || level.bandwidth;
+        let key;
+        for (let i = 0; i < dupKeys.length; i++) {
+            // Take the passed keys which are used to detect duplicates and
+            // in priority order find one that is populated on the given level
+            key = level[dupKeys[i]];
+            if (key) {
+                break;
+            }
+        }
+
+        if (!key) {
+            return false;
+        }
         const foundDuplicate = this[key];
         this[key] = 1;
         return foundDuplicate;

--- a/test/unit/quality-labels-test.js
+++ b/test/unit/quality-labels-test.js
@@ -5,6 +5,7 @@ import {
     createLabel,
     getCustomLabel,
     findClosestBandwidth,
+    hasRedundantLabels,
     toKbps
 } from 'providers/utils/quality-labels';
 
@@ -201,6 +202,25 @@ describe('quality-labels', function() {
                 const actual = generateLabel(level, customLabels, false);
                 expect(actual).to.equal('medium');
             });
+        });
+    });
+
+    describe('#hasRedundantLabels', () => {
+        it('should return true if multiple labels are the same', () => {
+            const levels = [{ label: 'Video 1' }, { label: 'Video 2' }, { label: 'Video 2' }];
+            expect(hasRedundantLabels(levels)).to.be.true;
+        });
+        it('should return false if multiple labels are not the same', () => {
+            const levels = [{ label: 'Video 1' }, { label: 'Video 2' }, { label: 'Video 3' }];
+            expect(hasRedundantLabels(levels)).to.be.false;
+        });
+        it('should return false if multiple labels are the not same with some nulls', () => {
+            const levels = [{ label: 'Video 1' }, { label: 'Video 2' }, { label: 'Video 3' }, { label: null }, { label: null }];
+            expect(hasRedundantLabels(levels)).to.be.false;
+        });
+        it('should return false if multiple labels are the same with some nulls', () => {
+            const levels = [{ label: 'Video 1' }, { label: 'Video 2' }, { label: 'Video 1' }, { label: null }, { label: null }];
+            expect(hasRedundantLabels(levels)).to.be.true;
         });
     });
 });


### PR DESCRIPTION
### This PR will...
Add a utility for detecting duplicate labels in levels

### Why is this Pull Request needed?
Duplicate labels should cause an override from the JW side - updating shaka to 2.5.7 caused this in our stack due to the setup of a stream which previously did not have labels present but with the update is now given them (or they are derived)

### Are there any points in the code the reviewer needs to double check?
Nope

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/7393

#### Addresses Issue(s):

JW8-10818

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
