### PR TITLE
[JW8-10925] Change programController's volume/mute setters

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -862,8 +862,8 @@ Object.assign(Controller.prototype, {
         }
 
         function updateProgramSoundSettings() {
-            _programController.mute = _model.getMute();
-            _programController.volume = _model.get('volume');
+            _programController.setMute(_model.getMute());
+            _programController.setVolume(_model.get('volume'));
         }
 
         this.preload = preload;

--- a/src/js/program/ad-program-controller.js
+++ b/src/js/program/ad-program-controller.js
@@ -198,7 +198,6 @@ export default class AdProgramController extends ProgramController {
     set mute(mute) {
         const { mediaController, model, provider } = this;
         model.set('mute', mute);
-        super.mute = mute;
         if (!mediaController) {
             provider.mute(mute);
         }
@@ -207,7 +206,6 @@ export default class AdProgramController extends ProgramController {
     set volume(volume) {
         const { mediaController, model, provider } = this;
         model.set('volume', volume);
-        super.volume = volume;
         if (!mediaController) {
             provider.volume(volume);
         }

--- a/src/js/program/ad-program-controller.js
+++ b/src/js/program/ad-program-controller.js
@@ -198,6 +198,7 @@ export default class AdProgramController extends ProgramController {
     set mute(mute) {
         const { mediaController, model, provider } = this;
         model.set('mute', mute);
+        super.setMute(mute);
         if (!mediaController) {
             provider.mute(mute);
         }
@@ -206,6 +207,7 @@ export default class AdProgramController extends ProgramController {
     set volume(volume) {
         const { mediaController, model, provider } = this;
         model.set('volume', volume);
+        super.setVolume(volume);
         if (!mediaController) {
             provider.volume(volume);
         }

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -626,25 +626,6 @@ class ProgramController extends Events {
     }
 
     /**
-     * Mutes or unmutes the activate media.
-     * Syncs across all media elements.
-     * @param {boolean} mute - Mute or unmute media?
-     * @returns {void}
-     */
-    set mute(mute) {
-        const { background, mediaController, mediaPool } = this;
-
-        if (mediaController) {
-            mediaController.mute = mute;
-        }
-        if (background.currentMedia) {
-            background.currentMedia.mute = mute;
-        }
-
-        mediaPool.syncMute(mute);
-    }
-
-    /**
      * Seeks the media to the provided position.
      * Set the item's starttime so that if detached while seeking it resumes from the correct time.
      * ALso set the item's starttime so that if we seek before loading, we load and begin at the correct time.
@@ -692,12 +673,31 @@ class ProgramController extends Events {
     }
 
     /**
+     * Mutes or unmutes the activate media.
+     * Syncs across all media elements.
+     * @param {boolean} mute - Mute or unmute media?
+     * @returns {void}
+     */
+    setMute(mute) {
+        const { background, mediaController, mediaPool } = this;
+
+        if (mediaController) {
+            mediaController.mute = mute;
+        }
+        if (background.currentMedia) {
+            background.currentMedia.mute = mute;
+        }
+
+        mediaPool.syncMute(mute);
+    }
+
+    /**
      * Sets the volume level.
      * Syncs across all media elements.
      * @param {number} volume - A number from 0 to 1.
      * @returns {void}
      */
-    set volume(volume) {
+    setVolume(volume) {
         const { background, mediaController, mediaPool } = this;
 
         if (mediaController) {


### PR DESCRIPTION
### This PR will...
- Change setters for `volume` and `mute` in `programController` to `setMute` and `setVolume` methods

### Why is this Pull Request needed?
- With recent webpack changes, super setters are causing recursive infinite loop.

### Are there any points in the code the reviewer needs to double check?
Here is the build that this issue started happening: https://jenkins.jwplayer.com/view/JW7/job/jw7-commercial-master/12584/

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/7428

#### Addresses Issue(s):
JW8-10925

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
