### PR TITLE
Revert "[JW8-11359] Fix issues with native rendering captions incorrectly setting to "inuse""

### DIFF
--- a/src/js/providers/tracks-mixin.ts
+++ b/src/js/providers/tracks-mixin.ts
@@ -324,8 +324,8 @@ const Tracks: TracksMixin = {
                     } else {
                         trackId = track._id = createId(track, this._textTracks ? this._textTracks.length : 0) as string;
                     }
-                    if (_tracksById[trackId] || this.renderNatively) {
-                        // tracks without unique ids must not be marked as "inuse", unless they are natively renddered and explicitly set to not "inuse"
+                    if (_tracksById[trackId]) {
+                        // tracks without unique ids must not be marked as "inuse"
                         continue;
                     }
                     track.inuse = true;


### PR DESCRIPTION
Reverts jwplayer/jwplayer#3776

This change broke 608 captions - when renderCaptionsNatively is enabled, 608 captions do not show up in the captions menu.  Reopening  JW8-11359
