### PR TITLE
[JW8-11311] Ignore seeking state when resetting currentTime to 0 while idle

### DIFF
--- a/src/js/providers/video-listener-mixin.ts
+++ b/src/js/providers/video-listener-mixin.ts
@@ -127,6 +127,8 @@ const VideoListenerMixin: VideoListenerInt = {
             if (this.video.currentTime === bufferStart) {
                 return;
             }
+        } else if (this.state === STATE_IDLE && this.video.currentTime === 0) {
+            return;
         }
         this.seeking = true;
     },


### PR DESCRIPTION
### This PR will...
Ignore seeking state when resetting currentTime to 0 while idle

### Why is this Pull Request needed?
hls.js and shaka may perform seeks on level errors that should be ignored. Seek or pauses on the video element can change player state.

#### Addresses Issue(s):
JW8-11311

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
