### PR TITLE
[JW8-11849] Run the resize check until the size of the player is stable

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -115,6 +115,12 @@ function View(_api, _model) {
         playerBounds = bounds(_playerElement);
         floatingController.updatePlayerBounds(playerBounds);
 
+        // If we have bad values for either dimension, return early
+        if (!containerWidth || !containerHeight) {
+            _responsiveListener();
+            return;
+        }
+
         // If the container is the same size as before, return early
         if (containerWidth === _lastWidth && containerHeight === _lastHeight) {
             // Listen for player to be added to DOM
@@ -124,18 +130,12 @@ function View(_api, _model) {
             _model.set('inDom', inDOM);
             return;
         }
-        // If we have bad values for either dimension, return early
-        if (!containerWidth || !containerHeight) {
-            // If we haven't established player size, try again
-            if (!_lastWidth || !_lastHeight) {
-                _responsiveListener();
-            }
-        }
 
         // Don't update container dimensions to 0, 0 when not in DOM
-        if (containerWidth || containerHeight || inDOM) {
+        if (containerWidth && containerHeight && inDOM) {
             _model.set('containerWidth', containerWidth);
             _model.set('containerHeight', containerHeight);
+            _responsiveListener();
         }
         _model.set('inDom', inDOM);
 
@@ -199,6 +199,7 @@ function View(_api, _model) {
     this.responsiveListener = _responsiveListener;
 
     function _responsiveUpdate() {
+        console.log('.');
         if (!_this.isSetup || floatingController.isInTransition()) {
             return;
         }


### PR DESCRIPTION
### This PR will...
The idea here to keep running the `_responsiveUpdate` function until the sizing of the player's container is stable. There are times when a transition is used that we need to wait some time from the onset of the initiating event until the player's container size has settled. These changes make it so that the `_responsiveUpdate` will continue to run every frame until `containerWidth === _lastWidth` and `containerHeight === _lastHeight`.

### Why is this Pull Request needed?
Floating the player immediate after autoplay leaves the player size in flux while it transitions to floating.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?
None.

#### Addresses Issue(s):
JW8-11849

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
