### PR TITLE
[JW8-11323] Ignore seeking state change while idle

### DIFF
--- a/src/js/providers/video-listener-mixin.ts
+++ b/src/js/providers/video-listener-mixin.ts
@@ -127,7 +127,7 @@ const VideoListenerMixin: VideoListenerInt = {
             if (this.video.currentTime === bufferStart) {
                 return;
             }
-        } else if (this.state === STATE_IDLE && this.video.currentTime === 0) {
+        } else if (this.state === STATE_IDLE) {
             return;
         }
         this.seeking = true;


### PR DESCRIPTION
### This PR will...
Ignore seeking state change while idle

### Why is this Pull Request needed?
So that the player state does not change to paused when starttime is set in the config.

#### Addresses Issue(s):
JW8-11323

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
