### PR TITLE
[JW8-11719] Don't auto fullscreen while floating

### DIFF
--- a/src/js/view/utils/views-manager.js
+++ b/src/js/view/utils/views-manager.js
@@ -41,8 +41,8 @@ function matchIntersection(entry, group) {
 function onOrientationChange() {
     views.forEach(view => {
         const model = view.model;
-        if (model.get('audioMode') || !model.get('controls') || model.get('visibility') < 0.75) {
-            // return early if chromeless player/audio only mode and player is less than 75% visible
+        if (model.get('audioMode') || model.get('isFloating') || !model.get('controls') || model.get('visibility') < 0.75) {
+            // exit early if audio only mode, player is floating, chromeless player, or player is less than 75% visible
             return;
         }
 


### PR DESCRIPTION
### This PR will...
Prevent the player from going fullscreen on orientation change in Android Chrome when the player is floating.

### Why is this Pull Request needed?
Users find it jarring and requested enhancement.

#### Addresses Issue(s):
JW8-11719

### Checklist
- [x] Jenkins builds and unit tests are passing
- [x] I have reviewed the automated results
