### PR TITLE
Fix html5 instream attach/detach provider cleanup in Safari

### DIFF
--- a/src/js/program/ad-program-controller.js
+++ b/src/js/program/ad-program-controller.js
@@ -78,7 +78,6 @@ export default class AdProgramController extends ProgramController {
     }
 
     usePsuedoProvider(provider) {
-        this.provider = provider;
         if (!provider) {
             return;
         }
@@ -96,7 +95,7 @@ export default class AdProgramController extends ProgramController {
         if (!provider || !this.mediaPool) {
             return;
         }
-
+        this.provider = provider;
         const { model, playerModel } = this;
         const isVpaidProvider = provider.type === 'vpaid';
 
@@ -141,8 +140,12 @@ export default class AdProgramController extends ProgramController {
     }
 
     destroy() {
-        const { model, mediaPool, playerModel } = this;
+        const { model, mediaPool, playerModel, provider } = this;
         model.off();
+        if (provider && provider.destroy) {
+            provider.destroy();
+        }
+        this.provider = null;
 
         // We only use one media element from ads; getPrimedElement will return it
         const mediaElement = mediaPool.getPrimedElement();

--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -21,7 +21,7 @@ export default class MediaController extends Events {
         this.provider = provider;
         this.providerListener = new ProviderListener(this);
         this.thenPlayPromise = cancelable(() => {});
-        addProviderListeners(this);
+        this.addProviderListeners();
         this.eventQueue = new ApiQueueDecorator(this, ['trigger'],
             () => !this.attached || this.background);
     }
@@ -316,14 +316,15 @@ export default class MediaController extends Events {
     set volume(volume) {
         this.provider.volume(volume);
     }
+
+    addProviderListeners() {
+        this.provider.off();
+        this.provider.on('all', this.providerListener, this);
+    }
 }
 
 function syncPlayerWithMediaModel(mediaModel) {
     // Sync player state with mediaModel state
     const mediaState = mediaModel.get('mediaState');
     mediaModel.trigger('change:mediaState', mediaModel, mediaState, mediaState);
-}
-
-function addProviderListeners(mediaController) {
-    mediaController.provider.on('all', mediaController.providerListener, mediaController);
 }

--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -21,7 +21,8 @@ export default class MediaController extends Events {
         this.provider = provider;
         this.providerListener = new ProviderListener(this);
         this.thenPlayPromise = cancelable(() => {});
-        this.addProviderListeners();
+        provider.off();
+        provider.on('all', this.providerListener, this);
         this.eventQueue = new ApiQueueDecorator(this, ['trigger'],
             () => !this.attached || this.background);
     }
@@ -315,11 +316,6 @@ export default class MediaController extends Events {
 
     set volume(volume) {
         this.provider.volume(volume);
-    }
-
-    addProviderListeners() {
-        this.provider.off();
-        this.provider.on('all', this.providerListener, this);
     }
 }
 

--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -268,6 +268,7 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
             clearTimeouts();
             // Stop listening to track changes so disabling the current track doesn't update the model
             this.removeTracksListener(_videotag.textTracks, 'change', this.textTrackChangeHandler);
+            this.removeTracksListener(_videotag.textTracks, 'addtrack', this.addTrackHandler);
 
             // Prevent sideloaded tracks from showing during ad playback
             if (_shouldToggleTrackOnDetach()) {
@@ -645,11 +646,19 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
     };
 
     this.destroy = function() {
+        const { addTrackHandler, cueChangeHandler, textTrackChangeHandler } = _this;
+        const textTracks = _videotag.textTracks;
+        _this.off();
         _beforeResumeHandler = noop;
         _removeListeners(MediaEvents, _videotag);
-        this.removeTracksListener(_videotag.audioTracks, 'change', _audioTrackChangeHandler);
-        this.removeTracksListener(_videotag.textTracks, 'change', _this.textTrackChangeHandler);
-        this.off();
+        _this.removeTracksListener(_videotag.audioTracks, 'change', _audioTrackChangeHandler);
+        _this.removeTracksListener(textTracks, 'change', textTrackChangeHandler);
+        _this.removeTracksListener(textTracks, 'addtrack', addTrackHandler);
+        if (cueChangeHandler) {
+            for (let i = 0, len = textTracks.length; i < len; i++) {
+                textTracks[i].removeEventListener('cuechange', cueChangeHandler);
+            }
+        }
     };
 
     this.init = function(item) {

--- a/src/js/providers/tracks-mixin.js
+++ b/src/js/providers/tracks-mixin.js
@@ -15,8 +15,8 @@ const Tracks = {
     _metaCuesByTextTime: null,
     _currentTextTrackIndex: -1,
     _unknownCount: 0,
-    _activeCues: {},
-    _cues: {},
+    _activeCues: null,
+    _cues: null,
     _initTextTracks,
     addTracksListener,
     clearTracks,
@@ -61,6 +61,8 @@ function setTextTracks(tracks) {
     if (!this._textTracks) {
         this._initTextTracks();
     } else {
+        this._activeCues = {};
+        this._cues = {};
         // Remove the 608 captions track that was mutated by the browser
         this._unknownCount = 0;
         this._textTracks = this._textTracks.filter((track) => {
@@ -701,8 +703,8 @@ function _cueChangeHandler(e) {
 
     if (activeCues && activeCues.length) {
         const previousActiveCues = this._activeCues[_id];
-        this._activeCues[_id] = Array.prototype.slice.call(activeCues);
-        this.triggerActiveCues(activeCues, previousActiveCues);
+        const currentActiveCues = this._activeCues[_id] = Array.prototype.slice.call(activeCues);
+        this.triggerActiveCues(currentActiveCues, previousActiveCues);
     } else {
         this._activeCues[_id] = null;
     }
@@ -733,8 +735,8 @@ function parseNativeID3Cues(cues, previousCues) {
     });
 }
 
-function triggerActiveCues(activeCues, previousActiveCues) {
-    const dataCues = Array.prototype.filter.call(activeCues, cue => {
+function triggerActiveCues(currentActiveCues, previousActiveCues) {
+    const dataCues = currentActiveCues.filter((cue) => {
         // Prevent duplicate meta events for cues that were active in the previous "cuechange" event
         if (previousActiveCues && previousActiveCues.some(prevCue => cuesMatch(cue, prevCue))) {
             return false;


### PR DESCRIPTION
### This PR will...
Properly destroy providers used for instream playback by ad-program-controller.
Removes all `video.textTracks` and `textTracks[track]` event listeners added by the provider.

### Why is this Pull Request needed?
The instream provider was handling textTrack cue change events, and due to a shared object being used to track triggered cues, some "meta"  were never triggered by the main provider.

This issue probably went unnoticed previously because there were fewer overlapping metadata cues in Safari tests.

### Are there any Pull Requests open in other repos which need to be merged with this?
Test updates and some small but important fixes to Safari side hls playlist loading: https://github.com/jwplayer/jwplayer-commercial/pull/7435

#### Addresses Issue(s):
JW8-10898

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
