### PR TITLE
[JW8-11913] Re-implement directSelect for addClickAction

### DIFF
--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -175,7 +175,12 @@ function initSelectListeners(ui) {
         return;
     }
 
+    const { el } = ui;
+
     const interactClickhandler = (e) => {
+        if (!!ui.directSelect && e.target !== el) {
+            return;
+        }
         if (now() - ui.lastStart > LONG_PRESS_DELAY && ui.clicking === true) { 
             ui.clicking = false;
             return;
@@ -191,7 +196,9 @@ function initSelectListeners(ui) {
 
     const interactPreClickHandler = (e) => {
         const { target } = e;
-
+        if (!!ui.directSelect && target !== el) {
+            return;
+        }
         if (e.isPrimary && target.tageName === 'BUTTON') {
             target.focus();
         }

--- a/src/js/view/utils/add-click-action.ts
+++ b/src/js/view/utils/add-click-action.ts
@@ -1,7 +1,7 @@
 import UI from 'utils/ui';
 
 export function addClickAction(element: HTMLElement, clickAction: (evt: Event) => void, ctx?: any): UI {
-    const ui = new UI(element).on('click tap enter', clickAction, ctx);
+    const ui = new UI(element, { directSelect: true }).on('click tap enter', clickAction, ctx);
     
     return ui;
 }


### PR DESCRIPTION
### This PR will...
- Re-implement directSelect for addClickAction.

### Why is this Pull Request needed?
Fixes issues where event listeners are only meant for a specific element and not its children.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-11913

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
