### PR TITLE
[JW8-11755] Reduce FOS transition CLS

### DIFF
--- a/src/css/jwplayer/flags/floatingplayer.less
+++ b/src/css/jwplayer/flags/floatingplayer.less
@@ -4,16 +4,6 @@
 .jw-wrapper.jw-float-transition {
     /* stylelint-disable-next-line */
     display: none!important;
-
-    .jw-controls {
-        /* stylelint-disable-next-line */
-        display: none!important;
-    }
-
-    .jw-display-controls {
-        /* stylelint-disable-next-line */
-        display: none!important;
-    }
 }
 
 .jw-flag-floating {

--- a/src/css/jwplayer/flags/floatingplayer.less
+++ b/src/css/jwplayer/flags/floatingplayer.less
@@ -1,5 +1,21 @@
 @import "../../shared-imports/vars.less";
 
+// Force controls to hide during float transition to decrease CLS penalty.
+.jw-wrapper.jw-float-transition {
+    /* stylelint-disable-next-line */
+    display: none!important;
+
+    .jw-controls {
+        /* stylelint-disable-next-line */
+        display: none!important;
+    }
+
+    .jw-display-controls {
+        /* stylelint-disable-next-line */
+        display: none!important;
+    }
+}
+
 .jw-flag-floating {
     background-size: cover;
     background-color: #000;

--- a/src/js/view/floating/floating-controller.ts
+++ b/src/js/view/floating/floating-controller.ts
@@ -368,5 +368,6 @@ export default class FloatingController {
         if (!this._floatingStoppedForever && this.getFloatingConfig() && this.getFloatMode() === 'notVisible') {
             this._boundThrottledMobileFloatScrollHandler();
         }
+        this.transitionFloating(false);
     }
 }

--- a/src/js/view/floating/floating-controller.ts
+++ b/src/js/view/floating/floating-controller.ts
@@ -7,7 +7,8 @@ import { deviceIsLandscape } from 'utils/dom';
 import { isIframe } from 'utils/browser';
 import {
     addClass,
-    removeClass
+    removeClass,
+    toggleClass
 } from 'utils/dom';
 import { STATE_IDLE, STATE_COMPLETE, STATE_ERROR } from 'events/events';
 import { isNumber } from 'utils/underscore';
@@ -54,17 +55,6 @@ const removeFPWatcher = (fc: FloatingController) => {
     if (watcherIDX !== -1) {
         watchers.splice(watcherIDX, 1);
     }
-};
-
-const preTransition = (fc: FloatingController) => {
-    const { _model, _wrapperEl } = fc;
-    addClass(_wrapperEl, 'jw-float-transition');
-    // Prevent layout shift in controls when player moves to pre-transition state.
-    _model.once('forceResponsiveListener', () => {
-        _model.once('responsiveUpdate', () => {
-            removeClass(_wrapperEl, 'jw-float-transition');
-        }, fc);
-    }, fc);
 };
 
 export default class FloatingController {
@@ -162,9 +152,8 @@ export default class FloatingController {
         if (this.getFloatingPlayer() === null) {
             this.setFloatingPlayer(this._playerEl);
 
-            preTransition(this);
             this._model.set('isFloating', true);
-
+            this.transitionFloating(true);
             addClass(this._playerEl, 'jw-flag-floating');
 
             if (mobileFloatIntoPlace) {
@@ -212,7 +201,7 @@ export default class FloatingController {
             return;
         }
 
-        preTransition(this);
+        this.transitionFloating(true);
         this.setFloatingPlayer(null);
         this._model.set('isFloating', false);
         const playerBounds = this._playerBounds;
@@ -251,6 +240,10 @@ export default class FloatingController {
 
         // Perform resize and trigger "float" event responsively to prevent layout thrashing
         this._model.trigger('forceResponsiveListener', {});
+    }
+    
+    transitionFloating(isTransitionIn: boolean): void {
+        toggleClass(this._wrapperEl, 'jw-float-transition', isTransitionIn);
     }
 
     updateFloatingSize(): void {

--- a/src/js/view/floating/floating-controller.ts
+++ b/src/js/view/floating/floating-controller.ts
@@ -56,6 +56,17 @@ const removeFPWatcher = (fc: FloatingController) => {
     }
 };
 
+const preTransition = (fc: FloatingController) => {
+    const { _model, _wrapperEl } = fc;
+    addClass(_wrapperEl, 'jw-float-transition');
+    // Prevent layout shift in controls when player moves to pre-transition state.
+    _model.once('forceResponsiveListener', () => {
+        _model.once('responsiveUpdate', () => {
+            removeClass(_wrapperEl, 'jw-float-transition');
+        }, fc);
+    }, fc);
+};
+
 export default class FloatingController {
     _playerEl: HTMLElement;
     _wrapperEl: HTMLElement;
@@ -151,6 +162,7 @@ export default class FloatingController {
         if (this.getFloatingPlayer() === null) {
             this.setFloatingPlayer(this._playerEl);
 
+            preTransition(this);
             this._model.set('isFloating', true);
 
             addClass(this._playerEl, 'jw-flag-floating');
@@ -200,6 +212,7 @@ export default class FloatingController {
             return;
         }
 
+        preTransition(this);
         this.setFloatingPlayer(null);
         this._model.set('isFloating', false);
         const playerBounds = this._playerBounds;

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -202,7 +202,6 @@ function View(_api, _model) {
         _this.updateBounds();
         _this.updateStyles();
         _this.checkResized();
-        floatingController.transitionFloating(false);
     }
 
     function updateContainerStyles(width, height) {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -202,7 +202,7 @@ function View(_api, _model) {
         _this.updateBounds();
         _this.updateStyles();
         _this.checkResized();
-        _model.trigger('responsiveUpdate');
+        floatingController.transitionFloating(false);
     }
 
     function updateContainerStyles(width, height) {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -202,6 +202,7 @@ function View(_api, _model) {
         _this.updateBounds();
         _this.updateStyles();
         _this.checkResized();
+        _model.trigger('responsiveUpdate');
     }
 
     function updateContainerStyles(width, height) {


### PR DESCRIPTION
### This PR will...
Reduce CLS penalty on floating player transition by hiding controls when forcing responsive listener

### Why is this Pull Request needed?
Prevents CLS when controls are detected having moved with wrapper to new floating coordinates

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-11755

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
