### PR TITLE
[JW8-11868] Fix background apps pausing in iOS Safari

### DIFF
--- a/src/js/providers/html5.ts
+++ b/src/js/providers/html5.ts
@@ -123,7 +123,11 @@ function VideoProvider(this: HTML5Provider, _playerId: string, _playerConfig: Ge
     const MediaEvents = {
         progress(this: ProviderWithMixins): void {
             VideoEvents.progress.call(_this);
-            _toggleMute();
+            // Workaround for an issue in Safari 14 that causes muted, autostarted HLS streams to infinitely buffer.
+            // Bug Report: https://feedbackassistant.apple.com/feedback/9097587
+            if (isAudioStream()) {
+                _toggleMute();
+            }
             checkStaleStream();
         },
 
@@ -1045,8 +1049,7 @@ function VideoProvider(this: HTML5Provider, _playerId: string, _playerConfig: Ge
                 return;
             }
             const isPlaying = !_videotag.paused;
-            _videotag.muted =
-                _this.muteToggle = false;
+            _videotag.muted = _this.muteToggle = false;
             if (isAudio) {
                 // For audio-only set muted back to player config value
                 _videotag.muted = _playerConfig.mute;


### PR DESCRIPTION
### This PR will...
Only execute the mute toggle on progress if the stream is audio only because the toggle causes background apps to pause.
### Why is this Pull Request needed?
This is an update to two previous changes that were put in as workarounds for bugs in Safari 14 and iOS.
One was for muted seeking on iOS and in Safari https://github.com/jwplayer/jwplayer/pull/3845 and the other was for muted, autoplayed streams infinitely buffering in Safari 14 https://github.com/jwplayer/jwplayer/pull/3865.

#### Addresses Issue(s):

JW8-11868

### Checklist
- [x] Jenkins builds and unit tests are passing
- [x] I have reviewed the automated results
