### PR TITLE
[JW8-11722] Fix player memory leaks

### DIFF
--- a/src/js/api/core-shim.js
+++ b/src/js/api/core-shim.js
@@ -115,7 +115,7 @@ Object.assign(CoreShim.prototype, {
                 mediaPool = SharedMediaPool(mediaPool.getPrimedElement(), mediaPool);
             }
 
-            const primeUi = new UI(getElementWindow(this.originalContainer)).once('gesture', () => {
+            const primeUi = this.primeUi = new UI(getElementWindow(this.originalContainer)).once('gesture', () => {
                 mediaPool.prime();
                 this.preload();
                 primeUi.destroy();
@@ -151,7 +151,7 @@ Object.assign(CoreShim.prototype, {
 
             // Assign CoreMixin.prototype (formerly controller) properties to this instance making api.core the controller
             Object.assign(this, CoreMixin.prototype);
-            this.setup(config, api, this.originalContainer, this._events, commandQueue, mediaPool);
+            this.playerSetup(config, api, this.originalContainer, this._events, commandQueue, mediaPool);
 
             const coreModel = this._model;
             // Switch the error log handlers after the real model has been set
@@ -178,12 +178,20 @@ Object.assign(CoreShim.prototype, {
         });
     },
     playerDestroy() {
+        if (this.destroy) {
+            // Destroy core player (controller.js) mixin
+            this.destroy();
+        }
         if (this.apiQueue) {
             this.apiQueue.destroy();
         }
 
         if (this.setup) {
             this.setup.destroy();
+        }
+
+        if (this.primeUi) {
+            this.primeUi.destroy();
         }
 
         // Removes the ErrorContainer if it has been shown
@@ -196,6 +204,7 @@ Object.assign(CoreShim.prototype, {
             this._model =
             this.modelShim =
             this.apiQueue =
+            this.primeUi =
             this.setup = null;
     },
     getContainer() {

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -84,10 +84,13 @@ Object.assign(Controller.prototype, {
             this._apiQueue =
             this._captions =
             this._programController = null;
+        if (this.clearSetupVars) {
+            this.clearSetupVars();
+        }
     },
     playerSetup(config, _api, originalContainer, eventListeners, commandQueue, mediaPool) {
-        const _this = this;
-        const _model = _this._model = new Model();
+        let _this = this;
+        let _model = _this._model = new Model();
 
         let _view;
         let _captions;
@@ -138,10 +141,24 @@ Object.assign(Controller.prototype, {
             });
         }
 
-        const _programController = this._programController = new ProgramController(_model, mediaPool, _api._publicApi);
+        let _programController = this._programController = new ProgramController(_model, mediaPool, _api._publicApi);
         updateProgramSoundSettings();
         addProgramControllerListeners();
         initQoe(_model, _programController);
+
+        _this.clearSetupVars = function() {
+            if (eventsReadyQueue) {
+                eventsReadyQueue.destroy();
+            }
+            _this =
+                _programController =
+                _model =
+                _view =
+                checkAutoStartCancelable =
+                updatePlaylistCancelable =
+                apiQueue =
+                eventsReadyQueue = null;
+        };
 
         _model.on(ERROR, _this.triggerError, _this);
 
@@ -1174,7 +1191,7 @@ Object.assign(Controller.prototype, {
         };
 
         // Setup ApiQueueDecorator after instance methods have been assigned
-        const apiQueue = this._apiQueue = new ApiQueueDecorator(this, [
+        let apiQueue = this._apiQueue = new ApiQueueDecorator(this, [
             'play',
             'pause',
             'setCurrentAudioTrack',

--- a/src/js/controller/model.ts
+++ b/src/js/controller/model.ts
@@ -175,7 +175,9 @@ class Model extends SimpleModel {
         if (this._provider) {
             this._provider.off(null, null, this);
             this._provider.destroy();
+            this._provider = null;
         }
+        this.providerController = null;
     }
 
     getVideo(): ImplementedProvider | null {

--- a/src/js/controller/qoe.ts
+++ b/src/js/controller/qoe.ts
@@ -120,7 +120,7 @@ function trackFirstFrame(model: QoeModel, programController: ProgramController):
     programController.on(MEDIA_TIME, model._onTime);
 }
 
-const initQoe = function(initialModel: Model, programController: ProgramController): void {
+export function initQoe(initialModel: Model, programController: ProgramController): void {
     function onMediaModel(model: QoeModel, mediaModel: MediaModel, oldMediaModel: MediaModel): void {
         // finish previous item
         if (model._qoeItem && oldMediaModel) {
@@ -142,6 +142,12 @@ const initQoe = function(initialModel: Model, programController: ProgramControll
     }
 
     initialModel.change('mediaModel', onMediaModel);
-};
+}
 
-export default initQoe;
+export function destroyQoe(model: any): void {
+    model._qoeItem =
+    model._triggerFirstFrame =
+    model._onTime =
+    model._onPlayAttempt =
+    model._onTabVisible = null;
+}

--- a/src/js/plugins/plugin.js
+++ b/src/js/plugins/plugin.js
@@ -87,7 +87,7 @@ Object.assign(Plugin.prototype, {
             if (__HEADLESS__) {
                 return;
             }
-            const overlaysElement = api.getContainer().querySelector('.jw-overlays');
+            const overlaysElement = this.getContainer().querySelector('.jw-overlays');
             if (!overlaysElement) {
                 return;
             }

--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -85,9 +85,17 @@ export default class MediaController extends Events {
         if (provider.getContainer()) {
             provider.remove();
         }
+        if (this.eventQueue) {
+            this.eventQueue.destroy();
+        }
         delete provider.instreamMode;
-        this.provider = null;
-        this.item = null;
+        this.provider =
+            this.mediaModel =
+            this.model =
+            this.eventQueue =
+            this.item =
+            this.providerListener =
+            this.thenPlayPromise = null;
     }
 
     attach() {

--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -2,7 +2,7 @@ import cancelable from 'utils/cancelable';
 import Events from 'utils/backbone.events';
 import ApiQueueDecorator from 'api/api-queue';
 import { PlayerError, getPlayAttemptFailedErrorCode } from 'api/errors';
-import { ProviderListener } from 'program/program-listeners';
+import { providerListener } from 'program/program-listeners';
 import { MediaModel } from 'controller/model';
 import { seconds } from 'utils/strings';
 import {
@@ -19,7 +19,7 @@ export default class MediaController extends Events {
         this.mediaModel = new MediaModel();
         this.model = model;
         this.provider = provider;
-        this.providerListener = new ProviderListener(this);
+        this.providerListener = providerListener;
         this.thenPlayPromise = cancelable(() => {});
         provider.off();
         provider.on('all', this.providerListener, this);

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -1,7 +1,7 @@
 import Providers from 'providers/providers';
 import MediaController from 'program/media-controller';
 import cancelable from 'utils/cancelable';
-import { MediaControllerListener } from 'program/program-listeners';
+import { mediaControllerListener } from 'program/program-listeners';
 import Events from 'utils/backbone.events';
 import BackgroundMedia from 'program/background-media';
 import { PLAYER_STATE, STATE_IDLE, STATE_BUFFERING, STATE_PAUSED } from 'events/events';
@@ -24,7 +24,7 @@ class ProgramController extends Events {
         this.background = BackgroundMedia();
         this.mediaPool = mediaPool;
         this.mediaController = null;
-        this.mediaControllerListener = MediaControllerListener(model);
+        this.mediaControllerListener = mediaControllerListener;
         this.model = model;
         this.providers = new Providers(model.getConfiguration());
         this.loadPromise = null;
@@ -804,8 +804,7 @@ function assignMediaContainer(model, mediaController) {
 }
 
 function forwardEvents(mediaController, target) {
-    const { mediaControllerListener } = target;
-    mediaController.off().on('all', mediaControllerListener, target);
+    mediaController.off().on('all', target.mediaControllerListener, target);
 }
 
 function getSource(item) {

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -101,7 +101,8 @@ class ProgramController extends Events {
             // Resolve and exit on asyncActiveItem() itemPromiseError,
             // or if setActiveItem was called again changing itemSetContext
             if (playlistItem === null ||
-                itemSetContext !== this.itemSetContext) {
+                itemSetContext !== this.itemSetContext ||
+                this.providers === null) {
                 return null;
             }
 
@@ -430,7 +431,12 @@ class ProgramController extends Events {
         this.off();
         this._destroyBackgroundMedia();
         this._destroyActiveMedia();
-        this.apiContext = null;
+        this.asyncItems =
+            this.loadPromise =
+            this.mediaControllerListener =
+            this.model =
+            this.providers =
+            this.apiContext = null;
     }
 
     /**

--- a/src/js/program/program-listeners.ts
+++ b/src/js/program/program-listeners.ts
@@ -13,175 +13,170 @@ import type MediaController from 'program/media-controller';
 import type { AllProviderEventsListener, AllProviderEvents, ProviderEvents } from 'providers/default';
 import type { PlayerError } from 'api/errors';
 
-export function ProviderListener(mediaController: MediaController): AllProviderEventsListener {
-    return function<E extends keyof AllProviderEvents>(type: E, data: AllProviderEvents[E]): void {
-        const mediaModel: MediaModel = mediaController.mediaModel;
-        const event: AllProviderEvents[E] & { type: E } = Object.assign({}, data, {
-            type: type
-        });
+export function providerListener<E extends keyof AllProviderEvents>(this: MediaController, type: E, data: AllProviderEvents[E]): void {
+    const mediaModel: MediaModel = this.mediaModel;
+    const event: AllProviderEvents[E] & { type: E } = Object.assign({}, data, {
+        type: type
+    });
 
-        switch (type) {
-            case MEDIA_TYPE:
-                if (mediaModel.get(MEDIA_TYPE) === (event as unknown as ProviderEvents['mediaType']).mediaType) {
-                    return;
-                }
-                mediaModel.set(MEDIA_TYPE, (event as unknown as ProviderEvents['mediaType']).mediaType);
-                break;
-            case MEDIA_VISUAL_QUALITY:
-                mediaModel.set(MEDIA_VISUAL_QUALITY, Object.assign({}, data));
+    switch (type) {
+        case MEDIA_TYPE:
+            if (mediaModel.get(MEDIA_TYPE) === (event as unknown as ProviderEvents['mediaType']).mediaType) {
                 return;
-            case MEDIA_MUTE:
-                // Only forward and queue mute changes
-                if (data[MEDIA_MUTE] === mediaController.model.getMute()) {
-                    return;
-                }
-                break;
-            case PLAYER_STATE: {
-                const { newstate } = data as ProviderEvents['state'];
-                if (newstate === STATE_IDLE) {
-                    mediaController.thenPlayPromise.cancel();
-                    mediaModel.srcReset();
-                }
-                // Always fire change:mediaState to keep player model in sync
-                const previousState = mediaModel.attributes.mediaState;
-                mediaModel.attributes.mediaState = newstate;
-                mediaModel.trigger('change:mediaState', mediaModel, newstate, previousState);
-                break;
             }
-            case MEDIA_COMPLETE:
-                mediaController.beforeComplete = true;
-                mediaController.trigger(MEDIA_BEFORECOMPLETE, event);
-                if (mediaController.attached && !mediaController.background) {
-                    mediaController._playbackComplete();
-                }
+            mediaModel.set(MEDIA_TYPE, (event as unknown as ProviderEvents['mediaType']).mediaType);
+            break;
+        case MEDIA_VISUAL_QUALITY:
+            mediaModel.set(MEDIA_VISUAL_QUALITY, Object.assign({}, data));
+            return;
+        case MEDIA_MUTE:
+            // Only forward and queue mute changes
+            if (data[MEDIA_MUTE] === this.model.getMute()) {
                 return;
-            case MEDIA_ERROR:
-                if (mediaModel.get('setup')) {
-                    mediaController.thenPlayPromise.cancel();
-                    mediaModel.srcReset();
-                } else {
-                    // A MEDIA_ERROR received before setup is a preload error
-                    // We stop propagation here allow the player to try loading once more when playback is initiated
-                    // MEDIA_ERROR codes are in the 200,000 range; adding 100,000 puts it in the 300,000 warning range.
-                    type = WARNING as E;
-                    (event as unknown as PlayerError).code += 100000;
-                }
-                break;
-            case MEDIA_META: {
-                const { duration, metadataType, seekRange } = data as ProviderEvents['meta'];
-                if (!metadataType) {
-                    (event as unknown as ProviderEvents['meta']).metadataType = 'unknown';
-                }
-                if (isValidNumber(duration)) {
-                    mediaModel.set('seekRange', seekRange);
-                    mediaModel.set('duration', duration);
-                }
-                break;
             }
-            case MEDIA_BUFFER:
-                mediaModel.set('buffer', (data as ProviderEvents['bufferChange']).bufferPercent);
-                /* falls through to update duration while media is loaded */
-            case MEDIA_TIME: {
-                const timeData = data as ProviderEvents['time'] | ProviderEvents['bufferChange'];
-                mediaModel.set('seekRange', timeData.seekRange);
-                mediaModel.set('position', timeData.position);
-                mediaModel.set('currentTime', timeData.currentTime);
-                const duration = timeData.duration;
-                if (isValidNumber(duration)) {
-                    mediaModel.set('duration', duration);
-                }
-                if (type === MEDIA_TIME && 'starttime' in mediaController.item) {
-                    delete mediaController.item.starttime;
-                }
-                break;
+            break;
+        case PLAYER_STATE: {
+            const { newstate } = data as ProviderEvents['state'];
+            if (newstate === STATE_IDLE) {
+                this.thenPlayPromise.cancel();
+                mediaModel.srcReset();
             }
-            case MEDIA_SEEKED: {
-                // After seeking, if the video tag is in a paused state, update the player state to "paused"
-                const { mediaElement } = mediaController;
-                if (mediaElement && mediaElement.paused) {
-                    mediaModel.set('mediaState', 'paused');
-                }
-                break;
-            }
-            case MEDIA_LEVELS:
-                mediaModel.set(MEDIA_LEVELS, (data as ProviderEvents['levels']).levels);
-                /* falls through to update current level */
-            case MEDIA_LEVEL_CHANGED: {
-                const { currentQuality, levels } = data as ProviderEvents['levelsChanged'];
-                if (currentQuality > -1 && levels.length > 1) {
-                    mediaModel.set('currentLevel', parseInt(currentQuality as any));
-                }
-                break;
-            }
-            case AUDIO_TRACKS:
-                mediaModel.set(AUDIO_TRACKS, (data as ProviderEvents['audioTracks']).tracks);
-                /* falls through to update current track */
-            case AUDIO_TRACK_CHANGED: {
-                const { currentTrack, tracks } = data as ProviderEvents['audioTrackChanged'];
-
-                if (currentTrack > -1 && tracks.length > 0 && currentTrack < tracks.length) {
-                    mediaModel.set('currentAudioTrack', parseInt(currentTrack as any));
-                }
-                break;
-            }
-            default:
-                break;
+            // Always fire change:mediaState to keep player model in sync
+            const previousState = mediaModel.attributes.mediaState;
+            mediaModel.attributes.mediaState = newstate;
+            mediaModel.trigger('change:mediaState', mediaModel, newstate, previousState);
+            break;
         }
+        case MEDIA_COMPLETE:
+            this.beforeComplete = true;
+            this.trigger(MEDIA_BEFORECOMPLETE, event);
+            if (this.attached && !this.background) {
+                this._playbackComplete();
+            }
+            return;
+        case MEDIA_ERROR:
+            if (mediaModel.get('setup')) {
+                this.thenPlayPromise.cancel();
+                mediaModel.srcReset();
+            } else {
+                // A MEDIA_ERROR received before setup is a preload error
+                // We stop propagation here allow the player to try loading once more when playback is initiated
+                // MEDIA_ERROR codes are in the 200,000 range; adding 100,000 puts it in the 300,000 warning range.
+                type = WARNING as E;
+                (event as unknown as PlayerError).code += 100000;
+            }
+            break;
+        case MEDIA_META: {
+            const { duration, metadataType, seekRange } = data as ProviderEvents['meta'];
+            if (!metadataType) {
+                (event as unknown as ProviderEvents['meta']).metadataType = 'unknown';
+            }
+            if (isValidNumber(duration)) {
+                mediaModel.set('seekRange', seekRange);
+                mediaModel.set('duration', duration);
+            }
+            break;
+        }
+        case MEDIA_BUFFER:
+            mediaModel.set('buffer', (data as ProviderEvents['bufferChange']).bufferPercent);
+            /* falls through to update duration while media is loaded */
+        case MEDIA_TIME: {
+            const timeData = data as ProviderEvents['time'] | ProviderEvents['bufferChange'];
+            mediaModel.set('seekRange', timeData.seekRange);
+            mediaModel.set('position', timeData.position);
+            mediaModel.set('currentTime', timeData.currentTime);
+            const duration = timeData.duration;
+            if (isValidNumber(duration)) {
+                mediaModel.set('duration', duration);
+            }
+            if (type === MEDIA_TIME && 'starttime' in this.item) {
+                delete this.item.starttime;
+            }
+            break;
+        }
+        case MEDIA_SEEKED: {
+            // After seeking, if the video tag is in a paused state, update the player state to "paused"
+            const mediaElement = this.mediaElement;
+            if (mediaElement && mediaElement.paused) {
+                mediaModel.set('mediaState', 'paused');
+            }
+            break;
+        }
+        case MEDIA_LEVELS:
+            mediaModel.set(MEDIA_LEVELS, (data as ProviderEvents['levels']).levels);
+            /* falls through to update current level */
+        case MEDIA_LEVEL_CHANGED: {
+            const { currentQuality, levels } = data as ProviderEvents['levelsChanged'];
+            if (currentQuality > -1 && levels.length > 1) {
+                mediaModel.set('currentLevel', parseInt(currentQuality as any));
+            }
+            break;
+        }
+        case AUDIO_TRACKS:
+            mediaModel.set(AUDIO_TRACKS, (data as ProviderEvents['audioTracks']).tracks);
+            /* falls through to update current track */
+        case AUDIO_TRACK_CHANGED: {
+            const { currentTrack, tracks } = data as ProviderEvents['audioTrackChanged'];
 
-        mediaController.trigger(type, event);
-    };
+            if (currentTrack > -1 && tracks.length > 0 && currentTrack < tracks.length) {
+                mediaModel.set('currentAudioTrack', parseInt(currentTrack as any));
+            }
+            break;
+        }
+        default:
+            break;
+    }
+
+    this.trigger(type, event);
 }
 
-type AllMediaEventsListener = <E extends keyof AllProviderEventsListener>(type: E, data: AllProviderEventsListener[E] & { type: E }) => void;
-
-export function MediaControllerListener(model: Model): AllMediaEventsListener {
-    return function<E extends keyof AllProviderEventsListener>(this: ProgramController, type: E, event: AllProviderEventsListener[E] & { type: E }): void {
-        switch (type) {
-            case PLAYER_STATE:
-                // This "return" is important because
-                //  we are choosing to not propagate model event.
-                //  Instead letting the master controller do so
-                return;
-            case MEDIA_VOLUME:
-                model.set(MEDIA_VOLUME, event[MEDIA_VOLUME]);
-                return;
-            case MEDIA_MUTE:
-                model.set(MEDIA_MUTE, event[MEDIA_MUTE]);
-                return;
-            case MEDIA_RATE_CHANGE:
-                model.set('playbackRate', (event as ProviderEvents['ratechange']).playbackRate);
-                return;
-            case MEDIA_META: {
-                Object.assign(model.get('itemMeta'), (event as ProviderEvents['meta']).metadata);
-                break;
-            }
-            case MEDIA_LEVEL_CHANGED:
-                model.persistQualityLevel((event as ProviderEvents['levelsChanged']).currentQuality,
-                    (event as ProviderEvents['levelsChanged']).levels);
-                break;
-            case SUBTITLES_TRACK_CHANGED:
-                model.persistVideoSubtitleTrack((event as ProviderEvents['subtitlesTrackChanged']).currentTrack,
-                    (event as ProviderEvents['subtitlesTrackChanged']).tracks);
-                break;
-            case MEDIA_TIME:
-                if ((event as ProviderEvents['time']).targetLatency) {
-                    model.set('dvrSeekLimit', (event as ProviderEvents['time']).targetLatency as number);
-                }
-                /* falls through to to trigger model event off model */
-            case MEDIA_SEEK:
-            case MEDIA_SEEKED:
-            case NATIVE_FULLSCREEN:
-            case SUBTITLES_TRACKS:
-            case 'subtitlesTracksData':
-                model.trigger(type, event);
-                break;
-            case BANDWIDTH_ESTIMATE: {
-                model.persistBandwidthEstimate((event as ProviderEvents['bandwidthEstimate']).bandwidthEstimate);
-                return;
-            }
-            default:
+export function mediaControllerListener<E extends keyof AllProviderEventsListener>(this: ProgramController, type: E, event: AllProviderEventsListener[E] & { type: E }): void {
+    const model: Model = this.model;
+    switch (type) {
+        case PLAYER_STATE:
+            // This "return" is important because
+            //  we are choosing to not propagate model event.
+            //  Instead letting the master controller do so
+            return;
+        case MEDIA_VOLUME:
+            model.set(MEDIA_VOLUME, event[MEDIA_VOLUME]);
+            return;
+        case MEDIA_MUTE:
+            model.set(MEDIA_MUTE, event[MEDIA_MUTE]);
+            return;
+        case MEDIA_RATE_CHANGE:
+            model.set('playbackRate', (event as ProviderEvents['ratechange']).playbackRate);
+            return;
+        case MEDIA_META: {
+            Object.assign(model.get('itemMeta'), (event as ProviderEvents['meta']).metadata);
+            break;
         }
+        case MEDIA_LEVEL_CHANGED:
+            model.persistQualityLevel((event as ProviderEvents['levelsChanged']).currentQuality,
+                (event as ProviderEvents['levelsChanged']).levels);
+            break;
+        case SUBTITLES_TRACK_CHANGED:
+            model.persistVideoSubtitleTrack((event as ProviderEvents['subtitlesTrackChanged']).currentTrack,
+                (event as ProviderEvents['subtitlesTrackChanged']).tracks);
+            break;
+        case MEDIA_TIME:
+            if ((event as ProviderEvents['time']).targetLatency) {
+                model.set('dvrSeekLimit', (event as ProviderEvents['time']).targetLatency as number);
+            }
+            /* falls through to to trigger model event off model */
+        case MEDIA_SEEK:
+        case MEDIA_SEEKED:
+        case NATIVE_FULLSCREEN:
+        case SUBTITLES_TRACKS:
+        case 'subtitlesTracksData':
+            model.trigger(type, event);
+            break;
+        case BANDWIDTH_ESTIMATE: {
+            model.persistBandwidthEstimate((event as ProviderEvents['bandwidthEstimate']).bandwidthEstimate);
+            return;
+        }
+        default:
+    }
 
-        this.trigger(type, event);
-    };
+    this.trigger(type, event);
 }

--- a/test/data/api-methods.js
+++ b/test/data/api-methods.js
@@ -29,6 +29,7 @@ export default {
     getCurrentTime: null,
     getDuration: null,
     getEnvironment: null,
+    getFloating: null,
     getFullscreen: null,
     getHeight: null,
     getItemMeta: null,
@@ -74,6 +75,7 @@ export default {
     setCurrentAudioTrack: null,
     setCurrentCaptions: null,
     setCurrentQuality: null,
+    setFloating: null,
     setFullscreen: null,
     setMute: null,
     setPlaybackRate: null,
@@ -89,7 +91,5 @@ export default {
     skipAd: null,
     trigger: null,
     // In tests that iterate through these methods, call remove last
-    remove: null,
-    getFloating: null,
-    setFloating: null
+    remove: null
 };

--- a/test/unit/model-qoe-test.js
+++ b/test/unit/model-qoe-test.js
@@ -5,7 +5,7 @@ import { STATE_IDLE, STATE_PLAYING, STATE_LOADING, STATE_STALLED, MEDIA_PLAY_ATT
     MEDIA_FIRST_FRAME } from 'events/events';
 import { dateTime } from 'utils/clock';
 import { now } from 'utils/date';
-import initQoe from 'controller/qoe';
+import { initQoe } from 'controller/qoe';
 
 describe('Model QoE', function() {
 

--- a/test/unit/plugins-test.js
+++ b/test/unit/plugins-test.js
@@ -9,7 +9,8 @@ const globalPluginsModel = new PluginsModel();
 
 const mockApi = () => ({
     id: 'player',
-    addPlugin: sinon.spy()
+    addPlugin: sinon.spy(),
+    getContainer: () => ({ querySelector: sinon.spy() })
 });
 
 function mockModel(attributes) {

--- a/test/unit/program-controller-test.js
+++ b/test/unit/program-controller-test.js
@@ -185,16 +185,15 @@ describe('ProgramController', function () {
         const callback = sandbox.spy();
         programController.on('all', callback, {});
         programController.stopVideo();
-        const itemPromise = programController.setActiveItem(0)
-            .then(function () {
-                const provider = programController.mediaController.provider;
+        return programController.setActiveItem(0)
+            .then(function (mediaController) {
+                const provider = mediaController.provider;
+                programController.destroy();
                 providerEvents.forEach(event => {
                     provider.trigger(event.type, event);
                 });
                 expect(callback).to.have.callCount(0);
             });
-        programController.destroy();
-        return itemPromise;
     });
 
     it('forwards queued provider events when provider is foregrounded', function() {


### PR DESCRIPTION
### This PR will...

- Don't overwrite core.setup
- Don't overwrite core.playerDestroy
- Don't overwrite updatePlaylist
- Have shim and os methods call commercial and core ones instead of replacing methods with scopes that hoist references to the original
  - Call controller.playerSetup() from core-shim.setup() promise callback
  - Call controller.destroy() from core-shim.playerDestroy() (the latter was being skipped after being overwritten, and setup was rewritten and never destroyed)
  - updatePlaylist uses base implementation and calls extended one when available
- Clean up "prime" UI instance DOM event listeners
- Don't copy Api instance into plugin addToPlayer method (cyclical reference)
- Cleanup `core` reference after call to api.remove()
- destroy plugin instances (vast) on remove
- Cleanup QoE callback upon destroy
- Cleanup MediaController properties on destroy
- Cleanup ProgramController properties on destroy

### Why is this Pull Request needed?
Improve GC after removing or replacing players, and after playing multiple playlist items and ad breaks.

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/7934

#### Addresses Issue(s):
JW8-11722

### Checklist
- [x] Jenkins builds and unit tests are passing
- [x] I have reviewed the automated results
