### PR TITLE
[JW8-10913] Add adWarning event

### DIFF
--- a/src/js/events/events.ts
+++ b/src/js/events/events.ts
@@ -166,6 +166,11 @@ export const AD_SKIPPED = 'adSkipped';
 */
 export const AD_TIME = 'adTime';
 
+/**
+ *  Event triggered for ad warnings (i.e. non-fatal errors)
+*/
+export const AD_WARNING = 'adWarning';
+
 // Events
 
 /**


### PR DESCRIPTION
JW8-10913

### This PR will...

- Adds the new `adWarning` event to the list of events the player handles

### Why is this Pull Request needed?

- We added a new `adWarning` event to the VAST plugin.

### Are there any points in the code the reviewer needs to double check?

n/a

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-commercial/pull/7443
https://github.com/jwplayer/jwplayer-ads-vast/pull/638

#### Addresses Issue(s):

JW8-10913

### Checklist
- [x] Jenkins builds and unit tests are passing
- [x] I have reviewed the automated results
