### PR TITLE
[JW8-11891] Prevent preroll from being interrupted (iOS) when nextup display is clicked

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -622,7 +622,7 @@ Object.assign(Controller.prototype, {
                     if (inInteraction() && !_backgroundLoading) {
                         const video = _model.get('mediaElement');
                         if (_this._instreamAdapter) {
-                            video.src = '';
+                            video.preload = 'none';
                         }
                         video.load();
                     }

--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -617,8 +617,6 @@ Object.assign(Controller.prototype, {
                 }
 
                 if (_interruptPlay) {
-                    // Force tags to prime if we're about to play an ad
-                    // Resetting the source in order to prime is OK since we'll be switching it anyway
                     if (inInteraction() && !_backgroundLoading) {
                         const video = _model.get('mediaElement');
                         if (_this._instreamAdapter) {


### PR DESCRIPTION
### This PR will...
Prevent preroll from being interrupted (iOS) when nextup display is clicked
### Why is this Pull Request needed?
The preroll ad would show a buffer icon before erroring on iOS Safari when the nextup display was clicked.
### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-11891

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
