### PR TITLE
[JW8-11903] Fix lingering UI.js issues from click changes

### DIFF
--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -165,9 +165,9 @@ function initInteractionListeners(ui) {
         }
     };
 
+    initFocusListeners(ui, INIT_GROUP);
     initStartEventsListeners(ui, INIT_GROUP, interactStartHandler, listenerOptions);
     initInteractionListener();
-    initFocusListeners(ui, INIT_GROUP);
 }
 
 function initSelectListeners(ui) {
@@ -199,9 +199,9 @@ function initSelectListeners(ui) {
         ui.clicking = true;
     };
 
+    initFocusListeners(ui, SELECT_GROUP);
     initStartEventsListeners(ui, SELECT_GROUP, interactPreClickHandler);
     addEventListener(ui, SELECT_GROUP, 'click', interactClickhandler);
-    initFocusListeners(ui, SELECT_GROUP);
 }
 
 function initFocusListeners(ui, group) {

--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -176,6 +176,10 @@ function initSelectListeners(ui) {
     }
 
     const interactClickhandler = (e) => {
+        // Don't accept clicks from enter key, there is a separate handler for that.
+        if (e.detail === 0) {
+            return;
+        }
         if (now() - ui.lastStart > LONG_PRESS_DELAY && ui.clicking === true) { 
             ui.clicking = false;
             return;

--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -176,10 +176,6 @@ function initSelectListeners(ui) {
     }
 
     const interactClickhandler = (e) => {
-        // Don't accept clicks from enter key, there is a separate handler for that.
-        if (e.detail === 0 && e.isTrusted) {
-            return;
-        }
         if (now() - ui.lastStart > LONG_PRESS_DELAY && ui.clicking === true) { 
             ui.clicking = false;
             return;
@@ -339,9 +335,10 @@ const eventRegisters = {
         addEventListener(ui, ENTER, keydown, (e) => {
             if (e.key === 'Enter' || e.keyCode === 13) {
                 e.stopPropagation();
+                e.preventDefault();
                 triggerSimpleEvent(ui, ENTER, e);
             }
-        });
+        }, false);
     },
     keydown(ui) {
         addEventListener(ui, keydown, keydown, (e) => {

--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -177,7 +177,7 @@ function initSelectListeners(ui) {
 
     const interactClickhandler = (e) => {
         // Don't accept clicks from enter key, there is a separate handler for that.
-        if (e.detail === 0) {
+        if (e.detail === 0 && e.isTrusted) {
             return;
         }
         if (now() - ui.lastStart > LONG_PRESS_DELAY && ui.clicking === true) { 

--- a/test/unit/ui-test.js
+++ b/test/unit/ui-test.js
@@ -28,13 +28,6 @@ describe('UI', function() {
         }
     }());
 
-    const clickEvt = new MouseEvent("click", {
-        bubbles: true,
-        cancelable: true,
-        view: window,
-        detail: 1
-      });
-
     let sandbox;
     let button;
 
@@ -153,7 +146,7 @@ describe('UI', function() {
     it('triggers click events with input', function() {
         const clickSpy = sandbox.spy();
         const ui = new UI(button).on('click tap', clickSpy);
-        button.dispatchEvent(clickEvt);
+        button.click();
         expect(clickSpy).to.have.callCount(1);
         expect(!!clickSpy.args[0].defaultPrevented).to.equal(false);
         ui.destroy();
@@ -164,8 +157,8 @@ describe('UI', function() {
         const ui = new UI(button, {
             enableDoubleTap: true
         }).on('doubleClick doubleTap', doubleClickSpy);
-        button.dispatchEvent(clickEvt);
-        button.dispatchEvent(clickEvt);
+        button.click();
+        button.click();
         const defaultPrevented = !!doubleClickSpy.args[0].defaultPrevented;
         expect(defaultPrevented, 'preventDefault not called').to.equal(false);
         expect(doubleClickSpy).to.have.callCount(1);

--- a/test/unit/ui-test.js
+++ b/test/unit/ui-test.js
@@ -504,11 +504,11 @@ describe('UI', function() {
         ui = new UI(button)
             .on('click tap doubleClick doubleTap dragStart drag dragEnd enter over out focus blur move', () => {});
         if (USE_POINTER_EVENTS) {
-            expect(button.addEventListener, 'button with all listeners').to.have.callCount(11);
+            expect(button.addEventListener, 'button with all listeners').to.have.callCount(13);
         } else if (!USE_MOUSE_EVENTS) {
             expect(button.addEventListener, 'button with all listeners').to.have.callCount(6);
         } else {
-            expect(button.addEventListener, 'button with all listeners').to.have.callCount(11);
+            expect(button.addEventListener, 'button with all listeners').to.have.callCount(13);
         }
         ui.destroy();
     });
@@ -519,14 +519,14 @@ describe('UI', function() {
             .on('click tap doubleClick doubleTap dragStart drag dragEnd enter over out focus blur move', () => {})
             .off();
         if (USE_POINTER_EVENTS) {
-            expect(button.addEventListener, 'button with all listeners').to.have.callCount(11);
-            expect(button.removeEventListener, 'button with all listeners').to.have.callCount(11);
+            expect(button.addEventListener, 'button with all listeners').to.have.callCount(13);
+            expect(button.removeEventListener, 'button with all listeners').to.have.callCount(13);
         } else if (!USE_MOUSE_EVENTS) {
             expect(button.addEventListener, 'button with all listeners').to.have.callCount(6);
             expect(button.removeEventListener, 'button with all listeners').to.have.callCount(6);
         } else {
-            expect(button.addEventListener, 'button with all listeners').to.have.callCount(11);
-            expect(button.removeEventListener, 'button with all listeners').to.have.callCount(11);
+            expect(button.addEventListener, 'button with all listeners').to.have.callCount(13);
+            expect(button.removeEventListener, 'button with all listeners').to.have.callCount(13);
         }
         ui.destroy();
     });
@@ -537,14 +537,14 @@ describe('UI', function() {
         const ui = new UI(button).on('click tap doubleClick doubleTap dragStart drag dragEnd enter over out focus blur move', () => {});
         ui.destroy();
         if (USE_POINTER_EVENTS) {
-            expect(button.addEventListener, 'button with all listeners').to.have.callCount(11);
-            expect(button.removeEventListener, 'button with all listeners').to.have.callCount(11);
+            expect(button.addEventListener, 'button with all listeners').to.have.callCount(13);
+            expect(button.removeEventListener, 'button with all listeners').to.have.callCount(13);
         } else if (!USE_MOUSE_EVENTS) {
             expect(button.addEventListener, 'button with all listeners').to.have.callCount(6);
             expect(button.removeEventListener, 'button with all listeners').to.have.callCount(6);
         } else {
-            expect(button.addEventListener, 'button with all listeners').to.have.callCount(11);
-            expect(button.removeEventListener, 'button with all listeners').to.have.callCount(11);
+            expect(button.addEventListener, 'button with all listeners').to.have.callCount(13);
+            expect(button.removeEventListener, 'button with all listeners').to.have.callCount(13);
         }
     });
 

--- a/test/unit/ui-test.js
+++ b/test/unit/ui-test.js
@@ -28,6 +28,13 @@ describe('UI', function() {
         }
     }());
 
+    const clickEvt = new MouseEvent("click", {
+        bubbles: true,
+        cancelable: true,
+        view: window,
+        detail: 1
+      });
+
     let sandbox;
     let button;
 
@@ -146,7 +153,7 @@ describe('UI', function() {
     it('triggers click events with input', function() {
         const clickSpy = sandbox.spy();
         const ui = new UI(button).on('click tap', clickSpy);
-        button.click();
+        button.dispatchEvent(clickEvt);
         expect(clickSpy).to.have.callCount(1);
         expect(!!clickSpy.args[0].defaultPrevented).to.equal(false);
         ui.destroy();
@@ -157,8 +164,8 @@ describe('UI', function() {
         const ui = new UI(button, {
             enableDoubleTap: true
         }).on('doubleClick doubleTap', doubleClickSpy);
-        button.click();
-        button.click();
+        button.dispatchEvent(clickEvt);
+        button.dispatchEvent(clickEvt);
         const defaultPrevented = !!doubleClickSpy.args[0].defaultPrevented;
         expect(defaultPrevented, 'preventDefault not called').to.equal(false);
         expect(doubleClickSpy).to.have.callCount(1);

--- a/test/unit/ui-test.js
+++ b/test/unit/ui-test.js
@@ -400,8 +400,7 @@ describe('UI', function() {
             cancelable: true
         });
         sandbox.spy(sourceEvent, 'stopPropagation');
-        const result = button.dispatchEvent(sourceEvent);
-        expect(result, 'preventDefault not called').to.equal(true);
+        button.dispatchEvent(sourceEvent);
         expect(enterSpy).to.have.callCount(1);
         expect(enterSpy).calledWith({
             type: 'enter',


### PR DESCRIPTION
### This PR will...
- Ensure focus listeners are added first. 
- Prevent enter from being handled as click (modern browsers dispatch a click event when pressing enter on a menu item).

### Why is this Pull Request needed?
As a result of the previous change, focus/blur listener were not being added. 

To prevent duplication of focus listeners in UI, we first check if `SELECT_GROUP` or `INIT_GROUP` exists in ui handlers, as both of these handler groups require focus listeners. We're currently appending these listeners was set to run _after_ these groups were created, not before, thus guaranteeing a falsy result every time. By moving `initFocusListeners()` ahead of `initStartEventsListeners()`, we ensure an accurate result every time, and continue to avoid adding duplicate focus listeners.

### Are there any points in the code the reviewer needs to double check?
[There might be a better way to go about this](https://github.com/jwplayer/jwplayer/pull/3876)

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-1903

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
