### PR TITLE
[JW8-11770] Floating transition fixes

### DIFF
--- a/src/css/jwplayer/flags/floatingplayer.less
+++ b/src/css/jwplayer/flags/floatingplayer.less
@@ -1,11 +1,5 @@
 @import "../../shared-imports/vars.less";
 
-// Force controls to hide during float transition to decrease CLS penalty.
-.jw-wrapper.jw-float-transition {
-    /* stylelint-disable-next-line */
-    display: none!important;
-}
-
 .jw-flag-floating {
     background-size: cover;
     background-color: #000;

--- a/src/js/view/floating/floating-controller.ts
+++ b/src/js/view/floating/floating-controller.ts
@@ -174,8 +174,6 @@ export default class FloatingController {
             }
             setTimeout(() => {
                 this.transitionFloating(false);
-                // Perform resize and trigger "float" event responsively to prevent layout thrashing
-                this._model.trigger('forceResponsiveListener', {});
             }, 50);
 
             // Copy background from preview element
@@ -225,8 +223,6 @@ export default class FloatingController {
             });
             setTimeout(() => {
                 this.transitionFloating(false);
-                // Perform resize and trigger "float" event responsively to prevent layout thrashing
-                this._model.trigger('forceResponsiveListener', {});
             }, 50);
         };
 
@@ -248,13 +244,17 @@ export default class FloatingController {
     }
     
     transitionFloating(isTransitionIn: boolean): void {
+        this._inTransition = isTransitionIn;
         // Hiding the wrapper will impact player viewability momentarily, but reduce CLS
         // We could hide the wrappers contents (controls, overlays) and reduce some CLS, but not as much
-        this._inTransition = isTransitionIn;
         const wrapper = this._wrapperEl;
         style(wrapper, {
             display: isTransitionIn ? 'none' : null
         });
+        if (!isTransitionIn) {
+            // Perform resize and trigger "float" event responsively to prevent layout thrashing
+            this._model.trigger('forceResponsiveListener', {});
+        }
     }
 
     isInTransition(): boolean {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -196,7 +196,7 @@ function View(_api, _model) {
     this.responsiveListener = _responsiveListener;
 
     function _responsiveUpdate() {
-        if (!_this.isSetup) {
+        if (!_this.isSetup || floatingController.isInTransition()) {
             return;
         }
         _this.updateBounds();
@@ -506,7 +506,6 @@ function View(_api, _model) {
         });
         if (_this.isSetup && aspectratio && !model.get('isFloating')) {
             style(_playerElement, getPlayerSizeStyles(model, model.get('width')));
-            _responsiveUpdate();
         }
     }
 

--- a/test/unit/view/floating/floating-controller-test.js
+++ b/test/unit/view/floating/floating-controller-test.js
@@ -305,12 +305,11 @@ describe('FloatingController', function() {
                 fc.updateFloatingSize = sinon.spy();
                 fc._model.trigger = sinon.spy();
                 fc.startFloating();
-                expect(fc._model.get('isFloating')).to.be.true;
-                expect(fc._playerEl.classList.contains('jw-flag-floating')).to.be.true;
+                expect(fc._model.get('isFloating'), 'isFloating').to.be.true;
+                expect(fc._playerEl.classList.contains('jw-flag-floating'), 'contains jw-flag-floating').to.be.true;
                 expect(fc._playerEl.style.backgroundImage).to.eq('url("preview.img")');
-                expect(fc.updateFloatingSize.called).to.be.true;
-                expect(fc._floatingUI.enable.called).to.be.true;
-                expect(fc._model.trigger.calledWith('forceResponsiveListener', {})).to.be.true;
+                expect(fc.updateFloatingSize).to.be.called;
+                expect(fc._floatingUI.enable).to.be.called;
                 // reset currently floating player
                 fc.stopFloating();
             });
@@ -407,8 +406,6 @@ describe('FloatingController', function() {
                 expect(fc._model.get('isFloating')).to.be.false;
                 expect(fc.getFloatingPlayer()).to.eq(null);
                 expect(fc.disableFloatingUI.called).to.be.true;
-                expect(fc._model.trigger.calledWith('forceResponsiveListener', {})).to.be.true;
-                expect(fc._model.trigger.calledWith('forceAspectRatioChange', {})).to.be.true;
                 expect(fc._playerEl.style.backgroundImage).to.eq('');
                 expect(fc._wrapperEl.style.width).to.eq('');
                 expect(fc._wrapperEl.style.maxWidth).to.eq('');


### PR DESCRIPTION
### This PR will...
Reduce float transition CLS without triggering a resize and with fewer responsive listener updates.

### Why is this Pull Request needed?
Toggling floating should not cause resize events to width and height 0 (or viewability of 0 - we've had complaints about that when implementing floating). The CLS workaround in #3837 hides the wrapper which is essentially everything in the player container and the elemt we use to determine player size and viewability.

### Are there any points in the code the reviewer needs to double check?
Viewability is still impacted momentarily by the changes made in #3837

### Are there any Pull Requests open in other repos which need to be merged with this?
This replaces #3849 which can be closed.

#### Addresses Issue(s):
JW8-11770

Does not address viewability flipping to `0` because wrapper is not displayed. This can also impact ad performance.

### Checklist
- [x] Jenkins builds and unit tests are passing
- [x] I have reviewed the automated results
