### PR TITLE
[JW8-11240] Copy preload setting from updated playlist item

### DIFF
--- a/src/js/playlist/playlist.js
+++ b/src/js/playlist/playlist.js
@@ -31,7 +31,7 @@ export function normalizePlaylistItem(model, item, feedData) {
 
     playlistItem.preload = getPreload(item.preload, preload);
 
-    playlistItem.allSources = formatSources(item, model);
+    playlistItem.allSources = formatSources(playlistItem, model);
 
     playlistItem.sources = filterSources(playlistItem.allSources, providers);
 


### PR DESCRIPTION
### This PR will...
Fix copying of "preload" config option from top level to playlist source object. 

### Why is this Pull Request needed?
Fix support for setting of the preload option in the config and have it applied to sources in the playlist:
```
{ 
    playlist: feedUrl,
    preload:"auto"
}
```
#### Addresses Issue(s):
JW8-11240

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
