### PR TITLE
Remote meta tag vuln from element creation

### DIFF
--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -82,7 +82,7 @@ function domParse(html) {
 
 
 export function sanitizeScriptNodes(element) {
-    const nodes = element.querySelectorAll('script,object,iframe');
+    const nodes = element.querySelectorAll('script,object,iframe,meta');
     for (let i = nodes.length; i--;) {
         const node = nodes[i];
         node.parentNode.removeChild(node);


### PR DESCRIPTION
### This PR will...
Disallow meta tags from being placed into rendered elements in the player

### Why is this Pull Request needed?
You can inject a redirection meta tag which could forward someone to a nefarious website without their permission. Currently only affects Chrome, or Safari once the player begins to play

### Are there any points in the code the reviewer needs to double check?
Nope

### Are there any Pull Requests open in other repos which need to be merged with this?
Nope

#### Addresses Issue(s):

JW8-11338

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
