### PR TITLE
Add ability for VTT parser to parse synchronously

### DIFF
--- a/src/js/parsers/captions/vttparser.js
+++ b/src/js/parsers/captions/vttparser.js
@@ -32,11 +32,12 @@ const whitespaceRegex = /^\s+/;
 const arrowRegex = /-->/;
 const headerRegex = /^WEBVTT([ \t].*)?$/;
 
-const VTTParser = function(window, decoder) {
+const VTTParser = function(window, decoder, syncCueParsing) {
     this.window = window;
     this.state = 'INITIAL';
     this.buffer = '';
     this.decoder = decoder || new StringDecoder();
+    this.syncCueParsing = syncCueParsing;
     this.regionList = [];
     this.maxCueBatch = 1000;
 };
@@ -343,7 +344,7 @@ VTTParser.prototype = {
         let currentCueBatch = 0;
         function processBuffer() {
             try {
-                while (self.buffer && currentCueBatch <= self.maxCueBatch) {
+                while (self.buffer && (currentCueBatch <= self.maxCueBatch || self.syncCueParsing)) {
                     // We can't parse a line until we have the full line.
                     if (!fullLineRegex.test(self.buffer)) {
                         self.flush();


### PR DESCRIPTION
### This PR will...
Allow our VTT parser to parse synchrously (off by default)

### Why is this Pull Request needed?
Our shaka plugin requires synchronous parsing to provide all cues (see linked pr)

### Are there any points in the code the reviewer needs to double check?
Nah

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/7575

#### Addresses Issue(s):

JW8-11143

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
