### PR TITLE
Security fix: `utils.crossdomain` sets `href` on anchor

### DIFF
--- a/src/js/utils/helpers.ts
+++ b/src/js/utils/helpers.ts
@@ -42,16 +42,13 @@ import { between } from 'utils/math';
 import { log } from 'utils/log';
 import { genId } from 'utils/random-id-generator';
 
-// TODO: deprecate (jwplayer-ads-vast uses utils.crossdomain(url))
+// TODO: Deprecate in v9
 function crossdomain(uri: string): boolean {
-    const a = document.createElement('a');
-    const b = document.createElement('a');
-    a.href = location.href;
+    const URL = window.URL;
     try {
-        b.href = uri;
-        b.href = b.href; /* IE fix for relative urls */ // eslint-disable-line no-self-assign
-        return a.protocol + '//' + a.host !== b.protocol + '//' + b.host;
-    } catch (e) {/* swallow */}
+        const b = new URL(uri, location.origin);
+        return location.protocol + '//' + location.host !== b.protocol + '//' + b.host;
+    } catch (e) {/* no-op */}
     return true;
 }
 


### PR DESCRIPTION
### This PR will...
Remove util code that sets `href` on link element since it can result in the browser making a prefetch request (security).

### Why is this Pull Request needed?
Setting `href` on an anchor can trigger a request to prefetch the resolved URL. This util is deprecated and should not allow malicious parties to trigger requests using the player library.

### Checklist
- [x] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
