### PR TITLE
[JW8-1130] Add horiztontal volume slider to video player

### DIFF
--- a/src/css/controls/flags/audioplayer.less
+++ b/src/css/controls/flags/audioplayer.less
@@ -77,10 +77,15 @@
             }
         }
 
-        .jw-horizontal-volume-container.jw-open ~ .jw-slider-time {
-            flex: 1 1 auto;
-            width: auto;
-            transition: opacity 300ms, width 300ms;
+        .jw-horizontal-volume-container {
+            ~ .jw-slider-time {
+                transition: opacity @slider-tansition-duration, width @slider-tansition-duration;
+            }
+
+            &.jw-open ~ .jw-slider-time {
+                flex: 1 1 auto;
+                width: auto;
+            }
         }
 
         .jw-slider-volume ~ .jw-icon-volume {

--- a/src/css/controls/flags/audioplayer.less
+++ b/src/css/controls/flags/audioplayer.less
@@ -77,37 +77,14 @@
             }
         }
 
-        .jw-horizontal-volume-container {
-            transition: width 300ms @default-timing-function;
-            width: 0;
-
-            &.jw-open {
-                width: @volume-rail-length;
-
-                .jw-slider-volume {
-                    padding-right: 24px;
-                    transition: opacity 300ms;
-                    opacity: 1;
-                }
-
-                ~ .jw-slider-time {
-                    flex: 1 1 auto;
-                    width: auto;
-                    transition: opacity 300ms, width 300ms;
-                }
-            }
+        .jw-horizontal-volume-container.jw-open ~ .jw-slider-time {
+            flex: 1 1 auto;
+            width: auto;
+            transition: opacity 300ms, width 300ms;
         }
 
-        .jw-slider-volume {
-            opacity: 0;
-
-            .jw-knob {
-                transform: translate(-50%, -50%);
-            }
-
-            ~ .jw-icon-volume {
-                margin-right: @volume-rail-length;
-            }
+        .jw-slider-volume ~ .jw-icon-volume {
+            margin-right: @volume-rail-length;
         }
     }
 

--- a/src/css/controls/imports/slider.less
+++ b/src/css/controls/imports/slider.less
@@ -190,9 +190,16 @@
     }
 }
 
