### PR TITLE
Headless Player [JW8-10813]

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,7 +11,8 @@
         "__REPO__": false,
         "__SELF_HOSTED__": false,
         "__DEBUG__": false,
-        "__BUILD_VERSION__": false
+        "__BUILD_VERSION__": false,
+        "__HEADLESS__": false
     },
     "parserOptions": {
         "sourceType": "module"
@@ -27,8 +28,12 @@
             "error",
             {
                 "name": "VTTCue",
-                "message": "import VTTCue from 'parsers/captions/vttcue'"
+                "message": "import VTTCue from 'os/parsers/captions/vttcue'"
             }
+        ],
+        "no-restricted-properties": [2,
+            { "property": "findIndex" },  // Intended to block usage of Array.prototype.findIndex
+            { "property": "find" }        // Intended to block usage of Array.prototype.find
         ],
         "no-for-of-loops/no-for-of-loops": 2,
         "no-unsanitized/method": 2,

--- a/src/js/api/Setup.js
+++ b/src/js/api/Setup.js
@@ -31,16 +31,21 @@ const Setup = function(_model) {
 
         const pluginsPromise = loadPlugins(_model, api);
 
-        const corePromise = __HEADLESS__ ? loadCore(_model) : loadCoreBundle(_model);
-
-        const setup = Promise.all([
-            corePromise,
-            pluginsPromise,
-            loadProvider(_model),
-            loadModules(_model, api),
-            loadSkin(_model),
-            loadTranslations(_model)
-        ]);
+        const setup = __HEADLESS__ ?
+            Promise.all([
+                loadCore(_model),
+                pluginsPromise,
+                loadProvider(_model),
+                new Promise((resolve) => setTimeout(resolve, 0))
+            ]) :
+            Promise.all([
+                loadCoreBundle(_model),
+                pluginsPromise,
+                loadProvider(_model),
+                loadModules(_model, api),
+                loadSkin(_model),
+                loadTranslations(_model)
+            ]);
 
         const timeout = new Promise((resolve, reject) => {
             _setupFailureTimeout = setTimeout(() => {

--- a/src/js/api/Setup.js
+++ b/src/js/api/Setup.js
@@ -1,4 +1,5 @@
-import loadCoreBundle from 'api/core-loader';
+import { loadCore } from 'api/core-loader';
+import { loadCoreBundle } from 'api/core-bundle-loader';
 import loadPlugins from 'plugins/plugins';
 import {
     loadProvider,
@@ -30,8 +31,10 @@ const Setup = function(_model) {
 
         const pluginsPromise = loadPlugins(_model, api);
 
+        const corePromise = __HEADLESS__ ? loadCore(_model) : loadCoreBundle(_model);
+
         const setup = Promise.all([
-            loadCoreBundle(_model),
+            corePromise,
             pluginsPromise,
             loadProvider(_model),
             loadModules(_model, api),

--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -51,7 +51,9 @@ function resetPlayer(api, core) {
     }
     api.off();
     core.playerDestroy();
-    core.getContainer().removeAttribute('data-jwplayer-id');
+    if (!__HEADLESS__) {
+        core.getContainer().removeAttribute('data-jwplayer-id');
+    }
 }
 
 /**
@@ -88,7 +90,9 @@ export default function Api(element) {
     let core = coreFactory(this, element);
 
     qoeTimer.tick('init');
-    element.setAttribute('data-jwplayer-id', playerId);
+    if (!__HEADLESS__) {
+        element.setAttribute('data-jwplayer-id', playerId);
+    }
 
     Object.defineProperties(this, /** @lends Api.prototype */ {
         /**

--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -28,6 +28,9 @@ function coreFactory(api, element) {
         event.setupTime = api._qoe.between('setup', 'ready');
     });
     core.on('all', (type, event) => {
+        if (__HEADLESS__ && __DEBUG__) {
+            console.log('[core trigger]', type);
+        }
         api.trigger(type, event);
     });
 

--- a/src/js/api/core-bundle-loader.js
+++ b/src/js/api/core-bundle-loader.js
@@ -1,0 +1,134 @@
+import Item from 'playlist/item';
+import { fixSources, wrapPlaylistIndex } from 'playlist/playlist';
+import { SupportsMatrix } from 'providers/providers-supported';
+import registerProvider from 'providers/providers-register';
+import { ControlsLoader } from 'controller/controls-loader';
+import { SETUP_ERROR_LOADING_CORE_JS } from 'api/errors';
+import { loadCore, chunkLoadErrorHandler, bundleContainsProviders } from 'api/core-loader';
+
+let bundlePromise = null;
+
+export function loadCoreBundle(model) {
+    if (!bundlePromise) {
+        bundlePromise = selectBundle(model);
+    }
+    return bundlePromise;
+}
+
+function selectBundle(model) {
+    const controls = model.get('controls');
+    const polyfills = requiresPolyfills();
+    const html5Provider = requiresProvider(model, 'html5');
+
+    if (controls && polyfills && html5Provider) {
+        return loadControlsPolyfillHtml5Bundle();
+    }
+    if (controls && html5Provider) {
+        return loadControlsHtml5Bundle();
+    }
+    if (controls && polyfills) {
+        return loadControlsPolyfillBundle();
+    }
+    if (controls) {
+        return loadControlsBundle();
+    }
+    return loadWebCore();
+}
+
+function requiresPolyfills() {
+    const IntersectionObserverEntry = window.IntersectionObserverEntry;
+    return !IntersectionObserverEntry ||
+        !('IntersectionObserver' in window) ||
+        !('intersectionRatio' in IntersectionObserverEntry.prototype);
+}
+
+export function requiresProvider(model, providerName) {
+    const playlist = model.get('playlist');
+    if (Array.isArray(playlist) && playlist.length) {
+        const wrappedIndex = wrapPlaylistIndex(model.get('item'), playlist.length);
+        const sources = fixSources(Item(playlist[wrappedIndex]), model);
+        for (let i = 0; i < sources.length; i++) {
+            const source = sources[i];
+            const providersManager = model.getProviders();
+            for (let j = 0; j < SupportsMatrix.length; j++) {
+                const provider = SupportsMatrix[j];
+                if (providersManager.providerSupports(provider, source)) {
+                    return (provider.name === providerName);
+                }
+            }
+        }
+    }
+    return false;
+}
+
+function loadControlsPolyfillHtml5Bundle() {
+    const loadPromise = require.ensure([
+        'controller/controller',
+        'view/controls/controls',
+        'intersection-observer',
+        'providers/html5'
+    ], function (require) {
+        // These modules should be required in this order
+        require('intersection-observer');
+        const CoreMixin = require('controller/controller').default;
+        ControlsLoader.controls = require('view/controls/controls').default;
+        registerProvider(require('providers/html5').default);
+        return CoreMixin;
+    }, chunkLoadErrorHandler(SETUP_ERROR_LOADING_CORE_JS + 105), 'jwplayer.core.controls.polyfills.html5');
+    bundleContainsProviders.html5 = loadPromise;
+    return loadPromise;
+}
+
+function loadControlsHtml5Bundle() {
+    const loadPromise = require.ensure([
+        'controller/controller',
+        'view/controls/controls',
+        'providers/html5'
+    ], function (require) {
+        const CoreMixin = require('controller/controller').default;
+        ControlsLoader.controls = require('view/controls/controls').default;
+        registerProvider(require('providers/html5').default);
+        return CoreMixin;
+    }, chunkLoadErrorHandler(SETUP_ERROR_LOADING_CORE_JS + 104), 'jwplayer.core.controls.html5');
+    bundleContainsProviders.html5 = loadPromise;
+    return loadPromise;
+}
+
+function loadControlsPolyfillBundle() {
+    return require.ensure([
+        'controller/controller',
+        'view/controls/controls',
+        'intersection-observer'
+    ], function (require) {
+        require('intersection-observer');
+        const CoreMixin = require('controller/controller').default;
+        ControlsLoader.controls = require('view/controls/controls').default;
+        return CoreMixin;
+    }, chunkLoadErrorHandler(SETUP_ERROR_LOADING_CORE_JS + 103), 'jwplayer.core.controls.polyfills');
+}
+
+function loadControlsBundle() {
+    return require.ensure([
+        'controller/controller',
+        'view/controls/controls'
+    ], function (require) {
+        const CoreMixin = require('controller/controller').default;
+        ControlsLoader.controls = require('view/controls/controls').default;
+        return CoreMixin;
+    }, chunkLoadErrorHandler(SETUP_ERROR_LOADING_CORE_JS + 102), 'jwplayer.core.controls');
+}
+
+function loadWebCore() {
+    return loadIntersectionObserverIfNeeded().then(loadCore);
+}
+
+function loadIntersectionObserverIfNeeded() {
+    if (requiresPolyfills()) {
+        return require.ensure([
+            'intersection-observer'
+        ], function (require) {
+            return require('intersection-observer');
+        }, chunkLoadErrorHandler(SETUP_ERROR_LOADING_CORE_JS + 120), 'polyfills.intersection-observer');
+    }
+    return Promise.resolve();
+}

--- a/src/js/api/core-loader.js
+++ b/src/js/api/core-loader.js
@@ -1,20 +1,6 @@
-import Item from 'playlist/item';
-import { fixSources, wrapPlaylistIndex } from 'playlist/playlist';
-import ProvidersSupported from 'providers/providers-supported';
-import registerProvider from 'providers/providers-register';
-import { ControlsLoader } from 'controller/controls-loader';
 import { PlayerError, SETUP_ERROR_LOADING_CORE_JS, MSG_CANT_LOAD_PLAYER } from 'api/errors';
 
-let bundlePromise = null;
-
 export const bundleContainsProviders = {};
-
-export default function loadCoreBundle(model) {
-    if (!bundlePromise) {
-        bundlePromise = selectBundle(model);
-    }
-    return bundlePromise;
-}
 
 export function chunkLoadErrorHandler(code, error) {
     // Webpack require.ensure error: "Loading chunk 3 failed"
@@ -29,126 +15,10 @@ export function chunkLoadWarningHandler(code, error) {
     };
 }
 
-export function selectBundle(model) {
-    const controls = model.get('controls');
-    const polyfills = requiresPolyfills();
-    const html5Provider = requiresProvider(model, 'html5');
-
-    if (controls && polyfills && html5Provider) {
-        return loadControlsPolyfillHtml5Bundle();
-    }
-    if (controls && html5Provider) {
-        return loadControlsHtml5Bundle();
-    }
-    if (controls && polyfills) {
-        return loadControlsPolyfillBundle();
-    }
-    if (controls) {
-        return loadControlsBundle();
-    }
-    return loadCore();
-}
-
-export function requiresPolyfills() {
-    const IntersectionObserverEntry = window.IntersectionObserverEntry;
-    return !IntersectionObserverEntry ||
-        !('IntersectionObserver' in window) ||
-        !('intersectionRatio' in IntersectionObserverEntry.prototype);
-}
-
-export function requiresProvider(model, providerName) {
-    const playlist = model.get('playlist');
-    if (Array.isArray(playlist) && playlist.length) {
-        const wrappedIndex = wrapPlaylistIndex(model.get('item'), playlist.length);
-        const sources = fixSources(Item(playlist[wrappedIndex]), model);
-        for (let i = 0; i < sources.length; i++) {
-            const source = sources[i];
-            const providersManager = model.getProviders();
-            for (let j = 0; j < ProvidersSupported.length; j++) {
-                const provider = ProvidersSupported[j];
-                if (providersManager.providerSupports(provider, source)) {
-                    return (provider.name === providerName);
-                }
-            }
-        }
-    }
-    return false;
-}
-
-function loadControlsPolyfillHtml5Bundle() {
-    const loadPromise = require.ensure([
-        'controller/controller',
-        'view/controls/controls',
-        'intersection-observer',
-        'providers/html5'
-    ], function (require) {
-        // These modules should be required in this order
-        require('intersection-observer');
-        const CoreMixin = require('controller/controller').default;
-        ControlsLoader.controls = require('view/controls/controls').default;
-        registerProvider(require('providers/html5').default);
-        return CoreMixin;
-    }, chunkLoadErrorHandler(SETUP_ERROR_LOADING_CORE_JS + 105), 'jwplayer.core.controls.polyfills.html5');
-    bundleContainsProviders.html5 = loadPromise;
-    return loadPromise;
-}
-
-function loadControlsHtml5Bundle() {
-    const loadPromise = require.ensure([
-        'controller/controller',
-        'view/controls/controls',
-        'providers/html5'
-    ], function (require) {
-        const CoreMixin = require('controller/controller').default;
-        ControlsLoader.controls = require('view/controls/controls').default;
-        registerProvider(require('providers/html5').default);
-        return CoreMixin;
-    }, chunkLoadErrorHandler(SETUP_ERROR_LOADING_CORE_JS + 104), 'jwplayer.core.controls.html5');
-    bundleContainsProviders.html5 = loadPromise;
-    return loadPromise;
-}
-
-function loadControlsPolyfillBundle() {
+export function loadCore() {
     return require.ensure([
-        'controller/controller',
-        'view/controls/controls',
-        'intersection-observer'
+        'controller/controller'
     ], function (require) {
-        require('intersection-observer');
-        const CoreMixin = require('controller/controller').default;
-        ControlsLoader.controls = require('view/controls/controls').default;
-        return CoreMixin;
-    }, chunkLoadErrorHandler(SETUP_ERROR_LOADING_CORE_JS + 103), 'jwplayer.core.controls.polyfills');
-}
-
-function loadControlsBundle() {
-    return require.ensure([
-        'controller/controller',
-        'view/controls/controls'
-    ], function (require) {
-        const CoreMixin = require('controller/controller').default;
-        ControlsLoader.controls = require('view/controls/controls').default;
-        return CoreMixin;
-    }, chunkLoadErrorHandler(SETUP_ERROR_LOADING_CORE_JS + 102), 'jwplayer.core.controls');
-}
-
-function loadCore() {
-    return loadIntersectionObserverIfNeeded().then(() => {
-        return require.ensure([
-            'controller/controller'
-        ], function (require) {
-            return require('controller/controller').default;
-        }, chunkLoadErrorHandler(SETUP_ERROR_LOADING_CORE_JS + 101), 'jwplayer.core');
-    });
-}
-
-function loadIntersectionObserverIfNeeded() {
-    if (requiresPolyfills()) {
-        return require.ensure([
-            'intersection-observer'
-        ], function (require) {
-            return require('intersection-observer');
-        }, chunkLoadErrorHandler(SETUP_ERROR_LOADING_CORE_JS + 120), 'polyfills.intersection-observer');
-    }
-    return Promise.resolve();
+        return require('controller/controller').default;
+    }, chunkLoadErrorHandler(SETUP_ERROR_LOADING_CORE_JS + 101), 'jwplayer.core');
 }

--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -100,15 +100,17 @@ Object.assign(CoreShim.prototype, {
 
         // Create/get click-to-play media element, and call .load() to unblock user-gesture to play requirement
         let mediaPool = MediaElementPool();
-        if (!model.get('backgroundLoading')) {
-            mediaPool = SharedMediaPool(mediaPool.getPrimedElement(), mediaPool);
-        }
+        if (!__HEADLESS__) {
+            if (!model.get('backgroundLoading')) {
+                mediaPool = SharedMediaPool(mediaPool.getPrimedElement(), mediaPool);
+            }
 
-        const primeUi = new UI(getElementWindow(this.originalContainer)).once('gesture', () => {
-            mediaPool.prime();
-            this.preload();
-            primeUi.destroy();
-        });
+            const primeUi = new UI(getElementWindow(this.originalContainer)).once('gesture', () => {
+                mediaPool.prime();
+                this.preload();
+                primeUi.destroy();
+            });
+        }
 
         model.on('change:errorEvent', logError);
 
@@ -290,7 +292,7 @@ function setupError(core, api, error) {
 
         const contextual = model.get('contextual');
         // Remove (and hide) the player if it failed to set up in contextual mode; otherwise, show the error view
-        if (!contextual) {
+        if (!contextual && !__HEADLESS__) {
             const errorContainer = ErrorContainer(core, playerError);
             if (ErrorContainer.cloneIcon) {
                 errorContainer.querySelector('.jw-icon').appendChild(ErrorContainer.cloneIcon('error'));

--- a/src/js/api/global-api.js
+++ b/src/js/api/global-api.js
@@ -1,7 +1,7 @@
-import availableProviders from 'providers/providers-supported';
+import { SupportsMatrix } from 'providers/providers-supported';
 import registerProvider from 'providers/providers-register';
 
 export default {
-    availableProviders,
+    availableProviders: SupportsMatrix,
     registerProvider
 };

--- a/src/js/api/setup-steps.js
+++ b/src/js/api/setup-steps.js
@@ -2,11 +2,11 @@ import { PLAYLIST_LOADED, ERROR } from 'events/events';
 import PlaylistLoader from 'playlist/loader';
 import Playlist, { filterPlaylist, validatePlaylist, wrapPlaylistIndex } from 'playlist/playlist';
 import ScriptLoader from 'utils/scriptloader';
-import { bundleContainsProviders } from 'api/core-loader';
 import { composePlayerError, PlayerError,
     SETUP_ERROR_LOADING_PLAYLIST, SETUP_ERROR_LOADING_PROVIDER,
     ERROR_LOADING_TRANSLATIONS, ERROR_LOADING_TRANSLATIONS_EMPTY_RESPONSE } from 'api/errors';
 import { getCustomLocalization, isLocalizationComplete, loadJsonTranslation, isTranslationAvailable, applyTranslation } from 'utils/language';
+import { bundleContainsProviders } from 'api/core-loader';
 
 export function loadPlaylist(_model) {
     const playlist = _model.get('playlist');
@@ -54,6 +54,10 @@ export function loadProvider(_model) {
         } catch (e) {
             e.code += SETUP_ERROR_LOADING_PLAYLIST;
             throw e;
+        }
+
+        if (__HEADLESS__) {
+            return Promise.resolve();
         }
 
         const providersManager = _model.getProviders();

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -87,15 +87,23 @@ Object.assign(Controller.prototype, {
 
         const _backgroundLoading = _model.get('backgroundLoading');
 
-        const viewModel = new ViewModel(_model);
+        if (__HEADLESS__) {
+            _model.attributes.visibility = 1.0;
+        } else {
+            const viewModel = new ViewModel(_model);
 
-        _view = this._view = new View(_api, viewModel);
-        _view.on('all', (type, event) => {
-            if (event && event.doNotForward) {
-                return;
-            }
-            _trigger(type, event);
-        }, _this);
+            _view = this._view = new View(_api, viewModel);
+            _view.on('all', (type, event) => {
+                if (event && event.doNotForward) {
+                    return;
+                }
+                _trigger(type, event);
+            }, _this);
+
+            viewModel.on('viewSetup', (viewElement) => {
+                showView(this, viewElement);
+            });
+        }
 
         const _programController = this._programController = new ProgramController(_model, mediaPool, _api._publicApi);
         updateProgramSoundSettings();
@@ -220,26 +228,27 @@ Object.assign(Controller.prototype, {
         });
 
         // Ensure captionsList event is raised after playlistItem
-        _captions = new Captions(_model);
-        _captions.on('all', _trigger, _this);
-
-        viewModel.on('viewSetup', (viewElement) => {
-            showView(this, viewElement);
-        });
+        if (!__HEADLESS__) {
+            _captions = new Captions(_model);
+            _captions.on('all', _trigger, _this);
+        }
 
         this.playerReady = function() {
+            if (__HEADLESS__) {
+                playerReadyNotify();
+            } else {
+                // Fire 'ready' once the view has resized so that player width and height are available
+                // (requires the container to be in the DOM)
+                _view.once(RESIZE, () => {
+                    try {
+                        playerReadyNotify();
+                    } catch (error) {
+                        _this.triggerError(convertToPlayerError(MSG_TECHNICAL_ERROR, ERROR_COMPLETING_SETUP, error));
+                    }
+                });
 
-            // Fire 'ready' once the view has resized so that player width and height are available
-            // (requires the container to be in the DOM)
-            _view.once(RESIZE, () => {
-                try {
-                    playerReadyNotify();
-                } catch (error) {
-                    _this.triggerError(convertToPlayerError(MSG_TECHNICAL_ERROR, ERROR_COMPLETING_SETUP, error));
-                }
-            });
-
-            _view.init();
+                _view.init();
+            }
         };
 
         function playerReadyNotify() {
@@ -350,7 +359,7 @@ Object.assign(Controller.prototype, {
             if (_model.get('state') === 'idle' && _model.get('autostart') === false) {
                 // If video has not been primed on Android, test that video will play before preloading
                 // This ensures we always prime the tag on play when necessary
-                if (!mediaPool.primed() && OS.android) {
+                if (!__HEADLESS__ && !mediaPool.primed() && OS.android) {
                     const video = mediaPool.getTestElement();
                     const muted = _this.getMute();
                     Promise.resolve().then(() => startPlayback(video, { muted })).then(() => {
@@ -582,7 +591,8 @@ Object.assign(Controller.prototype, {
 
             // Detect and store browser autoplay setting in the model.
             const adConfig = _model.get('advertising');
-            canAutoplay(mediaPool, {
+            const autoPlayCheck = __HEADLESS__ ? Promise.resolve.bind(Promise) : canAutoplay;
+            autoPlayCheck(mediaPool, {
                 cancelable: checkAutoStartCancelable,
                 muted: _this.getMute(),
                 allowMuted: adConfig ? adConfig.autoplayadsmuted : true
@@ -590,7 +600,7 @@ Object.assign(Controller.prototype, {
                 _model.set('canAutoplay', result);
 
                 // Only apply autostartMuted on un-muted autostart attempt.
-                if (result === AUTOPLAY_MUTED && !_this.getMute()) {
+                if (result === (__HEADLESS__ || AUTOPLAY_MUTED) && !_this.getMute()) {
                     _model.set('autostartMuted', true);
                     updateProgramSoundSettings();
 
@@ -600,7 +610,7 @@ Object.assign(Controller.prototype, {
                     });
                 }
 
-                if (_this.getMute() && _model.get('enableDefaultCaptions')) {
+                if (_captions && _this.getMute() && _model.get('enableDefaultCaptions')) {
                     _captions.selectDefaultIndex(1);
                 }
 
@@ -611,7 +621,7 @@ Object.assign(Controller.prototype, {
                     _actionOnAttach = null;
                 });
             }).catch(error => {
-                _model.set('canAutoplay', AUTOPLAY_DISABLED);
+                _model.set('canAutoplay', (__HEADLESS__ || AUTOPLAY_DISABLED));
                 _model.set('autostart', false);
                 // Emit event unless test was explicitly canceled.
                 if (!checkAutoStartCancelable.cancelled()) {
@@ -819,11 +829,11 @@ Object.assign(Controller.prototype, {
         }
 
         function _getCurrentCaptions() {
-            return _captions.getCurrentIndex();
+            return _captions ? _captions.getCurrentIndex() : -1;
         }
 
         function _getCaptionsList() {
-            return _captions.getCaptionsList();
+            return _captions ? _captions.getCaptionsList() : [];
         }
 
         /* Used for the InStream API */
@@ -862,6 +872,8 @@ Object.assign(Controller.prototype, {
                 state = !_model.get('fullscreen');
             }
 
+            // TODO: rather than the player responding to this state change this should be view / provider based with
+            //  Promise resolution for modern browsers
             _model.set('fullscreen', state);
             if (_this._instreamAdapter && _this._instreamAdapter._adModel) {
                 _this._instreamAdapter._adModel.set('fullscreen', state);
@@ -872,6 +884,9 @@ Object.assign(Controller.prototype, {
             _programController
                 .on('all', _trigger, _this)
                 .on('subtitlesTracks', (e) => {
+                    if (!_captions) {
+                        return;
+                    }
                     _captions.setSubtitlesTracks(e.tracks);
                     const defaultCaptionsIndex = _captions.getCurrentIndex();
 
@@ -1049,15 +1064,29 @@ Object.assign(Controller.prototype, {
         };
 
         // View passthroughs
-        this.resize = _view.resize;
-        this.getSafeRegion = _view.getSafeRegion;
-        this.setCaptions = _view.setCaptions;
+        if (__HEADLESS__) {
+            // These should be overridden by the app using the headless player
+            this.resize = this.setCaptions = function() {};
+            this.getSafeRegion = () => ({
+                x: 0,
+                y: 0,
+                width: 0,
+                height: 0
+            });
+        } else {
+            this.resize = _view.resize;
+            this.getSafeRegion = _view.getSafeRegion;
+            this.setCaptions = _view.setCaptions;
+        }
 
         this.checkBeforePlay = function() {
             return _beforePlay;
         };
 
         this.setControls = function (mode) {
+            if (__HEADLESS__) {
+                return;
+            }
             if (!isBoolean(mode)) {
                 mode = !_model.get('controls');
             }
@@ -1159,7 +1188,9 @@ Object.assign(Controller.prototype, {
         // Add commands from CoreLoader to queue
         apiQueue.queue.push.apply(apiQueue.queue, commandQueue);
 
-        _view.setup();
+        if (_view) {
+            _view.setup();
+        }
     },
     get(property) {
         if (property in INITIAL_MEDIA_STATE) {

--- a/src/js/environment/environment.ts
+++ b/src/js/environment/environment.ts
@@ -31,13 +31,15 @@ const noop: () => void = () => {
 function supportsPassive(): boolean {
     let passiveOptionRead = false;
 
-    try {
-        const opts: GenericObject = Object.defineProperty({}, 'passive', {
-            get: () => (passiveOptionRead = true)
-        });
-        window.addEventListener('testPassive', noop, opts);
-        window.removeEventListener('testPassive', noop, opts);
-    } catch (e) {/* noop */}
+    if (!__HEADLESS__) {
+        try {
+            const opts: GenericObject = Object.defineProperty({}, 'passive', {
+                get: () => (passiveOptionRead = true)
+            });
+            window.addEventListener('testPassive', noop, opts);
+            window.removeEventListener('testPassive', noop, opts);
+        } catch (e) {/* noop */}
+    }
 
     return passiveOptionRead;
 }
@@ -184,7 +186,7 @@ Object.defineProperties(Features, {
         enumerable: true
     },
     backgroundLoading: {
-        get: memoize(() => !(OS.iOS || Browser.safari || OS.tizen)),
+        get: memoize(() => __HEADLESS__ || !(OS.iOS || Browser.safari || OS.tizen)),
         enumerable: true
     }
 });

--- a/src/js/jwplayer.js
+++ b/src/js/jwplayer.js
@@ -29,7 +29,13 @@ const jwplayer = function(query) {
     } else if (typeof query === 'string') {
         player = playerById(query);
         if (!player) {
-            domElement = document.getElementById(query);
+            if (__HEADLESS__) {
+                // Use polyfill createElement to create player container
+                domElement = document.createElement('div');
+                domElement.id = query;
+            } else {
+                domElement = document.getElementById(query);
+            }
         }
     } else if (typeof query === 'number') {
         player = instances[query];

--- a/src/js/plugins/model.ts
+++ b/src/js/plugins/model.ts
@@ -9,7 +9,7 @@ class PluginModel {
     setupPlugin(url: string): Promise<PluginObj> {
         const registeredPlugin = this.getPlugin(url);
         if (registeredPlugin) {
-            if (registeredPlugin.url !== url) {
+            if (registeredPlugin.url !== url && !__HEADLESS__) {
                 log(`JW Plugin "${getPluginName(url)}" already loaded from "${registeredPlugin.url}". Ignoring "${url}."`);
             }
             return registeredPlugin.promise;

--- a/src/js/plugins/plugin.js
+++ b/src/js/plugins/plugin.js
@@ -84,6 +84,9 @@ Object.assign(Plugin.prototype, {
         const pluginInstance = new PluginClass(api, config, div);
 
         pluginInstance.addToPlayer = function() {
+            if (__HEADLESS__) {
+                return;
+            }
             const overlaysElement = api.getContainer().querySelector('.jw-overlays');
             if (!overlaysElement) {
                 return;

--- a/src/js/plugins/utils.ts
+++ b/src/js/plugins/utils.ts
@@ -13,14 +13,19 @@ export function getPluginErrorCode(pluginURL: string): number {
 
 export function configurePlugin(pluginObj: PluginObj, pluginConfig: GenericObject, api: PlayerAPI): PluginObj {
     const pluginName = pluginObj.name;
+    const pluginOptions = Object.assign({}, pluginConfig);
+
+    if (__HEADLESS__) {
+        const pluginInstance = pluginObj.getNewInstance(api, pluginOptions);
+        api.addPlugin(pluginName, pluginInstance);
+        return pluginInstance;
+    }
 
     const div = document.createElement('div');
     div.id = api.id + '_' + pluginName;
     div.className = 'jw-plugin jw-reset';
 
-    const pluginOptions = Object.assign({}, pluginConfig);
     const pluginInstance = pluginObj.getNewInstance(api, pluginOptions, div);
-
     api.addPlugin(pluginName, pluginInstance);
     return pluginInstance;
 }

--- a/src/js/program/ad-program-controller.js
+++ b/src/js/program/ad-program-controller.js
@@ -14,27 +14,29 @@ export default class AdProgramController extends ProgramController {
 
         adModel.mediaModel.attributes.mediaType = 'video';
 
-        // Ad plugins must use only one element, and must use the same element during playback of an item
-        // (i.e. prerolls, midrolls, and postrolls must use the same tag)
-        let mediaElement;
-        if (this.backgroundLoading) {
-            mediaElement = mediaPool.getAdElement();
-        } else {
-            // Take the tag that we're using to play the current item. The tag has been freed before reaching this point
-            mediaElement = model.get('mediaElement');
+        if (!__HEADLESS__) {
+            // Ad plugins must use only one element, and must use the same element during playback of an item
+            // (i.e. prerolls, midrolls, and postrolls must use the same tag)
+            let mediaElement;
+            if (this.backgroundLoading) {
+                mediaElement = mediaPool.getAdElement();
+            } else {
+                // Take the tag that we're using to play the current item. The tag has been freed before reaching this point
+                mediaElement = model.get('mediaElement');
 
-            adModel.attributes.mediaElement = mediaElement;
-            adModel.attributes.mediaSrc = mediaElement.src;
+                adModel.attributes.mediaElement = mediaElement;
+                adModel.attributes.mediaSrc = mediaElement.src;
 
-            // Listen to media element for events that indicate src was reset or load() was called
-            const srcResetListener = this.srcResetListener = () => {
-                this.srcReset();
-            };
-            mediaElement.addEventListener('emptied', srcResetListener);
-            mediaElement.playbackRate = mediaElement.defaultPlaybackRate = 1;
+                // Listen to media element for events that indicate src was reset or load() was called
+                const srcResetListener = this.srcResetListener = () => {
+                    this.srcReset();
+                };
+                mediaElement.addEventListener('emptied', srcResetListener);
+                mediaElement.playbackRate = mediaElement.defaultPlaybackRate = 1;
+            }
+
+            this.mediaPool = SharedMediaPool(mediaElement, mediaPool);
         }
-
-        this.mediaPool = SharedMediaPool(mediaElement, mediaPool);
     }
 
     setup() {
@@ -61,8 +63,10 @@ export default class AdProgramController extends ProgramController {
             this.trigger(ERROR, data);
         }, this);
 
-        if (!primedElement.paused) {
-            primedElement.pause();
+        if (!__HEADLESS__) {
+            if (!primedElement.paused) {
+                primedElement.pause();
+            }
         }
     }
 
@@ -116,6 +120,10 @@ export default class AdProgramController extends ProgramController {
             this._stateHandler(state);
         });
         provider.attachMedia();
+        if (__HEADLESS__) {
+            const mediaContainer = playerModel.get('mediaContainer');
+            provider.setContainer(mediaContainer);
+        }
         provider.volume(playerModel.get('volume'));
         provider.mute(playerModel.getMute());
         if (provider.setPlaybackRate) {
@@ -139,8 +147,18 @@ export default class AdProgramController extends ProgramController {
     }
 
     destroy() {
-        const { model, mediaPool, playerModel } = this;
+        const { mediaController, model, mediaPool, playerModel } = this;
         model.off();
+
+        if (__HEADLESS__) {
+            if (this.provider) {
+                this.provider.remove();
+                this.provider = null;
+                mediaController.destroy();
+            }
+            return;
+        }
+
         // Do not destroy or remove provider event listeners since non-linear ads may continue to run after this point
         this.provider = null;
 

--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -202,9 +202,13 @@ export default class MediaController extends Events {
         if (!this.attached) {
             return false;
         }
-        // A provider without a video tag cannot be backgrounded
         const provider = this.provider;
+        if (__HEADLESS__) {
+            // A headless provider that does not return a container is backgrounded
+            return !provider.getContainer();
+        }
         if (!provider.video) {
+            // A provider without a video tag cannot be backgrounded
             return false;
         }
         // A backgrounded provider does not have a parent container, or has one, but without the media tag as a child
@@ -256,7 +260,7 @@ export default class MediaController extends Events {
     set background(shouldBackground) {
         const provider = this.provider;
         // A provider without a video tag must use attach and detach
-        if (!provider.video) {
+        if (!provider.video && !__HEADLESS__) {
             if (shouldBackground) {
                 this.detach();
             } else {
@@ -273,7 +277,11 @@ export default class MediaController extends Events {
             if (!this.background) {
                 this.thenPlayPromise.cancel();
                 this.pause();
-                container.removeChild(provider.video);
+                if (provider.removeFromContainer) {
+                    provider.removeFromContainer();
+                } else {
+                    container.removeChild(provider.video);
+                }
                 this.container = null;
             }
         } else {

--- a/src/js/program/media-element-pool.ts
+++ b/src/js/program/media-element-pool.ts
@@ -18,11 +18,13 @@ export default function MediaElementPool(): MediaElementPoolInt {
     const maxPrimedTags = MEDIA_POOL_SIZE;
     const elements: HTMLVideoElement[] = [];
     const pool: HTMLVideoElement[] = [];
-    for (let i = 0; i < maxPrimedTags; i++) {
-        const mediaElement = createMediaElement();
-        elements.push(mediaElement);
-        pool.push(mediaElement);
-        primeMediaElementForPlayback(mediaElement);
+    if (!__HEADLESS__) {
+        for (let i = 0; i < maxPrimedTags; i++) {
+            const mediaElement = createMediaElement();
+            elements.push(mediaElement);
+            pool.push(mediaElement);
+            primeMediaElementForPlayback(mediaElement);
+        }
     }
 
     // Reserve an element exclusively for ads

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -32,6 +32,11 @@ class ProgramController extends Events {
         this.asyncItems = [];
         this.itemSetContext = 0;
 
+        if (__HEADLESS__) {
+            // Headless player will call setContainer with an empty object or null to signal whether it should display content
+            model.set('mediaContainer', {});
+        }
+
         if (!this.backgroundLoading) {
             // If background loading is not supported, set the shared media element
             model.set('mediaElement', this.mediaPool.getPrimedElement());

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -52,7 +52,7 @@ class ProgramController extends Events {
     asyncActiveItem(index) {
         const { model } = this;
         // Set the player state to buffering if there is a playlist item callback
-        const deferBufferingState = setTimeout(() => {
+        const deferBufferingState = __HEADLESS__ ? -1 : setTimeout(() => {
             model.set(PLAYER_STATE, STATE_BUFFERING);
         }, 50);
         return this.getAsyncItem(index).run().then((playlistItem) => {

--- a/src/js/providers/provider-loaders.js
+++ b/src/js/providers/provider-loaders.js
@@ -1,0 +1,13 @@
+import registerProvider from 'providers/providers-register';
+import { chunkLoadErrorHandler } from '../api/core-loader';
+
+export const Loaders = {
+    html5: function() {
+        return require.ensure(['providers/html5'], function(require) {
+            const provider = require('providers/html5').default;
+            registerProvider(provider);
+            return provider;
+        }, chunkLoadErrorHandler(152), 'provider.html5');
+    }
+};
+

--- a/src/js/providers/providers-loaded.js
+++ b/src/js/providers/providers-loaded.js
@@ -1,2 +1,1 @@
-const ProvidersLoaded = {};
-export default ProvidersLoaded;
+export const ProvidersLoaded = {};

--- a/src/js/providers/providers-register.ts
+++ b/src/js/providers/providers-register.ts
@@ -3,6 +3,7 @@ import { SupportsMatrix } from 'providers/providers-supported';
 import DefaultProvider from 'providers/default';
 import type { ImplementedProvider } from 'providers/default';
 import { find, matches, isFunction, defaults } from 'utils/underscore';
+import Events from 'utils/backbone.events';
 
 export default function registerProvider(provider: ImplementedProvider): void {
     const name = provider.getName().name;
@@ -23,6 +24,10 @@ export default function registerProvider(provider: ImplementedProvider): void {
             name: name,
             supports: provider.supports
         });
+    }
+
+    if (__HEADLESS__) {
+        defaults(provider.prototype, Events);
     }
 
     // Fill in any missing properties with the defaults - looks at the prototype chain

--- a/src/js/providers/providers-register.ts
+++ b/src/js/providers/providers-register.ts
@@ -1,5 +1,5 @@
-import ProvidersLoaded from 'providers/providers-loaded';
-import ProvidersSupported from 'providers/providers-supported';
+import { ProvidersLoaded } from 'providers/providers-loaded';
+import { SupportsMatrix } from 'providers/providers-supported';
 import DefaultProvider from 'providers/default';
 import type { ImplementedProvider } from 'providers/default';
 import { find, matches, isFunction, defaults } from 'utils/underscore';
@@ -13,13 +13,13 @@ export default function registerProvider(provider: ImplementedProvider): void {
     }
 
     // If there isn't a "supports" val for this guy
-    if (!find(ProvidersSupported, matches({ name: name }))) {
+    if (!find(SupportsMatrix, matches({ name: name }))) {
         if (!isFunction(provider.supports)) {
             throw new Error('Tried to register a provider with an invalid object');
         }
 
         // The most recent provider will be in the front of the array, and chosen first
-        ProvidersSupported.unshift({
+        SupportsMatrix.unshift({
             name: name,
             supports: provider.supports
         });

--- a/src/js/providers/providers-supported.ts
+++ b/src/js/providers/providers-supported.ts
@@ -23,7 +23,7 @@ const MimeTypes = {
     hls: 'application/vnd.apple.mpegurl'
 };
 
-const SupportsMatrix = [
+export const SupportsMatrix = __HEADLESS__ ? [] : [
     {
         name: 'html5',
         supports: supportsType
@@ -31,41 +31,37 @@ const SupportsMatrix = [
 ];
 
 export function supportsType(source: PlaylistItemSource): boolean {
-    {
-        if (isAndroidHls(source) === false) {
-            return false;
-        }
-
-        if (!video.canPlayType) {
-            return false;
-        }
-
-        const file = source.file;
-        const type = source.type;
-
-        // Ensure RTMP files are not seen as videos
-        if (isRtmp(file, type)) {
-            return false;
-        }
-
-        let mimeType = source.mimeType || MimeTypes[type];
-
-        // Not OK to use HTML5 with no extension
-        if (!mimeType) {
-            return false;
-        }
-
-        // source.mediaTypes is an Array of media types that MediaSource must support for the stream to play
-        // Ex: ['video/webm; codecs="vp9"', 'audio/webm; codecs="vorbis"']
-        const mediaTypes = source.mediaTypes;
-        if (mediaTypes && mediaTypes.length) {
-            mimeType = [mimeType].concat(mediaTypes.slice()).join('; ');
-        }
-
-        // Last, but not least, we ask the browser
-        // (But only if it's a video with an extension known to work in HTML5)
-        return !!video.canPlayType(mimeType);
+    if (__HEADLESS__ || !video || !video.canPlayType) {
+        return false;
     }
-}
 
-export default SupportsMatrix;
+    if (isAndroidHls(source) === false) {
+        return false;
+    }
+
+    const file = source.file;
+    const type = source.type;
+
+    // Ensure RTMP files are not seen as videos
+    if (isRtmp(file, type)) {
+        return false;
+    }
+
+    let mimeType = source.mimeType || MimeTypes[type];
+
+    // Not OK to use HTML5 with no extension
+    if (!mimeType) {
+        return false;
+    }
+
+    // source.mediaTypes is an Array of media types that MediaSource must support for the stream to play
+    // Ex: ['video/webm; codecs="vp9"', 'audio/webm; codecs="vorbis"']
+    const mediaTypes = source.mediaTypes;
+    if (mediaTypes && mediaTypes.length) {
+        mimeType = [mimeType].concat(mediaTypes.slice()).join('; ');
+    }
+
+    // Last, but not least, we ask the browser
+    // (But only if it's a video with an extension known to work in HTML5)
+    return !!video.canPlayType(mimeType);
+}

--- a/src/js/providers/providers.js
+++ b/src/js/providers/providers.js
@@ -1,26 +1,16 @@
-import ProvidersSupported from 'providers/providers-supported';
-import registerProvider from 'providers/providers-register';
-import ProvidersLoaded from 'providers/providers-loaded';
-import { chunkLoadErrorHandler } from '../api/core-loader';
+import { SupportsMatrix } from 'providers/providers-supported';
+import { ProvidersLoaded } from 'providers/providers-loaded';
+import { Loaders } from 'providers/provider-loaders';
 
 function Providers(config) {
     this.config = config || {};
 }
 
-export const Loaders = {
-    html5: function() {
-        return require.ensure(['providers/html5'], function(require) {
-            const provider = require('providers/html5').default;
-            registerProvider(provider);
-            return provider;
-        }, chunkLoadErrorHandler(152), 'provider.html5');
-    }
-};
-
 Object.assign(Providers.prototype, {
 
     load: function(providerName) {
-        const providerLoaderMethod = Loaders[providerName];
+        const providerLoaders = __HEADLESS__ ? {} : Loaders;
+        const providerLoaderMethod = providerLoaders[providerName];
         const rejectLoad = () => {
             return Promise.reject(new Error('Failed to load media'));
         };
@@ -45,9 +35,9 @@ Object.assign(Providers.prototype, {
     // Find the name of the first provider which can support the media source-type
     choose: function(source) {
         if (source === Object(source)) {
-            const count = ProvidersSupported.length;
+            const count = SupportsMatrix.length;
             for (let i = 0; i < count; i++) {
-                const provider = ProvidersSupported[i];
+                const provider = SupportsMatrix[i];
                 if (this.providerSupports(provider, source)) {
                     // prefer earlier providers
                     const priority = count - i - 1;

--- a/src/js/providers/video-actions-mixin.ts
+++ b/src/js/providers/video-actions-mixin.ts
@@ -11,6 +11,7 @@ export interface VideoActionsInt {
     resize(this: ProviderWithMixins, width: number, height: number, stretching: string): void;
     getContainer(): HTMLElement | null;
     setContainer(this: ProviderWithMixins, element: HTMLElement): void;
+    removeFromContainer(this: ProviderWithMixins): void;
     remove(this: ProviderWithMixins): void;
     atEdgeOfLiveStream(this: ProviderWithMixins): boolean;
 }
@@ -106,13 +107,18 @@ const VideoActionsMixin: VideoActionsInt = {
         }
     },
 
+    removeFromContainer(this: ProviderWithMixins): void {
+        const { container, video } = this;
+        this.container = null;
+        if (container && container === video.parentNode) {
+            container.removeChild(video);
+        }
+    },
+
     remove(this: ProviderWithMixins): void {
         this.stop();
         this.destroy();
-        const container = this.container;
-        if (container && container === this.video.parentNode) {
-            container.removeChild(this.video);
-        }
+        this.removeFromContainer();
     },
 
     atEdgeOfLiveStream(this: ProviderWithMixins): boolean {

--- a/src/js/types/globals.d.ts
+++ b/src/js/types/globals.d.ts
@@ -11,3 +11,4 @@ declare interface Document {
 
 declare const __SELF_HOSTED__: boolean;
 declare const __REPO__: string;
+declare const __HEADLESS__: boolean;

--- a/src/js/utils/helpers.ts
+++ b/src/js/utils/helpers.ts
@@ -109,4 +109,25 @@ const helpers: { [key: string]: () => any } = Object.assign({}, parser, validato
     noop
 });
 
+if (__HEADLESS__) {
+    Object.assign(helpers, {
+        addClass: noop,
+        hasClass: noop,
+        removeClass: noop,
+        replaceClass: noop,
+        toggleClass: noop,
+        classList: () => [],
+        createElement: (html) => document.createElement(html),
+        emptyElement: noop,
+        addStyleSheet: noop,
+        openLink:
+            (link, target, additionalOptions) =>
+                console.error(`[headless] utils.openLink(${link}, ${target}, ${additionalOptions})`),
+        replaceInnerHtml: noop,
+        css: noop,
+        clearCss: noop,
+        style: noop,
+        transform: noop
+    });
+}
 export default helpers;

--- a/src/js/utils/language.js
+++ b/src/js/utils/language.js
@@ -74,6 +74,9 @@ function extractLanguage(doc) {
 }
 
 export function getLanguage() {
+    if (__HEADLESS__) {
+        return navigator.language || 'en';
+    }
     let language = extractLanguage(document);
     if (!language && isIframe()) {
         try {

--- a/src/js/utils/playerutils.ts
+++ b/src/js/utils/playerutils.ts
@@ -2,13 +2,15 @@ import { version } from 'version';
 import { isFileProtocol } from 'utils/validator';
 
 export const getScriptPath = function(scriptName: string): string {
-    const scripts = document.getElementsByTagName('script');
-    for (let i = 0; i < scripts.length; i++) {
-        const src = scripts[i].src;
-        if (src) {
-            const index = src.lastIndexOf('/' + scriptName);
-            if (index >= 0) {
-                return src.substr(0, index + 1);
+    if (!__HEADLESS__) {
+        const scripts = document.getElementsByTagName('script');
+        for (let i = 0; i < scripts.length; i++) {
+            const src = scripts[i].src;
+            if (src) {
+                const index = src.lastIndexOf('/' + scriptName);
+                if (index >= 0) {
+                    return src.substr(0, index + 1);
+                }
             }
         }
     }

--- a/src/js/utils/video.ts
+++ b/src/js/utils/video.ts
@@ -1,2 +1,2 @@
-const video = document.createElement('video');
+const video = __HEADLESS__ ? null : document.createElement('video');
 export default video;

--- a/src/js/view/utils/views-manager.js
+++ b/src/js/view/utils/views-manager.js
@@ -76,22 +76,24 @@ function onScroll(e) {
     });
 }
 
-document.addEventListener('visibilitychange', onVisibilityChange);
-document.addEventListener('webkitvisibilitychange', onVisibilityChange);
-
-if (isAndroidChrome && hasOrientation) {
-    window.screen.orientation.addEventListener('change', onOrientationChange);
-}
-
-window.addEventListener('beforeunload', () => {
-    document.removeEventListener('visibilitychange', onVisibilityChange);
-    document.removeEventListener('webkitvisibilitychange', onVisibilityChange);
-    window.removeEventListener('scroll', onScroll);
+if (!__HEADLESS__) {
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    document.addEventListener('webkitvisibilitychange', onVisibilityChange);
 
     if (isAndroidChrome && hasOrientation) {
-        window.screen.orientation.removeEventListener('change', onOrientationChange);
+        window.screen.orientation.addEventListener('change', onOrientationChange);
     }
-});
+
+    window.addEventListener('beforeunload', () => {
+        document.removeEventListener('visibilitychange', onVisibilityChange);
+        document.removeEventListener('webkitvisibilitychange', onVisibilityChange);
+        window.removeEventListener('scroll', onScroll);
+
+        if (isAndroidChrome && hasOrientation) {
+            window.screen.orientation.removeEventListener('change', onOrientationChange);
+        }
+    });
+}
 
 export default {
     add: function(view) {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -41,8 +41,9 @@ import Title from 'view/title';
 import FloatingDragUI from 'view/floating-drag-ui';
 import ResizeListener from 'view/utils/resize-listener';
 
-
-require('css/jwplayer.less');
+if (!__HEADLESS__) {
+    require('css/jwplayer.less');
+}
 
 let ControlsModule;
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,5 @@
 // Bundle files chunked by webpack
-import ProvidersLoaded from 'providers/providers-loaded';
+import { ProvidersLoaded } from 'providers/providers-loaded';
 import html5 from 'providers/html5';
 import 'parsers/captions/vttparser';
 import 'view/controls/controls';

--- a/test/unit/providers-test.js
+++ b/test/unit/providers-test.js
@@ -1,4 +1,5 @@
-import Providers, { Loaders } from 'providers/providers';
+import Providers from 'providers/providers';
+import { Loaders } from 'providers/provider-loaders';
 import Source from 'playlist/source';
 import _ from 'utils/underscore';
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,7 @@ const compileConstants = {
     __SELF_HOSTED__: true,
     __REPO__: `''`,
     __DEBUG__: false,
+    __HEADLESS__: false,
     __BUILD_VERSION__: `'${getBuildVersion()}'`,
     __FLASH_VERSION__: 18
 };
@@ -78,8 +79,8 @@ const webpackConfig = {
                         babelrc: false,
                         presets: [
                             ['@babel/preset-env', { loose: true, modules: false }],
-                            ["@babel/preset-typescript", {
-                                "onlyRemoveTypeImports": true
+                            ['@babel/preset-typescript', {
+                                onlyRemoveTypeImports: true
                             }]
                         ],
                         plugins: [


### PR DESCRIPTION
### This PR will...
Add a new `__HEADLESS__` compiler constant used to output a headless player library. The headless player _aims_ to exclude code that does not rely on the DOM so that it can execute player logic with custom providers in JavaScript environments outside of web browsers.

The headless player has no view, controls, media providers or captions support. The headless player API still defines all the methods of the web player, but the following methods are no-ops or differ as listed below:
- `addButton()`
- `getSafeRegion()`
- `getAdBlock()`
- `resize()`
- `setCaptions()`
- `setControls()`
- `getCurrentCaptions()`
- `getCaptionsList()`
- `getViewable()` always returns `true`
- `getControls()` always returns `false`
- `setFullscreen()` toggles internal state and trigger events but isn't bound to any view or provider
- `getFullscreen()` returns internal state, not device fullscreen state

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/7252

#### Addresses Issue(s):
JW8-10813

### Checklist
- [x] Jenkins builds and unit tests are passing
- [x] I have reviewed the automated results
