### PR TITLE
Track "fairplay" DRM playback

### DIFF
--- a/src/js/providers/default.ts
+++ b/src/js/providers/default.ts
@@ -54,7 +54,7 @@ export type ProviderEvents = {
         height?: number;
         width?: number;
         seekRange?: SeekRange;
-        drm?: 'widevine' | 'playready' | 'clearkey' | null;
+        drm?: 'widevine' | 'playready' | 'fairplay' | 'clearkey' | null;
     };
     [Event.MEDIA_BUFFER]: {
         bufferPercent: number;


### PR DESCRIPTION
### This PR will...
Include `drm` in `"meta": { metadataType: "media" }` event from html5 provider.

### Why is this Pull Request needed?
Allows tracking of "fairplay" DRM playback in the same way that "widevine" and "playready" playback is tracked.

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-analytics/pull/640

### Checklist
- [x] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
