### PR TITLE
[JW8-11630, JW8-11644] Prevent CC label duplication when captions are rendered by the browser

### DIFF
--- a/src/js/controller/captions.js
+++ b/src/js/controller/captions.js
@@ -66,13 +66,19 @@ const Captions = function(_model) {
             _tracksById = {};
             _unknownCount = 0;
         } else {
-            for (let i = 0; i < tracks.length; i++) {
-                _addTrack(tracks[i]);
-            }
-
-            // To avoid duplicate tracks in the menu when we reuse an _id, regenerate the tracks array
-            const allTracks = Object.keys(_tracksById).map(id => _tracksById[id]);
-            _tracks = allTracks.filter(track => !track.sideloaded).concat(allTracks.filter(track => !!track.sideloaded));
+            tracks.forEach(track => _addTrack(track));
+            // Make _tracks order match (video) tracks
+            _tracks.sort((trackA, trackB) => {
+                const videoTracksIndexOfA = tracks.indexOf(trackA);
+                if (videoTracksIndexOfA === -1) {
+                    return 1;
+                }
+                const videoTracksIndexOfB = tracks.indexOf(trackB);
+                if (videoTracksIndexOfB === -1) {
+                    return -1;
+                }
+                return videoTracksIndexOfA - videoTracksIndexOfB;
+            });
         }
 
         _setCaptionsList();
