### PR TITLE
[JW8-11067] Headless Player Updates: Instream

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -326,6 +326,14 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
             playlist = [item];
         }
 
+        if (__HEADLESS__) {
+            playlist = playlist.map(playlistItem => {
+                const newItem = Object.assign({}, playlistItem);
+                delete newItem.vastAd;
+                return newItem;
+            });
+        }
+
         const adModel = _adProgram.model;
         adModel.set('playlist', playlist);
         _model.set('hideAdsControls', false);

--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -251,6 +251,10 @@ export default class MediaController extends Events {
 
         this.item = item;
         this.provider.init(item);
+        if (__HEADLESS__) {
+            this.provider.mute(this.model.getMute());
+            this.provider.volume(this.model.get('volume'));
+        }
     }
 
     set audioTrack(index) {

--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -284,7 +284,12 @@ export default class MediaController extends Events {
                 if (provider.removeFromContainer) {
                     provider.removeFromContainer();
                 } else {
-                    container.removeChild(provider.video);
+                    if (__HEADLESS__) {
+                        console.error('Provider should implement `removeFromContainer()` to background provider media view. Calling `provider.setContainer(null)` instead.');
+                        provider.setContainer(null);
+                    } else {
+                        container.removeChild(provider.video);
+                    }
                 }
                 this.container = null;
             }

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -747,7 +747,9 @@ class ProgramController extends Events {
             background.currentMedia.mute = mute;
         }
 
-        mediaPool.syncMute(mute);
+        if (!__HEADLESS__) {
+            mediaPool.syncMute(mute);
+        }
     }
 
     /**
@@ -766,7 +768,9 @@ class ProgramController extends Events {
             background.currentMedia.volume = volume;
         }
 
-        mediaPool.syncVolume(volume);
+        if (!__HEADLESS__) {
+            mediaPool.syncVolume(volume);
+        }
     }
 
     set itemCallback(callback) {


### PR DESCRIPTION
### This PR will...
Update headless player for better compatibility with instream ad playback.
- Remove cyclical `vastAd` object from instream playlist items received from vast plugin
- Update provider volume and mute upon activation
- Do not call `container.removeChild` in headless player, regardless of provider implementation
- Remove `mediaPool.syncMute`  calls from headless player

### Why is this Pull Request needed?
Allows for headless external providers to play ads as expected using instream.

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/7617

#### Addresses Issue(s):
JW8-11067

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
