### PR TITLE
[JW8-11004][JW8-11003] Fix audioTrack selection handling and gear toggling

### DIFF
--- a/src/js/view/controls/components/menu/settings-menu.js
+++ b/src/js/view/controls/components/menu/settings-menu.js
@@ -91,7 +91,7 @@ class SettingsMenu extends Menu {
         if (!this.children.audioTracks) {
             return;
         }
-        this.children.audioTracks.items[trackIndex].activate();
+        selectMenuItem(this.children.audioTracks, trackIndex);
     }
 
     onCaptionsList(model, captionsList) {
@@ -353,6 +353,7 @@ class SettingsMenu extends Menu {
         const shouldShowGear = 
             !!children.quality || 
             !!children.playbackRates || 
+            !!children.audioTracks ||
             Object.keys(children).length > 1;
 
         controlbar.elements.settingsButton.toggle(shouldShowGear);


### PR DESCRIPTION
### This PR will...
- Use proper handler for audioTrack selection
- Add audioTracks menu to menus that show gear icon

### Why is this Pull Request needed?
https://jwplayer.atlassian.net/browse/SERV-7396
https://jwplayer.atlassian.net/browse/JW8-11003

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-11003

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
