### PR TITLE
[JW8-11992] Revert "Fix viewability pause not working during ad buffering"

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -579,11 +579,6 @@ Object.assign(Controller.prototype, {
             const adState = _getAdState();
 
             if (adState) {
-                // prevents the interaction with controls during ad playback to overwrite autostart playReason
-                if (_model.get('autostart') && adState === 'paused') {
-                    _model.set('playReason', 'autostart');
-                }
-                _this._instreamAdapter.off('state', _pauseAd, _this);
                 // this will resume the ad. _api.playAd would load a new ad
                 _api.pauseAd(false, meta);
                 return Promise.resolve();
@@ -743,12 +738,7 @@ Object.assign(Controller.prototype, {
             const adState = _getAdState();
             if (adState && adState !== STATE_PAUSED) {
                 _updatePauseReason(meta);
-                if (adState === STATE_BUFFERING) {
-                    _this._instreamAdapter.once('state', _pauseAd, _this);
-                    _this._instreamAdapter.noResume = true;
-                } else {
-                    _api.pauseAd(true, meta);
-                }
+                _api.pauseAd(true, meta);
                 return;
             }
 
@@ -766,11 +756,6 @@ Object.assign(Controller.prototype, {
                         _interruptPlay = true;
                     }
             }
-        }
-
-        function _pauseAd() {
-            const reason = _model.get('pauseReason');
-            _api.pauseAd(true, { reason });
         }
 
         function _isIdle() {


### PR DESCRIPTION
Reverts [[JW8-11793] Fix viewability pause not working during ad buffering](jwplayer/jwplayer#3864)

### This PR will...
Revert ad viewability during buffering bugfix changes.

### Why is this Pull Request needed?
A hotfix to see if these changes are causing a customer to experience a drop in VCR: See JW8-11992

The additional changes that have gone into `controller.js` since this was initially merged are:
- [#3870 [JW8-11888] Additional Memory Leake Fixes](https://github.com/jwplayer/jwplayer/pull/3870)
- [#3891 Adding PiP Support](https://github.com/jwplayer/jwplayer/pull/3891)
- [#3886 [JW8-11885] Fix PlayReason not Updating after Seek](https://github.com/jwplayer/jwplayer/pull/3886)
- [#3897 [JW8-11941] Fix DAI PostRolls not playing when seeking past video duration](https://github.com/jwplayer/jwplayer/pull/3897)
- [#3898 Exit out of PiP or Fullscreen when entering the other](https://github.com/jwplayer/jwplayer/pull/3898)

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):
Relates to: JW8-11992

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
