### PR TITLE
[JW8-12020] Pip player pausing automatically when navigating to new tabs

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -325,6 +325,9 @@ function View(_api, _model) {
     };
 
     function updateVisibility() {
+        if (_model.get('pip')) {
+            return;
+        }
         _model.set('visibility', getVisibility(_model, _playerElement));
     }
 


### PR DESCRIPTION
### This PR will...
Prevent pausing of Pip player when navigating to different tabs when `autoPause` config is set.

Note: This only works on Chrome as Firefox has its own proprietary Pip API/functionality.
### Why is this Pull Request needed?
Pip player was pausing when navigating to a different browser tab/window.
### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-12020

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
