### PR TITLE
[JW8-11770] Ensure wrapper is revealed when final resize triggered

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -187,7 +187,7 @@ function View(_api, _model) {
             _this.trigger(FLOAT, { floating });
             updateVisibility();
 
-            // On iOS, an ad may receive the original resize event before wrapper is revealed.
+            // On mobile Chrome an ad may receive the original resize event before wrapper is revealed.
             // Listen for wrapper to be revealed
             if (!containerHeight && !containerWidth) {
                 _this.responsiveListener();

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -186,6 +186,12 @@ function View(_api, _model) {
             _currentlyFloating = floating;
             _this.trigger(FLOAT, { floating });
             updateVisibility();
+
+            // On iOS, an ad may receive the original resize event before wrapper is revealed.
+            // Listen for wrapper to be revealed
+            if (!containerHeight && !containerWidth) {
+                _this.responsiveListener();
+            }
         }
     };
 


### PR DESCRIPTION
### This PR will...

### Why is this Pull Request needed?
Resize event is being triggered on iOS Chrome mid float-transition, while wrapper is `display: none;`, causing an incorrect height/width reading when interfacing with our ima plugin.

### Are there any points in the code the reviewer needs to double check?
Since this is for a floating transition bug, I might prefer to instead come up with a way to pre-calculate the size change of the player on float and set container height/width/breakpoint/floating within the floatingController instead of forcing the responsiveListener (we no longer use bounds to calculate float position so no issue there).

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-11770

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
