### PR TITLE
Deselect previous audio track when using setCurrentAudioTrack

### DIFF
--- a/src/js/view/controls/components/menu/settings-menu.js
+++ b/src/js/view/controls/components/menu/settings-menu.js
@@ -91,7 +91,7 @@ class SettingsMenu extends Menu {
         if (!this.children.audioTracks) {
             return;
         }
-        this.children.audioTracks.items[trackIndex].activate();
+        selectMenuItem(this.children.audioTracks, trackIndex);
     }
 
     onCaptionsList(model, captionsList) {


### PR DESCRIPTION
### This PR will...

Fix #3685

### Why is this Pull Request needed?

To be able to properly use both audio track menu and JS API `setCurrentAudioTrack`.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
