### PR TITLE
[JW8-11368] Add headless player model get/set access and internal casting integration methods

### DIFF
--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -197,6 +197,13 @@ export default function Api(element) {
 
     });
 
+    if (__HEADLESS__) {
+        this.get = (attribute) => core.get(attribute);
+        this.set = (attribute, value) => core.set(attribute, value);
+        this.castVideo = (castProvider, item) => core.castVideo(castProvider, item);
+        this.stopCast = () => core.stopCast();
+    }
+
     Object.assign(this, /** @lends Api.prototype */ {
         /**
          * A map of event listeners.

--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -65,6 +65,15 @@ const CoreShim = function(originalContainer) {
     ], () => true);
 };
 
+if (__HEADLESS__) {
+    CoreShim.prototype.set = function(property, value) {
+        if (!this.modelShim) {
+            return;
+        }
+        return this.modelShim.set(property, value);
+    };
+}
+
 Object.assign(CoreShim.prototype, {
     on: Events.on,
     once: Events.once,

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -51,6 +51,12 @@ function normalizeState(newstate) {
 const Controller = function() {};
 const noop = function() {};
 
+if (__HEADLESS__) {
+    Controller.prototype.set = function(property, value) {
+        return this._model.set(property, value);
+    };
+}
+
 Object.assign(Controller.prototype, {
     setup(config, _api, originalContainer, eventListeners, commandQueue, mediaPool) {
         const _this = this;


### PR DESCRIPTION
### This PR will...
Give the headless player model access through `api.set` and `api.set` methods. Also give headless player ability to implement external chromecast integrations using `api.castVideo` and `api.stopCast`.

### Why is this Pull Request needed?
For SDKs to have direct access to the player model properties used in integrations like casting.

### Other points

See confluence docs
https://jwplayer.atlassian.net/wiki/spaces/JW8/pages/1016660021/Headless+JavaScript+Player#6.-Private-model-access

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/7694

#### Addresses Issue(s):
JW8-11368

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
