### PR TITLE
[JW8-12039] Fix timetipText to use html line break

### DIFF
--- a/src/js/view/controls/components/timeslider.ts
+++ b/src/js/view/controls/components/timeslider.ts
@@ -280,7 +280,7 @@ class TimeSlider extends Slider {
 
         this.setActiveCue(time);
         if (this.activeCue) {
-            timetipText = this.activeCue.text + '\n' + timeText;
+            timetipText = this.activeCue.text + '<br>' + timeText;
         } else {
             timetipText = timeText;
 


### PR DESCRIPTION
### This PR will...
Change the newline to a <br> in the `timetipText`.

### Why is this Pull Request needed?
We had a newline!

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW8-12039

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
