### PR TITLE
[JW8-11108] Display notLive text for DVR streams

### DIFF
--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -282,7 +282,7 @@ export default class Controlbar {
             // jw-dvr-live: Player is in DVR mode but not at the live edge.
             toggleClass(liveElement, 'jw-dvr-live', dvrNotLive);
             setAttribute(liveElement, 'aria-label', dvrNotLive ? notLive : liveBroadcast);
-            liveElement.textContent = liveBroadcast;
+            liveElement.textContent = dvrNotLive ? notLive : liveBroadcast;
         }, this);
         _model.change('altText', this.setAltText, this);
         _model.change('customButtons', this.updateButtons, this);


### PR DESCRIPTION
### This PR will...
Update the DVR Live button to display the `notLive` text when the stream is not at the live edge.

### Why is this Pull Request needed?
Bugfix

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?
Nah

#### Addresses Issue(s):

JW8-11108

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
