### PR TITLE
[JW8-11727] Further Optimize FOS Drag Handling

### DIFF
--- a/src/css/jwplayer/flags/floatingplayer.less
+++ b/src/css/jwplayer/flags/floatingplayer.less
@@ -30,7 +30,6 @@
         &.jw-floating-dragging {
             /* stylelint-disable-next-line */
             transition: none!important;
-            will-change: transform;
         }
 
         .jw-media {

--- a/src/js/view/floating/floating-drag-ui.js
+++ b/src/js/view/floating/floating-drag-ui.js
@@ -1,5 +1,5 @@
 import UI from 'utils/ui';
-import { transform } from 'utils/css';
+import { transform, style } from 'utils/css';
 import { addClass, removeClass } from 'utils/dom';
 
 export default class FloatingDragUI {
@@ -9,10 +9,14 @@ export default class FloatingDragUI {
     }
 
     disable() {
-        if (this.ui) {
+        const container = this.container;
+        if (container) {
             // 'Dragged' state is reset so the transition animation can fire again if the player re-floats.
-            removeClass(this.container, 'jw-floating-dragged');
-            removeClass(this.container, 'jw-floating-dragging');
+            removeClass(container, 'jw-floating-dragged');
+            removeClass(container, 'jw-floating-dragging');
+            setWillChange(container, 'auto');
+        }
+        if (this.ui) {
             this.ui.destroy();
             this.ui = null;
         }
@@ -45,6 +49,7 @@ export default class FloatingDragUI {
                 // Class prevents initial animation styles from overriding translate styling.
                 addClass(container, 'jw-floating-dragged');
                 addClass(container, 'jw-floating-dragging');
+                setWillChange(container, 'transform');
             })
             .on('drag', (e) => {
                 const { pageX, pageY } = e;
@@ -54,6 +59,7 @@ export default class FloatingDragUI {
             })
             .on('dragEnd', () => {
                 removeClass(container, 'jw-floating-dragging');
+                setWillChange(container, 'auto');
                 x = deltaX;
                 y = deltaY;
             });
@@ -62,3 +68,4 @@ export default class FloatingDragUI {
 
 const calculateMax = (windowLength, offset, length) => windowLength - offset - length;
 const calculateDelta = (last, current, first, max, min) => Math.max(Math.min(last + current - first, max), min);
+const setWillChange = (element, willChange) => style(element, { willChange });

--- a/src/js/view/floating/floating-drag-ui.js
+++ b/src/js/view/floating/floating-drag-ui.js
@@ -55,7 +55,7 @@ export default class FloatingDragUI {
                 const { pageX, pageY } = e;
                 deltaX = calculateDelta(x, pageX, startX, maxDeltaX, minDeltaX);
                 deltaY = calculateDelta(y, pageY, startY, maxDeltaY, minDeltaY);
-                transform(container, `translate3d(${deltaX}px, ${deltaY}px, 0)`);
+                transform(container, `translate(${deltaX}px, ${deltaY}px)`);
             })
             .on('dragEnd', () => {
                 removeClass(container, 'jw-floating-dragging');


### PR DESCRIPTION
### This PR will...
- Further optimize dragging by ensuring browser removes `will-change` from `.jw-wrapper` on `dragEnd`
- Swaps `translate3d` for `translate` to further optimize for mobile devices, as composite/GPU rendering is already triggered by `will-change: transform` when appropriate (IE does not support `will-change`, so we use `translateZ` to force a composite in this case).

### Why is this Pull Request needed?
`will-change` cannot be removed once set in a style sheet. While this is not a major issue issue (it's currently only being applied to `.jw-wrapper` for FOS drag optimization), it's sub-optimal. By switching the adding/removal of `will-change` to JS, we ensure it's completely removed at the end of dragging.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):
JW8-11727

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
