### PR TITLE
[JW8-12075] Fix fullscreen icon not showing in FF and Edge during IMA ads

### DIFF
--- a/src/js/view/controls/controlbar.js
+++ b/src/js/view/controls/controlbar.js
@@ -286,6 +286,7 @@ export default class Controlbar {
         // Initial State
         elements.play.show();
         elements.fullscreen.show();
+        elements.imaFullscreen.show();
         if (elements.mute) {
             elements.mute.show();
         }


### PR DESCRIPTION
### This PR will...
Mimic `fullscreen` button behavior in `imaFullscreen` button by initializing the `imaFullscreen` button similar to how the regular `fullscreen` button is. Not doing so caused the underlying hidden style from `button.ts` to take precedent in firefox and edge.
### Why is this Pull Request needed?
bugfix
### Are there any points in the code the reviewer needs to double check?
Nah
### Are there any Pull Requests open in other repos which need to be merged with this?
Nah
#### Addresses Issue(s):

JW8-12075

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
