### PR TITLE
[JW8-11309] Ignore seeks by provider player engines that jump start gaps

### DIFF
--- a/src/js/providers/video-listener-mixin.ts
+++ b/src/js/providers/video-listener-mixin.ts
@@ -120,9 +120,15 @@ const VideoListenerMixin: VideoListenerInt = {
     },
 
     seeking(this: ProviderWithMixins): void {
+        // TODO: Use trigger(MEDIA_SEEK) implementation from html5 removed from hlsjs/shaka providers
+        if (this.state === STATE_LOADING) {
+            // Ignore seeks performed by shaka-player and hls.js to jump initial buffer gap before play
+            const bufferStart = this.video.buffered.length ? this.video.buffered.start(0) : -1;
+            if (this.video.currentTime === bufferStart) {
+                return;
+            }
+        }
         this.seeking = true;
-        // TODO: this.trigger(MEDIA_SEEK implementation from html5 should be moved here
-        //  and removed frrom hlsjs/shaka providers
     },
 
     seeked(this: ProviderWithMixins): void {


### PR DESCRIPTION
### This PR will...
Ignore seeks by provider player engines that jump start gaps.

### Why is this Pull Request needed?
To maintain current event flow with videos that have start gaps where shaka seeks after clicking play and before playback begins.

This is the expected order even though there is a seek before play. If we track that seek by setting provider `seeking` to true then a "time", "firstFrame", "seeked" and "visualQuality" will all fire before the "play" event.
```
displayClick
beforePlay
playAttempt
play
firstFrame
visualQuality
time
```

### Resolves issue
JW8-11309 [🥒 d5a38312c90b3f9a](https://jenkins.jwplayer.com/view/Player-Test-release/job/jw7-wdio-commercial-release-cucumber-chrome/128/allure/#suites/0e3ceb5436353f9d1d9971ec26ff1af5/d5a38312c90b3f9a/)


### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
