### PR TITLE
[JW8-10949] Fix event order when replaying

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -500,46 +500,45 @@ Object.assign(Controller.prototype, {
                 return Promise.resolve();
             }
 
-            let setItemPromise = Promise.resolve();
             if (_model.get('state') === STATE_COMPLETE) {
                 _stop(true);
-                setItemPromise = _this.setItemIndex(0);
+                return _this.setItemIndex(0).then(() => {
+                    return _play(meta);
+                });
             }
 
-            return setItemPromise.then(() => {
-                if (!_beforePlay) {
-                    _beforePlay = true;
-                    _this.trigger(MEDIA_BEFOREPLAY, {
-                        playReason,
-                        startTime: meta && meta.startTime ? meta.startTime : _model.get('playlistItem').starttime
-                    });
-                    _beforePlay = false;
+            if (!_beforePlay) {
+                _beforePlay = true;
+                _this.trigger(MEDIA_BEFOREPLAY, {
+                    playReason,
+                    startTime: meta && meta.startTime ? meta.startTime : _model.get('playlistItem').starttime
+                });
+                _beforePlay = false;
 
-                    if (inInteraction() && !mediaPool.primed()) {
-                        mediaPool.prime();
-                    }
-
-                    if (playReason === 'playlist' && _model.get('autoPause').viewability) {
-                        _checkPauseOnViewable(_model, _model.get('viewable'));
-                    }
-
-                    if (_interruptPlay) {
-                        // Force tags to prime if we're about to play an ad
-                        // Resetting the source in order to prime is OK since we'll be switching it anyway
-                        if (inInteraction() && !_backgroundLoading) {
-                            _model.get('mediaElement').load();
-                        }
-                        _interruptPlay = false;
-                        _actionOnAttach = null;
-                        return Promise.resolve();
-                    }
+                if (inInteraction() && !mediaPool.primed()) {
+                    mediaPool.prime();
                 }
 
-                return _programController.playVideo(playReason)
-                    // If playback succeeded that means we captured a gesture (and used it to prime the pool)
-                    // Avoid priming again in beforePlay because it could cause BGL'd media to be source reset
-                    .then(mediaPool.played);
-            });
+                if (playReason === 'playlist' && _model.get('autoPause').viewability) {
+                    _checkPauseOnViewable(_model, _model.get('viewable'));
+                }
+
+                if (_interruptPlay) {
+                    // Force tags to prime if we're about to play an ad
+                    // Resetting the source in order to prime is OK since we'll be switching it anyway
+                    if (inInteraction() && !_backgroundLoading) {
+                        _model.get('mediaElement').load();
+                    }
+                    _interruptPlay = false;
+                    _actionOnAttach = null;
+                    return Promise.resolve();
+                }
+            }
+
+            return _programController.playVideo(playReason)
+                // If playback succeeded that means we captured a gesture (and used it to prime the pool)
+                // Avoid priming again in beforePlay because it could cause BGL'd media to be source reset
+                .then(mediaPool.played);
         }
 
         function _getReason(meta) {


### PR DESCRIPTION
### This PR will...
- Wait for `setItemIndex(0)` promise before triggering `beforePlay` event

### Why is this Pull Request needed?
- `setItemIndex(0)` fires `playlistItem` event
- If we do not wait for the promise, `beforePlay` event fires before we trigger `playlistItem` event
- Wrong event order breaks ad plugins

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-10949

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
