### PR TITLE
[JW8-10893] Fix voiceover not announcing volume slider

### DIFF
--- a/src/css/controls/imports/slider.less
+++ b/src/css/controls/imports/slider.less
@@ -213,3 +213,11 @@
         height: 11px;
     }
 }
+
+.jw-horizontal-volume-container {
+    display: none;
+
+    .jw-flag-audio-player & {
+        display: flex;
+    }
+}

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -113,7 +113,8 @@ export default class Controlbar {
 
             const volumeButtonEl = volumeGroup.element();
             menus.push(volumeGroup);
-            setAttribute(volumeButtonEl, 'role', 'button');
+            // Use 'group' role so that voiceover identifies volume slider and button
+            setAttribute(volumeButtonEl, 'role', 'group');
             _model.change('mute', (model, muted) => {
                 const muteText = muted ? localization.unmute : localization.mute;
                 setAttribute(volumeButtonEl, 'aria-label', muteText);


### PR DESCRIPTION
### This PR will...
Fix the volume slider not being announced by Voiceover when tabbing through elements.
It also only displays the `jw-horizontal-volume-container` for audio only players. 

### Why is this Pull Request needed?
Accessibility
### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

[JW8-10893](https://jwplayer.atlassian.net/browse/JW8-10893)

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
