### PR TITLE
[JW8-11592] Fix focus issue in settings menu when closing with keypress

### DIFF
--- a/src/js/view/controls/components/menu/settings-menu.js
+++ b/src/js/view/controls/components/menu/settings-menu.js
@@ -340,8 +340,7 @@ class SettingsMenu extends Menu {
                     focusEl = previousSibling(gearButton);
                     break;
                 }
-                focusEl = gearButton;
-                break;
+                /* falls through */    
             case 'Esc':
                 focusEl = gearButton;
                 break;

--- a/src/js/view/controls/components/menu/settings-menu.js
+++ b/src/js/view/controls/components/menu/settings-menu.js
@@ -342,6 +342,9 @@ class SettingsMenu extends Menu {
                 }
                 focusEl = gearButton;
                 break;
+            case 'Esc':
+                focusEl = gearButton;
+                break;
             default:
                 break;
         }


### PR DESCRIPTION
### This PR will...
leave the focus on the settings menu cog when closed via "Esc" key

### Why is this Pull Request needed?
related to accessibility features as well as more consistent player behavior  

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):
JW8-11592

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
