### PR TITLE
Utilize WebVTT polyfill internally but respect globals externally

### DIFF
--- a/src/js/polyfills/webvtt.js
+++ b/src/js/polyfills/webvtt.js
@@ -954,9 +954,12 @@ WebVTT.processCues = function (window, cues, overlay, updateBoxPosition) {
     }());
 };
 
-let webVttExport = window.WebVTT;
-if (!webVttExport) {
-    window.WebVTT = webVttExport = WebVTT;
+// We want to always use our polyfill in player, but should respect what is on the
+// window unless it is not present
+let webVttExport = WebVTT;
+
+if (!window.WebVTT) {
+    window.WebVTT = webVttExport;
 }
 
 export default webVttExport;


### PR DESCRIPTION
### This PR will...
Update our WebVTT Polyfill with the following functionality
* Always utilize polyfill internally when _not_ rendering captions natively
* Only set WebVTT on the global scope if it is not present when the polyfill loads

With these changes, caption styling menu should work in all instances regardless of WebVTT status in the global scope.

### Why is this Pull Request needed?
If a user uses their own VTT polyfill, none of our caption styling functionality works because in our polyfill we have logic which helps us apply styling to the dynamically created captions elements.

### Are there any points in the code the reviewer needs to double check?
No, but would love input on test cases. I tested:
* Firefox with & w/o `renderCaptionsNatively`
* Firefox with an external WebVTT polyfill loaded in before our polyfill
* Safari with `renderCaptionsNatively` both `true` and `false`

### Are there any Pull Requests open in other repos which need to be merged with this?
Nope

#### Addresses Issue(s):

JW8-11022

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
