### PR TITLE
[JW8-11914] Fix synthetic click issue

### DIFF
--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -107,7 +107,6 @@ function initInteractionListeners(ui) {
         const { pageX, pageY } = getCoords(e);
 
         ui.dragged = false;
-        ui.lastStart = now();
         ui.startX = pageX;
         ui.startY = pageY;
 
@@ -175,11 +174,11 @@ function initSelectListeners(ui) {
         return;
     }
 
-    const interactClickhandler = (e) => {
+    const interactClickHandler = (e) => {
         if (now() - ui.lastStart > LONG_PRESS_DELAY && ui.clicking === true) { 
-            ui.clicking = false;
             return;
         }
+
         const click = e.type === 'click';
         checkDoubleTap(ui, e, click);
         if (click) {
@@ -199,9 +198,15 @@ function initSelectListeners(ui) {
         ui.clicking = true;
     };
 
+    const interactPostClickHandler = () => {
+        ui.clicking = false;
+    };
+
     initFocusListeners(ui, SELECT_GROUP);
     initStartEventsListeners(ui, SELECT_GROUP, interactPreClickHandler);
-    addEventListener(ui, SELECT_GROUP, 'click', interactClickhandler);
+    addEventListener(ui, SELECT_GROUP, 'click', interactClickHandler);
+    // Ensure ui.clicking is always set to false on click (even if user has moved mouse) by listening for event on document
+    addEventListener(ui, WINDOW_GROUP, 'click', interactPostClickHandler);
 }
 
 function initFocusListeners(ui, group) {


### PR DESCRIPTION
### This PR will...
- Ensure `ui.clicking` is set to `false` after every click handling.
- Re-use current pointer capture logic in clickHandler
  - In case where cursor is moved before click released, click event will still be dispatched on original target (same as original behavior)
- Remove redundant `lastStart`
- Capitalize the "H" in `interactClickHandler`

### Why is this Pull Request needed?
Calling `element.click()` in cases where `ui.clicking` is incorrectly set to `true` will result in the event not being handled.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-11914

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
