### PR TITLE
[JW8-12039] Show time and text for duration of chapter in timetip

### DIFF
--- a/src/js/view/controls/components/chapters.mixin.ts
+++ b/src/js/view/controls/components/chapters.mixin.ts
@@ -39,6 +39,7 @@ export interface ChaptersMixinInt {
     chaptersFailed: () => void;
     addCue: (this: TimeSliderWithMixins, obj: GenericObject) => void;
     drawCues: (this: TimeSliderWithMixins) => void;
+    setActiveCue: (this: TimeSliderWithMixins, time: number) => void;
     resetCues: (this: TimeSliderWithMixins) => void;
 }
 
@@ -75,16 +76,26 @@ const ChaptersMixin: ChaptersMixinInt = {
 
         this.cues.forEach((cue) => {
             cue.align(duration);
-            cue.el.addEventListener('mouseover', () => {
-                this.activeCue = cue;
-            });
-            cue.el.addEventListener('mouseout', () => {
-                this.activeCue = null;
-            });
             this.elementRail.appendChild(cue.el);
         });
     },
 
+    setActiveCue: function (this: TimeSliderWithMixins, time: number): void {
+        // Activate the latest cue from the time to display chapter text for duration of chapter.
+        this.activeCue = this.cues.reduce((closeCue: Cue | null, cue: Cue) => {
+            if (time < cue.time) {
+                return closeCue;
+            }
+            if (!closeCue) {
+                return cue;
+            }
+            if (cue.time > closeCue.time) {
+                return cue;
+            }
+            return closeCue;
+        }, null);
+    },
+    
     resetCues: function(this: TimeSliderWithMixins): void {
         this.cues.forEach((cue: Cue) => {
             if (cue.el.parentNode) {

--- a/src/js/view/controls/components/timeslider.ts
+++ b/src/js/view/controls/components/timeslider.ts
@@ -100,7 +100,6 @@ class TimeSlider extends Slider {
     timeTip: TimeTipIcon;
     cues: Cue[];
     seekThrottled: Function;
-    mobileHoverDistance: number;
     seekTo?: number;
     streamType?: string;
     activeCue?: Cue | null;
@@ -126,7 +125,6 @@ class TimeSlider extends Slider {
                 this.updateAriaText,
                 ARIA_TEXT_UPDATE_INTERVAL_MS),
             ARIA_TEXT_UPDATE_TIMES);
-        this.mobileHoverDistance = 5;
 
         this.setup();
     }
@@ -278,26 +276,13 @@ class TimeSlider extends Slider {
         }
 
         let timetipText;
+        const timeText = timeFormat(time, true);
 
-        // With touch events, we never will get the hover events on the cues that cause cues to be active.
-        // Therefore use the info we about the scroll position to detect if there is a nearby cue to be active.
-        if (evt.pointerType === 'touch') {
-            this.activeCue = this.cues.reduce((closeCue, cue) => {
-                if (
-                    Math.abs(position - (parseInt(cue.pct as string) / 100 * railBounds.width))
-                        < this.mobileHoverDistance
-                ) {
-                    return cue;
-                }
-                return closeCue;
-            }, undefined);
-        }
-
+        this.setActiveCue(time);
         if (this.activeCue) {
-            timetipText = this.activeCue.text;
+            timetipText = this.activeCue.text + '\n' + timeText;
         } else {
-            const allowNegativeTime = true;
-            timetipText = timeFormat(time, allowNegativeTime);
+            timetipText = timeText;
 
             // If DVR and within live buffer
             if (duration < 0 && time > -1) {


### PR DESCRIPTION
### This PR will...
- Set timetip text to display both chapter text and time on hover if cues exist
- Remove mobile hover logic for cues since the active text will display for entire chapter
- Remove listeners to set active text on cue hover since it will be set for duration of chapter
### Why is this Pull Request needed?
Improvement
### Are there any points in the code the reviewer needs to double check?
All changes since its been a minute
### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-12039

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
