### PR TITLE
[JW8-11181] Check for elementFromPoint with clientX and clientY

### DIFF
--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -311,7 +311,7 @@ const eventRegisters = {
                 if (e.pointerType !== 'touch' && 'x' in e) {
                     // elementFromPoint to handle an issue where setPointerCapture is causing a pointerout event
                     const overElement = document.elementFromPoint(e.x, e.y);
-                    const overElementFromClient = document.elementFromPoint(e.clientX, e.clientY);
+                    const overElementFromClient = 'clientX' in e ? document.elementFromPoint(e.clientX, e.clientY) : null;
                     if (!el.contains(overElement) && !el.contains(overElementFromClient)) {
                         triggerEvent(ui, OUT, e);
                     }

--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -311,7 +311,8 @@ const eventRegisters = {
                 if (e.pointerType !== 'touch' && 'x' in e) {
                     // elementFromPoint to handle an issue where setPointerCapture is causing a pointerout event
                     const overElement = document.elementFromPoint(e.x, e.y);
-                    if (!el.contains(overElement)) {
+                    const overElementFromClient = document.elementFromPoint(e.clientX, e.clientY);
+                    if (!el.contains(overElement) && !el.contains(overElementFromClient)) {
                         triggerEvent(ui, OUT, e);
                     }
                 }

--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -308,11 +308,10 @@ const eventRegisters = {
         if (USE_POINTER_EVENTS) {
             const { el } = ui;
             addEventListener(ui, OUT, 'pointerout', (e) => {
-                if (e.pointerType !== 'touch' && 'x' in e) {
+                if (e.pointerType !== 'touch' && 'clientX' in e) {
                     // elementFromPoint to handle an issue where setPointerCapture is causing a pointerout event
-                    const overElement = document.elementFromPoint(e.x, e.y);
-                    const overElementFromClient = 'clientX' in e ? document.elementFromPoint(e.clientX, e.clientY) : null;
-                    if (!el.contains(overElement) && !el.contains(overElementFromClient)) {
+                    const overElement = document.elementFromPoint(e.clientX, e.clientY);
+                    if (!el.contains(overElement)) {
                         triggerEvent(ui, OUT, e);
                     }
                 }


### PR DESCRIPTION
### This PR will...
- Check the element from `document.elementFromPoint` using `clientX` and `clientY`

### Why is this Pull Request needed?
- For IE 11, the pointer event `e` has incorrect values of `x` and `y`, causing the `body` of the `document` to be selected as `overElement`, instead of the actual `volumeSlider`
- Using `clientX` and `clientY` to get the position relative to the viewport fixes the issue

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-11181

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
