### PR TITLE
[JW8-12027] Maintain focus on gear button after 'Enter' is pressed

### DIFF
--- a/src/js/view/controls/components/menu/settings-menu.js
+++ b/src/js/view/controls/components/menu/settings-menu.js
@@ -340,7 +340,8 @@ class SettingsMenu extends Menu {
                     focusEl = previousSibling(gearButton);
                     break;
                 }
-                /* falls through */    
+                /* falls through */
+            case 'Enter':
             case 'Esc':
                 focusEl = gearButton;
                 break;


### PR DESCRIPTION
### This PR will...
Keep the focus on gear button element after `Enter` key is pressed
### Why is this Pull Request needed?
Focus was being lost once exiting the settings menu
### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-12027

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
