### PR TITLE
Fix `startOnSeek` with `item.starttime` 

### DIFF
--- a/src/js/providers/video-listener-mixin.ts
+++ b/src/js/providers/video-listener-mixin.ts
@@ -98,7 +98,7 @@ const VideoListenerMixin: VideoListenerInt = {
         }
 
         // only emit time events when playing or seeking
-        if (this.state === STATE_PLAYING || this.seeking) {
+        if (this.state === STATE_PLAYING || (this.seeking && this.state !== STATE_IDLE)) {
             this.trigger(MEDIA_TIME, timeEventObject);
         }
     },


### PR DESCRIPTION
### This PR will...
Prevent "time" events from firing when video element currentTime changes before loading

### Why is this Pull Request needed?
We pass item start time to `shakaPlayer.load(url, item.starttime)`. Shaka will set `video.currentTime` to this value before playback begins triggering a seek. This seek should not trigger a "time" event while the provide is IDLE otherwise, the ad plugin's `startOnSeek: 'pre'` logic will kick in and begin an ad break without user-interaction or `jwplayer().play()` being called.

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):
JW8-11301

### Checklist
- [x] Jenkins builds and unit tests are passing
- [x] I have reviewed the automated results
