### PR TITLE
[JW8-11109] Fix bug that shows first frame of video before preroll

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -566,7 +566,9 @@ Object.assign(Controller.prototype, {
                     // Resetting the source in order to prime is OK since we'll be switching it anyway
                     if (inInteraction() && !_backgroundLoading) {
                         const video = _model.get('mediaElement');
-                        video.src = '';
+                        if (_this._instreamAdapter) {
+                            video.src = '';
+                        }
                         video.load();
                     }
                     _interruptPlay = false;

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -565,7 +565,9 @@ Object.assign(Controller.prototype, {
                     // Force tags to prime if we're about to play an ad
                     // Resetting the source in order to prime is OK since we'll be switching it anyway
                     if (inInteraction() && !_backgroundLoading) {
-                        _model.get('mediaElement').load();
+                        const video = _model.get('mediaElement');
+                        video.src = '';
+                        video.load();
                     }
                     _interruptPlay = false;
                     _actionOnAttach = null;


### PR DESCRIPTION
### This PR will...
- Clear video tag source before calling `videotag.load()` to force prime before ad playback

### Why is this Pull Request needed?
- Calling `videotag.load()` caused the first frame of the video content to show, even when we have already started blocking the content by calling `jwplayer().createInstream().init()`

### Are there any points in the code the reviewer needs to double check?
- This bug happens for all ads plugins
- This bug was introduced 2.5 years ago, with this change: https://github.com/jwplayer/jwplayer/commit/d0e768d755b88e07e0be23b9d4c097f33681ff59#diff-15fcddfc5fb5f2333b37e0588e65df209035661bb83f68a5e4d0637c2b260e92R442
- Wasn't sure if there was a better way to force prime the video tag than to call `load()` - if there is, that would be a better solution

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):
JW8-11109

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
