### PR TITLE
[JW8-11711] Remove Next Up Overlay CLS

### DIFF
--- a/src/css/controls/flags/controls-hidden.less
+++ b/src/css/controls/flags/controls-hidden.less
@@ -14,8 +14,22 @@
         bottom: 0.5em;
     }
 
-    .jw-nextup-container {
-        bottom: 0;
+    &:not(.jw-flag-touch.jw-breakpoint-4):not(.jw-flag-touch.jw-breakpoint-5):not(.jw-flag-touch.jw-breakpoint-6):not(.jw-flag-touch.jw-breakpoint-7) {
+        .jw-nextup-container {
+            transform: translateY((@mobile-touch-target * 1.5));
+        }
+    }
+
+    &.jw-flag-touch.jw-state-playing {
+        &.jw-breakpoint-7,
+        &.jw-breakpoint-6,
+        &.jw-breakpoint-5,
+        &.jw-breakpoint-4 {
+            .jw-nextup-container {
+                /* For bottom styling from touch.less */
+                transform: translateY(4.25em);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
### This PR will...
- Remove the CLS caused by the Next Up Overlay when the controls show/hide by using a transform instead of `bottom: 0` styling when the controls hide/show.
### Why is this Pull Request needed?
Web Vitals CLS Improvements
### Are there any points in the code the reviewer needs to double check?
See comment
### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-11711

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
