### PR TITLE
[JW8-11308] Add new API to expose player viewable percentage

### DIFF
--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -443,6 +443,16 @@ export default function Api(element) {
         },
 
         /**
+         * Gets the player's visibility.
+         * @returns {Number} Returns a number between 0 and 1 that represents how much of the player is in the document viewport.
+         * Returns 0 if the player is not in an active tab, or if the player is completely out of the viewport.
+         * @since v8.18.0
+         */
+        getPercentViewable() {
+            return core.get('visibility');
+        },
+
+        /**
          * Gets the rate at which playback should occur while media is playing.
          * @default 1.0
          * @returns {number} The playback rate of the media element (`HTMLMediaElement.playbackRate`).

--- a/test/data/api-methods.js
+++ b/test/data/api-methods.js
@@ -33,6 +33,7 @@ export default {
     getHeight: null,
     getItemMeta: null,
     getMute: null,
+    getPercentViewable: null,
     getPlaybackRate: null,
     getPlaylist: null,
     getPlaylistIndex: null,

--- a/test/unit/api-test.js
+++ b/test/unit/api-test.js
@@ -282,6 +282,7 @@ describe('Api', function() {
         expect(api.getItemMeta(), '.getItemMeta()').to.eql({});
         expect(api.getMute(), '.getMute()').to.equal(undefined);
         expect(api.getVolume(), '.getVolume()').to.equal(undefined);
+        expect(api.getPercentViewable(), '.getPercentViewable()').to.equal(undefined);
         expect(api.getPlaybackRate(), '.getPlaybackRate()').to.equal(undefined);
         expect(api.getPlaylist(), '.getPlaylist()').to.equal(undefined);
         expect(api.getPlaylistIndex(), '.getPlaylistIndex()').to.equal(undefined);
@@ -331,6 +332,7 @@ describe('Api', function() {
             expect(api.getItemMeta(), '.getItemMeta()').to.eql({});
             expect(api.getMute(), '.getMute()').to.be.a('boolean');
             expect(api.getVolume(), '.getVolume()').to.be.a('number');
+            expect(api.getPercentViewable(), '.getPercentViewable()').to.equal(undefined);
             expect(api.getPlaybackRate(), '.getPlaybackRate()').to.equal(1);
             expect(api.getPlaylist(), '.getPlaylist()').to.be.an('array');
             expect(api.getPlaylistIndex(), '.getPlaylistIndex()').to.equal(0);


### PR DESCRIPTION
### This PR will...
- Add new API to expose `visibility`, which represents the percent viewable of the player

### Why is this Pull Request needed?
- Feature request from the Data Team

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-11308

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
