### PR TITLE
[JW8-11793] Enforce autoPause when unfloating during ad loading

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -440,6 +440,9 @@ Object.assign(Controller.prototype, {
         function _checkPlayOnViewable(model, viewable) {
             const adState = _getAdState();
             if (model.get('playOnViewable')) {
+                if (adState) {
+                    _this._instreamAdapter.noResume = !viewable;
+                }
                 if (viewable) {
                     const reason = 'viewable';
                     const autoPauseAds = model.get('autoPause').pauseAds;
@@ -471,6 +474,7 @@ Object.assign(Controller.prototype, {
             if (adState) {
                 if (model.get('autoPause').pauseAds) {
                     _pauseWhenNotViewable(viewable);
+                    _this._instreamAdapter.noResume = !viewable;
                 } else {
                     _pauseAfterAd(viewable);
                 }

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -577,6 +577,7 @@ Object.assign(Controller.prototype, {
             const adState = _getAdState();
 
             if (adState) {
+                _this._instreamAdapter.noResume = false;
                 // this will resume the ad. _api.playAd would load a new ad
                 _api.pauseAd(false, meta);
                 return Promise.resolve();

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -215,6 +215,9 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
         const { newstate } = event;
         if (newstate === STATE_PLAYING) {
             _controller.trigger(AD_PLAY, event);
+            if (_this.noResume && _model.get('autoPause').pauseAds) {
+                _this.pause();
+            }
         } else if (newstate === STATE_PAUSED) {
             _controller.trigger(AD_PAUSE, event);
         }


### PR DESCRIPTION
### This PR will...
- Enforce pause after ad loading complete when pause is initiated during ad loading due to viewability

### Why is this Pull Request needed?
- The playback should not resume when the preroll errors out and the player is not viewable.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-11793

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
