### PR TITLE
[JW8-11855] [JW8-11853] [JW8-11754] [JW8-11478] Refine Click Handling

### DIFF
--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -193,10 +193,8 @@ function initSelectListeners(ui) {
     const interactPreClickHandler = (e) => {
         const { target } = e;
 
-        if (e.isPrimary) {
-            if (target.tagName === 'BUTTON') {
-                target.focus();
-            }
+        if (e.isPrimary && target.tageName === 'BUTTON') {
+            target.focus();
         }
         ui.lastStart = now();
         ui.clicking = true;

--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -9,8 +9,11 @@ const USE_POINTER_EVENTS = ('PointerEvent' in window) && !OS.android;
 const USE_MOUSE_EVENTS = !USE_POINTER_EVENTS && !(TOUCH_SUPPORT && OS.mobile);
 
 const WINDOW_GROUP = 'window';
-const keydown = 'keydown';
+const INIT_GROUP = 'init';
+const FOCUS_GROUP = 'focus';
+const SELECT_GROUP = 'select';
 
+const keydown = 'keydown';
 const { passiveEvents } = Features;
 const DEFAULT_LISTENER_OPTIONS = passiveEvents ? { passive: true } : false;
 
@@ -42,6 +45,7 @@ export default class UI extends Events {
         this.startX = 0;
         this.startY = 0;
         this.event = null;
+        this.clicking = false;
     }
 
     on(name, callback, context) {
@@ -84,8 +88,7 @@ function eventsApi(name) {
 }
 
 function initInteractionListeners(ui) {
-    const initGroup = 'init';
-    if (ui.handlers[initGroup]) {
+    if (ui.handlers[INIT_GROUP]) {
         return;
     }
     const { el, passive } = ui;
@@ -93,7 +96,6 @@ function initInteractionListeners(ui) {
 
     const interactStartHandler = (e) => {
         removeClass(el, 'jw-tab-focus');
-
         if (isRightClick(e)) {
             return;
         }
@@ -121,10 +123,6 @@ function initInteractionListeners(ui) {
             addEventListener(ui, WINDOW_GROUP, 'pointermove', interactDragHandler, listenerOptions);
             addEventListener(ui, WINDOW_GROUP, 'pointercancel', interactEndHandler);
             addEventListener(ui, WINDOW_GROUP, 'pointerup', interactEndHandler);
-
-            if (el.tagName === 'BUTTON') {
-                el.focus();
-            }
         } else if (type === 'mousedown') {
             addEventListener(ui, WINDOW_GROUP, 'mousemove', interactDragHandler, listenerOptions);
             addEventListener(ui, WINDOW_GROUP, 'mouseup', interactEndHandler);
@@ -170,42 +168,65 @@ function initInteractionListeners(ui) {
         if (ui.dragged) {
             ui.dragged = false;
             triggerEvent(ui, DRAG_END, e);
-        } else if (e.type.indexOf('cancel') === -1 && el.contains(e.target)) {
-            if (now() - ui.lastStart > LONG_PRESS_DELAY) {
-                return;
-            }
-            const isPointerEvent = (e.type === 'pointerup' || e.type === 'pointercancel');
-            const click = e.type === 'mouseup' || isPointerEvent && e.pointerType === 'mouse';
-            checkDoubleTap(ui, e, click);
-            if (click) {
-                triggerEvent(ui, CLICK, e);
-            } else {
-                triggerEvent(ui, TAP, e);
-
-                // preventDefault to not dispatch the 300ms delayed click after a tap
-                if (e.type === 'touchend' && !passiveEvents) {
-                    preventDefault(e);
-                }
-            }
         }
     };
 
-    // If its not mobile, add mouse listener.  Add touch listeners so touch devices that aren't Android or iOS
-    // (windows phones) still get listeners just in case they want to use them.
-    if (USE_POINTER_EVENTS) {
-        addEventListener(ui, initGroup, 'pointerdown', interactStartHandler, listenerOptions);
-    } else {
-        if (USE_MOUSE_EVENTS) {
-            addEventListener(ui, initGroup, 'mousedown', interactStartHandler, listenerOptions);
-        }
-        // Always add this, in case we don't properly identify the device as mobile
-        addEventListener(ui, initGroup, 'touchstart', interactStartHandler, listenerOptions);
-    }
+    initStartEventsListeners(ui, INIT_GROUP, interactStartHandler, listenerOptions);
     initInteractionListener();
-    addEventListener(ui, initGroup, 'blur', () => {
+    initFocusListeners(ui);
+}
+
+function initSelectListeners(ui) {
+    if (ui.handlers[SELECT_GROUP]) {
+        return;
+    }
+
+    const interactClickhandler = (e) => {
+        if (!ui.el.contains(e.target)) {
+            return;
+        }
+        if (now() - ui.lastStart > LONG_PRESS_DELAY && ui.clicking === true) { 
+            ui.clicking = false;
+            return;
+        }
+        const click = e.type === 'click';
+        checkDoubleTap(ui, e, click);
+        if (click) {
+            triggerEvent(ui, CLICK, e);
+        } else {
+            triggerEvent(ui, TAP, e);
+        }
+    };
+
+    const interactPreClickHandler = (e) => {
+        const { target } = e;
+
+        if (!ui.el.contains(target)) {
+            return;
+        }
+        if (e.isPrimary) {
+            if (target.tagName === 'BUTTON') {
+                target.focus();
+            }
+        }
+        ui.lastStart = now();
+        ui.clicking = true;
+    };
+
+    initStartEventsListeners(ui, SELECT_GROUP, interactPreClickHandler);
+    addEventListener(ui, SELECT_GROUP, 'click', interactClickhandler);
+    initFocusListeners(ui);
+}
+
+function initFocusListeners(ui) {
+    if (ui.handlers[FOCUS_GROUP]) {
+        return;
+    }
+    const { el } = ui;
+    addEventListener(ui, FOCUS_GROUP, 'blur', () => {
         removeClass(el, 'jw-tab-focus');
     });
-    addEventListener(ui, initGroup, 'focus', () => {
+    addEventListener(ui, FOCUS_GROUP, 'focus', () => {
         if (lastInteractionListener.event && lastInteractionListener.event.type === keydown) {
             addClass(el, 'jw-tab-focus');
         }
@@ -241,25 +262,18 @@ const eventRegisters = {
         initInteractionListeners(ui);
     },
     click(ui) {
-        initInteractionListeners(ui);
+        initSelectListeners(ui);
     },
     tap(ui) {
-        if (OS.iOS && OS.version.major < 11) {
-            const body = document.body;
-            if (body) {
-                // When controls are disabled iOS 10 does not dispatch media element touchstart/end events without this line
-                body.ontouchstart = body.ontouchstart || function() {};
-            }
-        }
-        initInteractionListeners(ui);
+        initSelectListeners(ui);
     },
     doubleTap(ui) {
         ui.enableDoubleTap = true;
-        initInteractionListeners(ui);
+        initSelectListeners(ui);
     },
     doubleClick(ui) {
         ui.enableDoubleTap = true;
-        initInteractionListeners(ui);
+        initSelectListeners(ui);
     },
     longPress(ui) {
         const longPress = 'longPress';
@@ -473,4 +487,16 @@ function preventDefault(evt) {
     if (evt.preventDefault) {
         evt.preventDefault();
     }
+}
+
+function initStartEventsListeners(ui, group, handler, options) {
+    // If its not mobile, add mouse listener.  Add touch listeners so touch devices that aren't Android or iOS
+    // (windows phones) still get listeners just in case they want to use them.
+    if (USE_POINTER_EVENTS) {
+        addEventListener(ui, group, 'pointerdown', handler, options);
+    } else if (USE_MOUSE_EVENTS) {
+        addEventListener(ui, group, 'mousedown', handler, options);
+    }
+    // Always add this, in case we don't properly identify the device as mobile
+    addEventListener(ui, group, 'touchstart', handler, options);
 }

--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -130,11 +130,6 @@ function initInteractionListeners(ui) {
             addEventListener(ui, WINDOW_GROUP, 'touchmove', interactDragHandler, listenerOptions);
             addEventListener(ui, WINDOW_GROUP, 'touchcancel', interactEndHandler);
             addEventListener(ui, WINDOW_GROUP, 'touchend', interactEndHandler);
-
-            // Prevent scrolling the screen while dragging on mobile.
-            if (!passive) {
-                preventDefault(e);
-            }
         }
     };
 
@@ -182,9 +177,6 @@ function initSelectListeners(ui) {
     }
 
     const interactClickhandler = (e) => {
-        if (!ui.el.contains(e.target)) {
-            return;
-        }
         if (now() - ui.lastStart > LONG_PRESS_DELAY && ui.clicking === true) { 
             ui.clicking = false;
             return;
@@ -201,9 +193,6 @@ function initSelectListeners(ui) {
     const interactPreClickHandler = (e) => {
         const { target } = e;
 
-        if (!ui.el.contains(target)) {
-            return;
-        }
         if (e.isPrimary) {
             if (target.tagName === 'BUTTON') {
                 target.focus();

--- a/src/js/view/controls/components/button.ts
+++ b/src/js/view/controls/components/button.ts
@@ -1,6 +1,7 @@
-import UI from 'utils/ui';
 import svgParse from 'utils/svgParser';
 import helpers from 'utils/helpers';
+import { addClickAction } from 'view/utils/add-click-action';
+import type UI from 'utils/ui';
 import type { PlayerAPI } from 'types/generic.type';
 
 export type Button = {
@@ -30,7 +31,7 @@ export default function (
 
     element.style.display = 'none';
 
-    const ui: UI = new UI(element).on('click tap enter', apiAction || helpers.noop);
+    const ui: UI = addClickAction(element, apiAction || helpers.noop);
 
     if (svgIcons) {
         Array.prototype.forEach.call(svgIcons, svgIcon => {

--- a/src/js/view/controls/components/custom-button.ts
+++ b/src/js/view/controls/components/custom-button.ts
@@ -1,6 +1,6 @@
 import { style } from 'utils/css';
-import UI from 'utils/ui';
 import svgParse from 'utils/svgParser';
+import { addClickAction } from 'view/utils/add-click-action';
 
 let collection: Record<string, XMLDocument> = {};
 
@@ -20,7 +20,7 @@ class CustomButton {
     id: string;
     buttonElement: HTMLElement;
 
-    constructor(img: string, ariaText: string, callback: Function, id: string, btnClass: string) {
+    constructor(img: string, ariaText: string, callback: (event: Event) => void, id: string, btnClass: string) {
         const buttonElement = document.createElement('div');
         buttonElement.className = `jw-icon jw-icon-inline jw-button-color jw-reset ${btnClass || ''}`;
         buttonElement.setAttribute('button', id);
@@ -45,7 +45,7 @@ class CustomButton {
 
         buttonElement.appendChild(iconElement);
 
-        new UI(buttonElement).on('click tap enter', callback, this);
+        addClickAction(buttonElement, callback, this);
 
         // Prevent button from being focused on mousedown so that the tooltips don't remain visible until
         // the user interacts with another element on the page

--- a/src/js/view/controls/components/menu/menu-item.js
+++ b/src/js/view/controls/components/menu/menu-item.js
@@ -1,11 +1,10 @@
-import UI from 'utils/ui';
 import { toggleClass, createElement } from 'utils/dom';
 import { itemRadioButtonTemplate, itemTemplate } from 'view/controls/templates/menu/menu-item';
-
+import { addClickAction } from 'view/utils/add-click-action';
 export class MenuItem {
     constructor(_content, _action, _template = itemTemplate) {
         this.el = createElement(_template(_content));
-        this.ui = new UI(this.el).on('click tap enter', _action, this);
+        this.ui = addClickAction(this.el, _action, this);
     }
     destroy() {
         if (this.el.parentNode) {

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -11,6 +11,7 @@ import { prependChild, setAttribute, toggleClass, openLink, addClass } from 'uti
 import { timeFormat } from 'utils/parser';
 import UI from 'utils/ui';
 import { genId, FEED_SHOWN_ID_LENGTH } from 'utils/random-id-generator';
+import { addClickAction } from 'view/utils/add-click-action';
 
 function text(name, role) {
     const element = document.createElement('span');
@@ -344,7 +345,7 @@ export default class Controlbar {
             this.ui.push(castUi);
         }
 
-        const durationUi = new UI(elements.duration).on('click tap enter', function () {
+        const durationUi = addClickAction(elements.duration, function () {
             if (this._model.get('streamType') === 'DVR') {
                 // Seek to "Live" position within live buffer, but not before current position
                 const currentPosition = this._model.get('position');

--- a/src/js/view/controls/next-display-icon.ts
+++ b/src/js/view/controls/next-display-icon.ts
@@ -1,16 +1,17 @@
-import UI from 'utils/ui';
+import { addClickAction } from 'view/utils/add-click-action';
 import type { PlayerAPI } from 'types/generic.type';
 import type PlaylistItem from 'playlist/item';
 import type Model from 'controller/model';
+import type UI from 'utils/ui';
 
 export default class NextDisplayIcon {
     el: HTMLElement;
     ui: UI;
 
     constructor(model: Model, api: PlayerAPI, element: HTMLElement) {
-        const iconDisplay = element.querySelector('.jw-icon');
+        const iconDisplay = element.querySelector('.jw-icon') as HTMLElement;
 
-        this.ui = new UI(iconDisplay).on('click tap enter', function(): void {
+        this.ui = addClickAction(iconDisplay, function(): void {
             api.next({ reason: 'interaction' });
         });
 

--- a/src/js/view/controls/nextuptooltip.js
+++ b/src/js/view/controls/nextuptooltip.js
@@ -7,6 +7,7 @@ import { cloneIcon } from 'view/controls/icons';
 import { offsetToSeconds, isPercentage } from 'utils/strings';
 import { genId, FEED_SHOWN_ID_LENGTH } from 'utils/random-id-generator';
 import { timeFormat } from 'utils/parser';
+import { addClickAction } from 'view/utils/add-click-action';
 
 export default class NextUpTooltip {
     constructor(_model, _api, playerElement) {
@@ -57,7 +58,7 @@ export default class NextUpTooltip {
         }, this);
 
         // Close button
-        this.closeUi = new UI(this.closeButton, { directSelect: true }).on('click tap enter', function() {
+        this.closeUi = addClickAction(this.closeButton, function() {
             this.nextUpSticky = false;
             this.toggle(false);
         }, this);

--- a/src/js/view/controls/play-display-icon.ts
+++ b/src/js/view/controls/play-display-icon.ts
@@ -1,9 +1,9 @@
 import Events from 'utils/backbone.events';
-import UI from 'utils/ui';
 import { addClass, createElement } from 'utils/dom';
+import { addClickAction } from 'view/utils/add-click-action';
 import type { PlayerAPI } from 'types/generic.type';
 import type ViewModel from 'view/view-model';
-
+import type UI from 'utils/ui';
 export default class PlayDisplayIcon extends Events {
     icon: Element | null;
     el: HTMLElement;
@@ -15,7 +15,7 @@ export default class PlayDisplayIcon extends Events {
 
         this.icon = iconDisplay;
         this.el = element;
-        this.ui = new UI(iconDisplay).on('click tap enter', (evt) => {
+        this.ui = addClickAction(iconDisplay, (evt) => {
             this.trigger(evt.type);
         });
 

--- a/src/js/view/controls/rewind-display-icon.ts
+++ b/src/js/view/controls/rewind-display-icon.ts
@@ -1,16 +1,16 @@
-import UI from 'utils/ui';
+import { addClickAction } from 'view/utils/add-click-action';
+import type UI from 'utils/ui';
 import type ViewModel from 'view/view-model';
 import type { PlayerAPI } from 'types/generic.type';
-
 export default class RewindDisplayIcon {
     el: HTMLElement;
     ui: UI;
 
     constructor(model: ViewModel, api: PlayerAPI, element: HTMLElement) {
-        const iconDisplay = element.querySelector('.jw-icon');
+        const iconDisplay = element.querySelector('.jw-icon') as HTMLElement;
 
         this.el = element;
-        this.ui = new UI(iconDisplay).on('click tap enter', function(): void {
+        this.ui = addClickAction(iconDisplay, function(): void {
             const currentPosition = model.get('position');
             const duration = model.get('duration');
             const rewindPosition = currentPosition - 10;

--- a/src/js/view/controls/tizen/tizen-controlbar.ts
+++ b/src/js/view/controls/tizen/tizen-controlbar.ts
@@ -14,7 +14,7 @@ type ControlbarElement = HTMLElement | Button | TimeSlider;
 
 interface CustomButtonProps {
     btnClass: string;
-    callback: Function;
+    callback: (event: Event) => void;
     id: string;
     img: string;
     tooltip: string;

--- a/src/js/view/floating/floating-close-button.js
+++ b/src/js/view/floating/floating-close-button.js
@@ -1,9 +1,9 @@
 import { createElement } from 'utils/dom';
-import UI from 'utils/ui';
 import floatingCloseButton from 'templates/floating-close-button';
 import { cloneIcon } from 'view/controls/icons';
 import Events from 'utils/backbone.events';
 import { USER_ACTION } from 'events/events';
+import { addClickAction } from 'view/utils/add-click-action';
 
 export default class FloatingCloseButton extends Events {
     constructor(container, ariaLabel) {
@@ -11,7 +11,7 @@ export default class FloatingCloseButton extends Events {
         this.element = createElement(floatingCloseButton(ariaLabel));
 
         this.element.appendChild(cloneIcon('close'));
-        this.ui = new UI(this.element, { directSelect: true }).on('click tap enter', () => {
+        this.ui = addClickAction(this.element, () => {
             this.trigger(USER_ACTION);
         });
 

--- a/src/js/view/logo.js
+++ b/src/js/view/logo.js
@@ -1,9 +1,9 @@
 import logoTemplate from 'templates/logo';
 import { LOGO_CLICK } from 'events/events';
-import UI from 'utils/ui';
 import { style } from 'utils/css';
 import { createElement } from 'utils/dom';
 import Events from 'utils/backbone.events';
+import { addClickAction } from 'view/utils/add-click-action';
 
 const LogoDefaults = {
     linktarget: '_blank',
@@ -88,11 +88,7 @@ export default function Logo(_model) {
             _logo.setAttribute('aria-label', _model.get('localization').logo);
         }
 
-        this.ui = new UI(_logo).on('click tap enter', function (evt) {
-            if (evt && evt.stopPropagation) {
-                evt.stopPropagation();
-            }
-
+        this.ui = addClickAction(_logo, function () {
             this.trigger(LOGO_CLICK, {
                 link: _settings.link,
                 linktarget: _settings.linktarget

--- a/src/js/view/utils/add-click-action.ts
+++ b/src/js/view/utils/add-click-action.ts
@@ -1,8 +1,7 @@
 import UI from 'utils/ui';
 
 export function addClickAction(element: HTMLElement, clickAction: (evt: Event) => void, ctx?: any): UI {
-    const ui = new UI(element, { directSelect: true });
-    ui.on('click tap enter', clickAction, ctx);
+    const ui = new UI(element).on('click tap enter', clickAction, ctx);
     
     return ui;
 }

--- a/src/js/view/utils/add-click-action.ts
+++ b/src/js/view/utils/add-click-action.ts
@@ -1,0 +1,8 @@
+import UI from 'utils/ui';
+
+export function addClickAction(element: HTMLElement, clickAction: (evt: Event) => void, ctx?: any): UI {
+    const ui = new UI(element, { directSelect: true });
+    ui.on('click tap enter', clickAction, ctx);
+    
+    return ui;
+}

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -436,7 +436,7 @@ function View(_api, _model) {
                                 toggleClass(_playerElement, 'jw-floating-dismissible', hasClass(_playerElement, 'jw-flag-controls-hidden'));
                             }
                             _captionsRenderer.renderCues(true);
-                        } else if (_controls) {
+                        } else {
                             if (!_controls.showing) {
                                 _controls.userActive();
                             } else {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -418,47 +418,39 @@ function View(_api, _model) {
                 _getCurrentElement().focus();
 
                 if (_controls) {
+                    if (OS.mobile) {
+                        const state = model.get('state');
+                        if (controls &&
+                            ((state === STATE_IDLE || state === STATE_COMPLETE) ||
+                            (model.get('instream') && state === STATE_PAUSED))) {
+                            api.playToggle(reasonInteraction());
+                        }
+                        if (controls && state === STATE_PAUSED) {
+                            // Toggle visibility of the controls when tapping the media
+                            // Do not add mobile toggle "jw-flag-controls-hidden" in these cases
+                            if (model.get('instream') || model.get('castActive') || (model.get('mediaType') === 'audio')) {
+                                return;
+                            }
+                            toggleClass(_playerElement, 'jw-flag-controls-hidden');
+                            if (_this.dismissible) {
+                                toggleClass(_playerElement, 'jw-floating-dismissible', hasClass(_playerElement, 'jw-flag-controls-hidden'));
+                            }
+                            _captionsRenderer.renderCues(true);
+                        } else if (_controls) {
+                            if (!_controls.showing) {
+                                _controls.userActive();
+                            } else {
+                                _controls.userInactive();
+                            }
+                        }
+                        return;
+                    }
                     if (settingsMenuVisible()) {
                         _controls.settingsMenu.close();
                     } else if (infoOverlayVisible()) {
                         _controls.infoOverlay.close();
                     } else {
                         api.playToggle(reasonInteraction());
-                    }
-                }
-            },
-            tap: () => {
-                _this.trigger(DISPLAY_CLICK);
-                if (settingsMenuVisible()) {
-                    _controls.settingsMenu.close();
-                }
-                if (infoOverlayVisible()) {
-                    _controls.infoOverlay.close();
-                }
-                const state = model.get('state');
-
-                if (controls &&
-                    ((state === STATE_IDLE || state === STATE_COMPLETE) ||
-                    (model.get('instream') && state === STATE_PAUSED))) {
-                    api.playToggle(reasonInteraction());
-                }
-
-                if (controls && state === STATE_PAUSED) {
-                    // Toggle visibility of the controls when tapping the media
-                    // Do not add mobile toggle "jw-flag-controls-hidden" in these cases
-                    if (model.get('instream') || model.get('castActive') || (model.get('mediaType') === 'audio')) {
-                        return;
-                    }
-                    toggleClass(_playerElement, 'jw-flag-controls-hidden');
-                    if (_this.dismissible) {
-                        toggleClass(_playerElement, 'jw-floating-dismissible', hasClass(_playerElement, 'jw-flag-controls-hidden'));
-                    }
-                    _captionsRenderer.renderCues(true);
-                } else if (_controls) {
-                    if (!_controls.showing) {
-                        _controls.userActive();
-                    } else {
-                        _controls.userInactive();
                     }
                 }
             },

--- a/test/unit/ui-test.js
+++ b/test/unit/ui-test.js
@@ -143,91 +143,19 @@ describe('UI', function() {
         ui.destroy();
     });
 
-    it('triggers click events with pointer and mouse input', function() {
+    it('triggers click events with input', function() {
         if (!USE_POINTER_EVENTS && !USE_MOUSE_EVENTS) {
             return;
         }
         const clickSpy = sandbox.spy();
         const ui = new UI(button).on('click tap', clickSpy);
-        let startResult;
-        let sourceEvent;
-        if (USE_POINTER_EVENTS) {
-            const pointerMouseOptions = xyCoords(0, 0, {
-                isPrimary: true,
-                pointerType: 'mouse',
-                view: window,
-                bubbles: true,
-                cancelable: true
-            });
-            startResult = button.dispatchEvent(new PointerEvent('pointerdown', pointerMouseOptions));
-            sourceEvent = new PointerEvent('pointerup', pointerMouseOptions);
-        } else {
-            const mouseOptions = xyCoords(0, 0, {
-                view: window,
-                bubbles: true,
-                cancelable: true
-            });
-            startResult = button.dispatchEvent(new MouseEvent('mousedown', mouseOptions));
-            sourceEvent = new MouseEvent('mouseup', mouseOptions);
-        }
-        button.dispatchEvent(sourceEvent);
-
-        expect(startResult, 'preventDefault not called').to.equal(true);
+        button.click();
         expect(clickSpy).to.have.callCount(1);
-        expect(clickSpy).calledWith({
-            type: 'click',
-            pointerType: 'mouse',
-            pageX: 0,
-            pageY: 0,
-            sourceEvent,
-            target: button,
-            currentTarget: button
-        });
-
+        expect(!!clickSpy.args[0].defaultPrevented).to.equal(false);
         ui.destroy();
     });
 
-    it('triggers tap events with pointer and touch input', function() {
-        if (!USE_POINTER_EVENTS && !TOUCH_SUPPORT) {
-            // Touch not supported in this browser
-            return;
-        }
-        const tapSpy = sandbox.spy();
-        const ui = new UI(button).on('click tap', tapSpy);
-        let startResult;
-        let sourceEvent;
-        if (USE_POINTER_EVENTS) {
-            const pointerTouchOptions = xyCoords(0, 0, {
-                isPrimary: true,
-                pointerType: 'touch',
-                view: window,
-                bubbles: true,
-                cancelable: true
-            });
-            startResult = button.dispatchEvent(new PointerEvent('pointerdown', pointerTouchOptions));
-            sourceEvent = new PointerEvent('pointerup', pointerTouchOptions);
-        } else if (TOUCH_SUPPORT) {
-            const touchEvent = createTouchEvent('touchstart');
-            startResult = button.dispatchEvent(touchEvent);
-            sourceEvent = createTouchEvent('touchend');
-        }
-        button.dispatchEvent(sourceEvent);
-
-        expect(startResult, 'preventDefault not called').to.equal(true);
-        expect(tapSpy).to.have.callCount(1);
-        expect(tapSpy).calledWith({
-            type: 'tap',
-            pointerType: 'touch',
-            pageX: 0,
-            pageY: 0,
-            sourceEvent,
-            target: button,
-            currentTarget: button
-        });
-        ui.destroy();
-    });
-
-    it('triggers doubleClick events with pointer and mouse input', function() {
+    it('triggers doubleClick events with input', function() {
         if (!USE_POINTER_EVENTS && !USE_MOUSE_EVENTS) {
             return;
         }
@@ -235,92 +163,12 @@ describe('UI', function() {
         const ui = new UI(button, {
             enableDoubleTap: true
         }).on('doubleClick doubleTap', doubleClickSpy);
-        let startResult;
-        let sourceEvent;
-        if (USE_POINTER_EVENTS) {
-            const pointerMouseOptions = xyCoords(0, 0, {
-                isPrimary: true,
-                pointerType: 'mouse',
-                view: window,
-                bubbles: true,
-                cancelable: true
-            });
-            startResult = button.dispatchEvent(new PointerEvent('pointerdown', pointerMouseOptions));
-            button.dispatchEvent(new PointerEvent('pointerup', pointerMouseOptions));
-            button.dispatchEvent(new PointerEvent('pointerdown', pointerMouseOptions));
-            sourceEvent = new PointerEvent('pointerup', pointerMouseOptions);
-            button.dispatchEvent(sourceEvent);
-        } else {
-            const mouseOptions = xyCoords(0, 0, {
-                view: window,
-                bubbles: true,
-                cancelable: true
-            });
-            startResult = button.dispatchEvent(new MouseEvent('mousedown', mouseOptions));
-            button.dispatchEvent(new MouseEvent('mouseup', mouseOptions));
-            button.dispatchEvent(new MouseEvent('mousedown', mouseOptions));
-            sourceEvent = new MouseEvent('mouseup', mouseOptions);
-            button.dispatchEvent(sourceEvent);
-        }
-
-        expect(startResult, 'preventDefault not called').to.equal(true);
+        button.click();
+        button.click();
+        const defaultPrevented = !!doubleClickSpy.args[0].defaultPrevented;
+        expect(defaultPrevented, 'preventDefault not called').to.equal(false);
         expect(doubleClickSpy).to.have.callCount(1);
-        expect(doubleClickSpy).calledWith({
-            type: 'doubleClick',
-            pointerType: 'mouse',
-            pageX: 0,
-            pageY: 0,
-            sourceEvent,
-            target: button,
-            currentTarget: button
-        });
 
-        ui.destroy();
-    });
-
-    it('triggers doubleTap events with pointer and touch input', function() {
-        const doubleTapSpy = sandbox.spy();
-        const ui = new UI(button, {
-            enableDoubleTap: true
-        }).on('doubleClick doubleTap', doubleTapSpy);
-        let startResult;
-        let sourceEvent;
-        if (USE_POINTER_EVENTS) {
-            const pointerTouchOptions = xyCoords(0, 0, {
-                isPrimary: true,
-                pointerType: 'touch',
-                view: window,
-                bubbles: true,
-                cancelable: true
-            });
-            startResult = button.dispatchEvent(new PointerEvent('pointerdown', pointerTouchOptions));
-            button.dispatchEvent(new PointerEvent('pointerup', pointerTouchOptions));
-            button.dispatchEvent(new PointerEvent('pointerdown', pointerTouchOptions));
-            sourceEvent = new PointerEvent('pointerup', pointerTouchOptions);
-            button.dispatchEvent(sourceEvent);
-        } else if (TOUCH_SUPPORT) {
-            const touchEvent = createTouchEvent('touchstart');
-            startResult = button.dispatchEvent(touchEvent);
-            button.dispatchEvent(createTouchEvent('touchend'));
-            button.dispatchEvent(createTouchEvent('touchstart'));
-            sourceEvent = createTouchEvent('touchend');
-            button.dispatchEvent(sourceEvent);
-        } else {
-            // Touch not supported in this browser
-            ui.destroy();
-            return;
-        }
-        expect(startResult, 'preventDefault not called').to.equal(true);
-        expect(doubleTapSpy).to.have.callCount(1);
-        expect(doubleTapSpy).calledWith({
-            type: 'doubleTap',
-            pointerType: 'touch',
-            pageX: 0,
-            pageY: 0,
-            sourceEvent,
-            target: button,
-            currentTarget: button
-        });
         ui.destroy();
     });
 
@@ -662,11 +510,11 @@ describe('UI', function() {
         ui = new UI(button)
             .on('click tap doubleClick doubleTap dragStart drag dragEnd enter over out focus blur move', () => {});
         if (USE_POINTER_EVENTS) {
-            expect(button.addEventListener, 'button with all listeners').to.have.callCount(9);
+            expect(button.addEventListener, 'button with all listeners').to.have.callCount(12);
         } else if (!USE_MOUSE_EVENTS) {
             expect(button.addEventListener, 'button with all listeners').to.have.callCount(6);
         } else {
-            expect(button.addEventListener, 'button with all listeners').to.have.callCount(10);
+            expect(button.addEventListener, 'button with all listeners').to.have.callCount(12);
         }
         ui.destroy();
     });
@@ -677,14 +525,14 @@ describe('UI', function() {
             .on('click tap doubleClick doubleTap dragStart drag dragEnd enter over out focus blur move', () => {})
             .off();
         if (USE_POINTER_EVENTS) {
-            expect(button.addEventListener, 'button with all listeners').to.have.callCount(9);
-            expect(button.removeEventListener, 'button with all listeners').to.have.callCount(9);
+            expect(button.addEventListener, 'button with all listeners').to.have.callCount(12);
+            expect(button.removeEventListener, 'button with all listeners').to.have.callCount(12);
         } else if (!USE_MOUSE_EVENTS) {
             expect(button.addEventListener, 'button with all listeners').to.have.callCount(6);
             expect(button.removeEventListener, 'button with all listeners').to.have.callCount(6);
         } else {
-            expect(button.addEventListener, 'button with all listeners').to.have.callCount(10);
-            expect(button.removeEventListener, 'button with all listeners').to.have.callCount(10);
+            expect(button.addEventListener, 'button with all listeners').to.have.callCount(12);
+            expect(button.removeEventListener, 'button with all listeners').to.have.callCount(12);
         }
         ui.destroy();
     });
@@ -695,14 +543,14 @@ describe('UI', function() {
         const ui = new UI(button).on('click tap doubleClick doubleTap dragStart drag dragEnd enter over out focus blur move', () => {});
         ui.destroy();
         if (USE_POINTER_EVENTS) {
-            expect(button.addEventListener, 'button with all listeners').to.have.callCount(9);
-            expect(button.removeEventListener, 'button with all listeners').to.have.callCount(9);
+            expect(button.addEventListener, 'button with all listeners').to.have.callCount(12);
+            expect(button.removeEventListener, 'button with all listeners').to.have.callCount(12);
         } else if (!USE_MOUSE_EVENTS) {
             expect(button.addEventListener, 'button with all listeners').to.have.callCount(6);
             expect(button.removeEventListener, 'button with all listeners').to.have.callCount(6);
         } else {
-            expect(button.addEventListener, 'button with all listeners').to.have.callCount(10);
-            expect(button.removeEventListener, 'button with all listeners').to.have.callCount(10);
+            expect(button.addEventListener, 'button with all listeners').to.have.callCount(12);
+            expect(button.removeEventListener, 'button with all listeners').to.have.callCount(12);
         }
     });
 

--- a/test/unit/ui-test.js
+++ b/test/unit/ui-test.js
@@ -144,9 +144,6 @@ describe('UI', function() {
     });
 
     it('triggers click events with input', function() {
-        if (!USE_POINTER_EVENTS && !USE_MOUSE_EVENTS) {
-            return;
-        }
         const clickSpy = sandbox.spy();
         const ui = new UI(button).on('click tap', clickSpy);
         button.click();
@@ -156,9 +153,6 @@ describe('UI', function() {
     });
 
     it('triggers doubleClick events with input', function() {
-        if (!USE_POINTER_EVENTS && !USE_MOUSE_EVENTS) {
-            return;
-        }
         const doubleClickSpy = sandbox.spy();
         const ui = new UI(button, {
             enableDoubleTap: true


### PR DESCRIPTION
### This PR will...
- Replace current click handling with click listener in order to:
  - Prevent an additional "click" dispatched by browsers that would bleed through to underlying elements
  - Allow for passive click listeners
  - Enable VoiceOver click
  - Allow triggered clicks to be dispatched to player elements
  - Reduce number of event listeners on elements utilizing UI.js
- Move `addClickAction` from commercial to OS
- Use addClickAction to facilitate click handling on simple elements
- Remove now-redundant condition in UI.js (click listener is directly added to the element, rather than the window group as it was the previous implementation. There's no reason to check element contents)
- Simplify unit tests

### Why is this Pull Request needed?
- Fixes clickthrough bugs
- Allows VoiceOver click

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/7996

#### Addresses Issue(s):
[JW8-11855] [JW8-11853] [JW8-11754] [JW8-11478]

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
