### PR TITLE
Safer iOS 10 tap workaround

### DIFF
--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -21,12 +21,6 @@ const LONG_PRESS_DELAY = 500;
 let longPressTimeout;
 let lastInteractionListener;
 
-if (OS.iOS && OS.version.major < 11) {
-    const body = self.document.body;
-    // When controls are disabled iOS 10 does not dispatch media element touchstart/end events without this line
-    body.ontouchstart = body.ontouchstart || function() {};
-}
-
 export default class UI extends Events {
 
     constructor(element, options) {
@@ -250,6 +244,13 @@ const eventRegisters = {
         initInteractionListeners(ui);
     },
     tap(ui) {
+        if (OS.iOS && OS.version.major < 11) {
+            const body = document.body;
+            if (body) {
+                // When controls are disabled iOS 10 does not dispatch media element touchstart/end events without this line
+                body.ontouchstart = body.ontouchstart || function() {};
+            }
+        }
         initInteractionListeners(ui);
     },
     doubleTap(ui) {


### PR DESCRIPTION
### This PR will...
Fix a regression that could cause jwplayer.js to fail to embed when put in the head element. 

### Why is this Pull Request needed?
Moves a workaround added in #3661 to safer place and avoids an exception if the ui module is run before `document.body` is defined.

#### Addresses Issue(s):
JW8-11086

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
