### PR TITLE
[JW8-11112] HTML5 Provider Safari CC and mediaType event fixes

### DIFF
--- a/src/js/providers/html5.js
+++ b/src/js/providers/html5.js
@@ -148,7 +148,6 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
             VideoEvents.loadeddata.call(_this);
             _setAudioTracks(_videotag.audioTracks);
             _checkDelayedSeek(_this.getDuration());
-            checkVisualQuality();
         },
 
         canplay() {
@@ -156,11 +155,7 @@ function VideoProvider(_playerId, _playerConfig, mediaElement) {
             if (!_androidHls) {
                 _setMediaType();
             }
-            if (Browser.ie && Browser.version.major === 9) {
-                // In IE9, set tracks here since they are not ready
-                // on load
-                _this.setTextTracks(_this._textTracks);
-            }
+            checkVisualQuality();
             VideoEvents.canplay.call(_this);
         },
 

--- a/src/js/providers/video-listener-mixin.js
+++ b/src/js/providers/video-listener-mixin.js
@@ -13,6 +13,10 @@ import { between } from 'utils/math';
 
 const VideoListenerMixin = {
     canplay() {
+        // If we're not rendering natively text tracks will be provided from another source - don't duplicate them here
+        if (this.renderNatively) {
+            this.setTextTracks(this.video.textTracks);
+        }
         this.trigger(MEDIA_BUFFER_FULL);
     },
 
@@ -36,6 +40,9 @@ const VideoListenerMixin = {
             metadata.drm = drmUsed;
         }
         this.trigger(MEDIA_META, metadata);
+    },
+
+    loadeddata() {
     },
 
     timeupdate() {
@@ -163,13 +170,6 @@ const VideoListenerMixin = {
         this.streamBitrate = -1;
         if (this.state !== STATE_IDLE && this.state !== STATE_COMPLETE) {
             this.trigger(MEDIA_COMPLETE);
-        }
-    },
-
-    loadeddata () {
-        // If we're not rendering natively text tracks will be provided from another source - don't duplicate them here
-        if (this.renderNatively) {
-            this.setTextTracks(this.video.textTracks);
         }
     }
 };


### PR DESCRIPTION
### This PR will...
- Detect captions in Safari after they have been disabled in MacBook touchbar on a previous page load
- Do not trigger a "mediaType" event of type audio, right before "mediaType" of type video

### Why is this Pull Request needed?
When subtitles are disabled via the touchbar, media element text tracks are disabled causing our player to ignore them. This also messes with the timing of track change events in relation to media "loadeddata".

Both 608 tracks and videoWidth/Height may not be populated on "loadeddata". Using "canplay"  which fire a little later after enough media is loaded to begin playback ensures we detect text tracks and the content type (video or audio by checking video width and height) correctly.

#### Addresses Issue(s):
JW8-11112

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
