### PR TITLE
[JW8-10948] Attempt to play after setActiveItem promise resolves

### DIFF
--- a/src/js/program/ad-program-controller.js
+++ b/src/js/program/ad-program-controller.js
@@ -69,11 +69,11 @@ export default class AdProgramController extends ProgramController {
     setActiveItem(index) {
         this.stopVideo();
         this.provider = null;
-        super.setActiveItem(index)
+        return super.setActiveItem(index)
             .then((mediaController) => {
                 this._setProvider(mediaController.provider);
+                return this.playVideo();
             });
-        return this.playVideo();
     }
 
     usePsuedoProvider(provider) {


### PR DESCRIPTION
### This PR will...
- Attempt to play the next ad pod item after `setActiveItem` promise resolves

### Why is this Pull Request needed?
- Fix an issue with ad pod (vast) where `playAttempt` happens before the activeItem is set

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-10948


### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
