### PR TITLE
[JW8-11923] Fix diagonal drag on timeslider

### DIFF
--- a/src/js/types/generic.type.ts
+++ b/src/js/types/generic.type.ts
@@ -71,3 +71,5 @@ export type BoundingRect = {
     top: number;
     bottom: number;
 };
+
+export type GenericUIEvent = MouseEvent & { sourceEvent: Event };

--- a/src/js/view/controls/components/slider.ts
+++ b/src/js/view/controls/components/slider.ts
@@ -58,8 +58,8 @@ class Slider extends Events {
         this.railBounds = getRailBounds(this.elementRail as HTMLElement);
     }
 
-    dragEnd(evt: Event): void {
-        this.dragMove(evt as GenericUIEvent);
+    dragEnd(evt: GenericUIEvent): void {
+        this.dragMove(evt);
         this.trigger('dragEnd');
     }
 
@@ -99,9 +99,9 @@ class Slider extends Events {
         return false;
     }
 
-    tap(evt: Event): void {
+    tap(evt: GenericUIEvent): void {
         this.railBounds = getRailBounds(this.elementRail);
-        this.dragMove(evt as GenericUIEvent);
+        this.dragMove(evt);
     }
 
     limit(percentage: number): number {

--- a/src/js/view/controls/components/slider.ts
+++ b/src/js/view/controls/components/slider.ts
@@ -4,7 +4,7 @@ import Events from 'utils/backbone.events';
 import UI from 'utils/ui';
 import { between } from 'utils/math';
 import { bounds, createElement } from 'utils/dom';
-import type { BoundingRect } from 'types/generic.type';
+import type { BoundingRect, GenericUIEvent } from 'types/generic.type';
 
 interface Slider {
     className: string;
@@ -59,14 +59,18 @@ class Slider extends Events {
     }
 
     dragEnd(evt: Event): void {
-        this.dragMove(evt as MouseEvent);
+        this.dragMove(evt as GenericUIEvent);
         this.trigger('dragEnd');
     }
 
-    dragMove(evt: MouseEvent): boolean {
+    dragMove(evt: GenericUIEvent): boolean {
         const railBounds = this.railBounds = (this.railBounds) ? this.railBounds : getRailBounds(this.elementRail);
         let dimension: number;
         let percentage: number;
+
+        if (evt.sourceEvent.type === 'pointercancel') {
+            return false;
+        }
 
         if (this.orientation === 'horizontal') {
             dimension = evt.pageX;
@@ -97,7 +101,7 @@ class Slider extends Events {
 
     tap(evt: Event): void {
         this.railBounds = getRailBounds(this.elementRail);
-        this.dragMove(evt as MouseEvent);
+        this.dragMove(evt as GenericUIEvent);
     }
 
     limit(percentage: number): number {


### PR DESCRIPTION
This PR will...

    Fix an old bug where dragging the timeslider diagonally on mobile would result in seeking to 0.

Why is this Pull Request needed?
Are there any points in the code the reviewer needs to double check?
Are there any Pull Requests open in other repos which need to be merged with this?
Addresses Issue(s):

JW8-11923

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
