### PR TITLE
[JW8-11632] Fix html5 provider 203000 error with vast ad client and external provider playabck

### DIFF
--- a/src/js/providers/html5.ts
+++ b/src/js/providers/html5.ts
@@ -305,6 +305,9 @@ function VideoProvider(this: HTML5Provider, _playerId: string, _playerConfig: Ge
                 const videoLoad = this.videoLoad = _videotag.load;
                 _videotag.load = function(): void {
                     if (_videotag.src === location.href) {
+                        if (_currentQuality === -1) {
+                            _currentQuality = _pickInitialQuality(_levels);
+                        }
                         _setVideotagSource(_levels[_currentQuality]);
                         if (_this.state === STATE_PLAYING) {
                             _videotag.play();

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -197,6 +197,9 @@ export default class Controlbar {
         const nextElement = elements.next.element();
         const nextUpTip = SimpleTooltip(nextElement, 'next', localization.nextUp, () => {
             const nextUp = _model.get('nextUp');
+            if (!nextUp) {
+                return;
+            }
             feedShownId = genId(FEED_SHOWN_ID_LENGTH);
             this.trigger('nextShown', {
                 mode: nextUp.mode,


### PR DESCRIPTION
### This PR will...
Fix for manual tests using IVS provider


1. Guard against missing `nextUp` exception
2. Using the html5 provider to play an ad to the end, and then later reattach it to play playlist item results in a JavaScript exception

> Say we have a playlist with 2 items: an IVS stream item and a plain mp4 item (which plays through the html5 provider). When the IVS provider is playing a VAST mid roll to completion (so it fires ENDED), then the ad gets played through html5 provider, and the _currentQuality gets set to -1 (https://github.com/jwplayer/jwplayer/blob/master/src/js/providers/html5.ts#L134). Then if we hit ‘Next Up’ to play the mp4, https://github.com/jwplayer/jwplayer/blob/master/src/js/providers/html5.ts#L308 this gets fired, but it looks for a source at the -1 index, and then we get a “This media file cannot be played(Error code:203000)” fatal error.

Test Page (iPhone device or simulator)

1. Launch [test page](https://cvp-test.twitch.tv/8cce751f08edef10d41a89b0d565470dd3ed1a482364d719a35bd6ce10686e08/jw/ivs-provider-ads-plugins.html)
1. First player: let the preroll play and complete
2. Hit 'Next Up' so we skip to the next item in the playlist
3. Observe the 203000 error

### Resolves Issue:
JW8-11632

### Checklist
- [x] Jenkins builds and unit tests are passing
- [x] I have reviewed the automated results
