### PR TITLE
[JW8-11651] Implement nosnippet data attribute for error text

### DIFF
--- a/src/js/templates/error.ts
+++ b/src/js/templates/error.ts
@@ -12,7 +12,7 @@ export default (id: string, message: string | undefined, errorCode: string, code
                 `</style>` +
                 `<div class="jw-icon jw-reset"></div>` +
                 `<div class="jw-info-container jw-reset">` +
-                    `<div class="jw-error-text jw-reset-text" dir="auto">${(message || '')}<span class="jw-break jw-reset"></span>${detail}</div>` +
+                    `<div class="jw-error-text jw-reset-text" dir="auto" data-nosnippet="">${(message || '')}<span class="jw-break jw-reset"></span>${detail}</div>` +
                 `</div>` +
             `</div>` +
         `</div>`

--- a/src/js/templates/error.ts
+++ b/src/js/templates/error.ts
@@ -12,7 +12,7 @@ export default (id: string, message: string | undefined, errorCode: string, code
                 `</style>` +
                 `<div class="jw-icon jw-reset"></div>` +
                 `<div class="jw-info-container jw-reset">` +
-                    `<div class="jw-error-text jw-reset-text" dir="auto" data-nosnippet="">${(message || '')}<span class="jw-break jw-reset"></span>${detail}</div>` +
+                    `<div class="jw-error-text jw-reset-text" dir="auto" data-nosnippet>${(message || '')}<span class="jw-break jw-reset"></span>${detail}</div>` +
                 `</div>` +
             `</div>` +
         `</div>`


### PR DESCRIPTION
### This PR will...
Implement nosnippet data attribute for error text, preventing errored players from being indexed by search engine crawlers.

### Why is this Pull Request needed?
Errored players can be indexed by search engine crawlers.

### Are there any points in the code the reviewer needs to double check?
No.

### Are there any Pull Requests open in other repos which need to be merged with this?
No.

#### Addresses Issue(s):

JW8-11651

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
