### PR TITLE
[JW8-11885] Fix playReason not updating after a seek event

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -773,6 +773,9 @@ Object.assign(Controller.prototype, {
             if (state === STATE_ERROR) {
                 return;
             }
+            if (state === STATE_PLAYING && _model.get('playReason') !== meta.reason) {
+                _model.set('playReason', meta.reason);
+            }
             _programController.position = pos;
             const isIdle = state === STATE_IDLE;
             if (!_model.get('scrubbing') && (isIdle || state === STATE_COMPLETE)) {


### PR DESCRIPTION
### This PR will...
Assure that after a seek event, the appropriate playReason (external vs interaction) is assigned to the playReason attribute.
### Why is this Pull Request needed?
More consistency with player event reporting
### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-11885

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
