### PR TITLE
[JW8-11061] Fix exceptions on setup due to caption index

### DIFF
--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -35,7 +35,8 @@ const Captions = function(_model) {
                 /* eslint-disable no-loop-func */
                 const track = tracks[i];
                 if (_kindSupported(track.kind) && !_tracksById[track._id]) {
-                    _addTrack(track, true);
+                    track.sideloaded = true;
+                    _addTrack(track);
                     loadFile(track, (vttCues) => {
                         _addVTTCuesToTrack(track, vttCues);
                     }, error => {
@@ -71,7 +72,7 @@ const Captions = function(_model) {
 
             // To avoid duplicate tracks in the menu when we reuse an _id, regenerate the tracks array
             const allTracks = Object.keys(_tracksById).map(id => _tracksById[id]);
-            _tracks = allTracks.filter(track => !track.isSideload).concat(allTracks.filter(track => !!track.isSideload));
+            _tracks = allTracks.filter(track => !track.sideloaded).concat(allTracks.filter(track => !!track.sideloaded));
         }
 
         _setCaptionsList();
@@ -85,11 +86,10 @@ const Captions = function(_model) {
         track.data = vttCues;
     }
 
-    function _addTrack(track, isSideload) {
+    function _addTrack(track) {
         track.data = track.data || [];
         track.name = track.label || track.name || track.language;
         track._id = createId(track, _tracks.length);
-        track.isSideload = isSideload;
 
         if (!track.name) {
             const labelInfo = createLabel(track, _unknownCount);

--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -35,7 +35,7 @@ const Captions = function(_model) {
                 /* eslint-disable no-loop-func */
                 const track = tracks[i];
                 if (_kindSupported(track.kind) && !_tracksById[track._id]) {
-                    _addTrack(track);
+                    _addTrack(track, true);
                     loadFile(track, (vttCues) => {
                         _addVTTCuesToTrack(track, vttCues);
                     }, error => {
@@ -70,7 +70,8 @@ const Captions = function(_model) {
             }
 
             // To avoid duplicate tracks in the menu when we reuse an _id, regenerate the tracks array
-            _tracks = Object.keys(_tracksById).map(id => _tracksById[id]);
+            const allTracks = Object.keys(_tracksById).map(id => _tracksById[id]);
+            _tracks = allTracks.filter(track => !track.isSideload).concat(allTracks.filter(track => !!track.isSideload));
         }
 
         _setCaptionsList();
@@ -84,10 +85,11 @@ const Captions = function(_model) {
         track.data = vttCues;
     }
 
-    function _addTrack(track) {
+    function _addTrack(track, isSideload) {
         track.data = track.data || [];
         track.name = track.label || track.name || track.language;
         track._id = createId(track, _tracks.length);
+        track.isSideload = isSideload;
 
         if (!track.name) {
             const labelInfo = createLabel(track, _unknownCount);
@@ -152,8 +154,8 @@ const Captions = function(_model) {
     function _setCaptionsList() {
         const captionsList = _captionsMenu();
         if (listIdentity(captionsList) !== listIdentity(_model.get('captionsList'))) {
-            _selectDefaultIndex(_defaultIndex);
             _model.set('captionsList', captionsList);
+            _selectDefaultIndex(_defaultIndex);
         }
     }
 


### PR DESCRIPTION
### This PR will...
1. Send all sided loaded captions to the end of the menu
2. Set `captionsList` before setting the `defaultIndex` for captions

### Why is this Pull Request needed?
1. Side loaded captions are causing hls VTT captions to load incorrect index. Open for suggestions if there is a better way
2. This was causing exception when the `defaultIndex` from previous selection (before refreshing the browser) was larger than the number of side loaded captions loaded

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-11061

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
