### PR TITLE
[JW8-11903] Remove duplicate listener group "focus" for initFocusListeners

### DIFF
--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -10,7 +10,6 @@ const USE_MOUSE_EVENTS = !USE_POINTER_EVENTS && !(TOUCH_SUPPORT && OS.mobile);
 
 const WINDOW_GROUP = 'window';
 const INIT_GROUP = 'init';
-const FOCUS_BLUR_GROUP = 'focus_blur';
 const SELECT_GROUP = 'select';
 
 const keydown = 'keydown';
@@ -168,7 +167,7 @@ function initInteractionListeners(ui) {
 
     initStartEventsListeners(ui, INIT_GROUP, interactStartHandler, listenerOptions);
     initInteractionListener();
-    initFocusListeners(ui);
+    initFocusListeners(ui, INIT_GROUP);
 }
 
 function initSelectListeners(ui) {
@@ -202,18 +201,18 @@ function initSelectListeners(ui) {
 
     initStartEventsListeners(ui, SELECT_GROUP, interactPreClickHandler);
     addEventListener(ui, SELECT_GROUP, 'click', interactClickhandler);
-    initFocusListeners(ui);
+    initFocusListeners(ui, SELECT_GROUP);
 }
 
-function initFocusListeners(ui) {
-    if (ui.handlers[FOCUS_BLUR_GROUP]) {
+function initFocusListeners(ui, group) {
+    if (ui.handlers[INIT_GROUP] || ui.handlers[SELECT_GROUP]) {
         return;
     }
     const { el } = ui;
-    addEventListener(ui, FOCUS_BLUR_GROUP, 'blur', () => {
+    addEventListener(ui, group, 'blur', () => {
         removeClass(el, 'jw-tab-focus');
     });
-    addEventListener(ui, FOCUS_BLUR_GROUP, 'focus', () => {
+    addEventListener(ui, group, 'focus', () => {
         if (lastInteractionListener.event && lastInteractionListener.event.type === keydown) {
             addClass(el, 'jw-tab-focus');
         }

--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -10,7 +10,7 @@ const USE_MOUSE_EVENTS = !USE_POINTER_EVENTS && !(TOUCH_SUPPORT && OS.mobile);
 
 const WINDOW_GROUP = 'window';
 const INIT_GROUP = 'init';
-const FOCUS_GROUP = 'focus';
+const FOCUS_BLUR_GROUP = 'focus_blur';
 const SELECT_GROUP = 'select';
 
 const keydown = 'keydown';
@@ -206,14 +206,14 @@ function initSelectListeners(ui) {
 }
 
 function initFocusListeners(ui) {
-    if (ui.handlers[FOCUS_GROUP]) {
+    if (ui.handlers[FOCUS_BLUR_GROUP]) {
         return;
     }
     const { el } = ui;
-    addEventListener(ui, FOCUS_GROUP, 'blur', () => {
+    addEventListener(ui, FOCUS_BLUR_GROUP, 'blur', () => {
         removeClass(el, 'jw-tab-focus');
     });
-    addEventListener(ui, FOCUS_GROUP, 'focus', () => {
+    addEventListener(ui, FOCUS_BLUR_GROUP, 'focus', () => {
         if (lastInteractionListener.event && lastInteractionListener.event.type === keydown) {
             addClass(el, 'jw-tab-focus');
         }

--- a/test/unit/ui-test.js
+++ b/test/unit/ui-test.js
@@ -504,11 +504,11 @@ describe('UI', function() {
         ui = new UI(button)
             .on('click tap doubleClick doubleTap dragStart drag dragEnd enter over out focus blur move', () => {});
         if (USE_POINTER_EVENTS) {
-            expect(button.addEventListener, 'button with all listeners').to.have.callCount(12);
+            expect(button.addEventListener, 'button with all listeners').to.have.callCount(11);
         } else if (!USE_MOUSE_EVENTS) {
             expect(button.addEventListener, 'button with all listeners').to.have.callCount(6);
         } else {
-            expect(button.addEventListener, 'button with all listeners').to.have.callCount(12);
+            expect(button.addEventListener, 'button with all listeners').to.have.callCount(11);
         }
         ui.destroy();
     });
@@ -519,14 +519,14 @@ describe('UI', function() {
             .on('click tap doubleClick doubleTap dragStart drag dragEnd enter over out focus blur move', () => {})
             .off();
         if (USE_POINTER_EVENTS) {
-            expect(button.addEventListener, 'button with all listeners').to.have.callCount(12);
-            expect(button.removeEventListener, 'button with all listeners').to.have.callCount(12);
+            expect(button.addEventListener, 'button with all listeners').to.have.callCount(11);
+            expect(button.removeEventListener, 'button with all listeners').to.have.callCount(11);
         } else if (!USE_MOUSE_EVENTS) {
             expect(button.addEventListener, 'button with all listeners').to.have.callCount(6);
             expect(button.removeEventListener, 'button with all listeners').to.have.callCount(6);
         } else {
-            expect(button.addEventListener, 'button with all listeners').to.have.callCount(12);
-            expect(button.removeEventListener, 'button with all listeners').to.have.callCount(12);
+            expect(button.addEventListener, 'button with all listeners').to.have.callCount(11);
+            expect(button.removeEventListener, 'button with all listeners').to.have.callCount(11);
         }
         ui.destroy();
     });
@@ -537,14 +537,14 @@ describe('UI', function() {
         const ui = new UI(button).on('click tap doubleClick doubleTap dragStart drag dragEnd enter over out focus blur move', () => {});
         ui.destroy();
         if (USE_POINTER_EVENTS) {
-            expect(button.addEventListener, 'button with all listeners').to.have.callCount(12);
-            expect(button.removeEventListener, 'button with all listeners').to.have.callCount(12);
+            expect(button.addEventListener, 'button with all listeners').to.have.callCount(11);
+            expect(button.removeEventListener, 'button with all listeners').to.have.callCount(11);
         } else if (!USE_MOUSE_EVENTS) {
             expect(button.addEventListener, 'button with all listeners').to.have.callCount(6);
             expect(button.removeEventListener, 'button with all listeners').to.have.callCount(6);
         } else {
-            expect(button.addEventListener, 'button with all listeners').to.have.callCount(12);
-            expect(button.removeEventListener, 'button with all listeners').to.have.callCount(12);
+            expect(button.addEventListener, 'button with all listeners').to.have.callCount(11);
+            expect(button.removeEventListener, 'button with all listeners').to.have.callCount(11);
         }
     });
 


### PR DESCRIPTION
### This PR will...
Implement separate listener group for initFocusListeners

### Why is this Pull Request needed?
Prevent naming collisions with 'focus' which was already a separate listener group.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-11903

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
