### PR TITLE
[JW8-12067] Fix error message when display is clicked with controls disabled

### DIFF
--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -202,7 +202,7 @@ function initSelectListeners(ui) {
         if (!!ui.directSelect && target !== el) {
             return;
         }
-
+        initInteractionListener();
         if (e.isPrimary && target.tageName === 'BUTTON') {
             target.focus();
         }


### PR DESCRIPTION
### This PR will...
Fix error message when display is clicked with controls disabled
### Why is this Pull Request needed?
The displayClick event listener throws a JS error when the player controls are set to false. This does not happen if the controls are on. 
### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-12067

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
