### PR TITLE
Improvement: aria-valuetext attribute for TimeSlider component

### DIFF
--- a/src/js/utils/function-wrappers.ts
+++ b/src/js/utils/function-wrappers.ts
@@ -1,0 +1,21 @@
+// Helper function to wrap a function so that it can only be executed
+// a limited number of times before being "silenced"
+// Can be reset to allow the target function to be invoked again
+export const limit = (fn: Function, maxTimes: number) => {
+    let times = 0;
+    const wrapper = function(this: any, ...args: any[]): any {
+        times++;
+        if (times < maxTimes) {
+            return fn.apply(this, args);
+        }
+    };
+
+    return Object.assign(wrapper, {
+        reset: (): void => {
+            times = 0;
+        },
+        shush: (): void => {
+            times = Infinity;
+        }
+    });
+};

--- a/src/js/utils/parser.ts
+++ b/src/js/utils/parser.ts
@@ -114,3 +114,25 @@ export function timeFormat(sec: number, allowNegative?: boolean): string {
 
     return prefix + (hrs ? hrs + ':' : '') + (mins < 10 ? '0' : '') + mins + ':' + (secs < 10 ? '0' : '') + secs;
 }
+
+// Returns a formatted time string from "mm:ss" to "hh:mm:ss" for the given number of seconds
+export function timeFormatAria(sec: number): string {
+    if (isNaN(sec)) {
+        sec = parseInt(sec.toString());
+    }
+
+    if (isNaN(sec) || !isFinite(sec) || sec <= 0) {
+        return '0 seconds';
+    }
+
+    const hrs = Math.floor(sec / 3600);
+    const mins = Math.floor((sec - hrs * 3600) / 60);
+    const secs = Math.floor(sec % 60);
+
+    const hrsString = (hrs > 1 ? ' hours, ' : (hrs === 1 ? ' hour, ' : ''));
+    const minsString = (mins > 1 ? ' minutes, ' : (mins === 1 ? ' minute, ' : ''));
+    const secsString = (secs !== 1 ? ' seconds' : (secs === 1 ? ' second' : ''));
+
+    // TODO: I18n!!
+    return (hrs ? hrs + hrsString : '') + (mins ? mins + minsString : '') + secs + secsString;
+}

--- a/src/js/utils/underscore.js
+++ b/src/js/utils/underscore.js
@@ -518,16 +518,17 @@ export const throttle = function(func, wait, options) {
         context = args = null;
     };
     return function() {
+        const rightnow = now();
         if (!previous && options.leading === false) {
-            previous = now;
+            previous = rightnow;
         }
-        const remaining = wait - (now - previous);
+        const remaining = wait - (rightnow - previous);
         context = this;
         args = arguments;
         if (remaining <= 0) {
             clearTimeout(timeout);
             timeout = null;
-            previous = now;
+            previous = rightnow;
             result = func.apply(context, args);
             context = args = null;
         } else if (!timeout && options.trailing !== false) {

--- a/src/js/view/controls/components/timeslider.ts
+++ b/src/js/view/controls/components/timeslider.ts
@@ -81,7 +81,7 @@ class TimeTipIcon extends TooltipIcon {
         this.text.textContent = txt;
     }
 
-    getWidth (): number {
+    getWidth(): number {
         if (!this.containerWidth) {
             this.setWidth();
         }
@@ -89,7 +89,7 @@ class TimeTipIcon extends TooltipIcon {
         return this.containerWidth as number;
     }
 
-    setWidth (width?: number): void {
+    setWidth(width?: number): void {
         const tolerance = 16; // add a little padding so the tooltip isn't flush against the edge
 
         if (width) {
@@ -104,7 +104,7 @@ class TimeTipIcon extends TooltipIcon {
         this.containerWidth = bounds(this.container).width + tolerance;
     }
 
-    resetWidth (): void {
+    resetWidth(): void {
         this.containerWidth = 0;
     }
 }

--- a/src/js/view/controls/components/timeslider.ts
+++ b/src/js/view/controls/components/timeslider.ts
@@ -1,7 +1,7 @@
 import { throttle, each } from 'utils/underscore';
 import { between } from 'utils/math';
 import { style, transform } from 'utils/css';
-import { timeFormat } from 'utils/parser';
+import { timeFormat, timeFormatAria } from 'utils/parser';
 import { addClass, removeClass, setAttribute, bounds } from 'utils/dom';
 import UI from 'utils/ui';
 import Slider from 'view/controls/components/slider';
@@ -176,7 +176,7 @@ class TimeSlider extends Slider {
     onDuration(this: TimeSliderWithMixins, model: ViewModel, duration: number): void {
         this.updateTime(model.get('position'), duration);
         setAttribute(this.el, 'aria-valuemin', 0);
-        setAttribute(this.el, 'aria-valuemax', duration);
+        setAttribute(this.el, 'aria-valuemax', Math.abs(duration));
         this.drawCues();
     }
 
@@ -324,20 +324,23 @@ class TimeSlider extends Slider {
 
     updateAriaText(): void {
         const model = this._model;
-        const position = model.get('position');
-        const duration = model.get('duration');
-
-        let ariaText = timeFormat(position);
-        if (this.streamType !== 'DVR') {
-            ariaText += ` of ${timeFormat(duration)}`;
-        }
-
         const sliderElement = this.el;
-        if (document.activeElement !== sliderElement) {
-            this.timeUpdateKeeper.textContent = ariaText;
+        let position = model.get('position');
+        let duration = model.get('duration');
+
+        if (this.streamType === 'DVR') {
+            duration = Math.abs(duration);
+            position = duration + position;
         }
+
+        const ariaPositionText = timeFormatAria(position);
+        const ariaDurationText = timeFormatAria(duration);
+        const ariaString = `${ariaPositionText} of ${ariaDurationText}`;
+
+        this.timeUpdateKeeper.textContent = ariaString;
+
+        setAttribute(sliderElement, 'aria-valuetext', ariaString);
         setAttribute(sliderElement, 'aria-valuenow', position);
-        setAttribute(sliderElement, 'aria-valuetext', ariaText);
     }
 
     reset(this: TimeSliderWithMixins): void {


### PR DESCRIPTION
### This PR will...
Add an `aria-valuetext` attribute to the TimeSlider component. The value will be updated a maximum of 4 times before the updating stops so that the screen reader does not continually announce the time. Focusing and seeking of the TimeSlider will start updating the `aria-valuetext` attribute again (a maximum of 4 times). Blurring the TimeSlider will stop updating the value.

This update also includes a bug fix around the `throttle` function in underscore.js.

### Why is this Pull Request needed?
We did not have an `aria-valuetext` attribute at all and the previous TimeSlider bar. A naive implementation would result in the screen reader constantly announcing the time while the player and/or progress bar had the focus.

### Are there any points in the code the reviewer needs to double check?
1. Most of my testing was in NVDA on Windows Chrome.
1. I checked DVR but it would be good to double check that even though the calculations are relatively simple.
1. Blur/focus even behavior (especially) is really important to verify across a number of platforms and screen-readers.

#### Addresses Issue(s):

JW8-12007

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
