### PR TITLE
[JW8-11954] Incorrect play reason when buttons cause play event via API

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -773,11 +773,16 @@ Object.assign(Controller.prototype, {
 
         function _seek(pos, meta) {
             const state = _model.get('state');
+            const activeEl = document.activeElement;
+
             if (state === STATE_ERROR) {
                 return;
             }
             if (meta && state === STATE_PLAYING && _model.get('playReason') !== meta.reason) {
                 _model.set('playReason', meta.reason);
+            }
+            if (meta && !activeEl.classList.contains('jw-slider-time')) {
+                _model.set('playReason', 'external');
             }
             _programController.position = pos;
             const isIdle = state === STATE_IDLE;
@@ -785,6 +790,9 @@ Object.assign(Controller.prototype, {
                 if (isIdle) {
                     meta = meta || {};
                     meta.startTime = pos;
+                }
+                if (meta.reason !== _model.get('playReason')) {
+                    meta.reason = 'external';
                 }
                 this.play(meta);
             }

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -563,6 +563,7 @@ Object.assign(Controller.prototype, {
         }
 
         function _play(meta) {
+            const activeEl = document.activeElement;
             checkAutoStartCancelable.cancel();
             _stopPlaylist = false;
 
@@ -570,7 +571,10 @@ Object.assign(Controller.prototype, {
                 return Promise.resolve();
             }
 
-            const playReason = _getReason(meta);
+            let playReason = _getReason(meta);
+            if (meta && !activeEl.classList.contains('jwplayer') && !activeEl.classList.contains('jw-icon-playback') && !_model.get('interaction')) {
+                playReason = 'external';
+            }
             _model.set('playReason', playReason);
 
             const adState = _getAdState();
@@ -724,7 +728,11 @@ Object.assign(Controller.prototype, {
         }
 
         function _updatePauseReason(meta) {
-            const pauseReason = _getReason(meta);
+            const activeEl = document.activeElement;
+            let pauseReason = _getReason(meta);
+            if (meta && !activeEl.classList.contains('jwplayer') && !activeEl.classList.contains('jw-icon-playback') && !_model.get('interaction')) {
+                pauseReason = 'external';
+            }
             _model.set('pauseReason', pauseReason);
             _model.set('playOnViewable', (pauseReason === 'viewable'));
         }
@@ -781,7 +789,7 @@ Object.assign(Controller.prototype, {
             if (meta && state === STATE_PLAYING && _model.get('playReason') !== meta.reason) {
                 _model.set('playReason', meta.reason);
             }
-            if (meta && !activeEl.classList.contains('jw-slider-time')) {
+            if (meta && !activeEl.classList.contains('jw-slider-time') && !_model.get('interaction')) {
                 _model.set('playReason', 'external');
             }
             _programController.position = pos;
@@ -790,8 +798,6 @@ Object.assign(Controller.prototype, {
                 if (isIdle) {
                     meta = meta || {};
                     meta.startTime = pos;
-                }
-                if (meta.reason !== _model.get('playReason')) {
                     meta.reason = 'external';
                 }
                 this.play(meta);

--- a/src/js/view/controls/controls.js
+++ b/src/js/view/controls/controls.js
@@ -278,7 +278,9 @@ export default class Controls extends Events {
                 max = Math.max(position, -dvrSeekLimit);
             }
             const newSeek = between(position + amount, min, max);
+            model.set('interaction', true);
             api.seek(newSeek, reasonInteraction());
+            model.set('interaction', false);
         }
 
         function adjustVolume(amount) {
@@ -330,7 +332,9 @@ export default class Controls extends Events {
                         // Let event bubble up so the spacebar can control the toggle if focused on
                         return true;
                     }
+                    model.set('interaction', true);
                     api.playToggle(reasonInteraction());
+                    model.set('interaction', false);
                     break;
                 case 37: // left-arrow, if shortcuts are enabled, not adMode, and settings menu is hidden
                     if (!adMode && menuHidden) {


### PR DESCRIPTION
### This PR will...
Properly show the correct play reason for API calls made through buttons.
### Why is this Pull Request needed?
Our player was showing button controlled API calls as 'interactive' rather than 'external'.
### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-11954

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
