### PR TITLE
[JW8-11888] Additional memory leak fixes

### DIFF
--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -258,6 +258,11 @@ export default function Api(element) {
                 // core = null;
             }
 
+            // Clear this.plugins
+            Object.keys(pluginsMap).forEach((name) => {
+                delete pluginsMap[name];
+            });
+
             return this;
         },
 
@@ -1121,11 +1126,11 @@ Object.assign(Api.prototype, /** @lends Api.prototype */ {
     addPlugin(name, pluginInstance) {
         this.plugins[name] = pluginInstance;
 
-        this.on('ready', pluginInstance.addToPlayer);
-
-        // A swf plugin may rely on resize events
-        if (pluginInstance.resize) {
-            this.on('resize', pluginInstance.resizeHandler);
+        if (!__HEADLESS__) {
+            this.on('ready', pluginInstance.addToPlayer);
+            if (pluginInstance.resize) {
+                this.on('resize', pluginInstance.resizeHandler);
+            }
         }
     },
 

--- a/src/js/controller/async-item.ts
+++ b/src/js/controller/async-item.ts
@@ -112,4 +112,14 @@ export class AsyncItemController {
     clear (): void {
         this.async = null;
     }
+
+    destroy(): void {
+        this.model =
+            this.api =
+            this.promise =
+            this.resolve =
+            this.reject =
+            this.async =
+            this.asyncPromise = null as any;
+    }
 }

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -66,7 +66,7 @@ Object.assign(Controller.prototype, {
             this._view.destroy();
         }
         if (this._model) {
-            destroyQoe(this._model);
+            destroyQoe(this._model, this._programController);
             this._model.destroy();
         }
         if (this._apiQueue) {

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -511,7 +511,7 @@ Object.assign(Controller.prototype, {
                             return _this.updatePlaylist(Playlist(data.playlist), data);
                         }
                     });
-                    loadPromise = _loadPlaylist(item).then(updatePlaylistCancelable.async);
+                    loadPromise = _loadPlaylist(item).then(() => updatePlaylistCancelable.async());
                     break;
                 }
                 case 'object':
@@ -529,7 +529,7 @@ Object.assign(Controller.prototype, {
                 _this.triggerError(composePlayerError(error, ERROR_LOADING_PLAYLIST));
             });
 
-            loadPromise.then(checkAutoStartCancelable.async).catch(noop);
+            loadPromise.then(() => checkAutoStartCancelable.async()).catch(noop);
         }
 
         function _loadPlaylist(toLoad) {

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -78,7 +78,7 @@ Object.assign(Controller.prototype, {
         if (this._programController) {
             this._programController.destroy();
         }
-        this.instreamDestroy();
+        this.instreamDestroy(true);
         this._view =
             this._model =
             this._apiQueue =
@@ -1194,8 +1194,12 @@ Object.assign(Controller.prototype, {
             return this._instreamAdapter;
         };
 
-        this.instreamDestroy = function() {
+        this.instreamDestroy = function(noResume) {
             if (this._instreamAdapter) {
+                // When destroying the player `noResume` is passed to prevent resuming of main content
+                if (noResume) {
+                    this._instreamAdapter.noResume = true;
+                }
                 this._instreamAdapter.destroy();
                 this._instreamAdapter = null;
             }

--- a/src/js/controller/model.ts
+++ b/src/js/controller/model.ts
@@ -177,6 +177,9 @@ class Model extends SimpleModel {
             this._provider.destroy();
             this._provider = null;
         }
+        if (this.mediaModel) {
+            this.mediaModel.off();
+        }
         this.providerController = null;
     }
 

--- a/src/js/program/ad-program-controller.js
+++ b/src/js/program/ad-program-controller.js
@@ -148,14 +148,14 @@ export default class AdProgramController extends ProgramController {
     }
 
     destroy() {
-        const { mediaController, model, mediaPool, playerModel } = this;
+        const { model, mediaPool, playerModel } = this;
         model.off();
 
         if (__HEADLESS__) {
+            super.destroy();
             if (this.provider) {
                 this.provider.remove();
                 this.provider = null;
-                mediaController.destroy();
             }
             return;
         }

--- a/src/js/program/ad-program-controller.js
+++ b/src/js/program/ad-program-controller.js
@@ -157,6 +157,7 @@ export default class AdProgramController extends ProgramController {
                 this.provider.remove();
                 this.provider = null;
             }
+            model.off();
             return;
         }
 

--- a/src/js/program/media-controller.js
+++ b/src/js/program/media-controller.js
@@ -89,6 +89,9 @@ export default class MediaController extends Events {
             this.eventQueue.destroy();
         }
         delete provider.instreamMode;
+        if (this.thenPlayPromise) {
+            this.thenPlayPromise.cancel();
+        }
         this.provider =
             this.mediaModel =
             this.model =
@@ -185,10 +188,10 @@ export default class MediaController extends Events {
         const providerSetupPromise = provider.load(item);
         if (providerSetupPromise) {
             const thenPlayPromise = cancelable(() => {
-                return provider.play() || Promise.resolve();
+                return this.provider.play() || Promise.resolve();
             });
             this.thenPlayPromise = thenPlayPromise;
-            return providerSetupPromise.then(thenPlayPromise.async);
+            return providerSetupPromise.then(() => thenPlayPromise.async());
         }
         return provider.play() || Promise.resolve();
     }

--- a/src/js/program/program-controller.js
+++ b/src/js/program/program-controller.js
@@ -223,7 +223,7 @@ class ProgramController extends Events {
                     // Fail the playPromise to trigger "playAttemptFailed"
                     throw error;
                 })
-                .then(thenPlayPromise.async);
+                .then(() => thenPlayPromise.async());
         }
 
         return playPromise;
@@ -431,6 +431,13 @@ class ProgramController extends Events {
         this.off();
         this._destroyBackgroundMedia();
         this._destroyActiveMedia();
+        if (this.asyncItems) {
+            this.asyncItems.forEach(asyncItem => {
+                if (asyncItem) {
+                    asyncItem.destroy();
+                }
+            });
+        }
         this.asyncItems =
             this.loadPromise =
             this.mediaControllerListener =

--- a/src/js/utils/cancelable.ts
+++ b/src/js/utils/cancelable.ts
@@ -1,24 +1,28 @@
-type Cancelable = {
-    async: (...args: any[]) => Promise<any>;
-    cancel: () => void;
-    cancelled: () => boolean;
+
+class Cancelable {
+    private callback: ((result?: any) => any) | null;
+
+    constructor(callback: (result?: any) => any) {
+        this.callback = callback;
+    }
+
+    async(...args: any[]): Promise<any> {
+        return Promise.resolve().then(() => {
+            if (this.callback !== null) {
+                return this.callback(args);
+            }
+        });
+    }
+
+    cancel(): void {
+        this.callback = null;
+    }
+
+    cancelled(): boolean {
+        return this.callback === null;
+    }
 }
 
 export default function cancelable(callback: (result?: any) => any): Cancelable {
-    let cancelled = false;
-
-    return {
-        async: function(...args: any[]): Promise<any> {
-            return Promise.resolve().then(() => {
-                if (cancelled) {
-                    return;
-                }
-                return callback.apply(this, args);
-            });
-        },
-        cancel: () => {
-            cancelled = true;
-        },
-        cancelled: () => cancelled
-    };
+    return new Cancelable(callback);
 }


### PR DESCRIPTION
### This PR will...

make additional memory leak fixes for headless player:

- When destroying the player `noResume` is passed to prevent resuming of main contain
- Cleanup `api.plugins` on remove
- Cleanup headless cyclical reference in plugin loading promise
- Cleanup cyclical reference in player assigned plugin instance methods for resizing
- Call `super.destroy` in `AdProgramContoller` with headless player 
- Remove `model.mediaModel` listeners when destroying the model (JW8-11904)
- Cleanup `AsyncItemController` instances
- Cleanup `thenPlayPromise` `Cancellable` instance

### Why is this Pull Request needed?
Prevents unnecessary foregrounding of content while removing a player that is playing ads.

#### Addresses Issue(s):
Mobile SDK optimization
JW8-11888, JW8-11904


### Checklist
- [x] Jenkins builds and unit tests are passing
- [x] I have reviewed the automated results