@@ -89,7 +95,7 @@ const Captions = function(_model) {
     function _addTrack(track) {
         track.data = track.data || [];
         track.name = track.label || track.name || track.language;
-        track._id = createId(track, _tracks.length);
+        const id = createId(track, _tracks.length);
 
         if (!track.name) {
             const labelInfo = createLabel(track, _unknownCount);
@@ -97,8 +103,10 @@ const Captions = function(_model) {
             _unknownCount = labelInfo.unknownCount;
         }
 
-        // During the same playlist we may reu and readd tracks with the same _id; allow the new track to replace the old
-        _tracksById[track._id] = track;
+        // During the same playlist we may re-add tracks with the same _id; allow the new track to replace the old
+        track._id = id;
+        _tracksById[id] = track;
+        _tracks = _tracks.filter(tr => tr._id !== id);
         _tracks.push(track);
     }
 

--- a/src/js/providers/html5.ts
+++ b/src/js/providers/html5.ts
@@ -326,7 +326,6 @@ function VideoProvider(this: HTML5Provider, _playerId: string, _playerConfig: Ge
             }
 
             if (this.renderNatively) {
-                this.clearTracks();
                 this.setTextTracks(this.video.textTracks);
             }
             this.addTracksListener(_videotag.textTracks, 'change', this.textTrackChangeHandler);

--- a/src/js/providers/tracks-mixin.ts
+++ b/src/js/providers/tracks-mixin.ts
@@ -217,7 +217,7 @@ const Tracks: TracksMixin = {
 
             // IOS native captions does not remove the active cue from the dom when the track is disabled, so we must hide it
             const trackId = track._id;
-            if ((trackId && trackId.indexOf('nativecaptions') === 0) || (this.renderNatively && OS.iOS)) {
+            if ((trackId && isNativeCaptionsOrSubtitles(trackId)) || (this.renderNatively && OS.iOS)) {
                 track.mode = 'hidden';
             }
         }
@@ -248,7 +248,7 @@ const Tracks: TracksMixin = {
 
         tracksArray.forEach(itemTrack => {
             // only add valid and supported kinds https://developer.mozilla.org/en-US/docs/Web/HTML/Element/track
-            if (itemTrack.includedInManifest || (itemTrack.kind && !_kindSupported(itemTrack.kind))) {
+            if (itemTrack.includedInManifest || (itemTrack.kind && !isCaptionsOrSubtitles(itemTrack.kind))) {
                 return;
             }
             const textTrackAny = this._createTrack(itemTrack);
@@ -287,7 +287,7 @@ const Tracks: TracksMixin = {
             this._unknownCount = 0;
             this._textTracks = this._textTracks.filter((track) => {
                 const trackId = track._id as string;
-                if (this.renderNatively && trackId && trackId.indexOf('nativecaptions') === 0) {
+                if (this.renderNatively && trackId && isNativeCaptionsOrSubtitles(trackId)) {
                     delete _tracksById[trackId];
                     return false;
                 } else if (track.name && track.name.indexOf('Unknown') === 0) {
@@ -313,12 +313,12 @@ const Tracks: TracksMixin = {
                 let trackId: string = track._id || '';                
 
                 if (!trackId) {   
-                    if (track.inuse === false && track.kind === 'captions' && this.renderNatively) {
+                    if (track.inuse === false && isCaptionsOrSubtitles(track.kind) && this.renderNatively) {
                         // ignore native captions tracks from previous items that no longer can be re-used
                         track._id = 'native' + track.kind + i;
                         continue;
                     }
-                    if (track.kind === 'captions' || track.kind === 'metadata') {
+                    if (isCaptionsOrSubtitles(track.kind) || track.kind === 'metadata') {
                         trackId = track._id = 'native' + track.kind + i;
                         if (!track.label && track.kind === 'captions') {
                             // track label is read only in Safari
@@ -347,7 +347,7 @@ const Tracks: TracksMixin = {
                     track.removeEventListener('cuechange', handler);
                     track.addEventListener('cuechange', handler);
                     _tracksById[trackId] = track;
-                } else if (_kindSupported(track.kind)) {
+                } else if (isCaptionsOrSubtitles(track.kind)) {
                     const mode = track.mode;
                     let cue;
 
@@ -360,7 +360,7 @@ const Tracks: TracksMixin = {
                         continue;
                     }
 
-                    if (mode !== 'disabled' || trackId.indexOf('nativecaptions') !== 0) {
+                    if (mode !== 'disabled' || isNativeCaptionsOrSubtitles(trackId)) {
                         track.mode = mode;
                     }
 
@@ -408,6 +408,7 @@ const Tracks: TracksMixin = {
             return;
         }
         // Determine if the tracks are the same and the embedded + sideloaded count = # of tracks in the controlbar
+        itemTracks = itemTracks || null;
         const alreadyLoaded = itemTracks === this._itemTracks;
         if (!alreadyLoaded) {
             cancelXhr(this._itemTracks);
@@ -794,7 +795,7 @@ const Tracks: TracksMixin = {
 function textTrackChangeHandler(this: ProviderWithMixins): void {
     const textTracks = this.video.textTracks;
     const inUseTracks = filter(textTracks, function (track: TextTrackLike): boolean {
-        return (track.inuse || !track._id) && _kindSupported(track.kind);
+        return (track.inuse || !track._id) && isCaptionsOrSubtitles(track.kind);
     });
     if (!this._textTracks || _tracksModified.call(this, inUseTracks)) {
         this.setTextTracks(textTracks);
@@ -951,8 +952,12 @@ function _removeCues(renderNatively: boolean, tracks: TextTrackList | TextTrack[
     }
 }
 
-function _kindSupported(kind: string): boolean {
-    return kind === 'subtitles' || kind === 'captions';
+function isCaptionsOrSubtitles(kind: string): boolean {
+    return kind === 'captions' || kind === 'subtitles';
+}
+
+function isNativeCaptionsOrSubtitles(trackId: string): boolean {
+    return (/^native(?:captions|subtitles)/).test(trackId);
 }
 
 function getTextCueMetaEvent(cue: TrackCue): ProviderEvents['meta'] | null {


### PR DESCRIPTION
### This PR will...
1. Fixes a regression caused by #3763 that results in the menu item for side-loaded captions being duplicated after a midroll in Safari (where captions are rendered by the browser and only one video element is used for both the main content and the ads).
2. Makes the order of captions in the menu match the order tracks in `video.textTracks` which were incorrect when mixing in and out of band captions and subtitles. If the order does not match then selection of captions in the menu will not show the correct track.
3. Treats TextTracks of kind "captions" and "subtitles" the same. Safari can assign either kind (usually captions for 608 and subtitle for in-HLS VTT) and we should be treating both the same.

#### Addresses Issue(s):

JW8-11630
JW8-11644 (clone of ticket that the regression originated from)

### Checklist
- [x] Jenkins builds and unit tests are passing
- [x] I have reviewed the automated results
