### PR TITLE
Focus player on inactive only after action

### DIFF
--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -23,7 +23,6 @@ require('css/controls.less');
 const ACTIVE_TIMEOUT = OS.mobile ? 4000 : 2000;
 // Keys which bypass keyboard shortcuts being off
 const ALWAYS_ALLOWED_KEYS = [27];
-let shouldFocusOnInactive = false;
 
 ErrorContainer.cloneIcon = cloneIcon;
 instances.forEach(api => {
@@ -175,7 +174,7 @@ export default class Controls extends Events {
         const controlbar = this.controlbar = new Controlbar(api, model,
             this.playerContainer.querySelector('.jw-hidden-accessibility'));
         controlbar.on(USER_ACTION, () => {
-            shouldFocusOnInactive = true;
+            this.once('userInactive', () => this.focusPlayerElement(), this);
             this.userActive();
         });
         controlbar.on('nextShown', function (data) {
@@ -309,7 +308,6 @@ export default class Controls extends Events {
                     if (model.get('fullscreen')) {
                         api.setFullscreen(false);
                         this.playerContainer.blur();
-                        shouldFocusOnInactive = false;
                         this.userInactive();
                     } else {
                         const related = api.getPlugin('related');
@@ -417,7 +415,7 @@ export default class Controls extends Events {
 
         // Hide controls when focus leaves the player
         const blurCallback = (evt) => {
-            shouldFocusOnInactive = false;
+            this.off('userInactive', null, this);
             const focusedElement = evt.relatedTarget || document.querySelector(':focus');
             if (!focusedElement) {
                 return;
@@ -616,11 +614,6 @@ export default class Controls extends Events {
         this.showing = false;
         addClass(this.playerContainer, 'jw-flag-user-inactive');
         this.trigger('userInactive');
-
-        if (shouldFocusOnInactive) {
-            this.focusPlayerElement();
-            shouldFocusOnInactive = false;
-        }
     }
 
     addBackdrop() {

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -174,7 +174,8 @@ export default class Controls extends Events {
         const controlbar = this.controlbar = new Controlbar(api, model,
             this.playerContainer.querySelector('.jw-hidden-accessibility'));
         controlbar.on(USER_ACTION, () => {
-            this.once('userInactive', () => this.focusPlayerElement(), this);
+            this.off('userInactive', this.focusPlayerElement, this);
+            this.once('userInactive', this.focusPlayerElement, this);
             this.userActive();
         });
         controlbar.on('nextShown', function (data) {
@@ -415,7 +416,7 @@ export default class Controls extends Events {
 
         // Hide controls when focus leaves the player
         const blurCallback = (evt) => {
-            this.off('userInactive', null, this);
+            this.off('userInactive', this.focusPlayerElement, this);
             const focusedElement = evt.relatedTarget || document.querySelector(':focus');
             if (!focusedElement) {
                 return;


### PR DESCRIPTION
### This PR will...
Update our focus logic to focus the player when the player is previously focused and the controls blur. _This is currently not a problem in Firefox, but Chrome handles it differently_.

### Why is this Pull Request needed?
When you click a control in chrome and the controls fade, the player loses focus

### Are there any points in the code the reviewer needs to double check?
Left notes inline

Tested:
* Clicking controls, waiting, focus on
* Clicking controls, clicking elsewhere on the page, focus off
* Hovering over player without clicking anywhere on it, wait for controls fade, focus off
* Same three scenarios in both fullscreen and floating
* Fullscreen, click controls, esc to close player, focus on

### Are there any Pull Requests open in other repos which need to be merged with this?
Nah

#### Addresses Issue(s):

JW8-10904

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
