### PR TITLE
[JW8-11359] Fix issues with native rendering captions incorrectly setting to "inuse"

### DIFF
--- a/src/js/providers/tracks-mixin.ts
+++ b/src/js/providers/tracks-mixin.ts
@@ -324,8 +324,8 @@ const Tracks: TracksMixin = {
                     } else {
                         trackId = track._id = createId(track, this._textTracks ? this._textTracks.length : 0) as string;
                     }
-                    if (_tracksById[trackId]) {
-                        // tracks without unique ids must not be marked as "inuse"
+                    if (_tracksById[trackId] || this.renderNatively) {
+                        // tracks without unique ids must not be marked as "inuse", unless they are natively renddered and explicitly set to not "inuse"
                         continue;
                     }
                     track.inuse = true;


### PR DESCRIPTION
### This PR will...
- Fix issues with native rendering captions incorrectly being set to `inuse`

### Why is this Pull Request needed?
- Safari captions being natively rendered are not being cleared up for the next playlist item, because they are incorrectly being set to `inuse` after explicitly being set to `inuse = false`

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-11359

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
