### PR TITLE
Preroll is not preloaded for item when using recommendations with multiitem playlist

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -191,7 +191,7 @@ Object.assign(Controller.prototype, {
                     if (allowPreload && position && duration > 0 && position >= duration - BACKGROUND_LOAD_OFFSET) {
                         mediaModel.off('change:position', onPosition, this);
                         _programController.backgroundLoad(item, index);
-                    } else if (recsAuto) {
+                    } else if (recsAuto && !item) {
                         index = -1;
                         item = _model.get('nextUp');
                     }


### PR DESCRIPTION
### This PR will...
Fix a bug where the ads plugin would not preload ads if there was a multi-item playlist using recs

### Why is this Pull Request needed?
Bugfixing async api

### Are there any points in the code the reviewer needs to double check?
Left comments inline

#### Tested
* Config in the relevant ticket
    * BG Load occurs for 2nd playlist item now
    * BG Load occurs for recs still once the original 2 item playlist is complete

#### To Test
* Recs only playlist w/ autoplay and 10 second countdown
* Playlist only w/ autoplay and 10 second countdown

### Are there any Pull Requests open in other repos which need to be merged with this?
Nope

#### Addresses Issue(s):

JW8-10958

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
