### PR TITLE
[JW8-12049] Fix for settings menu not opening after setConfig is called on Safari

### DIFF
--- a/src/js/view/controls/components/menu/settings-menu.js
+++ b/src/js/view/controls/components/menu/settings-menu.js
@@ -383,6 +383,16 @@ class SettingsMenu extends Menu {
         if (controlBarButton) {
             const isVisible = !!children[menuName];
             controlBarButton.toggle(isVisible);
+        } else if (!controlBarButton && shouldShowGear) {
+            let childrenNames = Object.keys(this.children);
+            for (let i = 0; i < childrenNames.length; i++) {
+                let menu = this.children[childrenNames[i]];
+                let categoryButton = menu.categoryButton && menu.categoryButton.element();
+
+                if (this.buttonContainer.firstChild === categoryButton) {
+                    this.defaultChild = menu;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
### This PR will...
Address the settings menu not opening on Safari after setConfig() is called like so `jwplayer().setConfig({playbackRateControls: false})`. 
### Why is this Pull Request needed?
On Safari, when playbackRateControls are the first settings menu child and this is removed, the settings menu fails to open afterwards.
### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-12049

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
