### PR TITLE
[JW8-11176] Add loadNextItemOnError method to instream adapter

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -191,9 +191,7 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
         this.trigger(type, data);
 
         if (type === 'mediaError' || type === 'error') {
-            if (_array && _arrayIndex + 1 < _array.length) {
-                _loadNextItem();
-            }
+            this.loadNextItemOnError();
         }
     }
 
@@ -283,6 +281,16 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
                 this.trigger(PLAYLIST_COMPLETE, {});
             }
             this.destroy();
+        }
+    }
+
+    /**
+     * Called when an error occurs to load the next instream ad if it exists.
+     * @return {void}
+     */
+    this.loadNextItemOnError = function() {
+        if (_array && _arrayIndex + 1 < _array.length) {
+            _loadNextItem();
         }
     }
 

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -292,7 +292,7 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
         if (_array && _arrayIndex + 1 < _array.length) {
             _loadNextItem();
         }
-    }
+    };
 
     /**
      * Load an Item, playing it as an insteam ad.


### PR DESCRIPTION
### This PR will...
Add a new `loadNextItemOnError` method to the instream-adapter to be called when an ad error occurs
### Why is this Pull Request needed?
bugfix
### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-ads-vast/pull/650

#### Addresses Issue(s):

Specific Bug Ticket: [JW8-11176](https://jwplayer.atlassian.net/browse/JW8-11176)
Original Ticket: [JW8-11134](https://jwplayer.atlassian.net/browse/JW8-11134)

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
