### PR TITLE
[JW8-11180] Change the order back to hide the iOS captions after disabling for FF

### DIFF
--- a/src/js/providers/tracks-mixin.ts
+++ b/src/js/providers/tracks-mixin.ts
@@ -211,13 +211,14 @@ const Tracks: TracksMixin = {
     disableTextTrack(): void {
         const track = this.getCurrentTextTrack();
         if (track) {
+            // FF does not remove the active cue from the dom when the track is hidden, so we must disable it
+            track.mode = 'disabled';
+
             // IOS native captions does not remove the active cue from the dom when the track is disabled, so we must hide it
             const trackId = track._id;
             if ((trackId && trackId.indexOf('nativecaptions') === 0) || (this.renderNatively && OS.iOS)) {
                 track.mode = 'hidden';
             }
-            // FF does not remove the active cue from the dom when the track is hidden, so we must disable it
-            track.mode = 'disabled';
         }
     },
     enableTextTrack(): void {

--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -162,7 +162,6 @@ function initInteractionListeners(ui) {
 
     const interactEndHandler = (e) => {
         clearTimeout(longPressTimeout);
-        console.log('interaction end', ui.el);
         if (!ui.el) {
             return;
         }
@@ -312,7 +311,6 @@ const eventRegisters = {
                 if (e.pointerType !== 'touch' && 'clientX' in e) {
                     // elementFromPoint to handle an issue where setPointerCapture is causing a pointerout event
                     const overElement = document.elementFromPoint(e.clientX, e.clientY);
-                    console.log('here out', !el.contains(overElement), overElement);
                     if (!el.contains(overElement)) {
                         triggerEvent(ui, OUT, e);
                     }

--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -162,6 +162,7 @@ function initInteractionListeners(ui) {
 
     const interactEndHandler = (e) => {
         clearTimeout(longPressTimeout);
+        console.log('interaction end', ui.el);
         if (!ui.el) {
             return;
         }
@@ -311,6 +312,7 @@ const eventRegisters = {
                 if (e.pointerType !== 'touch' && 'clientX' in e) {
                     // elementFromPoint to handle an issue where setPointerCapture is causing a pointerout event
                     const overElement = document.elementFromPoint(e.clientX, e.clientY);
+                    console.log('here out', !el.contains(overElement), overElement);
                     if (!el.contains(overElement)) {
                         triggerEvent(ui, OUT, e);
                     }


### PR DESCRIPTION
### This PR will...
- Change the order back to disabling captions for FF before changing to hidden for iOS fullscreen

### Why is this Pull Request needed?
- The issue is not fixed if we change the order

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-11180

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
