### PR TITLE
[JW8-12029] Adding 'aria-expanded' attribute to the .jw-icon-settings button

### DIFF
--- a/src/js/view/controls/components/menu/settings-menu.js
+++ b/src/js/view/controls/components/menu/settings-menu.js
@@ -304,12 +304,13 @@ class SettingsMenu extends Menu {
     }
 
     open(evt) {
-        const gearButton = this.controlbar.elements.settingsButton.element();
-        gearButton.setAttribute('aria-expanded', true);
-
         if (this.visible) {
             return;
         }
+
+        const gearButton = this.controlbar.elements.settingsButton.element();
+        gearButton.setAttribute('aria-expanded', true);
+        
         this.el.parentNode.classList.add('jw-settings-open');
         this.trigger('visibility', { visible: true, evt });
         document.addEventListener('click', this.onDocumentClick);

--- a/src/js/view/controls/components/menu/settings-menu.js
+++ b/src/js/view/controls/components/menu/settings-menu.js
@@ -304,6 +304,9 @@ class SettingsMenu extends Menu {
     }
 
     open(evt) {
+        const gearButton = this.controlbar.elements.settingsButton.element();
+        gearButton.setAttribute('aria-expanded', true);
+
         if (this.visible) {
             return;
         }
@@ -326,6 +329,8 @@ class SettingsMenu extends Menu {
         // If closed by keypress, focus appropriate element.
         const key = normalizeKey(evt && evt.sourceEvent && evt.sourceEvent.key);
         const gearButton = this.controlbar.elements.settingsButton.element();
+        gearButton.setAttribute('aria-expanded', false);
+
         let focusEl;
 
         switch (key) {

--- a/src/js/view/controls/components/menu/settings-menu.js
+++ b/src/js/view/controls/components/menu/settings-menu.js
@@ -321,23 +321,24 @@ class SettingsMenu extends Menu {
     }
 
     close(evt) {
-        this.el.setAttribute('aria-expanded', 'false');
-        this.el.parentNode.classList.remove('jw-settings-open');
-        this.trigger('visibility', { visible: false, evt });
-        document.removeEventListener('click', this.onDocumentClick);
-        this.visible = false;
-        if (this.openMenus.length) {
-            this.closeChildren();
-        }
-
-        // If closed by keypress, focus appropriate element.
         const key = normalizeKey(evt && evt.sourceEvent && evt.sourceEvent.key);
         const gearButton = this.controlbar.elements.settingsButton.element();
         
         if (gearButton) {
             gearButton.setAttribute('aria-expanded', false);
         }
-
+        
+        this.el.setAttribute('aria-expanded', 'false');
+        this.el.parentNode.classList.remove('jw-settings-open');
+        
+        this.trigger('visibility', { visible: false, evt });
+        document.removeEventListener('click', this.onDocumentClick);
+        this.visible = false;
+        if (this.openMenus.length) {
+            this.closeChildren();
+        }
+        
+        // If closed by keypress, focus appropriate element.
         let focusEl;
 
         switch (key) {

--- a/src/js/view/controls/components/menu/settings-menu.js
+++ b/src/js/view/controls/components/menu/settings-menu.js
@@ -309,7 +309,9 @@ class SettingsMenu extends Menu {
         }
 
         const gearButton = this.controlbar.elements.settingsButton.element();
-        gearButton.setAttribute('aria-expanded', true);
+        if (gearButton) {
+            gearButton.setAttribute('aria-expanded', true);
+        }
 
         this.el.parentNode.classList.add('jw-settings-open');
         this.trigger('visibility', { visible: true, evt });
@@ -331,7 +333,10 @@ class SettingsMenu extends Menu {
         // If closed by keypress, focus appropriate element.
         const key = normalizeKey(evt && evt.sourceEvent && evt.sourceEvent.key);
         const gearButton = this.controlbar.elements.settingsButton.element();
-        gearButton.setAttribute('aria-expanded', false);
+        
+        if (gearButton) {
+            gearButton.setAttribute('aria-expanded', false);
+        }
 
         let focusEl;
 

--- a/src/js/view/controls/components/menu/settings-menu.js
+++ b/src/js/view/controls/components/menu/settings-menu.js
@@ -310,7 +310,7 @@ class SettingsMenu extends Menu {
 
         const gearButton = this.controlbar.elements.settingsButton.element();
         gearButton.setAttribute('aria-expanded', true);
-        
+
         this.el.parentNode.classList.add('jw-settings-open');
         this.trigger('visibility', { visible: true, evt });
         document.addEventListener('click', this.onDocumentClick);
@@ -319,6 +319,7 @@ class SettingsMenu extends Menu {
     }
 
     close(evt) {
+        this.el.setAttribute('aria-expanded', 'false');
         this.el.parentNode.classList.remove('jw-settings-open');
         this.trigger('visibility', { visible: false, evt });
         document.removeEventListener('click', this.onDocumentClick);

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -154,6 +154,7 @@ export default class Controlbar {
             this.trigger('settingsInteraction', 'quality', true, event);
         }, localization.settings, cloneIcons('settings'));
         setAttribute(settingsButton.element(), 'aria-controls', 'jw-settings-menu');
+        setAttribute(settingsButton.element(), 'aria-expanded', false);
 
         const captionsButton = button('jw-icon-cc jw-settings-submenu-button', (event) => {
             this.trigger('settingsInteraction', 'captions', false, event);


### PR DESCRIPTION
### This PR will...
Add 'aria-expanded' attribute to the `jw-icon-settings` button
### Why is this Pull Request needed?
It was not there before.
### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-12029

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
