### PR TITLE
Skip plugin loading and calling container.removeChild in headless player

### DIFF
--- a/src/js/plugins/model.ts
+++ b/src/js/plugins/model.ts
@@ -15,6 +15,9 @@ class PluginModel {
             return registeredPlugin.promise;
         }
         const plugin = this.addPlugin(url);
+        if (__HEADLESS__) {
+            return Promise.reject(`Skipping loading of unsupported js plugin "${url}" in headless player.`);
+        }
         return plugin.load();
     }
 


### PR DESCRIPTION
### This PR will...
Skip plugin loading and calling container.removeChild in headless player

### Why is this Pull Request needed?
Prevents the headless player from attempting to load "dai" and "googima" plugins based on `advertising` config. The SDKs must implement their own integration. Any js plugins should already be embeded prior to player setup ("vast" and "jwpsrv").

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/7644

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
