### PR TITLE
Cue Marker Class Additions

### DIFF
--- a/src/js/view/controls/components/chapters.mixin.js
+++ b/src/js/view/controls/components/chapters.mixin.js
@@ -6,10 +6,11 @@ class Cue {
         this.time = time;
         this.text = text;
         this.el = document.createElement('div');
-        this.el.className = 'jw-cue jw-reset';
+        let cssClasses = 'jw-cue jw-reset';
         if (cueType && typeof cueType === 'string') {
-            this.el.className += ` jw-cue-type-${cueType}`;
+            cssClasses += ` jw-cue-type-${cueType}`;
         }
+        this.el.className = cssClasses;
     }
 
     align(duration) {

--- a/src/js/view/controls/components/chapters.mixin.js
+++ b/src/js/view/controls/components/chapters.mixin.js
@@ -2,11 +2,14 @@ import { ajax } from 'utils/ajax';
 import srt from 'parsers/captions/srt';
 
 class Cue {
-    constructor (time, text) {
+    constructor (time, text, cueType) {
         this.time = time;
         this.text = text;
         this.el = document.createElement('div');
         this.el.className = 'jw-cue jw-reset';
+        if (cueType && typeof cueType === 'string') {
+            this.el.className += ` jw-cue-type-${cueType}`;
+        }
     }
 
     align(duration) {
@@ -43,7 +46,7 @@ const ChaptersMixin = {
     chaptersFailed: function () {},
 
     addCue: function (obj) {
-        this.cues.push(new Cue(obj.begin, obj.text));
+        this.cues.push(new Cue(obj.begin, obj.text, obj.cueType));
     },
 
     drawCues: function () {


### PR DESCRIPTION
### This PR will...
Add functionality which allows for users to add custom styling to any cues created with `player.addCues`

Example: `jwplayer().addCues([{begin: 1, text: 'test-cue', cueType: 'test'}]);` will add a css class of `jw-cue-type-test` to the cue which can then be independently styled

### Why is this Pull Request needed?
We need ads specific cue styling

### Are there any points in the code the reviewer needs to double check?
Class name and general feedback as per usual

### Are there any Pull Requests open in other repos which need to be merged with this?
No, I added notes to the jira ticket around how ads would implement

#### Addresses Issue(s):

JW8-10929

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
