### PR TITLE
[JW8-11941] Fix for DAI postrolls not playing when seeked past video duration

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -776,7 +776,7 @@ Object.assign(Controller.prototype, {
             if (state === STATE_ERROR) {
                 return;
             }
-            if (state === STATE_PLAYING && _model.get('playReason') !== meta.reason) {
+            if (meta && state === STATE_PLAYING && _model.get('playReason') !== meta.reason) {
                 _model.set('playReason', meta.reason);
             }
             _programController.position = pos;


### PR DESCRIPTION
### This PR will...
Fix the issue with DAI postrolls not playing when seeking past video duration using our API.
### Why is this Pull Request needed?
To fix a regression issue 
### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):
JW8-11941

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
