### PR TITLE
[JW8-11247] Tracking seeking state in video listener mixins

### DIFF
--- a/src/js/providers/default.ts
+++ b/src/js/providers/default.ts
@@ -7,7 +7,6 @@ import type * as Event from 'events/events';
 import type { TracksMixin, SimpleAudioTrack } from 'providers/tracks-mixin';
 import type { VideoActionsInt } from 'providers/video-actions-mixin';
 import type { VideoAttachedInt } from 'providers/video-attached-mixin';
-import type { VideoListenerInt } from 'providers/video-listener-mixin';
 import type PlaylistItem from 'playlist/item';
 import type { QualityLevel } from 'providers/data-normalizer';
 import type { PlaylistItemSource } from 'playlist/source';
@@ -224,7 +223,7 @@ export interface ImplementedProvider extends InternalProvider {
 export type AllProviderEvents = ProviderEvents & ProviderEventNotifications;
 export type AllProviderEventsListener = <E extends keyof AllProviderEvents>(type: E, data: AllProviderEvents[E]) => void;
 
-export type ProviderWithMixins = TracksMixin & VideoActionsInt & VideoAttachedInt & VideoListenerInt & ImplementedProvider & {
+export type ProviderWithMixins = TracksMixin & VideoActionsInt & VideoAttachedInt & ImplementedProvider & {
     drmUsed?: 'widevine' | 'playready' | 'clearkey' | null;
     // Providers can implement this method to add the invoked return value on "time" events `metadata.mpegts` property.
     getPtsOffset?(): number;

--- a/src/js/providers/html5.ts
+++ b/src/js/providers/html5.ts
@@ -71,7 +71,7 @@ interface HTML5Provider extends ProviderWithMixins {
 }
 
 function VideoProvider(this: HTML5Provider, _playerId: string, _playerConfig: GenericObject, mediaElement: HTMLVideoElement): void {
-    const _this = this;
+    const _this: HTML5Provider = this;
 
     // Current media state
     _this.state = STATE_IDLE;
@@ -104,12 +104,12 @@ function VideoProvider(this: HTML5Provider, _playerId: string, _playerConfig: Ge
     }
 
     const MediaEvents = {
-        progress(): void {
+        progress(this: ProviderWithMixins): void {
             VideoEvents.progress.call(_this);
             checkStaleStream();
         },
 
-        timeupdate(): void {
+        timeupdate(this: ProviderWithMixins): void {
             if (_this.currentTime >= 0) {
                 // Reset error retries after concurrent timeupdate events
                 _this.retries = 0;
@@ -128,13 +128,13 @@ function VideoProvider(this: HTML5Provider, _playerId: string, _playerConfig: Ge
 
         resize: checkVisualQuality,
 
-        ended(): void {
+        ended(this: ProviderWithMixins): void {
             _currentQuality = -1;
             clearTimeouts();
             VideoEvents.ended.call(_this);
         },
 
-        loadedmetadata(): void {
+        loadedmetadata(this: ProviderWithMixins): void {
             let duration = _this.getDuration();
             if (_androidHls && duration === Infinity) {
                 duration = 0;
@@ -149,20 +149,20 @@ function VideoProvider(this: HTML5Provider, _playerId: string, _playerConfig: Ge
             checkVisualQuality();
         },
 
-        durationchange(): void {
+        durationchange(this: ProviderWithMixins): void {
             if (_androidHls) {
                 return;
             }
             VideoEvents.progress.call(_this);
         },
 
-        loadeddata(): void {
+        loadeddata(this: ProviderWithMixins): void {
             checkStartDateTime();
             _setAudioTracks(_videotag.audioTracks);
             _checkDelayedSeek(_this.getDuration());
         },
 
-        canplay(): void {
+        canplay(this: ProviderWithMixins): void {
             _canSeek = true;
             if (!_androidHls) {
                 _setMediaType();
@@ -171,7 +171,7 @@ function VideoProvider(this: HTML5Provider, _playerId: string, _playerConfig: Ge
             VideoEvents.canplay.call(_this);
         },
 
-        seeking(): void {
+        seeking(this: ProviderWithMixins): void {
             const offset = _seekToTime !== null ? timeToPosition(_seekToTime) : _this.getCurrentTime();
             const position = timeToPosition(_timeBeforeSeek as number);
             _timeBeforeSeek = _seekToTime;
@@ -184,13 +184,13 @@ function VideoProvider(this: HTML5Provider, _playerId: string, _playerConfig: Ge
             });
         },
 
-        seeked(): void {
+        seeked(this: ProviderWithMixins): void {
             VideoEvents.seeked.call(_this);
             _this.ensureMetaTracksActive();
         },
 
-        waiting(): void{
-            if (_this.seeking) {
+        waiting(this: ProviderWithMixins): void{
+            if (_this.seeking || _this.video.seeking) {
                 _this.setState(STATE_LOADING);
             } else if (_this.state === STATE_PLAYING) {
                 if (_this.atEdgeOfLiveStream()) {

--- a/src/js/providers/video-listener-mixin.ts
+++ b/src/js/providers/video-listener-mixin.ts
@@ -19,6 +19,7 @@ export interface VideoListenerInt {
     timeupdate(): void;
     click(evt: Event): void;
     volumechange(): void;
+    seeking(): void;
     seeked(): void;
     playing(): void;
     pause(): void;
@@ -116,6 +117,12 @@ const VideoListenerMixin: VideoListenerInt = {
         this.trigger(MEDIA_MUTE, {
             mute: video.muted
         });
+    },
+
+    seeking(this: ProviderWithMixins): void {
+        this.seeking = true;
+        // TODO: this.trigger(MEDIA_SEEK implementation from html5 should be moved here
+        //  and removed frrom hlsjs/shaka providers
     },
 
     seeked(this: ProviderWithMixins): void {


### PR DESCRIPTION
### This PR will...
Set `provider.seeking` to `true` when receiving a `"seeking"` event from the video element. 

### Why is this Pull Request needed?
The video-event-listener mixin sets `provider.seeking` to `false` on `"seeked"` but expects the provider to set it to` true` when seeking starts. hlsjs and shaka only update `this.seeking` when seeking is performed using the player API. The `seeking` flag is never updated when seeking is initiated externally (by setting `video.currentTime`).

As a result, hlsjs and shaka's `"waiting"` video event handler interpret this event as a stall, because the `seeking` flag is `false` when it should be `true`.

### Are there any points in the code the reviewer needs to double check?
1. Ultimately the seeking/waiting listeners and seek/stall triggers should be implemented in the mixin, normalizing them across providers. We're still triggering JWP "seek" events when seeks are made externally which should be addressed eventually.
2. The video-listener-mixin does not extend the provider interface. Each method in this mixin is an HTMLVideoElement event handler. Providers bind event listeners to themselves using the mixin method's names, but the methods are not added to the provider. (See TS changes) This is important because providers have a `seeking` flag, while `"seeking"` is also the name of a video event and video-listener-mixin method.

### Are there any Pull Requests open in other repos which need to be merged with this?
No.

#### Addresses Issue(s):
JW8-11247

### Checklist
- [x] Jenkins builds and unit tests are passing
- [x] I have reviewed the automated results
