### PR TITLE
[JW8-11710] Prevent CLS in draggable floating player

### DIFF
--- a/src/css/jwplayer/flags/floatingplayer.less
+++ b/src/css/jwplayer/flags/floatingplayer.less
@@ -8,7 +8,6 @@
         position: fixed;
         //  Maximum allowable z-index to ensure always on top.
         z-index: 2147483647;
-        animation: jw-float-to-bottom 150ms cubic-bezier(0, 0.25, 0.25, 1) forwards 1;
         top: auto;
         bottom: 1rem;
         left: auto;
@@ -17,10 +16,21 @@
         max-height: 400px;
         margin: 0 auto;
 
+        @media screen and (min-width : 481px) {
+            &:not(.jw-floating-dragged) {
+                animation: jw-float-to-bottom 150ms cubic-bezier(0, 0.25, 0.25, 1) forwards 1;
+            }
+        }
         @media screen and (max-width : 480px) {
             width: 100%;
             left: 0;
             right: 0;
+        }
+
+        &.jw-floating-dragging {
+            /* stylelint-disable-next-line */
+            transition: none!important;
+            will-change: transform;
         }
 
         .jw-media {
@@ -30,10 +40,9 @@
         .jw-flag-touch& {
             @media screen and (max-device-width : 480px) and (orientation: portrait) {
                 animation: none;
-                top: 62px;
+                top: 0;
+                margin-top: 62px;
                 bottom: auto;
-                left: 0;
-                right: 0;
                 max-width: none;
                 max-height: none;
             }

--- a/src/js/utils/css.js
+++ b/src/js/utils/css.js
@@ -94,13 +94,7 @@ function _styleValue(property, value) {
 }
 
 export function transform(element, value) {
-    style(element, {
-        transform: value,
-        webkitTransform: value,
-        msTransform: value,
-        mozTransform: value,
-        oTransform: value
-    });
+    style(element, { transform: value });
 }
 
 let canvasColorContext;

--- a/src/js/view/floating/floating-controller.ts
+++ b/src/js/view/floating/floating-controller.ts
@@ -214,11 +214,6 @@ export default class FloatingController {
                 maxWidth: null,
                 width: null,
                 height: null,
-                left: null,
-                right: null,
-                top: null,
-                bottom: null,
-                margin: null,
                 transform: null,
                 transition: null,
                 'transition-timing-function': null

--- a/src/js/view/floating/floating-drag-ui.js
+++ b/src/js/view/floating/floating-drag-ui.js
@@ -1,5 +1,5 @@
 import UI from 'utils/ui';
-import { style } from 'utils/css';
+import { transform } from 'utils/css';
 import { addClass, removeClass } from 'utils/dom';
 
 export default class FloatingDragUI {
@@ -50,9 +50,7 @@ export default class FloatingDragUI {
                 const { pageX, pageY } = e;
                 deltaX = calculateDelta(x, pageX, startX, maxDeltaX, minDeltaX);
                 deltaY = calculateDelta(y, pageY, startY, maxDeltaY, minDeltaY);
-                style(container, {
-                    transform: `translate3d(${deltaX}px, ${deltaY}px, 0)`,
-                });
+                transform(container, `translate3d(${deltaX}px, ${deltaY}px, 0)`);
             })
             .on('dragEnd', () => {
                 removeClass(container, 'jw-floating-dragging');

--- a/src/js/view/floating/floating-drag-ui.js
+++ b/src/js/view/floating/floating-drag-ui.js
@@ -38,8 +38,8 @@ export default class FloatingDragUI {
                 const { offsetLeft, offsetTop, offsetWidth, offsetHeight } = container;
                 startX = pageX;
                 startY = pageY;
-                minDeltaX = calculateMin(offsetLeft);
-                minDeltaY = calculateMin(offsetTop);
+                minDeltaX = -offsetLeft;
+                minDeltaY = -offsetTop;
                 maxDeltaX = calculateMax(outerWidth, offsetLeft, offsetWidth);
                 maxDeltaY = calculateMax(outerHeight, offsetTop, offsetHeight);
                 // Class prevents initial animation styles from overriding translate styling.
@@ -62,6 +62,5 @@ export default class FloatingDragUI {
     }
 }
 
-const calculateMin = (offset) => 0 - offset;
 const calculateMax = (windowLength, offset, length) => windowLength - offset - length;
 const calculateDelta = (last, current, first, max, min) => Math.max(Math.min(last + current - first, max), min);

--- a/test/unit/css-test.js
+++ b/test/unit/css-test.js
@@ -83,16 +83,10 @@ describe('css', function() {
         transform(element, 'none');
 
         expect(element.style.transform, 'css transform').to.equal('none');
-        expect(element.style.msTransform, 'css transform ms').to.equal('none');
-        expect(element.style.mozTransform, 'css transform moz').to.equal('none');
-        expect(element.style.oTransform, 'css transform o').to.equal('none');
 
         transform(element, '');
 
         expect(element.style.transform, 'css transform').to.equal('');
-        expect(element.style.msTransform, 'css transform ms').to.equal('');
-        expect(element.style.mozTransform, 'css transform moz').to.equal('');
-        expect(element.style.oTransform, 'css transform o').to.equal('');
     });
 
     it('getRgba', function() {


### PR DESCRIPTION
### This PR will...
Refactor floating player logic to prevent layout shifts. DOM structure/UX are unchanged.

### Why is this Pull Request needed?
Dragging the floating player continually increases the web vitals CLS score, creating numerous layout shifts.

### Are there any points in the code the reviewer needs to double check?
An alternative would be to modify UI.js so that web vitals sees the dragging event as a user input:
<img width="826" alt="image" src="https://user-images.githubusercontent.com/2903955/110870777-c19c1580-8292-11eb-81fc-4e381aced327.png">

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-11710

### Checklist
- [x] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
