### PR TITLE
[JW8-11735] Add custom tizen loading icon

### DIFF
--- a/src/css/tizen/tizen-controlbar.less
+++ b/src/css/tizen/tizen-controlbar.less
@@ -9,13 +9,16 @@
 }
 
 .jw-tizen-app {
+    .jw-tizen-controls {
+        will-change: opacity;
+    }
+
     .jw-tizen-controlbar {
         align-items: center;
         justify-content: center;
         padding: 6% 6.25%;
         height: 100%;
         max-height: initial;
-        will-change: opacity;
         font-size: @tizen-skip-font-size;
 
         .jw-button-container {

--- a/src/css/tizen/tizen-states.less
+++ b/src/css/tizen/tizen-states.less
@@ -9,6 +9,54 @@
         .jw-tizen-controlbar {
             display: none;
         }
+
+        // Buffer Icon
+        .jw-display-icon-display .jw-icon {
+            .jw-svg-icon-buffer {
+                animation: none;
+
+                path {
+                    display: none;
+                }
+
+                circle {
+                    fill: transparent;
+                    stroke: @white;
+                    stroke-width: 13;
+                    stroke-dasharray: 471;
+                }
+
+                .jw-tizen-buffer-draw {
+                    animation: jw-draw 1.5s ease-in-out infinite;
+                }
+
+                .jw-tizen-buffer-erase {
+                    animation: jw-erase  1.5s ease-in-out infinite;
+                }
+            }
+
+            @keyframes jw-draw {
+                0% {
+                    stroke-dashoffset: 0;
+                }
+
+                50%,
+                100% {
+                    stroke-dashoffset: 471;
+                }
+            }
+
+            @keyframes jw-erase {
+                0%,
+                50% {
+                    stroke-dashoffset: -471;
+                }
+
+                100% {
+                    stroke-dashoffset: 0;
+                }
+            }
+        }
     }
 
     &.jw-state-paused.jw-flag-user-inactive:not(.jw-flag-seek) {

--- a/src/js/view/controls/tizen/tizen-controls.ts
+++ b/src/js/view/controls/tizen/tizen-controls.ts
@@ -78,48 +78,36 @@ class TizenControls extends Controls {
     }
 
     enable(api: PlayerAPI, model: ViewModel): void {
-        super.enable.call(this, api, model);
-
         addClass(this.playerContainer, 'jw-tizen-app jw-flag-fullscreen');
         this.api = api;
         this.model = model;
 
         const element = this.context.createElement('div');
         element.className = 'jw-tizen-controls jw-tizen-reset';
-        this.div = element;
-    
-        if (!this.backdrop) {
-            const backdrop = this.context.createElement('div');
-            backdrop.className = 'jw-controls-backdrop jw-reset';
-            this.backdrop = backdrop;
-            this.addBackdrop();
-        }
 
         // Pause Display
         if (!this.pauseDisplay) {
             const pauseDisplay = createElement(PauseDisplayTemplate());
             const title = new Title(model);
             title.setup(pauseDisplay.querySelector('.jw-pause-display-container'));
-            this.div.appendChild(pauseDisplay);
+            element.appendChild(pauseDisplay);
             this.pauseDisplay = pauseDisplay;
         }
 
         // Display Buttons - Buffering
-        if (!this.displayContainer || !this.div.querySelector('.jw-display')) {
+        if (!this.displayContainer) {
             const displayContainer = new DisplayContainer(model, api);
             createBufferIcon(this.context, displayContainer, 'jw-tizen-buffer-draw');
             createBufferIcon(this.context, displayContainer, 'jw-tizen-buffer-erase');
 
-            this.div.appendChild(displayContainer.element());
+            element.appendChild(displayContainer.element());
             this.displayContainer = displayContainer;
         }
 
         // Controlbar
-        const controlbar = this.controlbar = new TizenControlbar(api, model,
+        const controlbar = new TizenControlbar(api, model,
             this.playerContainer.querySelector('.jw-hidden-accessibility'));
-        controlbar.on('backClick', () => {
-            this.onBackClick();
-        });
+        controlbar.on('backClick', this.onBackClick, this);
 
         // Next Up Tooltip
         if (model.get('nextUpDisplay') && !controlbar.nextUpToolTip) {
@@ -131,32 +119,30 @@ class TizenControls extends Controls {
             controlbar.nextUpToolTip = nextUpToolTip;
 
             // NextUp needs to be behind the controlbar to not block other tooltips
-            this.div.appendChild(nextUpToolTip.element());
+            element.appendChild(nextUpToolTip.element());
         }
 
-        this.div.appendChild(controlbar.element());
+        element.appendChild(controlbar.element());
 
         // Seekbar
-        const seekbar = this.seekbar = new TizenSeekbar(model, api, this.controlbar.elements.time);
-        this.div.appendChild(seekbar.element());
+        const seekbar = this.seekbar = new TizenSeekbar(model, api, controlbar.elements.time);
+        element.appendChild(seekbar.element());
 
         // Settings/Tracks Menu
         const localization = model.get('localization');
         const settingsMenu = this.settingsMenu = new TizenMenu(api, model.player, this.controlbar, localization);
         settingsMenu.on(USER_ACTION, () => this.userActive());
-        this.controlbar.on('settingsInteraction', () => {
+        controlbar.on('settingsInteraction', () => {
             settingsMenu.toggle();
             const activeButton = this.div && this.div.querySelector('.jw-active');
             if (settingsMenu.visible && activeButton) {
                 removeClass(activeButton, 'jw-active');
             }
         });
-        this.div.insertBefore(settingsMenu.el, controlbar.element());
+        element.insertBefore(settingsMenu.el, controlbar.element());
 
         // Trigger backClick when all videos complete      
-        api.on('playlistComplete', () => {
-            this.onBackClick();
-        }, this);
+        api.on('playlistComplete', this.onBackClick, this);
 
         // Remove event listener added in base controls
         if (this.keydownCallback) {
@@ -168,6 +154,12 @@ class TizenControls extends Controls {
         this.keydownCallback = (evt) => this.handleKeydown(evt);
         document.addEventListener('keydown', this.keydownCallback);
 
+        // To enable features like the ad skip button
+        super.enable.call(this, api, model);
+        this.controlbar = controlbar;
+        this.div = element;
+
+        this.addBackdrop();
         this.addControls();
         this.playerContainer.focus({ preventScroll: true });
 

--- a/src/js/view/controls/tizen/tizen-controls.ts
+++ b/src/js/view/controls/tizen/tizen-controls.ts
@@ -19,6 +19,19 @@ const reasonInteraction = () => {
     return { reason: 'interaction' };
 };
 
+function createBufferIcon(context: HTMLDocument, displayContainer: DisplayContainer, className: string): void {
+    const circle = context.createElementNS('http://www.w3.org/2000/svg', 'circle');
+    circle.setAttribute('class', className);
+    circle.setAttribute('cx', '50%');
+    circle.setAttribute('cy', '50%');
+    circle.setAttribute('r', '75');
+
+    const svgContainer = displayContainer.element().querySelector('.jw-svg-icon-buffer');
+    if (svgContainer) {
+        svgContainer.appendChild(circle);
+    }
+}
+
 class TizenControls extends Controls {
     context: HTMLDocument;
     playerContainer: HTMLElement;
@@ -85,7 +98,6 @@ class TizenControls extends Controls {
         // Pause Display
         if (!this.pauseDisplay) {
             const pauseDisplay = createElement(PauseDisplayTemplate());
-
             const title = new Title(model);
             title.setup(pauseDisplay.querySelector('.jw-pause-display-container'));
             this.div.appendChild(pauseDisplay);
@@ -93,12 +105,12 @@ class TizenControls extends Controls {
         }
 
         // Display Buttons - Buffering
-        if (!this.displayContainer) {
-            const displayContainer = new DisplayContainer(model, api);
+        const displayContainer = new DisplayContainer(model, api);
+        createBufferIcon(this.context, displayContainer, 'jw-tizen-buffer-draw');
+        createBufferIcon(this.context, displayContainer, 'jw-tizen-buffer-erase');
 
-            this.div.appendChild(displayContainer.element());
-            this.displayContainer = displayContainer;
-        }
+        this.div.appendChild(displayContainer.element());
+        this.displayContainer = displayContainer;
 
         // Controlbar
         const controlbar = this.controlbar = new TizenControlbar(api, model,

--- a/src/js/view/controls/tizen/tizen-controls.ts
+++ b/src/js/view/controls/tizen/tizen-controls.ts
@@ -146,17 +146,20 @@ class TizenControls extends Controls {
         const baseControlbar = this.controlbar;
         if (baseControlbar) {
             const nextUpToolTip = baseControlbar.nextUpToolTip;
-            nextUpToolTip.off('all');
 
-            if (model.get('nextUp')) {
-                nextUpToolTip.onNextUp(model, model.get('nextUp'));
+            if (nextUpToolTip) {
+                nextUpToolTip.off('all');
+
+                if (model.get('nextUp')) {
+                    nextUpToolTip.onNextUp(model, model.get('nextUp'));
+                }
+
+                baseControlbar.nextUpToolTip = null;
+                controlbar.nextUpToolTip = nextUpToolTip;
+                element.appendChild(nextUpToolTip.element());
             }
 
-            controlbar.nextUpToolTip = nextUpToolTip;
-            element.appendChild(nextUpToolTip.element());
-
             // Destroy the controlbar being overridden
-            baseControlbar.nextUpToolTip = null;
             baseControlbar.destroy();
         }
 

--- a/src/js/view/controls/tizen/tizen-controls.ts
+++ b/src/js/view/controls/tizen/tizen-controls.ts
@@ -105,12 +105,14 @@ class TizenControls extends Controls {
         }
 
         // Display Buttons - Buffering
-        const displayContainer = new DisplayContainer(model, api);
-        createBufferIcon(this.context, displayContainer, 'jw-tizen-buffer-draw');
-        createBufferIcon(this.context, displayContainer, 'jw-tizen-buffer-erase');
+        if (!this.displayContainer || !this.div.querySelector('.jw-display')) {
+            const displayContainer = new DisplayContainer(model, api);
+            createBufferIcon(this.context, displayContainer, 'jw-tizen-buffer-draw');
+            createBufferIcon(this.context, displayContainer, 'jw-tizen-buffer-erase');
 
-        this.div.appendChild(displayContainer.element());
-        this.displayContainer = displayContainer;
+            this.div.appendChild(displayContainer.element());
+            this.displayContainer = displayContainer;
+        }
 
         // Controlbar
         const controlbar = this.controlbar = new TizenControlbar(api, model,


### PR DESCRIPTION
### This PR will...
- Add a custom buffering icon for Tizen

### Why is this Pull Request needed?
Bugfix

There were a combination of things happening.
- The buffering icon was lacking the `will-change` property that had been needed to get the controlbar icons to appear.
- The display-container was not always being added to the dom causing the buffer icon to not exist.
- Transforms, matrices, etc. were not working in conjunction with keyframes or transitions on Tizen.

Decided to opt for a simple custom buffering icon in the end, which looks like:

https://user-images.githubusercontent.com/26205421/117070759-2fe1df00-acfc-11eb-9d79-5af418a42dc3.mov


### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-11735

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
