### PR TITLE
[JW8-11548] Change "uniform" stretching snap to edges conditions

### DIFF
--- a/src/js/providers/video-actions-mixin.ts
+++ b/src/js/providers/video-actions-mixin.ts
@@ -43,12 +43,17 @@ const VideoActionsMixin: VideoActionsInt = {
             width: '',
             height: ''
         };
+        const aspectPlayer = width / height;
+        const aspectVideo = videoWidth / videoHeight;
         if (stretching === 'uniform') {
-            // Snap video to edges when the difference in aspect ratio is less than 9% and perceivable
-            const playerAspectRatio = width / height;
-            const videoAspectRatio = videoWidth / videoHeight;
-            const edgeMatch = Math.abs(playerAspectRatio - videoAspectRatio);
-            if (edgeMatch < 0.09 && edgeMatch > 0.0025) {
+            // Snap video to edges to eliminate letterboxing of less than 3px on either edge
+            let letterBarPixels;
+            if (aspectPlayer > aspectVideo) {
+                letterBarPixels = width - width / (aspectPlayer / aspectVideo);
+            } else {
+                letterBarPixels = height - height / (aspectVideo / aspectPlayer);
+            }
+            if (letterBarPixels < 6) {
                 styles.objectFit = 'fill';
                 stretching = 'exactfit';
             }
@@ -61,8 +66,6 @@ const VideoActionsMixin: VideoActionsInt = {
         if (fitVideoUsingTransforms) {
             if (stretching !== 'uniform') {
                 styles.objectFit = 'contain';
-                const aspectPlayer = width / height;
-                const aspectVideo = videoWidth / videoHeight;
                 // Use transforms to center and scale video in container
                 let scaleX = 1;
                 let scaleY = 1;


### PR DESCRIPTION
### This PR will...
Snap to edges in "uniform" stretching mode only when dimensions change by less than 6 pixels

### Why is this Pull Request needed?
Stretching of vertical video in fullscreen on Pixel 3 devices is noticeable. A 9:16 vertical video should not snap to edges in (Pixel 3) Chrome Android vertical fullscreen (393x678):

#### Addresses Issue(s):

JW8-11548

### Checklist
- [x] Jenkins builds and unit tests are passing
- [x] I have reviewed the automated results
