### PR TITLE
[JW8-11994]  Hide PIP in Tizen Browser

### DIFF
--- a/src/js/utils/browser.ts
+++ b/src/js/utils/browser.ts
@@ -4,7 +4,7 @@ function userAgentMatch(regex: RegExp): boolean {
 
 const isIPadOS13 = () => navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1;
 
-export const isFF = () => userAgentMatch(/gecko\//i);
+export const isFF = () => userAgentMatch(/gecko\//i) && !isTizen();
 
 export const isIETrident = () => userAgentMatch(/trident\/.+rv:\s*11/i);
 
@@ -27,15 +27,14 @@ export const isTizenApp = () => isTizen() && !userAgentMatch(/SamsungBrowser/);
 
 export const isChrome = () => userAgentMatch(/\s(?:(?:Headless)?Chrome|CriOS)\//i) &&
     !isEdge() &&
-    !userAgentMatch(/UCBrowser/i) &&
-    !isTizen();
+    !userAgentMatch(/UCBrowser/i);
 
 // Exclude Chromium Edge ("Edg/") from isIE
 export const isIE = () => !userAgentMatch(/\sEdg\/\d+/i) && (isEdge() || isIETrident() || isMSIE());
 
 export const isSafari = () => (userAgentMatch(/safari/i) &&
-    !userAgentMatch(/(?:Chrome|CriOS|chromium|android|phantom)/i)) ||
-    isTizen();
+    !userAgentMatch(/(?:Chrome|CriOS|chromium|android|phantom)/i)) &&
+    !isTizen();
 
 export const isIOS = () => userAgentMatch(/iP(hone|ad|od)/i) || isIPadOS13();
 

--- a/src/js/utils/browser.ts
+++ b/src/js/utils/browser.ts
@@ -4,7 +4,7 @@ function userAgentMatch(regex: RegExp): boolean {
 
 const isIPadOS13 = () => navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1;
 
-export const isFF = () => userAgentMatch(/gecko\//i) && !isTizen();
+export const isFF = () => userAgentMatch(/firefox\//i);
 
 export const isIETrident = () => userAgentMatch(/trident\/.+rv:\s*11/i);
 

--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -7,6 +7,7 @@ import VolumeTooltipIcon from 'view/controls/components/volumetooltipicon';
 import button from 'view/controls/components/button';
 import { SimpleTooltip } from 'view/controls/components/simple-tooltip';
 import Events from 'utils/backbone.events';
+import { isTizen } from 'utils/browser';
 import { prependChild, setAttribute, toggleClass, openLink, addClass } from 'utils/dom';
 import { timeFormat } from 'utils/parser';
 import UI from 'utils/ui';
@@ -73,7 +74,7 @@ function createPipButton(pipIcon, pipToggle, localization) {
     if (OS.mobile || pipIcon === 'disabled') {
         return;
     }
-    if (Browser.chrome || Browser.edge || Browser.safari) {
+    if (Browser.chrome && !isTizen() || Browser.edge || Browser.safari) {
         const pipButton = button(
             'jw-icon-pip jw-off',
             pipToggle,

--- a/src/js/view/controls/rightclick.js
+++ b/src/js/view/controls/rightclick.js
@@ -3,6 +3,7 @@ import { cloneIcon } from 'view/controls/icons';
 import { version } from 'version';
 import { createElement, emptyElement, addClass, removeClass, bounds } from 'utils/dom';
 import { Browser, OS } from 'environment/environment';
+import { isTizen } from 'utils/browser';
 import UI, { isRightClick } from 'utils/ui';
 import { isRtl } from 'utils/language';
 
@@ -59,7 +60,7 @@ export default class RightClick {
             });
         }
         this.pipMenu = !OS.mobile && model.get('pipIcon') !== 'disabled'
-            && (Browser.chrome || Browser.edge || Browser.safari);
+            && ((Browser.chrome &&!isTizen()) || Browser.edge || Browser.safari);
         if (this.pipMenu) {
             menuItems.splice(menuItems.length - 1, 0, {
                 type: 'pip'


### PR DESCRIPTION
### This PR will...
- Update UA detection for Chrome/Safari/Firefox
- Hide PIP icon in Tizen web browser.

### Why is this Pull Request needed?
- Samsung Browser supported TVs lack PiP support
- Samsung Browser on supported TVs uses [Chromium](https://developer.samsung.com/smarttv/develop/specifications/web-engine-specifications.html).
- "Gecko" string is contained in Chrome and Safari UAs

- TODO: Move from browser detection to feature detection.


### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-11994

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
