### PR TITLE
[JW8-11562] Fix volume slider expanding/collapsing in audio player during ads

### DIFF
--- a/src/css/controls/flags/audioplayer.less
+++ b/src/css/controls/flags/audioplayer.less
@@ -34,6 +34,7 @@
         .jw-button-container {
             padding-right: 3px;
             padding-left: 0;
+            justify-content: flex-start;
         }
 
         .jw-icon-tooltip,


### PR DESCRIPTION
### This PR will...
Prevent the volume slider from constantly expanding/collapsing on hover during ad playback by using `justify-content: flex-start` to override `justify-content: center`.

### Why is this Pull Request needed?
bugfix
### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-11562

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
