### PR TITLE
[JW8-11476] Clear captions list on attachMedia before adding new captions

### DIFF
--- a/src/js/providers/html5.ts
+++ b/src/js/providers/html5.ts
@@ -317,6 +317,7 @@ function VideoProvider(this: HTML5Provider, _playerId: string, _playerConfig: Ge
             }
 
             if (this.renderNatively) {
+                this.clearTracks();
                 this.setTextTracks(this.video.textTracks);
             }
             this.addTracksListener(_videotag.textTracks, 'change', this.textTrackChangeHandler);


### PR DESCRIPTION
### This PR will...
- Clear captions track when calling `attachMedia` so that the tracks are added on a fresh list

### Why is this Pull Request needed?
- Safari has issues with duplicated tracks after ad breaks

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-11476

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
