### PR TITLE
[JW8-11715] Remove display container layout shifts from autostarting

### DIFF
--- a/src/css/controls/flags/cast.less
+++ b/src/css/controls/flags/cast.less
@@ -30,6 +30,6 @@
 .jw-state-playing,
 .jw-state-paused {
     &.jw-flag-casting:not(.jw-flag-audio-player) .jw-display {
-        display: table;
+        display: flex;
     }
 }

--- a/src/css/controls/flags/user-inactive.less
+++ b/src/css/controls/flags/user-inactive.less
@@ -13,7 +13,7 @@
 
         &.jw-flag-casting {
             .jw-display {
-                display: table;
+                display: flex;
             }
         }
 

--- a/src/css/controls/imports/display.less
+++ b/src/css/controls/imports/display.less
@@ -35,7 +35,6 @@ display icons
 
 .jw-display-container {
     text-align: center;
-    vertical-align: middle;
 }
 
 .jw-display-controls {

--- a/src/css/controls/imports/display.less
+++ b/src/css/controls/imports/display.less
@@ -16,7 +16,9 @@ display icons
 */
 
 .jw-display {
-    display: table;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
     height: 100%;
     padding: @controlbar-height 0;
     position: relative;
@@ -32,8 +34,6 @@ display icons
 }
 
 .jw-display-container {
-    display: table-cell;
-    height: 100%;
     text-align: center;
     vertical-align: middle;
 }


### PR DESCRIPTION
### This PR will...
- Remove the layout shift caused by the display container in autostarting players by changing display from table to flex.
### Why is this Pull Request needed?
Web Vitals CLS
### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-11715

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
