### PR TITLE
[JW8-12015] Re-add "[JW8-11793] Fix viewability pause not working during ad buffering"

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -579,6 +579,11 @@ Object.assign(Controller.prototype, {
             const adState = _getAdState();
 
             if (adState) {
+                // prevents the interaction with controls during ad playback to overwrite autostart playReason
+                if (_model.get('autostart') && adState === 'paused') {
+                    _model.set('playReason', 'autostart');
+                }
+                _this._instreamAdapter.off('state', _pauseAd, _this);
                 // this will resume the ad. _api.playAd would load a new ad
                 _api.pauseAd(false, meta);
                 return Promise.resolve();
@@ -738,7 +743,12 @@ Object.assign(Controller.prototype, {
             const adState = _getAdState();
             if (adState && adState !== STATE_PAUSED) {
                 _updatePauseReason(meta);
-                _api.pauseAd(true, meta);
+                if (adState === STATE_BUFFERING) {
+                    _this._instreamAdapter.once('state', _pauseAd, _this);
+                    _this._instreamAdapter.noResume = true;
+                } else {
+                    _api.pauseAd(true, meta);
+                }
                 return;
             }
 
@@ -756,6 +766,11 @@ Object.assign(Controller.prototype, {
                         _interruptPlay = true;
                     }
             }
+        }
+
+        function _pauseAd() {
+            const reason = _model.get('pauseReason');
+            _api.pauseAd(true, { reason });
         }
 
         function _isIdle() {


### PR DESCRIPTION
### This PR will...
Re-add the ad viewability during buffering bugfix changes: https://github.com/jwplayer/jwplayer/pull/3864
This reverts the revert of those changes: jwplayer/jwplayer#3905.

### Why is this Pull Request needed?
bugfix
### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):
Relates to: JW8-11793

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
