### PR TITLE
[JW8-11366] Prevent recursive overlap correction when an empty box is moved to line position

### DIFF
--- a/src/js/polyfills/webvtt.js
+++ b/src/js/polyfills/webvtt.js
@@ -694,7 +694,7 @@ function moveBoxToLinePosition(window, styleBox, containerBox, boxPositions, num
 
         // Prevent empty boxes from entering recursive overlap correction.
         if (!b.height || !b.width) {
-            return b;
+            return specifiedPosition;
         }
     
         for (let i = 0; i < axis.length; i++) {

--- a/src/js/polyfills/webvtt.js
+++ b/src/js/polyfills/webvtt.js
@@ -692,6 +692,11 @@ function moveBoxToLinePosition(window, styleBox, containerBox, boxPositions, num
         let percentage = 0; // Lowest possible so the first thing we get is better.
         let bestAxis;
 
+        // Prevent empty boxes from entering recursive overlap correction.
+        if (!b.height || !b.width) {
+            return b;
+        }
+    
         for (let i = 0; i < axis.length; i++) {
             while (b.overlapsOppositeAxis(containerBox, axis[i]) ||
             (b.within(containerBox) && b.overlapsAny(boxPositions))) {


### PR DESCRIPTION
### This PR will...
Prevent recursive overlap correction when an empty box is moved to line position

### Why is this Pull Request needed?
When moveToLinePosition is called and the stylebox has no height, while loop never exists.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-11366

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
