### PR TITLE
Escape key should close menus even when in sub-menu

### DIFF
--- a/src/js/view/controls/components/menu/menu.js
+++ b/src/js/view/controls/components/menu/menu.js
@@ -85,6 +85,8 @@ export default class Menu extends Events {
                 case 'Esc':
                     focusEl = settingsElement;
                     this.close(event);
+                    // always close the main menu if coming from within a sub-menu
+                    this.mainMenu.close(event);
                     break;
                 default:
                     break;


### PR DESCRIPTION
### This PR will...
Update the menu logic to ensure the Escape key always fully closes the menu.
### Why is this Pull Request needed?
If navigating the menus with the keyboard, when using the Enter key to enter the Settings sub-menu from within the Captions menu, the focused element becomes the first item within the newly opened Settings menu. This causes a [different keydown handler](https://github.com/jwplayer/jwplayer/blob/master/src/js/view/controls/components/menu/menu.js#L87) to be used when pressing the Escape key to close the menu and results in the menu being _cleared_ but not _closed_. Ordinarily, the [settings-menu keydown handler is invoked](https://github.com/jwplayer/jwplayer/blob/master/src/js/view/controls/components/menu/settings-menu.js#L442).

See screenshots for example of current behavior:

![image](https://user-images.githubusercontent.com/9687200/104334077-ee64c400-54bf-11eb-813b-b7c330b38b7d.png)
![image](https://user-images.githubusercontent.com/9687200/104334087-f3c20e80-54bf-11eb-977f-013b5e350644.png)

### Are there any points in the code the reviewer needs to double check?
This solution seems to do the trick, although I may have missed cases where calling `mainMenu.close` in this new way will cause issues. There may also be a deeper solution here but I was unable to edit the underlying behavior of the `close` method in a way that did not cause issues with other menus either not closing or closing when they should not.

### Are there any Pull Requests open in other repos which need to be merged with this?
No
#### Addresses Issue(s):

JW8-11072

### Checklist
- [x] Jenkins builds and unit tests are passing
- [x] I have reviewed the automated results
