### PR TITLE
[JW8-11642] Trigger event when ad media is loaded onto the video tag

### DIFF
--- a/src/js/events/events.ts
+++ b/src/js/events/events.ts
@@ -165,7 +165,7 @@ export const AD_IMPRESSION = 'adImpression';
 /**
  * Event triggered on instream adapter when vast media is loaded onto the video tag.
  */
-export const AD_MEDIA_LAODED = 'adMediaLoaded';
+export const AD_MEDIA_LOADED = 'adMediaLoaded';
 
 /**
  * Event triggered when metadata is obtained during ad playback.

--- a/src/js/events/events.ts
+++ b/src/js/events/events.ts
@@ -163,6 +163,11 @@ export const AD_ERROR = 'adError';
 export const AD_IMPRESSION = 'adImpression';
 
 /**
+ * Event triggered on instream adapter when vast media is loaded onto the video tag.
+ */
+export const AD_MEDIA_LAODED = 'adMediaLoaded';
+
+/**
  * Event triggered when metadata is obtained during ad playback.
 */
 export const AD_META = 'adMeta';

--- a/src/js/events/events.ts
+++ b/src/js/events/events.ts
@@ -165,7 +165,7 @@ export const AD_IMPRESSION = 'adImpression';
 /**
  * Event triggered on instream adapter when vast media is loaded onto the video tag.
  */
-export const AD_MEDIA_LOADED = 'adMediaLoaded';
+export const AD_MEDIA_LOADED = 'mediaLoaded';
 
 /**
  * Event triggered when metadata is obtained during ad playback.

--- a/src/js/program/ad-program-controller.js
+++ b/src/js/program/ad-program-controller.js
@@ -1,4 +1,4 @@
-import { ERROR, FULLSCREEN, NATIVE_FULLSCREEN, MEDIA_COMPLETE, PLAYER_STATE, STATE_PLAYING, STATE_PAUSED } from 'events/events';
+import { AD_MEDIA_LAODED, ERROR, FULLSCREEN, NATIVE_FULLSCREEN, MEDIA_COMPLETE, PLAYER_STATE, STATE_PLAYING, STATE_PAUSED } from 'events/events';
 import ProgramController from 'program/program-controller';
 import Model from 'controller/model';
 import changeStateEvent from 'events/change-state-event';
@@ -75,6 +75,7 @@ export default class AdProgramController extends ProgramController {
         this.provider = null;
         return super.setActiveItem(index)
             .then((mediaController) => {
+                this.trigger(AD_MEDIA_LAODED);
                 this._setProvider(mediaController.provider);
                 return this.playVideo();
             });

--- a/src/js/program/ad-program-controller.js
+++ b/src/js/program/ad-program-controller.js
@@ -1,4 +1,4 @@
-import { AD_MEDIA_LAODED, ERROR, FULLSCREEN, NATIVE_FULLSCREEN, MEDIA_COMPLETE, PLAYER_STATE, STATE_PLAYING, STATE_PAUSED } from 'events/events';
+import { AD_MEDIA_LOADED, ERROR, FULLSCREEN, NATIVE_FULLSCREEN, MEDIA_COMPLETE, PLAYER_STATE, STATE_PLAYING, STATE_PAUSED } from 'events/events';
 import ProgramController from 'program/program-controller';
 import Model from 'controller/model';
 import changeStateEvent from 'events/change-state-event';
@@ -75,7 +75,7 @@ export default class AdProgramController extends ProgramController {
         this.provider = null;
         return super.setActiveItem(index)
             .then((mediaController) => {
-                this.trigger(AD_MEDIA_LAODED);
+                this.trigger(AD_MEDIA_LOADED);
                 this._setProvider(mediaController.provider);
                 return this.playVideo();
             });


### PR DESCRIPTION
### This PR will...
- Trigger instream adapter event when ad media is loaded onto the video tag

### Why is this Pull Request needed?
- Tracking purposes for OMID

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-ads-vast/pull/676

#### Addresses Issue(s):

JW8-11642

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
