### PR TITLE
[JW8-11999] Adds playReason for autostart after control interactions during ad playback

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -576,6 +576,10 @@ Object.assign(Controller.prototype, {
             const adState = _getAdState();
 
             if (adState) {
+                // prevents the interaction with controls during ad playback to overwrite autostart playReason
+                if (_model.get('autostart') && adState === 'paused') {
+                    _model.set('playReason', 'autostart');
+                }
                 _this._instreamAdapter.off('state', _pauseAd, _this);
                 // this will resume the ad. _api.playAd would load a new ad
                 _api.pauseAd(false, meta);


### PR DESCRIPTION
### This PR will...
Properly set the playReason as `autostart` (assuming player is set to autostart) after interactions with the player controls during ad playback.
### Why is this Pull Request needed?
After interacting with the controls during ad playback, the playReason was overwritten as `interaction`
### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-11999

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
