### PR TITLE
[JW8-11772] Fix `getEnvironment().Browser.edge` with Chromium Edge

### DIFF
--- a/src/js/environment/browser-version.ts
+++ b/src/js/environment/browser-version.ts
@@ -19,7 +19,13 @@ export function browserVersion(browserEnvironment: BrowserEnvironment, agent: st
     } else if (browserEnvironment.firefox) {
         version = agent.substring(agent.indexOf('Firefox') + 8);
     } else if (browserEnvironment.edge) {
-        version = agent.substring(agent.indexOf('Edge') + 5);
+        let index = agent.indexOf('Edge');
+        if (index === -1) {
+            index = agent.indexOf('Edg') + 4;
+        } else {
+            index += 5;
+        }
+        version = agent.substring(index);
     } else if (browserEnvironment.ie) {
         // Older versions of IE use MSIE; IE11 uses rv:
         if (agent.indexOf('rv:') !== -1) {

--- a/src/js/providers/tracks-mixin.ts
+++ b/src/js/providers/tracks-mixin.ts
@@ -377,8 +377,8 @@ const Tracks: TracksMixin = {
         this.removeTracksListener(tracks, 'change', handler);
         this.addTracksListener(tracks, 'change', handler);
 
-        if (Browser.edge || Browser.firefox) {
-            // Listen for TextTracks added to the videotag after the onloadeddata event in Edge and Firefox,
+        if ((Browser.edge && Browser.ie) || Browser.firefox) {
+            // Listen for TextTracks added to the videotag after the onloadeddata event in legacy Edge and Firefox,
             // NOT Safari! Handling this event in Safari 12 and lower results in captions not rendering after
             // instream or live restart (JW8-10815, JW8-11006)
             handler = this.addTrackHandler = this.addTrackHandler || addTrackHandler.bind(this);

--- a/src/js/utils/browser.ts
+++ b/src/js/utils/browser.ts
@@ -1,61 +1,43 @@
-const userAgent = navigator.userAgent;
-
 function userAgentMatch(regex: RegExp): boolean {
-    return userAgent.match(regex) !== null;
-}
-
-function lazyUserAgentMatch(regex: RegExp): () => boolean {
-    return () => userAgentMatch(regex);
-}
-
-// Always returns false as flash support is discontinued
-export function isFlashSupported(): false {
-    return false;
+    return navigator.userAgent.match(regex) !== null;
 }
 
 const isIPadOS13 = () => navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1;
-export const isFF = lazyUserAgentMatch(/gecko\//i);
-export const isIETrident = lazyUserAgentMatch(/trident\/.+rv:\s*11/i);
-export const isIPod = lazyUserAgentMatch(/iP(hone|od)/i);
+
+export const isFF = () => userAgentMatch(/gecko\//i);
+
+export const isIETrident = () => userAgentMatch(/trident\/.+rv:\s*11/i);
+
+export const isIPod = () => userAgentMatch(/iP(hone|od)/i);
+
 export const isIPad = () => userAgentMatch(/iPad/i) || isIPadOS13();
+
 export const isOSX = () => userAgentMatch(/Macintosh/i) && !isIPadOS13();
+
 // Check for Facebook App Version to see if it's Facebook
-export const isFacebook = lazyUserAgentMatch(/FBAV/i);
+export const isFacebook = () => userAgentMatch(/FBAV/i);
 
-export function isEdge(): boolean {
-    return userAgentMatch(/\sEdge\/\d+/i);
-}
+export const isEdge = () => userAgentMatch(/\sEdge?\/\d+/i);
 
-export function isMSIE(): boolean {
-    return userAgentMatch(/msie/i);
-}
+export const isMSIE = () => userAgentMatch(/msie/i);
 
-export function isTizen(): boolean {
-    return userAgentMatch(/SMART-TV/);
-}
+export const isTizen = () => userAgentMatch(/SMART-TV/);
 
-export function isTizenApp(): boolean {
-    return isTizen() && !userAgentMatch(/SamsungBrowser/);
-}
+export const isTizenApp = () => isTizen() && !userAgentMatch(/SamsungBrowser/);
 
-export function isChrome(): boolean {
-    return userAgentMatch(/\s(?:(?:Headless)?Chrome|CriOS)\//i) && !isEdge() &&
-        !userAgentMatch(/UCBrowser/i) &&
-        !isTizen();
-}
+export const isChrome = () => userAgentMatch(/\s(?:(?:Headless)?Chrome|CriOS)\//i) &&
+    !isEdge() &&
+    !userAgentMatch(/UCBrowser/i) &&
+    !isTizen();
 
-export function isIE(): boolean {
-    return isEdge() || isIETrident() || isMSIE();
-}
+// Exclude Chromium Edge ("Edg/") from isIE
+export const isIE = () => !userAgentMatch(/\sEdg\/\d+/i) && (isEdge() || isIETrident() || isMSIE());
 
-export function isSafari(): boolean {
-    return (userAgentMatch(/safari/i) && !userAgentMatch(/(?:Chrome|CriOS|chromium|android|phantom)/i)) ||
-        isTizen();
-}
+export const isSafari = () => (userAgentMatch(/safari/i) &&
+    !userAgentMatch(/(?:Chrome|CriOS|chromium|android|phantom)/i)) ||
+    isTizen();
 
-export function isIOS(): boolean {
-    return userAgentMatch(/iP(hone|ad|od)/i) || isIPadOS13();
-}
+export const isIOS = () => userAgentMatch(/iP(hone|ad|od)/i) || isIPadOS13();
 
 export function isAndroidNative(): boolean {
     // Android Browser appears to include a user-agent string for Chrome/18
@@ -65,13 +47,9 @@ export function isAndroidNative(): boolean {
     return isAndroid();
 }
 
-export function isAndroid(): boolean {
-    return userAgentMatch(/Android/i) && !userAgentMatch(/Windows Phone/i);
-}
+export const isAndroid = () => userAgentMatch(/Android/i) && !userAgentMatch(/Windows Phone/i);
 
-export function isMobile(): boolean {
-    return isIOS() || isAndroid() || userAgentMatch(/Windows Phone/i);
-}
+export const isMobile = () => isIOS() || isAndroid() || userAgentMatch(/Windows Phone/i);
 
 export function isIframe(): boolean {
     try {
@@ -81,7 +59,8 @@ export function isIframe(): boolean {
     }
 }
 
+// Always returns false as flash support is discontinued
+export const isFlashSupported = () => false;
+
 // Always returns 0 as flash support is discontinued
-export function flashVersion(): 0 {
-    return 0;
-}
+export const flashVersion = () => 0;

--- a/test/unit/browser-version-test.js
+++ b/test/unit/browser-version-test.js
@@ -63,4 +63,13 @@ describe('os-version', function() {
         expect(actual.major).to.equal(13);
         expect(actual.minor).to.equal(10586);
     });
+
+    it('returns the browser version from a Microsoft user agent, Chromium Edge', function() {
+        const agent = 'Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.96 Safari/537.36 Edg/88.0.705.50';
+        const actual = browserVersion({ edge: true }, agent);
+
+        expect(actual.version).to.equal('88.0.705.50');
+        expect(actual.major).to.equal(88);
+        expect(actual.minor).to.equal(0);
+    });
 });


### PR DESCRIPTION
### This PR will...
Fix `getEnvironment().Browser.edge` with Chromium Edge
- Makes `Browser.edge` true with Chromium Edge
- Makes `Browser.chrome` false with Chromium Edge
- Makes `Browser.ie` false with Chromium Edge (`Browser.ie` is true with legacy Edge)

Cleanup utils/browser.ts (use arrow functions in more places in place of `lazyUserAgentMatch` which can be removed) 

### Why is this Pull Request needed?
Users expect `jwplayer().getEnvironment()` to reflect the `Browser.edge` and "Edg/" version with Chromium Edge rather than `Browser.chrome` and Chrome version.

`Browser.edge && !Browser.ie` can be used to differentiate Chromium Edge from legacy Edge as `Browser.ie` is a catch-all for legacy Microsoft browsers.

#### Addresses Issue(s):
JW8-11772

### Checklist
- [x] Jenkins builds and unit tests are passing
- [x] I have reviewed the automated results
