### PR TITLE
[JW8-11238] Enable emsg messageData in IE

### DIFF
--- a/src/js/providers/tracks-mixin.ts
+++ b/src/js/providers/tracks-mixin.ts
@@ -851,7 +851,7 @@ function _addCueToTrack(renderNatively: boolean, track: TextTrackLike, vttCue: T
 
             if (vttCue.value) {
                 const event = cue.text ? getTextCueMetaEvent(cue) : null;
-                if (event.metadataType === 'emsg') {
+                if (event && event.metadataType === 'emsg') {
                     cue.value = vttCue.value;
                 }
             }

--- a/src/js/providers/tracks-mixin.ts
+++ b/src/js/providers/tracks-mixin.ts
@@ -850,8 +850,7 @@ function _addCueToTrack(renderNatively: boolean, track: TextTrackLike, vttCue: T
             cue = new window.TextTrackCue(vttCue.startTime, vttCue.endTime, vttCue.text);
 
             if (vttCue.value) {
-                    cue.value = vttCue.value;
-                }
+                cue.value = vttCue.value;
             }
         }
         insertCueInOrder(track, cue);

--- a/src/js/providers/tracks-mixin.ts
+++ b/src/js/providers/tracks-mixin.ts
@@ -848,6 +848,13 @@ function _addCueToTrack(renderNatively: boolean, track: TextTrackLike, vttCue: T
             // We need to convert VTTCue to TextTrackCue before adding them to the TextTrack
             // This unfortunately removes positioning properties from the cues
             cue = new window.TextTrackCue(vttCue.startTime, vttCue.endTime, vttCue.text);
+
+            if (vttCue.value) {
+                const event = cue.text ? getTextCueMetaEvent(cue) : null;
+                if (event.metadataType === 'emsg') {
+                    cue.value = vttCue.value;
+                }
+            }
         }
         insertCueInOrder(track, cue);
     } else {

--- a/src/js/providers/tracks-mixin.ts
+++ b/src/js/providers/tracks-mixin.ts
@@ -850,8 +850,6 @@ function _addCueToTrack(renderNatively: boolean, track: TextTrackLike, vttCue: T
             cue = new window.TextTrackCue(vttCue.startTime, vttCue.endTime, vttCue.text);
 
             if (vttCue.value) {
-                const event = cue.text ? getTextCueMetaEvent(cue) : null;
-                if (event && event.metadataType === 'emsg') {
                     cue.value = vttCue.value;
                 }
             }


### PR DESCRIPTION
### This PR will...
Assign vttCue value to IE TextTrackCue.

### Why is this Pull Request needed?
TracksMixin looks for `cue.value` to set up messageData.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-11238



### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
