### PR TITLE
[JW8-11678] Add AirPlay button in WebKit Web Views

### DIFF
--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -38,7 +38,7 @@ function div(classes) {
 }
 
 function createCastButton(castToggle, localization) {
-    if (Browser.safari) {
+    if ('WebKitPlaybackTargetAvailabilityEvent' in window) {
         const airplayButton = button(
             'jw-icon-airplay jw-off',
             castToggle,


### PR DESCRIPTION
### This PR will...
Use feature detection to decide whether the AirPlay button should be added to the control bar, so that it can be displayed when Airplay is available.

### Why is this Pull Request needed?
Our commercial Airplay module is enabled using feature detection; the presence of `WebKitPlaybackTargetAvailabilityEvent` global. Once enabled, the player listens for Airplay availability, and if triggered unhides the Airplay button.

When our user-agent check `Browser.safari` prevents the Airplay button from even being added, then there is nothing to show when Airplay is available. This is the case in iOS Web Views where the user-agent can be anything and by default does not match the Safari UA.

### Are there any points in the code the reviewer needs to double check?
No.

We are not changing `Browser.safari` to pass when the UA matches the default WKWebView UA (`"Mozilla/5.0 (iPhone; CPU iPhone OS 14_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko)"`) because that could impact other areas of the player that depend on it, and it still would not address this issue when the WebView UA is customized.

### Are there any Pull Requests open in other repos which need to be merged with this?
No.

#### Addresses Issue(s):
JW8-11678

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
