### PR TITLE
[JW8-11741] Fix thumbnail-tip text not wrapping

### DIFF
--- a/src/css/controls/imports/tooltip.less
+++ b/src/css/controls/imports/tooltip.less
@@ -143,7 +143,7 @@
 }
 
 .jw-tooltip-time {
-    .rect(100%, auto);
+    .rect(0, auto);
     bottom: 100%;
     line-height: normal;
     padding: 0;
@@ -154,7 +154,6 @@
         bottom: 0;
         min-height: 0;
         width: auto;
-        left: 0;
     }
 }
 

--- a/src/js/view/controls/components/timeslider.ts
+++ b/src/js/view/controls/components/timeslider.ts
@@ -297,16 +297,15 @@ class TimeSlider extends Slider {
         addClass(timeTip.el, 'jw-open');
 
         const timeTipWidth = timeTip.getWidth();
-        const widthPct = railBounds.width / 100;
         const tolerance = playerWidth - railBounds.width;
-        let timeTipPct = 0;
+        let timeTipPixels = 0;
         if (timeTipWidth > tolerance) {
-            // timeTip may go outside the bounds of the player. Determine the % of tolerance needed
-            timeTipPct = (timeTipWidth - tolerance) / (2 * 100 * widthPct);
+            // timeTip may go outside the bounds of the player. Determine the amount of tolerance needed in pixels.
+            timeTipPixels = (timeTipWidth - tolerance) / 2;
         }
-        const safePct: number = parseFloat(Math.min(1 - timeTipPct, Math.max(timeTipPct, pct)).toFixed(3));
-        const safePos = safePct * railBounds.width;
-        transform(timeTip.el, `translateX(${safePos}px)`);
+        const safePixels: number = parseFloat(Math.min(railBounds.width - timeTipPixels,
+            Math.max(timeTipPixels, position)).toFixed(3));
+        transform(timeTip.el, `translateX(${safePixels}px)`);
     }
 
     hideTimeTooltip(): void {

--- a/src/js/view/controls/components/timeslider.ts
+++ b/src/js/view/controls/components/timeslider.ts
@@ -303,8 +303,8 @@ class TimeSlider extends Slider {
             // timeTip may go outside the bounds of the player. Determine the amount of tolerance needed in pixels.
             timeTipPixels = (timeTipWidth - tolerance) / 2;
         }
-        const safePixels: number = parseFloat(Math.min(railBounds.width - timeTipPixels,
-            Math.max(timeTipPixels, position)).toFixed(3));
+        const safePixels: number = Math.round(Math.min(railBounds.width - timeTipPixels,
+            Math.max(timeTipPixels, position)) * 4) / 4;
         transform(timeTip.el, `translateX(${safePixels}px)`);
     }
 

--- a/src/js/view/controls/components/timeslider.ts
+++ b/src/js/view/controls/components/timeslider.ts
@@ -304,8 +304,9 @@ class TimeSlider extends Slider {
             // timeTip may go outside the bounds of the player. Determine the % of tolerance needed
             timeTipPct = (timeTipWidth - tolerance) / (2 * 100 * widthPct);
         }
-        const safePct: number = parseFloat(Math.min(1 - timeTipPct, Math.max(timeTipPct, pct)).toFixed(3)) * 100;
-        transform(timeTip.el, `translateX(${safePct}%)`);
+        const safePct: number = parseFloat(Math.min(1 - timeTipPct, Math.max(timeTipPct, pct)).toFixed(3));
+        const safePos = safePct * railBounds.width;
+        transform(timeTip.el, `translateX(${safePos}px)`);
     }
 
     hideTimeTooltip(): void {


### PR DESCRIPTION
### This PR will...
Use pixels instead of percentages for the timetip position. Using 100% width on `jw-tooltip-time` was causing the inner text to no longer wrap.

### Why is this Pull Request needed?
bugfix/web-vitals cls
### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-11741

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
