### PR TITLE
[JW8-11540] Focus element after applying aria-expanded

### DIFF
--- a/src/js/view/controls/components/menu/menu.js
+++ b/src/js/view/controls/components/menu/menu.js
@@ -363,12 +363,12 @@ export default class Menu extends Events {
         if (this.openMenus.length) {
             this.closeChildren();
         }
-        if (focusEl) {
-            focusEl.focus();
-        }
         this.el.scrollTop = 0;
         this.visible = true;
         this.el.setAttribute('aria-expanded', 'true');
+        if (focusEl) {
+            focusEl.focus();
+        }
     }
     close(evt) {
         // if visible, return


### PR DESCRIPTION
### This PR will...
- Focus the element within settings menu after applying `aria-expanded` when opening the menu

### Why is this Pull Request needed?
- On Safari, the menu is sometimes not opened when `focus()` is called on the icon within the menu, resulting the `focus` to not apply to the proper icon

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-11540

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
