### PR TITLE
[JW8-10700] Prevent html5 provider seek range from containing non-finite end values

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -436,7 +436,7 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
     _this.getSeekRange = function() {
         const seekRange = {
             start: 0,
-            end: _videotag.duration
+            end: 0
         };
 
         const seekable = _videotag.seekable;
@@ -444,6 +444,8 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
         if (seekable.length) {
             seekRange.end = _getSeekableEnd();
             seekRange.start = _getSeekableStart();
+        } else if (isFinite(_videotag.duration)) {
+            seekRange.end = _videotag.duration;
         }
 
         return seekRange;


### PR DESCRIPTION
### This PR will...
Prevent the html5 provider seek range from containing non-finite `end` values. The default seekable range (before `video.seekable` is populated) should be `{ start: 0, end: 0 }`.

### Why is this Pull Request needed?
Live streams have a `duration` of `Infinity`. Before `video.seekable` is populated we were using `video.duration` as the range `end`. That caused an exception when attempting to create a metadata cue for PDT in live streams (#3519) using that `end` value, and could also break manifest metadata loading by marking the `HlsPlaylistMetaLoader` state as complete up to `Infinity` 😞.

#### Addresses Issue(s):
#3519
JW8-10700

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
