### PR TITLE
[JW8-11759] Prevent `canplay` from being handled additional times while seeking

### DIFF
--- a/src/js/providers/html5.ts
+++ b/src/js/providers/html5.ts
@@ -179,6 +179,9 @@ function VideoProvider(this: HTML5Provider, _playerId: string, _playerConfig: Ge
         },
 
         canplay(this: ProviderWithMixins): void {
+            if (_this.seeking) {
+                return;
+            }
             _canSeek = true;
             if (!_androidHls) {
                 _setMediaType();

--- a/src/js/providers/html5.ts
+++ b/src/js/providers/html5.ts
@@ -179,7 +179,7 @@ function VideoProvider(this: HTML5Provider, _playerId: string, _playerConfig: Ge
         },
 
         canplay(this: ProviderWithMixins): void {
-            if (_this.seeking) {
+            if (_canSeek) {
                 return;
             }
             _canSeek = true;


### PR DESCRIPTION
Props to @robwalch for root cause analysis and implementation suggestions

### This PR will...
- Return early on `canplay` if seeking

### Why is this Pull Request needed?
- Prevents infinite buffer when seeking past loaded frames.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-11759

### Checklist
- [x] Jenkins builds and unit tests are passing
- [x] I have reviewed the automated results
