### PR TITLE
Revert changed styling from Tizen rebase

### DIFF
--- a/src/css/controls/imports/controlbar.less
+++ b/src/css/controls/imports/controlbar.less
@@ -90,6 +90,7 @@
 .jw-button-container {
     display: -webkit-box;
     display: -webkit-flex;
+    display: flex;
     flex-flow: row nowrap;
     flex: 1 1 auto;
     align-items: center;

--- a/src/css/controls/imports/settings-menu.less
+++ b/src/css/controls/imports/settings-menu.less
@@ -10,7 +10,8 @@
     pointer-events: auto;
 
     .jw-settings-open & {
-        display: block;
+        display: -webkit-box;
+        display: -webkit-flex;
         display: flex;
     }
 


### PR DESCRIPTION
### This PR will...
Revert styles that were changed in `controlbar.less` and `settings-menu.less` in a tizen rebase commit to styles used in previous release 8.17.4 and cut 8.18.0-beta.1
### Why is this Pull Request needed?
During a tizen rebase cleanup, the styles of `controlbar.less` and `settings-menu.less` were changed in this commit: https://github.com/jwplayer/jwplayer/commit/8a69bc591725ae45c635f31b568a135071f56a64
These changes seemed to have originated from this commit: https://github.com/jwplayer/jwplayer/commit/31a2059b38e2800057492e86a11d829894059da8

In an effort to keep the styling consistent with current previous styles and avoid any side-effects, the current changes were compared with the latest release 8.17.4: https://github.com/jwplayer/jwplayer/compare/v8.17.4...v8.18.0-beta.3

and with the previous cut 8.18.0-beta.1: https://github.com/jwplayer/jwplayer/compare/v8.18.0-beta.1...v8.18.0-beta.3

The style changes are the same between the latest release and the previous cut, so those changes are reverted here.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

N/A

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
