### PR TITLE
[JW8-10957] Use attached flag in setActiveItem while waiting for asyncActiveItem

### DIFF
--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -78,7 +78,7 @@ class ProgramController extends Events {
         // Reset the mediaModel now to synchronously "cancel" play promise callbacks
         // that check `mediaModel === model.mediaModel`
         if (mediaController) {
-            mediaController.off();
+            mediaController.detach();
             mediaController.mediaModel.off();
             model.attributes.mediaModel = new MediaModel();
             model.mediaModel.attributes = mediaController.mediaModel.clone();
@@ -122,6 +122,7 @@ class ProgramController extends Events {
                     // We can synchronously reuse the current mediaController
                     // Reinitialize the mediaController with the new item, allowing a new playback session
                     mediaController.activeItem = playlistItem;
+                    mediaController.attach();
                     this._setActiveMedia(mediaController);
                     return mediaController;
                 }

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -122,8 +122,6 @@ class ProgramController extends Events {
                     // We can synchronously reuse the current mediaController
                     // Reinitialize the mediaController with the new item, allowing a new playback session
                     mediaController.activeItem = playlistItem;
-                    mediaController.attached = true;
-                    mediaController.eventQueue.flush();
                     this._setActiveMedia(mediaController);
                     return mediaController;
                 }
@@ -444,6 +442,9 @@ class ProgramController extends Events {
 
         assignMediaContainer(model, mediaController);
         this.mediaController = mediaController;
+
+        mediaController.attached = true;
+        mediaController.eventQueue.flush();
 
         model.set('mediaElement', mediaController.mediaElement);
         model.setMediaModel(mediaModel);

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -78,7 +78,7 @@ class ProgramController extends Events {
         // Reset the mediaModel now to synchronously "cancel" play promise callbacks
         // that check `mediaModel === model.mediaModel`
         if (mediaController) {
-            mediaController.detach();
+            mediaController.attached = false;
             mediaController.mediaModel.off();
             model.attributes.mediaModel = new MediaModel();
             model.mediaModel.attributes = mediaController.mediaModel.clone();
@@ -122,7 +122,8 @@ class ProgramController extends Events {
                     // We can synchronously reuse the current mediaController
                     // Reinitialize the mediaController with the new item, allowing a new playback session
                     mediaController.activeItem = playlistItem;
-                    mediaController.attach();
+                    mediaController.attached = true;
+                    mediaController.eventQueue.flush();
                     this._setActiveMedia(mediaController);
                     return mediaController;
                 }

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -78,7 +78,6 @@ class ProgramController extends Events {
         // Reset the mediaModel now to synchronously "cancel" play promise callbacks
         // that check `mediaModel === model.mediaModel`
         if (mediaController) {
-            mediaController.attached = false;
             mediaController.mediaModel.off();
             model.attributes.mediaModel = new MediaModel();
             model.mediaModel.attributes = mediaController.mediaModel.clone();
@@ -442,9 +441,6 @@ class ProgramController extends Events {
 
         assignMediaContainer(model, mediaController);
         this.mediaController = mediaController;
-
-        mediaController.attached = true;
-        mediaController.eventQueue.flush();
 
         model.set('mediaElement', mediaController.mediaElement);
         model.setMediaModel(mediaModel);


### PR DESCRIPTION
### This PR will...
- Use `attached` flag in `mediaController` while waiting for the `asyncActiveItem` to block events

### Why is this Pull Request needed?
- Calling `mediaController.off` results all the events until `this._setActiveMedia(mediaController);` call, especially when we are re-using the same `mediaController` from the previous item
- `mediaType` event is fired when setting a new activeItem to `mediaController`
`mediaController.activeItem = playlistItem;`
-- `mediaType` event is lost if we use `mediaController.off`
-- Using `detach` to queue up the events and later flushing with `attach` solves the issue

### Are there any points in the code the reviewer needs to double check?
- Tried using `mediaController.attach()` and `mediaController.detach()`, but it was causing other regressions since they have other function calls (`setPlaybackRate` and ` provider.attachMedia()`)

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-10957

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
