### PR TITLE
[JW8-12067] Fix click on controls: false

### DIFF
--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -166,7 +166,6 @@ function initInteractionListeners(ui) {
 
     initFocusListeners(ui, INIT_GROUP);
     initStartEventsListeners(ui, INIT_GROUP, interactStartHandler, listenerOptions);
-    initInteractionListener();
 }
 
 function initSelectListeners(ui) {
@@ -216,6 +215,9 @@ function initSelectListeners(ui) {
 }
 
 function initFocusListeners(ui, group) {
+    if (!lastInteractionListener) {
+        lastInteractionListener = new UI(document).on('interaction');
+    }
     if (ui.handlers[INIT_GROUP] || ui.handlers[SELECT_GROUP]) {
         return;
     }
@@ -229,12 +231,6 @@ function initFocusListeners(ui, group) {
             addClass(el, 'jw-tab-focus');
         }
     });
-}
-
-function initInteractionListener() {
-    if (!lastInteractionListener) {
-        lastInteractionListener = new UI(document).on('interaction');
-    }
 }
 
 function checkDoubleClick(ui, e) {


### PR DESCRIPTION
### This PR will...
Fix error message when display is clicked with controls disabled
### Why is this Pull Request needed?
The displayClick event listener throws a JS error when the player controls are set to false. This does not happen if the controls are on. 
### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-12067

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
