### PR TITLE
[JW8-11742] Correct FOS Container Bounds

### DIFF
--- a/src/js/view/floating/floating-drag-ui.js
+++ b/src/js/view/floating/floating-drag-ui.js
@@ -38,14 +38,14 @@ export default class FloatingDragUI {
         this.ui = new UI(input, { preventScrolling: true })
             .on('dragStart', (e) => {
                 const { pageX, pageY } = e;
-                const { outerWidth, outerHeight } = window;
+                const { innerWidth, innerHeight } = window;
                 const { offsetLeft, offsetTop, offsetWidth, offsetHeight } = container;
                 startX = pageX;
                 startY = pageY;
                 minDeltaX = -offsetLeft;
                 minDeltaY = -offsetTop;
-                maxDeltaX = calculateMax(outerWidth, offsetLeft, offsetWidth);
-                maxDeltaY = calculateMax(outerHeight, offsetTop, offsetHeight);
+                maxDeltaX = calculateMax(innerWidth, offsetLeft, offsetWidth);
+                maxDeltaY = calculateMax(innerHeight, offsetTop, offsetHeight);
                 // Class prevents initial animation styles from overriding translate styling.
                 addClass(container, 'jw-floating-dragged');
                 addClass(container, 'jw-floating-dragging');


### PR DESCRIPTION
### This PR will...
Adjust the FOS container bounds to prevent dragging player outside of viewable area.

### Why is this Pull Request needed?
Mistakenly used outerWidth/outerHeight which includes scrollbars and other browser UI.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-11742

### Checklist
- [x] Jenkins builds and unit tests are passing
- [x] I have reviewed the automated results
