### PR TITLE
[JW8-11949] Fix broken seeking with no ad tag

### DIFF
--- a/src/js/view/view-model.ts
+++ b/src/js/view/view-model.ts
@@ -131,6 +131,10 @@ export default class ViewModel extends PlayerViewModel {
 
     set instreamModel(instreamModel: Model) {
         const previousInstream = this._instreamModel;
+        if (!previousInstream && !instreamModel) {
+            return;
+        }
+
         removeListeners(previousInstream, this);
 
         this._model.off('change:mediaModel', null, this);


### PR DESCRIPTION
### This PR will...
- Check if instream models exist/existed to prevent event listeners from being removed from the MediaModel.
- Because the event listeners were being removed from the mediaModel and not re-added, the timeslider was not receiving a duration change update so it thought the duration was 0.
### Why is this Pull Request needed?
bugfix
### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-11949

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
