### PR TITLE
[JW8-10955] Let ad plugins destroy ad providers

### DIFF
--- a/src/js/program/ad-program-controller.js
+++ b/src/js/program/ad-program-controller.js
@@ -140,11 +140,9 @@ export default class AdProgramController extends ProgramController {
     }
 
     destroy() {
-        const { model, mediaPool, playerModel, provider } = this;
+        const { model, mediaPool, playerModel } = this;
         model.off();
-        if (provider && provider.destroy) {
-            provider.destroy();
-        }
+        // Do not destroy or remove provider event listeners since non-linear ads may continue to run after this point
         this.provider = null;
 
         // We only use one media element from ads; getPrimedElement will return it


### PR DESCRIPTION
### This PR will...
Let ad plugins destroy ad providers

### Why is this Pull Request needed?
Ad providers can continue to run in non-linear mode after an ad break,
so don't destroy them at the end of a break with ad-program-controller.

Fixes a regression in development that destroys non-linear VPAID ads.

#### Addresses Issue(s):
JW8-10955

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
