### PR TITLE
[JW8-11686] Add mute toggle to allow muted seeking on ios

### DIFF
--- a/src/js/providers/html5.ts
+++ b/src/js/providers/html5.ts
@@ -190,8 +190,8 @@ function VideoProvider(this: HTML5Provider, _playerId: string, _playerConfig: Ge
                 _setMediaType();
             }
 
-            // // Workaround for a bug in iOS and Safari where you are unable to seek in initially muted streams
-            // // Bug Report: https://feedbackassistant.apple.com/feedback/9070511
+            // Workaround for a bug in iOS and Safari where you are unable to seek in initially muted streams
+            // Bug Report: https://feedbackassistant.apple.com/feedback/9070511
             if (iosMuteToggle && _videotag.muted) {
                 const isPlaying = !_videotag.paused;
                 _videotag.muted = false;

--- a/src/js/providers/html5.ts
+++ b/src/js/providers/html5.ts
@@ -800,6 +800,7 @@ function VideoProvider(this: HTML5Provider, _playerId: string, _playerConfig: Ge
         _videotag.pause();
     };
 
+    let iosMuteToggle = false;
     this.seek = function(seekToPosition: number): void {
         const seekRange = _this.getSeekRange();
         let seekToTime = seekToPosition;
@@ -809,6 +810,14 @@ function VideoProvider(this: HTML5Provider, _playerId: string, _playerConfig: Ge
         if (!_canSeek) {
             _canSeek = !!_getSeekableEnd();
         }
+
+        // Workaround for a bug in iOS where you are unable to seek in initially muted streams
+        if (OS.iOS && _videotag.muted && !iosMuteToggle) {
+            _videotag.muted = false;
+            _videotag.muted = true;
+        }
+        iosMuteToggle = true;
+
         if (_canSeek) {
             _delayedSeek = 0;
             // setting currentTime can throw an invalid DOM state exception if the video is not ready

--- a/src/js/providers/html5.ts
+++ b/src/js/providers/html5.ts
@@ -100,6 +100,9 @@ function VideoProvider(this: HTML5Provider, _playerId: string, _playerConfig: Ge
 
     let { loadAndParseHlsMetadata, minDvrWindow } = _playerConfig;
 
+    // Toggle for a bug in iOS and Safari where you are unable to seek in initially muted streams
+    const iosMuteToggle = OS.iOS || Browser.Safari;
+
     _this.loadAndParseHlsMetadata = loadAndParseHlsMetadata === undefined ? true : !!loadAndParseHlsMetadata;
 
     // Always render natively in iOS and Safari, where HLS is supported.
@@ -186,6 +189,20 @@ function VideoProvider(this: HTML5Provider, _playerId: string, _playerConfig: Ge
             if (!_androidHls) {
                 _setMediaType();
             }
+
+            // // Workaround for a bug in iOS and Safari where you are unable to seek in initially muted streams
+            // // Bug Report: https://feedbackassistant.apple.com/feedback/9070511
+            if (iosMuteToggle && _videotag.muted) {
+                const isPlaying = !_videotag.paused;
+                _videotag.muted = false;
+                _videotag.muted = true;
+
+                // Autostarted players may be paused after toggle
+                if (isPlaying && _videotag.paused) {
+                    _videotag.play();
+                }
+            }
+
             checkVisualQuality();
             VideoEvents.canplay.call(_this);
         },
@@ -800,7 +817,6 @@ function VideoProvider(this: HTML5Provider, _playerId: string, _playerConfig: Ge
         _videotag.pause();
     };
 
-    let iosMuteToggle = false;
     this.seek = function(seekToPosition: number): void {
         const seekRange = _this.getSeekRange();
         let seekToTime = seekToPosition;
@@ -810,14 +826,6 @@ function VideoProvider(this: HTML5Provider, _playerId: string, _playerConfig: Ge
         if (!_canSeek) {
             _canSeek = !!_getSeekableEnd();
         }
-
-        // Workaround for a bug in iOS where you are unable to seek in initially muted streams
-        if (OS.iOS && _videotag.muted && !iosMuteToggle) {
-            _videotag.muted = false;
-            _videotag.muted = true;
-        }
-        iosMuteToggle = true;
-
         if (_canSeek) {
             _delayedSeek = 0;
             // setting currentTime can throw an invalid DOM state exception if the video is not ready


### PR DESCRIPTION
### This PR will...
Provide a workaround for an iOS (& Safari) bug where you are unable to seek properly in a muted stream.
Seeking is possible if the stream was ever unmuted prior to setting currentTime.
This implements a toggle that will fire once to create a workaround.

Apple Bug Report: https://feedbackassistant.apple.com/feedback/9070511

### Why is this Pull Request needed?
Bugfix / Workaround
### Are there any points in the code the reviewer needs to double check?
~I tried to limit when this toggle was executed as much as possible. It can also be set on `canPlay`, but I didn't think it should fire for every muted iOS video since it only pertains to seeking.~
### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-11686

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
