### PR TITLE
[JW8-11514] Fix delayed float on mobile

### DIFF
--- a/src/js/view/floating/floating-controller.ts
+++ b/src/js/view/floating/floating-controller.ts
@@ -62,7 +62,7 @@ export default class FloatingController {
     _preview: Preview;
     _model: Model;
     _floatingUI: FloatingDragUI;
-    _mobileCheckCanFire?: boolean;
+    _mobileCheckCanFire: boolean;
     _mobileDebounceTimeout?: number;
     _floatingStoppedForever: boolean;
     _lastIntRatio: number;
@@ -91,6 +91,7 @@ export default class FloatingController {
         this._lastIntRatio = 0;
         this._playerBounds = playerBounds;
         this._isMobile = isMobile;
+        this._mobileCheckCanFire = true;
 
         this._boundThrottledMobileFloatScrollHandler = this.throttledMobileFloatScrollHandler.bind(this);
 


### PR DESCRIPTION
### This PR will...
Initialize `this._mobileCheckCanFire` to true to fix an issue where player would not start floating until scrolling ended on mobile.

Pre 8.17.0 refactor, this variable was initialized to true as seen here:
https://github.com/jwplayer/jwplayer/blob/v8.16.2/src/js/view/view.js#L366-L368
### Why is this Pull Request needed?
bugfix
### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-11514

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
