### PR TITLE
[JW8-11194] Handle async playlist item edge-cases

### DIFF
--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -12,9 +12,11 @@ import ErrorContainer from 'view/error-container';
 import MediaElementPool from 'program/media-element-pool';
 import SharedMediaPool from 'program/shared-media-pool';
 import UI, { getElementWindow } from 'utils/ui';
-import { PlayerError, composePlayerError, convertToPlayerError,
+import {
+    PlayerError, composePlayerError, convertToPlayerError,
     SETUP_ERROR_LOADING_PLAYLIST, SETUP_ERROR_PROMISE_API_CONFLICT, SETUP_ERROR_UNKNOWN,
-    MSG_TECHNICAL_ERROR } from 'api/errors';
+    MSG_TECHNICAL_ERROR, ASYNC_PLAYLIST_ITEM_REJECTED, SETUP_ERROR_ASYNC_SKIPPED_PLAYLIST
+} from 'api/errors';
 // Import modules used by core and related (TODO: move related loading into core/controls)
 import 'view/utils/views-manager';
 import 'view/utils/resize-listener';
@@ -148,7 +150,8 @@ Object.assign(CoreShim.prototype, {
             // Set the active playlist item after plugins are loaded and the view is setup
             return this.updatePlaylist(coreModel.get('playlist'), coreModel.get('feedData'))
                 .catch(error => {
-                    throw composePlayerError(error, SETUP_ERROR_LOADING_PLAYLIST);
+                    const code = error.code === ASYNC_PLAYLIST_ITEM_REJECTED ? SETUP_ERROR_ASYNC_SKIPPED_PLAYLIST : SETUP_ERROR_LOADING_PLAYLIST;
+                    throw composePlayerError(error, code);
                 });
         }).then(() => {
             if (!this.setup) {

--- a/src/js/api/errors.ts
+++ b/src/js/api/errors.ts
@@ -33,7 +33,7 @@ export const SETUP_ERROR_LOADING_CORE_JS = 101000;
 export const SETUP_ERROR_LOADING_PLAYLIST = 102000;
 
 /**
- * @enum {ErrorCode} Setup failed because the playlist failed to load.
+ * @enum {ErrorCode} Setup failed because all items in the playlist were skipped by the async callback.
  */
 export const SETUP_ERROR_ASYNC_SKIPPED_PLAYLIST = 102700;
 

--- a/src/js/api/errors.ts
+++ b/src/js/api/errors.ts
@@ -33,6 +33,11 @@ export const SETUP_ERROR_LOADING_CORE_JS = 101000;
 export const SETUP_ERROR_LOADING_PLAYLIST = 102000;
 
 /**
+ * @enum {ErrorCode} Setup failed because the playlist failed to load.
+ */
+export const SETUP_ERROR_ASYNC_SKIPPED_PLAYLIST = 102700;
+
+/**
  * @enum {ErrorCode} An exception occurred while completing player setup.
  */
 export const ERROR_COMPLETING_SETUP = 200001;
@@ -56,6 +61,11 @@ export const ERROR_LOADING_PLAYLIST_ITEM = 203000;
  * @enum {ErrorCode} The current playlist item has no source media.
  */
 export const ERROR_PLAYLIST_ITEM_MISSING_SOURCE = 203640;
+
+/**
+ * @enum {ErrorCode} An error occurred when switching playlist items.
+ */
+export const ASYNC_PLAYLIST_ITEM_REJECTED = 203700;
 
 /**
  * @enum {ErrorCode} Between playlist items, the required provider could not be loaded.

--- a/src/js/api/errors.ts
+++ b/src/js/api/errors.ts
@@ -63,7 +63,7 @@ export const ERROR_LOADING_PLAYLIST_ITEM = 203000;
 export const ERROR_PLAYLIST_ITEM_MISSING_SOURCE = 203640;
 
 /**
- * @enum {ErrorCode} An error occurred when switching playlist items.
+ * @enum {ErrorCode} Reached the end of the playlist while skipping items via async callback.
  */
 export const ASYNC_PLAYLIST_ITEM_REJECTED = 203700;
 


### PR DESCRIPTION
### This PR will...
Handle cases where the last item or all items are rejected/skipped using `setPlaylistItemCallback`.

### Why is this Pull Request needed?
Fixes a bug where the player would error when the last item was rejected, instead of going to a complete state or repeating the playlist.

When all items are rejected before setup, then setup should error with new "setupError" code 102700.

#### Addresses Issue(s):
JW8-11194

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
