### PR TITLE
[JW8-11359] Do not mark disabled native captions to "inuse"

### DIFF
--- a/src/js/providers/tracks-mixin.ts
+++ b/src/js/providers/tracks-mixin.ts
@@ -325,7 +325,7 @@ const Tracks: TracksMixin = {
                         trackId = track._id = createId(track, this._textTracks ? this._textTracks.length : 0) as string;
                     }
                     if (_tracksById[trackId] || (this.renderNatively && track.mode === 'disabled')) {
-                        // tracks without unique ids must not be marked as "inuse", unless they are natively renddered and explicitly set to not "disabled"
+                        // tracks without unique ids must not be marked as "inuse", unless they are natively rendered and explicitly set to "disabled"
                         continue;
                     }
                     track.inuse = true;

--- a/src/js/providers/tracks-mixin.ts
+++ b/src/js/providers/tracks-mixin.ts
@@ -324,8 +324,8 @@ const Tracks: TracksMixin = {
                     } else {
                         trackId = track._id = createId(track, this._textTracks ? this._textTracks.length : 0) as string;
                     }
-                    if (_tracksById[trackId]) {
-                        // tracks without unique ids must not be marked as "inuse"
+                    if (_tracksById[trackId] || (this.renderNatively && track.mode === 'disabled')) {
+                        // tracks without unique ids must not be marked as "inuse", unless they are natively renddered and explicitly set to not "disabled"
                         continue;
                     }
                     track.inuse = true;


### PR DESCRIPTION
### This PR will...
- Fix captions menu showing up for the next playlistItem incorrectly

### Why is this Pull Request needed?]
- Disabled tracks should not be marked as "inuse" when switching into a new playlistItem, so that the captions for the previous item is not displayed

### Are there any points in the code the reviewer needs to double check?
- Previous fix had an issue with 608 captions not being switched to "inuse"
- Will be checking the test results once this builds

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-11359

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
