### PR TITLE
[JW8-11966] Bugfix/remove

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -64,7 +64,7 @@ module.exports = function(grunt) {
             }
         },
 
-        watch : {
+        watch: {
             options: {
                 interrupt: false,
                 spawn: false,
@@ -101,7 +101,7 @@ module.exports = function(grunt) {
                 port: 3000,
                 // change this to '0.0.0.0' to access the server from outside
                 // change this to 'localhost' to restrict access to the server from outside
-                hostname: 'localhost'
+                hostname: '0.0.0.0'
             },
             livereload: {
                 options: {
@@ -214,7 +214,9 @@ module.exports = function(grunt) {
         const output = './bin-release/notice.txt';
         const done = this.async();
         fs.writeFile(output, notice, function(err4) {
-            if (err4) { throw err4; }
+            if (err4) {
+                throw err4; 
+            }
             console.log('Wrote file', output);
             done();
         });
@@ -232,7 +234,7 @@ module.exports = function(grunt) {
     });
 
     grunt.registerTask('type-check', 'Run type-check on ts files', function() {
-        runCommand('npm run type-check', '.')
+        runCommand('npm run type-check', '.');
     });
 
     // grunt.registerTask('docs', 'Generate API documentation', function() {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -101,7 +101,7 @@ module.exports = function(grunt) {
                 port: 3000,
                 // change this to '0.0.0.0' to access the server from outside
                 // change this to 'localhost' to restrict access to the server from outside
-                hostname: '0.0.0.0'
+                hostname: 'localhost'
             },
             livereload: {
                 options: {

--- a/src/js/api/api.js
+++ b/src/js/api/api.js
@@ -248,6 +248,11 @@ export default function Api(element) {
          * @returns {Api} The Player API instance
          */
         remove() {
+            // disable pip if enabled
+            if (this.getPip()) {
+                this.setPip(false);
+            }
+
             // Remove from array of players
             removePlayer(this);
 


### PR DESCRIPTION
### This PR will...

Fix the issue where `remove()` can be called and leave an orphaned PiP window


### Are there any points in the code the reviewer needs to double check?

I have placed the called to disable the pip directly in the API layer as `removePlayer` is called directly afterwards


#### Addresses Issue(s):

JW8-11966

### Checklist
- [x] Jenkins builds and unit tests are passing
- [x] I have reviewed the automated results
