### PR TITLE
[JW8-11734] Update timetip CLS changes

### DIFF
--- a/src/css/controls/imports/tooltip.less
+++ b/src/css/controls/imports/tooltip.less
@@ -149,7 +149,6 @@
     padding: 0;
     pointer-events: none;
     user-select: none;
-    will-change: transform;
 
     .jw-overlay {
         bottom: 0;

--- a/src/css/controls/imports/tooltip.less
+++ b/src/css/controls/imports/tooltip.less
@@ -61,6 +61,7 @@
         display: inline-block;
         min-width: 100%;
         vertical-align: middle;
+        min-height: 2.4em;
     }
 }
 
@@ -148,6 +149,7 @@
     padding: 0;
     pointer-events: none;
     user-select: none;
+    will-change: transform;
 
     .jw-overlay {
         bottom: 0;

--- a/src/js/view/controls/components/thumbnails.mixin.ts
+++ b/src/js/view/controls/components/thumbnails.mixin.ts
@@ -57,6 +57,8 @@ const ThumbnailsMixin: ThumbnailsMixinInt = {
                 thumbs.push(new Thumbnail(obj));
             }, this);
             this.drawCues();
+            // Set the initial timetip dimensions for the thumbnail
+            this.showThumbnail(0);
         }
     },
 

--- a/src/js/view/controls/components/timeslider.ts
+++ b/src/js/view/controls/components/timeslider.ts
@@ -1,6 +1,6 @@
 import { throttle, each } from 'utils/underscore';
 import { between } from 'utils/math';
-import { style } from 'utils/css';
+import { style, transform } from 'utils/css';
 import { timeFormat } from 'utils/parser';
 import { addClass, removeClass, setAttribute, bounds } from 'utils/dom';
 import UI from 'utils/ui';
@@ -305,7 +305,7 @@ class TimeSlider extends Slider {
             timeTipPct = (timeTipWidth - tolerance) / (2 * 100 * widthPct);
         }
         const safePct: number = parseFloat(Math.min(1 - timeTipPct, Math.max(timeTipPct, pct)).toFixed(3)) * 100;
-        style(timeTip.el, { transform: `translateX(${safePct}%)` });
+        transform(timeTip.el, `translateX(${safePct}%)`);
     }
 
     hideTimeTooltip(): void {


### PR DESCRIPTION
### This PR will...
- ~Add `will-change` property to class that is being transformed~
- Use `transform` instead of `style` for tooltip dragging
- Add a min-height to the timetip to prevent a layout shift occurring when the text of the timetip is first set and shown
- Call `showThumbnail` to initially set the dimensions of the thumbnail in the timetip to prevent a layout shift from occurring when the first thumbnail is shown

### Why is this Pull Request needed?
Web Vitals CLS Improvements

### Are there any points in the code the reviewer needs to double check?
See question about calling `showThumbnail`
### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-11734

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
