### PR TITLE
JW8-11321: Update back button aria label contextually

### DIFF
--- a/src/js/view/controls/components/menu/menu.js
+++ b/src/js/view/controls/components/menu/menu.js
@@ -22,6 +22,7 @@ export default class Menu extends Events {
         this.toggle = this.toggle.bind(this);
         this.name = _name;
         this.title = _title || _name;
+        this.localization = _localization;
         this.isSubmenu = !!_parentMenu;
         this.el = createElement(_template(this.isSubmenu, _name));
         this.buttonContainer = this.el.querySelector(`.jw-${this.name}-topbar-buttons`);
@@ -38,7 +39,7 @@ export default class Menu extends Events {
                 this.categoryButton = this.createCategoryButton();
             }
             if (this.parentMenu.parentMenu && !this.mainMenu.backButton) {
-                this.mainMenu.backButton = this.createBackButton(_localization);
+                this.mainMenu.backButton = this.createBackButton(this.localization);
             }
             this.itemsContainer = this.createItemsContainer();
             this.parentMenu.appendMenu(this);
@@ -122,6 +123,12 @@ export default class Menu extends Events {
         );
         prependChild(this.mainMenu.topbar.el, backButton.element());
         return backButton;
+    }
+    setBackButtonAriaLabel(labelText) {
+        const backButtonElement = this.mainMenu.backButton.element();
+        const localizedPrevious = this.localization.prev;
+        const backButtonText = labelText ? localizedPrevious + ' - ' + labelText : localizedPrevious;
+        backButtonElement.setAttribute('aria-label', backButtonText);
     }
     createTopbar() {
         const topbar = createElement(`<div class="jw-reset jw-submenu-topbar"></div>`);
@@ -329,12 +336,14 @@ export default class Menu extends Events {
         if (parentMenu.isSubmenu) {
             parentMenu.el.classList.remove('jw-settings-submenu-active');
             mainMenu.topbar.el.classList.add('jw-nested-menu-open');
-            const menuTitle = mainMenu.topbar.el.querySelector('.jw-settings-topbar-text');
-            menuTitle.setAttribute('name', this.title);
-            menuTitle.innerText = this.title;
+            const menuTitleElement = mainMenu.topbar.el.querySelector('.jw-settings-topbar-text');
+            menuTitleElement.setAttribute('name', this.title);
+            menuTitleElement.innerText = this.title;
+            const parentMenuTitle = parentMenu.title;
+            this.setBackButtonAriaLabel(parentMenuTitle);
             mainMenu.backButton.show();
             this.mainMenu.backButtonTarget = this.parentMenu;
-            focusEl = menuTitle;
+            focusEl = menuTitleElement;
         } else {
             mainMenu.topbar.el.classList.remove('jw-nested-menu-open');
             if (mainMenu.backButton) {

--- a/src/js/view/controls/components/menu/menu.js
+++ b/src/js/view/controls/components/menu/menu.js
@@ -127,7 +127,7 @@ export default class Menu extends Events {
     setBackButtonAriaLabel(labelText) {
         const backButtonElement = this.mainMenu.backButton.element();
         const localizedPrevious = this.localization.prev;
-        const backButtonText = labelText ? localizedPrevious + ' - ' + labelText : localizedPrevious;
+        const backButtonText = labelText ? localizedPrevious + ' - Button - ' + labelText : localizedPrevious;
         backButtonElement.setAttribute('aria-label', backButtonText);
     }
     createTopbar() {

--- a/src/js/view/controls/components/menu/menu.js
+++ b/src/js/view/controls/components/menu/menu.js
@@ -22,7 +22,7 @@ export default class Menu extends Events {
         this.toggle = this.toggle.bind(this);
         this.name = _name;
         this.title = _title || _name;
-        this.localization = _localization;
+        this.localizedPrevious = _localization.prev;
         this.isSubmenu = !!_parentMenu;
         this.el = createElement(_template(this.isSubmenu, _name));
         this.buttonContainer = this.el.querySelector(`.jw-${this.name}-topbar-buttons`);
@@ -39,7 +39,7 @@ export default class Menu extends Events {
                 this.categoryButton = this.createCategoryButton();
             }
             if (this.parentMenu.parentMenu && !this.mainMenu.backButton) {
-                this.mainMenu.backButton = this.createBackButton(this.localization);
+                this.mainMenu.backButton = this.createBackButton(this.localizedPrevious);
             }
             this.itemsContainer = this.createItemsContainer();
             this.parentMenu.appendMenu(this);
@@ -108,7 +108,7 @@ export default class Menu extends Events {
         const categoryButton = menuCategoryButton(this);
         return categoryButton;
     }
-    createBackButton(localization) {
+    createBackButton(localizedPrevious) {
         const getPreviousMenu = () => this.mainMenu.backButtonTarget;
         const backButton = button(
             'jw-settings-back', 
@@ -118,7 +118,7 @@ export default class Menu extends Events {
                     menu.open(evt);
                 }
             }, 
-            localization.prev, 
+            localizedPrevious,
             [cloneIcon('arrow-left')]
         );
         prependChild(this.mainMenu.topbar.el, backButton.element());
@@ -126,8 +126,7 @@ export default class Menu extends Events {
     }
     setBackButtonAriaLabel(labelText) {
         const backButtonElement = this.mainMenu.backButton.element();
-        const localizedPrevious = this.localization.prev;
-        const backButtonText = labelText ? localizedPrevious + ' - Button - ' + labelText : localizedPrevious;
+        const backButtonText = labelText ? this.localizedPrevious + ' - ' + labelText : this.localizedPrevious;
         backButtonElement.setAttribute('aria-label', backButtonText);
     }
     createTopbar() {


### PR DESCRIPTION
### This PR will...
This PR adds a method for updating the Aria Label of the back button in the captions menu based on what the previous menu viewed was. 

The aria label used to always be "Previous" (or whatever localized word(s) were chosen). Now, it will properly reflect the prior menu that was viewed, e.g., it will be "Previous - Closed Captions" when clicking into a sub-menu beyond the Closed Captions menu.

### Why is this Pull Request needed?
This PR improves the accessibility of these menus and therefore the player overall.
### Are there any points in the code the reviewer needs to double check?
This is my first PR - please double-check all of it!
### Are there any Pull Requests open in other repos which need to be merged with this?
Yes - there's a PR in commercial for a new cucumber test. https://github.com/jwplayer/jwplayer-commercial/pull/7692
#### Addresses Issue(s):

https://jwplayer.atlassian.net/browse/JW8-11321

### Checklist
- [x] Jenkins builds and unit tests are passing
- [x] I have reviewed the automated results
