### PR TITLE
[JW8-11877][JW8-11874][JW8-11880] Add getSkinName util and move loadPlugins to setup-steps

### DIFF
--- a/src/js/api/Setup.js
+++ b/src/js/api/Setup.js
@@ -1,11 +1,11 @@
 import { loadCore } from 'api/core-loader';
 import { loadCoreBundle } from 'api/core-bundle-loader';
-import loadPlugins from 'plugins/plugins';
 import {
     loadProvider,
     loadModules,
     loadSkin,
-    loadTranslations
+    loadTranslations,
+    loadPlugins
 } from 'api/setup-steps';
 import { PlayerError, SETUP_ERROR_TIMEOUT, MSG_CANT_LOAD_PLAYER } from 'api/errors';
 

--- a/src/js/api/setup-steps.js
+++ b/src/js/api/setup-steps.js
@@ -7,6 +7,7 @@ import { composePlayerError, PlayerError,
     ERROR_LOADING_TRANSLATIONS, ERROR_LOADING_TRANSLATIONS_EMPTY_RESPONSE } from 'api/errors';
 import { getCustomLocalization, isLocalizationComplete, loadJsonTranslation, isTranslationAvailable, applyTranslation } from 'utils/language';
 import { bundleContainsProviders } from 'api/core-loader';
+import pluginsPromise from 'plugins/plugins';
 
 export function loadPlaylist(_model) {
     const playlist = _model.get('playlist');
@@ -131,6 +132,8 @@ export function loadTranslations(_model) {
 export function loadModules(/* model, api */) {
     return Promise.resolve();
 }
+
+export const loadPlugins = pluginsPromise;
 
 function destroyed(_model) {
     return _model.attributes._destroyed;

--- a/src/js/api/setup-steps.js
+++ b/src/js/api/setup-steps.js
@@ -133,7 +133,9 @@ export function loadModules(/* model, api */) {
     return Promise.resolve();
 }
 
-export const loadPlugins = pluginsPromise;
+export function loadPlugins(model, api) {
+    return pluginsPromise(model, api);
+}
 
 function destroyed(_model) {
     return _model.attributes._destroyed;

--- a/src/js/view/utils/skin.js
+++ b/src/js/view/utils/skin.js
@@ -3,7 +3,7 @@ import { css, getRgba } from 'utils/css';
 
 export function getSkinName(url) {
     // Regex locates the characters after the last slash, until it encounters the file extension.
-    return url.replace(/^(.*\/)?(.*)-?.*\.(css)$/, '$2');
+    return url.replace(/^(.*\/)?(.*)-?.*\.(css).*$/, '$2');
 }
 
 export function normalizeSkin(skinConfig) {

--- a/src/js/view/utils/skin.js
+++ b/src/js/view/utils/skin.js
@@ -1,6 +1,11 @@
 import { prefix } from 'utils/strings';
 import { css, getRgba } from 'utils/css';
 
+export function getSkinName(url) {
+    // Regex locates the characters after the last slash, until it encounters the file extension.
+    return url.replace(/^(.*\/)?(.*)-?.*\.(css)$/, '$2');
+}
+
 export function normalizeSkin(skinConfig) {
     if (!skinConfig) {
         skinConfig = {};

--- a/test/unit/skin-test.js
+++ b/test/unit/skin-test.js
@@ -1,5 +1,5 @@
 import _ from 'test/underscore';
-import { normalizeSkin, handleColorOverrides } from 'view/utils/skin';
+import { getSkinName, normalizeSkin, handleColorOverrides } from 'view/utils/skin';
 import { clearCss } from 'utils/css';
 import diff from 'fast-diff';
 
@@ -40,6 +40,24 @@ describe('Skin Customization', function() {
     beforeEach(clearPlayerStyleSheets);
 
     after(clearPlayerStyleSheets);
+
+    describe('getSkinName', function() {
+
+        it('should return file name from stylesheet url', function() {
+            const skinName = getSkinName('https://playertest.longtailvideo.com/ethan.css');
+            expect(skinName).to.equal('ethan');
+        });
+
+        it('should return dashed file name from stylesheet url', function() {
+            const skinName = getSkinName('https://playertest.longtailvideo.com/ethan-skin.css');
+            expect(skinName).to.equal('ethan-skin');
+        });
+
+        it('should return input from non-url', function() {
+            const skinName = getSkinName('test');
+            expect(skinName).to.equal('test');
+        });
+    });
 
     describe('normalizeSkin', function() {
 

--- a/test/unit/skin-test.js
+++ b/test/unit/skin-test.js
@@ -53,6 +53,11 @@ describe('Skin Customization', function() {
             expect(skinName).to.equal('ethan-skin');
         });
 
+        it('should return file name from stylesheet url with extra parameters', function() {
+            const skinName = getSkinName('https://playertest.longtailvideo.com/ethan.css?param');
+            expect(skinName).to.equal('ethan');
+        });
+
         it('should return input from non-url', function() {
             const skinName = getSkinName('test');
             expect(skinName).to.equal('test');


### PR DESCRIPTION
### This PR will...
- Add a getSkinName util function to grab name from url or just return input
- Move loadPlugins to setup-steps
### Why is this Pull Request needed?
AMP Param extending
### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/amphtml/pull/44
https://github.com/jwplayer/jwplayer-commercial/pull/8023
#### Addresses Issue(s):

JW8-11877
JW8-11874
JW8-11880

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
