### PR TITLE
[JW8-10943] Destroy instream when setting a new item index

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -700,6 +700,7 @@ Object.assign(Controller.prototype, {
         }
 
         function _item(index, meta) {
+            _this.instreamDestroy();
             _stop(true);
             _this.setItemIndex(index);
             // Use this.play() so that command is queued until after "playlistItem" event
@@ -916,7 +917,6 @@ Object.assign(Controller.prototype, {
             setConfig(_this, newConfig);
         };
         this.setItemIndex = (index) => {
-            this.instreamDestroy();
             _programController.stopVideo();
 
             const playlist = _model.get('playlist');

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -916,6 +916,7 @@ Object.assign(Controller.prototype, {
             setConfig(_this, newConfig);
         };
         this.setItemIndex = (index) => {
+            this.instreamDestroy();
             _programController.stopVideo();
 
             const playlist = _model.get('playlist');


### PR DESCRIPTION
### This PR will...
- Destroy instream when we are setting a new item index to change to a different playlist item

### Why is this Pull Request needed?
- DAI instream was not destroyed when setting a new item index, resulting unwanted state changes

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-ads-dai/pull/55

#### Addresses Issue(s):

JW8-10943

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
