### PR TITLE
[JW8-11042] Guard against async item tampering in program-controller and ui modules

### DIFF
--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -337,7 +337,7 @@ class ProgramController extends Events {
         const backgroundMediaController = background.currentMedia;
         if (!backgroundMediaController) {
             return;
-        } else if (mediaController) {
+        } else if (mediaController && mediaController !== backgroundMediaController) {
             // An existing media controller means that we've changed the active item
             // The current background media is no longer relevant, so destroy it
             this._destroyMediaController(backgroundMediaController);
@@ -457,7 +457,7 @@ class ProgramController extends Events {
      */
     _destroyActiveMedia() {
         const { mediaController, model } = this;
-        if (!mediaController) {
+        if (!mediaController || !mediaController.provider) {
             return;
         }
 

--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -66,6 +66,9 @@ export default class UI extends Events {
     }
 
     destroy() {
+        if (!this.el) {
+            return;
+        }
         this.off();
         if (USE_POINTER_EVENTS) {
             releasePointerCapture(this);

--- a/test/unit/background-loading-test.js
+++ b/test/unit/background-loading-test.js
@@ -180,12 +180,15 @@ describe('Background Loading', function () {
         it('destroys background media if there is an active foreground item', function () {
             programController._setActiveMedia(mediaController);
             programController.backgroundActiveMedia();
-            programController._setActiveMedia(mediaController);
+            const mockProvider2 = new MockProvider();
+            mockProvider2.video = document.createElement('video');
+            const mediaController2 = new MediaController(mockProvider2, model);
+            programController._setActiveMedia(mediaController2);
             programController._setActiveMedia = sinon.spy();
             mediaPool.recycle = sinon.spy();
 
             programController.restoreBackgroundMedia();
-            expect(programController._setActiveMedia.calledOnce).to.equal(false);
+            expect(programController._setActiveMedia.calledOnce).to.equal(false, 'called _setActiveMedia');
             expect(mediaPool.recycle.calledOnce).to.equal(true);
             expect(programController.background.currentMedia).to.equal(null);
         });


### PR DESCRIPTION
### This PR will...
Add guards to prevent exceptions in detach logic whenthe instream API and setPlaylistItem() are used externally

### Why is this Pull Request needed?
Backwards compatibility with custom async playlist item ads integrations. See http://player-develop-test-jenkins.longtailvideo.com/builds/lastSuccessfulBuild/archive/test/public/async-8-12-poc.html

#### Addresses Issue(s):
JW8-11042

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
