### PR TITLE
[JW8-11563] Move _shouldAutoAdvance to playlist.js to reuse in commercial

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -3,7 +3,7 @@ import { showView } from 'api/core-shim';
 import setConfig from 'api/set-config';
 import ApiQueueDecorator from 'api/api-queue';
 import PlaylistLoader from 'playlist/loader';
-import Playlist, { filterPlaylist, validatePlaylist, wrapPlaylistIndex } from 'playlist/playlist';
+import Playlist, { filterPlaylist, validatePlaylist, wrapPlaylistIndex, shouldAutoAdvance } from 'playlist/playlist';
 import InstreamAdapter from 'controller/instream-adapter';
 import Captions from 'controller/captions';
 import Model from 'controller/model';
@@ -758,11 +758,6 @@ Object.assign(Controller.prototype, {
             return false;
         }
 
-        function _shouldAutoAdvance() {
-            // If it's the last item in the playlist
-            const idx = _model.get('item');
-            return idx !== _model.get('playlist').length - 1;
-        }
         function _completeHandler() {
             if (_this.completeCancelled()) {
                 return;
@@ -944,7 +939,7 @@ Object.assign(Controller.prototype, {
         this.next = noop;
         this.completeHandler = _completeHandler;
         this.completeCancelled = _completeCancelled;
-        this.shouldAutoAdvance = _shouldAutoAdvance;
+        this.shouldAutoAdvance = shouldAutoAdvance;
         this.nextItem = () => {
             _next({ reason: 'playlist' });
         };

--- a/src/js/playlist/playlist.js
+++ b/src/js/playlist/playlist.js
@@ -58,6 +58,13 @@ export function wrapPlaylistIndex(index, length) {
 
 export const fixSources = (item, model) => filterSources(formatSources(item, model), model.getProviders());
 
+export function shouldAutoAdvance() {
+    // If it's the last item in the playlist
+    const _model = this._model || this.model;
+    const idx = _model.get('item');
+    return idx !== _model.get('playlist').length - 1;
+}
+
 function formatItem(item) {
     const liveSyncDuration = item.sources[0].liveSyncDuration;
     item.dvrSeekLimit = item.liveSyncDuration = liveSyncDuration;


### PR DESCRIPTION
### This PR will...
Move _shouldAutoAdvance to playlist.js to reuse in Commercial

### Why is this Pull Request needed?
Part of a commercial PR.

### Are there any points in the code the reviewer needs to double check?
Would you rather I add move it to the os/controller prototype and call with super?

### Are there any Pull Requests open in other repos which need to be merged with this?
Yes

#### Addresses Issue(s):

JW8-11563

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
