### PR TITLE
[JW8-11547] Extend MEDIA_SEEK Provider event with more info

### DIFF
--- a/src/js/providers/default.ts
+++ b/src/js/providers/default.ts
@@ -78,6 +78,12 @@ export type ProviderEvents = {
     [Event.MEDIA_SEEK]: {
         position: number;
         offset: number;
+        duration: number;
+        currentTime: number;
+        seekRange: SeekRange;
+        metadata: {
+            currentTime: number;
+        };
     };
     [Event.MEDIA_RATE_CHANGE]: {
         playbackRate: number;

--- a/src/js/providers/html5.ts
+++ b/src/js/providers/html5.ts
@@ -178,15 +178,22 @@ function VideoProvider(this: HTML5Provider, _playerId: string, _playerConfig: Ge
         },
 
         seeking(this: ProviderWithMixins): void {
+            const timeBeforeSeek = _timeBeforeSeek as number;
             const offset = _seekToTime !== null ? timeToPosition(_seekToTime) : _this.getCurrentTime();
-            const position = timeToPosition(_timeBeforeSeek as number);
+            const position = timeToPosition(timeBeforeSeek);
             _timeBeforeSeek = _seekToTime;
             _seekToTime = null;
             _delayedSeek = 0;
             _this.seeking = true;
             _this.trigger(MEDIA_SEEK, {
                 position,
-                offset
+                offset,
+                duration: _this.getDuration(),
+                currentTime: timeBeforeSeek,
+                seekRange: _this.getSeekRange(),
+                metadata: {
+                    currentTime: timeBeforeSeek
+                }
             });
         },
 


### PR DESCRIPTION
### This PR will...
- Include `duration`, `seekRange`, and an un-updated `currentTime` in the emitted `MEDIA_SEEK` provider event
- Apply the properties to the event emitted by the HTML5 provider
### Why is this Pull Request needed?
Improvement ask for Live Channels
### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/7880
#### Addresses Issue(s):

JW8-11547

### Checklist
- [x] Jenkins builds and unit tests are passing
- [x] I have reviewed the automated results
