### PR TITLE
Always include plugin URL in function call

### DIFF
--- a/src/js/plugins/loader.ts
+++ b/src/js/plugins/loader.ts
@@ -28,7 +28,7 @@ const PluginLoader = function (this: PluginLoaderInt): void {
                 }).catch(error => {
                     pluginsModel.removePlugin(pluginUrl);
                     if (!error.code) {
-                        return new PlayerError(null, getPluginErrorCode(/* pluginUrl */), error);
+                        return new PlayerError(null, getPluginErrorCode(pluginUrl), error);
                     }
                     return error;
                 });

--- a/src/js/plugins/utils.ts
+++ b/src/js/plugins/utils.ts
@@ -6,7 +6,8 @@ export const getPluginName = function(url: string): string {
     return url.replace(/^(.*\/)?([^-]*)-?.*\.(js)$/, '$2');
 };
 
-export function getPluginErrorCode(/* pluginURL: string */): number {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function getPluginErrorCode(pluginURL: string): number {
     return 305000;
 }
 


### PR DESCRIPTION
### This PR will...
Re-include an arg that is passed to error creation on plugin load failure

### Why is this Pull Request needed?
Commercial has a function with the _exact same name_ as this one that operates differently and requires that param. When building commercial, it includes that function and not this one in OSS

### Are there any points in the code the reviewer needs to double check?
Nah

### Are there any Pull Requests open in other repos which need to be merged with this?
Nah

#### Addresses Issue(s):

JW8-11051

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
