### PR TITLE
[JW8-11074] Handle touch event on iOS10 with controls disabled

### DIFF
--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -21,6 +21,12 @@ const LONG_PRESS_DELAY = 500;
 let longPressTimeout;
 let lastInteractionListener;
 
+if (OS.iOS && OS.version.major < 11) {
+    const body = self.document.body;
+    // When controls are disabled iOS 10 does not dispatch media element touchstart/end events without this line
+    body.ontouchstart = body.ontouchstart || function() {};
+}
+
 export default class UI extends Events {
 
     constructor(element, options) {


### PR DESCRIPTION
### This PR will...
Add workaround that fixes ad clickthough with controls disabled in iOS 10 and lower.

### Why is this Pull Request needed?
The player's instream ad click through 'touchstart' listener is not dispatched when controls are disabled on on iOS 10. I added the `document.body` "touchstart" listener to investigate which elements on the page were receiving the "touchstart" event, but then everything suddenly worked! I accept this as a valid workaround because I cannot debug iOS 10 in Catalina with Safari 13.1. Since everything else works in Safari 11+, adding a noop handler only in Safari 10 is an acceptable and safe workaround.

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):
JW8-11074


### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
