### PR TITLE
Fix infinite loop for outstream replay

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -481,32 +481,7 @@ Object.assign(Controller.prototype, {
             return _model.get('state');
         }
 
-        function _play(meta) {
-            checkAutoStartCancelable.cancel();
-            _stopPlaylist = false;
-
-            if (_model.get('state') === STATE_ERROR) {
-                return Promise.resolve();
-            }
-
-            const playReason = _getReason(meta);
-            _model.set('playReason', playReason);
-
-            const adState = _getAdState();
-
-            if (adState) {
-                // this will resume the ad. _api.playAd would load a new ad
-                _api.pauseAd(false, meta);
-                return Promise.resolve();
-            }
-
-            if (_model.get('state') === STATE_COMPLETE) {
-                _stop(true);
-                return _this.setItemIndex(0).then(() => {
-                    return _play(meta);
-                });
-            }
-
+        function _playAttempt(meta, playReason) {
             if (!_beforePlay) {
                 _beforePlay = true;
                 _this.trigger(MEDIA_BEFOREPLAY, {
@@ -539,6 +514,35 @@ Object.assign(Controller.prototype, {
                 // If playback succeeded that means we captured a gesture (and used it to prime the pool)
                 // Avoid priming again in beforePlay because it could cause BGL'd media to be source reset
                 .then(mediaPool.played);
+        }
+
+        function _play(meta) {
+            checkAutoStartCancelable.cancel();
+            _stopPlaylist = false;
+
+            if (_model.get('state') === STATE_ERROR) {
+                return Promise.resolve();
+            }
+
+            const playReason = _getReason(meta);
+            _model.set('playReason', playReason);
+
+            const adState = _getAdState();
+
+            if (adState) {
+                // this will resume the ad. _api.playAd would load a new ad
+                _api.pauseAd(false, meta);
+                return Promise.resolve();
+            }
+
+            if (_model.get('state') === STATE_COMPLETE) {
+                _stop(true);
+                return _this.setItemIndex(0).then(() => {
+                    return _playAttempt(meta, playReason);
+                });
+            }
+
+            return _playAttempt(meta, playReason);
         }
 
         function _getReason(meta) {


### PR DESCRIPTION
### This PR will...
- Separate `_play` function into two so that `_play` is not called recursively

### Why is this Pull Request needed?
- Outstream has infinite loop issue when `replay` is set

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-###

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