+.jw-flag-horizontal-slider {
+    .jw-overlay {
+        display: none;
+    }
+}
+
 .jw-flag-audio-player,
 .jwplayer:not(.jw-flag-small-player) {
-    .jw-horizontal-volume-container {
+    .jw-flag-horizontal-slider ~ .jw-horizontal-volume-container {
+        display: flex;
         transition: width @slider-tansition-duration @default-timing-function;
         width: 0;
 
@@ -248,8 +255,4 @@
 
 .jw-horizontal-volume-container {
     display: none;
-
-    .jw-slider-volume {
-        opacity: 0;
-    }
 }

--- a/src/css/controls/imports/slider.less
+++ b/src/css/controls/imports/slider.less
@@ -115,7 +115,7 @@
 }
 
 .jw-slider-time,
-.jw-flag-audio-player .jw-slider-volume {
+.jw-horizontal-volume-container .jw-slider-volume {
     .rect(100%, 17px);
     align-items: center;
     background: transparent none;
@@ -190,6 +190,38 @@
     }
 }
 
+.jw-flag-audio-player,
+.jwplayer:not(.jw-breakpoint--1):not(.jw-breakpoint-0):not(.jw-breakpoint-1) {
+    .jw-horizontal-volume-container {
+        transition: width 300ms @default-timing-function;
+        width: 0;
+
+        &.jw-open {
+            width: @volume-rail-length;
+
+            .jw-slider-volume {
+                padding-right: 24px;
+                transition: opacity 300ms;
+                opacity: 1;
+            }
+        }
+
+        .jw-slider-volume {
+            opacity: 0;
+
+            .jw-knob {
+                transform: translate(-50%, -50%);
+            }
+        }
+    }
+
+    .jw-button-container {
+        .jw-icon {
+            flex: 0 0 auto;
+        }
+    }
+}
+
 .jw-breakpoint--1:not(.jw-flag-audio-player) {
     .jw-slider-time {
         height: 17px;
@@ -217,7 +249,7 @@
 .jw-horizontal-volume-container {
     display: none;
 
-    .jw-flag-audio-player & {
-        display: flex;
+    .jw-slider-volume {
+        opacity: 0;
     }
 }

--- a/src/css/controls/imports/slider.less
+++ b/src/css/controls/imports/slider.less
@@ -191,9 +191,9 @@
 }
 
 .jw-flag-audio-player,
-.jwplayer:not(.jw-breakpoint--1):not(.jw-breakpoint-0):not(.jw-breakpoint-1) {
+.jwplayer:not(.jw-flag-small-player) {
     .jw-horizontal-volume-container {
-        transition: width 300ms @default-timing-function;
+        transition: width @slider-tansition-duration @default-timing-function;
         width: 0;
 
         &.jw-open {
@@ -201,12 +201,12 @@
 
             .jw-slider-volume {
                 padding-right: 24px;
-                transition: opacity 300ms;
                 opacity: 1;
             }
         }
 
         .jw-slider-volume {
+            transition: opacity @slider-tansition-duration;
             opacity: 0;
 
             .jw-knob {

--- a/src/css/shared-imports/vars.less
+++ b/src/css/shared-imports/vars.less
@@ -110,6 +110,7 @@
 // Transition animation
 @default-timing-function: cubic-bezier(0, 0.25, 0.25, 1);
 @default-transition: 150ms @default-timing-function;
+@slider-tansition-duration: 300ms;
 
 // Settings menu and floating player close buttons
 @dismiss-top-padding: 3px;

--- a/src/js/controller/model.ts
+++ b/src/js/controller/model.ts
@@ -50,6 +50,7 @@ export type PlayerModelAttributes = {
     floating?: FloatConfig;
     fullscreen: boolean;
     height: number | string;
+    horizontalVolumeSlider?: boolean;
     id: string;
     inDom: boolean;
     instreamMode: boolean;

--- a/src/js/view/controls/components/volumetooltipicon.ts
+++ b/src/js/view/controls/components/volumetooltipicon.ts
@@ -81,8 +81,6 @@ export default class VolumeTooltipIcon extends TooltipIcon {
         this.addSliderHandlers(this.horizontalSlider.uiOver);
         this.addSliderHandlers(this.verticalSlider.uiOver);
 
-        this.updateSlider(_model, _model.get('audioMode'));
-
         this._model.change('audioMode', this.updateSlider, this);
     }
 

--- a/src/js/view/controls/components/volumetooltipicon.ts
+++ b/src/js/view/controls/components/volumetooltipicon.ts
@@ -50,6 +50,15 @@ export default class VolumeTooltipIcon extends TooltipIcon {
         horizontalContainer.appendChild(this.horizontalSlider.element());
         this.addContent(this.verticalSlider.element());
 
+        const hasHorizontalSlider = _model.get('horizontalVolumeSlider') || _model.get('audioMode');
+
+        if (hasHorizontalSlider) {
+            this.horizontalContainer.style.display = 'flex';
+            this.tooltip.style.display = 'none';
+        }
+
+        this.setHorizontalSliderTabIndex(null, hasHorizontalSlider);
+
         this.verticalSlider.on('update', function (this: VolumeTooltipIcon, evt: Event): void {
             this.trigger('update', evt);
         }, this);
@@ -81,12 +90,10 @@ export default class VolumeTooltipIcon extends TooltipIcon {
         this.addSliderHandlers(this.horizontalSlider.uiOver);
         this.addSliderHandlers(this.verticalSlider.uiOver);
 
-        this.onAudioMode(null, _model.get('audioMode'));
-
-        this._model.on('change:audioMode', this.onAudioMode, this);
+        this._model.on('change:audioMode', this.setHorizontalSliderTabIndex, this);
     }
 
-    onAudioMode(model: Model | null, val: boolean): void {
+    setHorizontalSliderTabIndex(model: Model | null, val: boolean): void {
         const tabIndex = val ? 0 : -1;
         setAttribute(this.horizontalContainer, 'tabindex', tabIndex);
     }

--- a/src/js/view/controls/components/volumetooltipicon.ts
+++ b/src/js/view/controls/components/volumetooltipicon.ts
@@ -83,19 +83,12 @@ export default class VolumeTooltipIcon extends TooltipIcon {
 
         this.updateSlider(_model, _model.get('audioMode'));
 
-        this._model.on('change:audioMode', this.updateSlider, this);
+        this._model.change('audioMode', this.updateSlider, this);
     }
 
     updateSlider(model: Model, audioMode: boolean): void {
         const hasHorizontalSlider = model.get('horizontalVolumeSlider') || audioMode;
-
-        if (hasHorizontalSlider) {
-            this.horizontalContainer.style.display = 'flex';
-            this.tooltip.style.display = 'none';
-        } else {
-            this.horizontalContainer.style.display = 'none';
-            this.tooltip.style.display = '';
-        }
+        toggleClass(this.element(), 'jw-flag-horizontal-slider', hasHorizontalSlider ? true : false);
     }
 
     addSliderHandlers(ui: UI): void {

--- a/src/js/view/controls/components/volumetooltipicon.ts
+++ b/src/js/view/controls/components/volumetooltipicon.ts
@@ -50,15 +50,6 @@ export default class VolumeTooltipIcon extends TooltipIcon {
         horizontalContainer.appendChild(this.horizontalSlider.element());
         this.addContent(this.verticalSlider.element());
 
-        const hasHorizontalSlider = _model.get('horizontalVolumeSlider') || _model.get('audioMode');
-
-        if (hasHorizontalSlider) {
-            this.horizontalContainer.style.display = 'flex';
-            this.tooltip.style.display = 'none';
-        }
-
-        this.setHorizontalSliderTabIndex(null, hasHorizontalSlider);
-
         this.verticalSlider.on('update', function (this: VolumeTooltipIcon, evt: Event): void {
             this.trigger('update', evt);
         }, this);
@@ -90,12 +81,21 @@ export default class VolumeTooltipIcon extends TooltipIcon {
         this.addSliderHandlers(this.horizontalSlider.uiOver);
         this.addSliderHandlers(this.verticalSlider.uiOver);
 
-        this._model.on('change:audioMode', this.setHorizontalSliderTabIndex, this);
+        this.updateSlider(_model, _model.get('audioMode'));
+
+        this._model.on('change:audioMode', this.updateSlider, this);
     }
 
-    setHorizontalSliderTabIndex(model: Model | null, val: boolean): void {
-        const tabIndex = val ? 0 : -1;
-        setAttribute(this.horizontalContainer, 'tabindex', tabIndex);
+    updateSlider(model: Model, audioMode: boolean): void {
+        const hasHorizontalSlider = model.get('horizontalVolumeSlider') || audioMode;
+
+        if (hasHorizontalSlider) {
+            this.horizontalContainer.style.display = 'flex';
+            this.tooltip.style.display = 'none';
+        } else {
+            this.horizontalContainer.style.display = 'none';
+            this.tooltip.style.display = '';
+        }
     }
 
     addSliderHandlers(ui: UI): void {


### PR DESCRIPTION
### This PR will...
Add  usage of the horizontal volume slider in the video player as designated in config. It also will:
- Disable the horizontal slider to only mute/unmute at breakpoints 1 and below
- Rename `onAudioMode` to `setHorizontalSliderTabIndex`
- Move applicable horizontal slider styles from audioplayer.less to slider.less
### Why is this Pull Request needed?
new feature
### Are there any points in the code the reviewer needs to double check?
left a comment
### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/7862
#### Addresses Issue(s):

JW8-1130

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
