### PR TITLE
Update OS.tizen to OS.tizenApp

### DIFF
--- a/src/js/api/core-bundle-loader.js
+++ b/src/js/api/core-bundle-loader.js
@@ -21,7 +21,7 @@ function selectBundle(model) {
     const polyfills = requiresPolyfills();
     const html5Provider = requiresProvider(model, 'html5');
 
-    if (OS.tizenApp) {
+    if (OS.tizen) {
         return loadWebCore();
     }
 

--- a/src/js/api/core-bundle-loader.js
+++ b/src/js/api/core-bundle-loader.js
@@ -21,7 +21,7 @@ function selectBundle(model) {
     const polyfills = requiresPolyfills();
     const html5Provider = requiresProvider(model, 'html5');
 
-    if (OS.tizen) {
+    if (OS.tizenApp) {
         return loadWebCore();
     }
 

--- a/src/js/controller/controls-loader.js
+++ b/src/js/controller/controls-loader.js
@@ -7,7 +7,7 @@ export const ControlsLoader = {};
 
 export function loadControls() {
     if (!controlsPromise) {
-        if (OS.tizen) {
+        if (OS.tizenApp) {
             controlsPromise = require.ensure(['view/controls/tizen/tizen-controls'], function (require) {
                 const ControlsModule = require('view/controls/tizen/tizen-controls').default;
                 ControlsLoader.controls = ControlsModule;

--- a/src/js/controller/model.ts
+++ b/src/js/controller/model.ts
@@ -287,12 +287,6 @@ class Model extends SimpleModel {
     // Mobile players always wait to become viewable.
     // Desktop players must have autostart set to viewable
     setAutoStart(autoStart?: AutoStart): void {
-        // Always autostart for tizen app
-        if (OS.tizenApp) {
-            this.set('autostart', true);
-            return;
-        }
-
         if (autoStart !== undefined) {
             this.set('autostart', autoStart);
         }

--- a/src/js/controller/model.ts
+++ b/src/js/controller/model.ts
@@ -288,7 +288,7 @@ class Model extends SimpleModel {
     // Desktop players must have autostart set to viewable
     setAutoStart(autoStart?: AutoStart): void {
         // Always autostart for tizen app
-        if (OS.tizen) {
+        if (OS.tizenApp) {
             this.set('autostart', true);
             return;
         }


### PR DESCRIPTION
### This PR will...
Change `OS.tizen` to `OS.tizenApp` where appropriate. This was originally needed so that the app could be developed on the in tizen studio, but the tizen app controls should not be loaded if the user is in the Samsung Browser.
### Why is this Pull Request needed?
Tizen Demo App
### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

N/A

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
