### PR TITLE
[JW8-11279] Reset media related settings menus on playlistItem

### DIFF
--- a/src/js/view/controls/components/menu/settings-menu.js
+++ b/src/js/view/controls/components/menu/settings-menu.js
@@ -192,9 +192,10 @@ class SettingsMenu extends Menu {
     }
 
     onPlaylistItem() {
-        // captions.js silently clears captions when the playlist item changes. The reason it silently clear captions
-        // instead of dispatching an event is because we don't want to emit 'captionsList' if the new list is empty.
+        // Remove menus related to mediaModel properties. They will be populated when the model is populated.
         this.removeMenu('captions');
+        this.removeMenu('audioTracks');
+        this.removeMenu('quality');
         this.controlbar.elements.captionsButton.hide();
     
         // Settings menu should not be visible when switching playlist items via controls or .load()


### PR DESCRIPTION
### This PR will...
Reset media related settings menus on playlistItem

### Why is this Pull Request needed?
Clear quality and audio track menus as soon as the playlist item changes. The mediaModel stores media levels and audio tracks. When the mediaModel is replaces between playlist items, this does not trigger a change event in the view model for all the mediaModel attributes that were once populated. View components should reset on playlist item.

## Are there any Pull Requests open in other repos which need to be merged with this?
Tangential but unrelated fix to `getAudioTracks()`
https://github.com/jwplayer/jwplayer-commercial/pull/7646

#### Addresses Issue(s):
JW8-11279


### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
