### PR TITLE
[JW8-11539] Set default target latency based on HLS playlist

### DIFF
--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -44,9 +44,6 @@ export const Defaults = {
 };
 
 export function getLiveSyncDuration(liveSyncDuration) {
-    if (!liveSyncDuration) {
-        return 25;
-    }
     if (liveSyncDuration < 5) {
         return 5;
     }

--- a/src/js/controller/model.ts
+++ b/src/js/controller/model.ts
@@ -1,6 +1,6 @@
 import { OS } from 'environment/environment';
 import SimpleModel from 'model/simplemodel';
-import { INITIAL_PLAYER_STATE, INITIAL_MEDIA_STATE } from 'model/player-model';
+import { INITIAL_PLAYER_STATE, INITIAL_MEDIA_STATE, DEFAULT_MIN_DVR_WINDOW, DEFAULT_DVR_SEEK_LIMIT } from 'model/player-model';
 import { InternalPlayerState, STATE_IDLE } from 'events/events';
 import { isValidNumber, isNumber } from 'utils/underscore';
 import { seconds } from 'utils/strings';
@@ -114,7 +114,9 @@ class Model extends SimpleModel {
         this.providerController = null;
         this._provider = null;
         this.addAttributes({
-            mediaModel: new MediaModel()
+            mediaModel: new MediaModel(),
+            minDvrWindow: DEFAULT_MIN_DVR_WINDOW,
+            dvrSeekLimit: DEFAULT_DVR_SEEK_LIMIT
         });
     }
 
@@ -154,7 +156,7 @@ class Model extends SimpleModel {
         (this.attributes as PlayerModelAttributes).playlistItem = null;
         this.set('item', index);
         this.set('minDvrWindow', item.minDvrWindow);
-        this.set('dvrSeekLimit', item.dvrSeekLimit);
+        this.set('dvrSeekLimit', item.dvrSeekLimit || DEFAULT_DVR_SEEK_LIMIT);
         this.set('playlistItem', item);
     }
 

--- a/src/js/model/player-model.ts
+++ b/src/js/model/player-model.ts
@@ -17,3 +17,6 @@ export const INITIAL_MEDIA_STATE = {
     buffer: 0,
     currentTime: 0,
 };
+
+export const DEFAULT_MIN_DVR_WINDOW = 120;
+export const DEFAULT_DVR_SEEK_LIMIT = 25;

--- a/src/js/playlist/item.js
+++ b/src/js/playlist/item.js
@@ -1,5 +1,6 @@
 import Source from 'playlist/source';
 import Track from 'playlist/track';
+import { DEFAULT_MIN_DVR_WINDOW } from 'model/player-model';
 
 const isArray = Array.isArray;
 /**
@@ -24,8 +25,7 @@ const Item = function(config) {
     const playlistItem = Object.assign({}, {
         sources: [],
         tracks: [],
-        minDvrWindow: 120,
-        dvrSeekLimit: 25
+        minDvrWindow: DEFAULT_MIN_DVR_WINDOW
     }, config);
 
     if ((playlistItem.sources === Object(playlistItem.sources)) && !isArray(playlistItem.sources)) {

--- a/src/js/playlist/playlist.js
+++ b/src/js/playlist/playlist.js
@@ -60,7 +60,9 @@ export const fixSources = (item, model) => filterSources(formatSources(item, mod
 
 function formatItem(item) {
     const liveSyncDuration = item.sources[0].liveSyncDuration;
-    item.dvrSeekLimit = item.liveSyncDuration = liveSyncDuration;
+    if (liveSyncDuration) {
+        item.liveSyncDuration = item.dvrSeekLimit = liveSyncDuration;
+    }
     return item;
 }
 

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -24,7 +24,7 @@ class ProgramController extends Events {
         this.background = BackgroundMedia();
         this.mediaPool = mediaPool;
         this.mediaController = null;
-        this.mediaControllerListener = MediaControllerListener(model, this);
+        this.mediaControllerListener = MediaControllerListener(model);
         this.model = model;
         this.providers = new Providers(model.getConfiguration());
         this.loadPromise = null;

--- a/src/js/program/program-listeners.ts
+++ b/src/js/program/program-listeners.ts
@@ -1,4 +1,4 @@
-import { isValidNumber, isNumber } from 'utils/underscore';
+import { isValidNumber } from 'utils/underscore';
 import {
     PLAYER_STATE, STATE_IDLE, MEDIA_VOLUME, MEDIA_MUTE,
     MEDIA_TYPE, AUDIO_TRACKS, AUDIO_TRACK_CHANGED,
@@ -90,7 +90,7 @@ export function ProviderListener(mediaController: MediaController): AllProviderE
                 if (isValidNumber(duration)) {
                     mediaModel.set('duration', duration);
                 }
-                if (type === MEDIA_TIME && isNumber(mediaController.item.starttime)) {
+                if (type === MEDIA_TIME && 'starttime' in mediaController.item) {
                     delete mediaController.item.starttime;
                 }
                 break;
@@ -168,6 +168,10 @@ export function MediaControllerListener(model: Model): AllMediaEventsListener {
                     (event as ProviderEvents['subtitlesTrackChanged']).tracks);
                 break;
             case MEDIA_TIME:
+                if ((event as ProviderEvents['time']).targetLatency) {
+                    model.set('dvrSeekLimit', (event as ProviderEvents['time']).targetLatency as number);
+                }
+                /* falls through to to trigger model event off model */
             case MEDIA_SEEK:
             case MEDIA_SEEKED:
             case NATIVE_FULLSCREEN:

--- a/src/js/program/program-listeners.ts
+++ b/src/js/program/program-listeners.ts
@@ -134,8 +134,8 @@ export function ProviderListener(mediaController: MediaController): AllProviderE
 
 type AllMediaEventsListener = <E extends keyof AllProviderEventsListener>(type: E, data: AllProviderEventsListener[E] & { type: E }) => void;
 
-export function MediaControllerListener(model: Model, programController: ProgramController): AllMediaEventsListener {
-    return function<E extends keyof AllProviderEventsListener>(type: E, event: AllProviderEventsListener[E] & { type: E }): void {
+export function MediaControllerListener(model: Model): AllMediaEventsListener {
+    return function<E extends keyof AllProviderEventsListener>(this: ProgramController, type: E, event: AllProviderEventsListener[E] & { type: E }): void {
         switch (type) {
             case PLAYER_STATE:
                 // This "return" is important because
@@ -182,6 +182,6 @@ export function MediaControllerListener(model: Model, programController: Program
             default:
         }
 
-        programController.trigger(type, event);
+        this.trigger(type, event);
     };
 }

--- a/src/js/providers/default.ts
+++ b/src/js/providers/default.ts
@@ -69,6 +69,7 @@ export type ProviderEvents = {
         currentTime: number;
         seekRange: SeekRange;
         latency?: number;
+        targetLatency?: number;
         metadata: {
             currentTime: number;
             mpegts?: number;
@@ -190,6 +191,7 @@ interface InternalProvider {
 
     getPlaybackRate: () => number;
     getLiveLatency: () => number | null;
+    getTargetLatency?: () => number | null;
     setControls: (bool?: boolean) => void;
     setState: (state: InternalPlayerState) => void;
 

--- a/src/js/providers/video-listener-mixin.ts
+++ b/src/js/providers/video-listener-mixin.ts
@@ -95,6 +95,12 @@ const VideoListenerMixin: VideoListenerInt = {
         const latency = this.getLiveLatency();
         if (latency !== null) {
             timeEventObject.latency = latency;
+            if (this.getTargetLatency) {
+                const targetLatency = this.getTargetLatency();
+                if (targetLatency !== null) {
+                    timeEventObject.targetLatency = targetLatency;
+                }
+            }
         }
 
         // only emit time events when playing or seeking

--- a/test/data/model-properties.js
+++ b/test/data/model-properties.js
@@ -117,5 +117,5 @@ export default {
     bandwidthEstimate: null,
     bitrateSelection: null,
     backgroundLoading: Features.backgroundLoading,
-    liveSyncDuration: 25
+    liveSyncDuration: undefined
 };

--- a/test/manual/events/src/providers/video-element-provider.ts
+++ b/test/manual/events/src/providers/video-element-provider.ts
@@ -16,7 +16,7 @@ const PROVIDER_NAME = 'headless-video-element';
 // These changes reflect the interface required for any provider registered with jwplayer
 interface CustomProvider extends Omit<ImplementedProvider,
     'prototype'|'seeking'|'stallTime'|'instreamMode'|'renderNatively'|'supports'|'video'|
-    'getCurrentTime'|'getDuration'|'getSeekRange'|'getLiveLatency'|'setCurrentSubtitleTrack'|'setControls'|
+    'getCurrentTime'|'getDuration'|'getSeekRange'|'getLiveLatency'|'getTargetLatency'|'setCurrentSubtitleTrack'|'setControls'|
     'getBandwidthEstimate'|'isLive'> {
     attachMedia(): void;
     detachMedia(): void;

--- a/test/unit/program-controller-test.js
+++ b/test/unit/program-controller-test.js
@@ -1,4 +1,5 @@
 import Model from 'controller/model';
+import Playlist from 'playlist/playlist';
 import ProgramController from 'program/program-controller';
 import MediaElementPool from 'program/media-element-pool';
 import { Features } from 'environment/environment';
@@ -27,10 +28,10 @@ const mp4Item = {
     ]
 };
 
-const defaultPlaylist = [
+const defaultPlaylist = Playlist([
     mp4Item,
     mp4Item
-];
+]);
 
 const providerEvents = [
     {


### PR DESCRIPTION
### This PR will...
- Let hls.js determine target latency (`liveSyncDuration` and `dvrSeekLimit`)
- Add targetLatency to time events

### Why is this Pull Request needed?
So that LL-HLS and HLS live streams have a target latency that matches the intent of the stream author and HLS spec, rather than the fixed default of 25 seconds set by jwplayer.

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/7787

#### Addresses Issue(s):
JW8-11539

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
