### PR TITLE
[JW8-11050] Start playlist on a specific index

### DIFF
--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -28,6 +28,7 @@ export const Defaults = {
     enableShortcuts: true,
     height: 360,
     intl: {},
+    item: 0,
     language: 'en',
     liveTimeout: null,
     localization: en,
@@ -96,6 +97,15 @@ const Config = function(options, persisted) {
     config.mute = !!config.mute;
     config.language = language;
     config.intl = intl;
+
+    const playlistIndex = config.playlistIndex;
+    if (playlistIndex) {
+        config.item = playlistIndex;
+    }
+
+    if (!isNumber(config.item)) {
+        config.item = 0;
+    }
 
     // If autoPause is configured with an empty block,
     // default autoPause.viewability to true.

--- a/src/js/api/core-loader.js
+++ b/src/js/api/core-loader.js
@@ -1,5 +1,5 @@
 import Item from 'playlist/item';
-import { fixSources } from 'playlist/playlist';
+import { fixSources, wrapPlaylistIndex } from 'playlist/playlist';
 import ProvidersSupported from 'providers/providers-supported';
 import registerProvider from 'providers/providers-register';
 import { ControlsLoader } from 'controller/controls-loader';
@@ -59,7 +59,8 @@ export function requiresPolyfills() {
 export function requiresProvider(model, providerName) {
     const playlist = model.get('playlist');
     if (Array.isArray(playlist) && playlist.length) {
-        const sources = fixSources(Item(playlist[0]), model);
+        const wrappedIndex = wrapPlaylistIndex(model.get('item'), playlist.length);
+        const sources = fixSources(Item(playlist[wrappedIndex]), model);
         for (let i = 0; i < sources.length; i++) {
             const source = sources[i];
             const providersManager = model.getProviders();

--- a/src/js/api/setup-steps.js
+++ b/src/js/api/setup-steps.js
@@ -1,6 +1,6 @@
 import { PLAYLIST_LOADED, ERROR } from 'events/events';
 import PlaylistLoader from 'playlist/loader';
-import Playlist, { filterPlaylist, validatePlaylist } from 'playlist/playlist';
+import Playlist, { filterPlaylist, validatePlaylist, wrapPlaylistIndex } from 'playlist/playlist';
 import ScriptLoader from 'utils/scriptloader';
 import { bundleContainsProviders } from 'api/core-loader';
 import { composePlayerError, PlayerError,
@@ -57,7 +57,8 @@ export function loadProvider(_model) {
         }
 
         const providersManager = _model.getProviders();
-        const { provider, name } = providersManager.choose(playlist[0].sources[0]);
+        const wrappedIndex = wrapPlaylistIndex(_model.get('item'), playlist.length);
+        const { provider, name } = providersManager.choose(playlist[wrappedIndex].sources[0]);
 
         // If provider already loaded or a locally registered one, return it
         if (typeof provider === 'function') {

--- a/src/js/model/player-model.ts
+++ b/src/js/model/player-model.ts
@@ -3,7 +3,6 @@ import { STATE_IDLE } from 'events/events';
 export const INITIAL_PLAYER_STATE = {
     audioMode: false,
     flashBlocked: false,
-    item: 0,
     itemMeta: {},
     playbackRate: 1,
     playRejected: false,

--- a/src/js/playlist/playlist.js
+++ b/src/js/playlist/playlist.js
@@ -47,6 +47,15 @@ export function normalizePlaylistItem(model, item, feedData) {
     return formatItem(playlistItem);
 }
 
+export function wrapPlaylistIndex(index, length) {
+    // If looping past the end, or before the beginning
+    let wrappedIndex = (parseInt(index, 10) || 0) % length;
+    if (wrappedIndex < 0) {
+        wrappedIndex += length;
+    }
+    return wrappedIndex;
+}
+
 export const fixSources = (item, model) => filterSources(formatSources(item, model), model.getProviders());
 
 function formatItem(item) {

--- a/test/mock/mock-model.js
+++ b/test/mock/mock-model.js
@@ -68,6 +68,7 @@ export default class MockModel extends SimpleModel {
             minDvrWindow: 60,
             seekRange: { start: 0, end: 0 },
             scrubbing: false,
+            item: 0,
             playlistItem: playlistItem,
             localization: en,
             logo: {

--- a/test/unit/playlist-test.js
+++ b/test/unit/playlist-test.js
@@ -1,4 +1,4 @@
-import Playlist, { validatePlaylist, normalizePlaylistItem } from 'playlist/playlist';
+import Playlist, { validatePlaylist, normalizePlaylistItem, wrapPlaylistIndex } from 'playlist/playlist';
 import Item from 'playlist/item';
 import Source from 'playlist/source';
 import _ from 'test/underscore';
@@ -125,5 +125,61 @@ describe('playlist', function() {
             expect(_.isEqual(item.sources[0].file, actual.file)).to.be.true;
         });
 
+    });
+
+    describe('wrapPlaylistIndex', function () {
+        it('returns index between 0 and length - 1', function() {
+            let result = wrapPlaylistIndex(0, 1);
+            expect(result).to.equal(0);
+            result = wrapPlaylistIndex(0, 2);
+            expect(result).to.equal(0);
+            result = wrapPlaylistIndex(1, 2);
+            expect(result).to.equal(1);
+            result = wrapPlaylistIndex(24, 50);
+            expect(result).to.equal(24);
+            result = wrapPlaylistIndex(49, 50);
+            expect(result).to.equal(49);
+        });
+
+        it('wraps index < 0', function() {
+            let result = wrapPlaylistIndex(-1, 1);
+            expect(result).to.equal(0);
+            result = wrapPlaylistIndex(-1, 10);
+            expect(result).to.equal(9);
+            result = wrapPlaylistIndex(-10, 10);
+            expect(result).to.equal(0);
+        });
+
+        it('wraps index of length or greater', function() {
+            let result = wrapPlaylistIndex(1, 1);
+            expect(result).to.equal(0);
+            result = wrapPlaylistIndex(10, 10);
+            expect(result).to.equal(0);
+            result = wrapPlaylistIndex(19, 10);
+            expect(result).to.equal(9);
+        });
+
+        it('wraps index < 0 by more than length', function() {
+            let result = wrapPlaylistIndex(-1000, 1);
+            expect(result).to.equal(0);
+            result = wrapPlaylistIndex(-2001, 10);
+            expect(result).to.equal(9);
+            result = wrapPlaylistIndex(-2020, 10);
+            expect(result).to.equal(0);
+        });
+
+        it('wraps index of length or greater by more than length', function() {
+            let result = wrapPlaylistIndex(1000, 1);
+            expect(result).to.equal(0);
+            result = wrapPlaylistIndex(2001, 10);
+            expect(result).to.equal(1);
+            result = wrapPlaylistIndex(2020, 10);
+            expect(result).to.equal(0);
+        });
+
+        it('returns NaN with length of 0', function() {
+            const result = wrapPlaylistIndex(0, 0);
+            expect(result).to.be.NaN;
+        });
     });
 });

--- a/test/unit/program-controller-test.js
+++ b/test/unit/program-controller-test.js
@@ -101,6 +101,7 @@ describe('ProgramController', function () {
 
     const createProgramController = function (customTestConfigOptions) {
         const config = Object.assign({}, defaultConfig, {
+            item: 0,
             playlist: defaultPlaylist.slice(0),
             mediaContainer: document.createElement('div'),
         }, customTestConfigOptions || {});


### PR DESCRIPTION
# This PR will...
Start playlist on a specific index using `config.playlistIndex`. Values are wrapped based on loaded playlist length so negative values count from the end of the playlist.

### Why is this Pull Request needed?
Allows for developers to setup the player so that playback begins on a specific playlist item. Previously we always started on the first item, without any way to cancel preloading or provider selection based on that item.

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/7531 (config schema update)

#### Addresses Issue(s):
JW8-11050

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
