### PR TITLE
[JW8-12177] Prevent playlistComplete from firing when related.autoplay is configured

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -859,7 +859,9 @@ Object.assign(Controller.prototype, {
                     // This prevents media from replaying when a completed video scrolls into view
                     _model.set('playOnViewable', false);
                     _model.set('state', STATE_COMPLETE);
-                    _this.trigger(PLAYLIST_COMPLETE, {});
+                    if (!_model.get('related') || _model.get('item') === _model.get('playlist').length - 1) {
+                        _this.trigger(PLAYLIST_COMPLETE, {});
+                    }
                 }
                 return;
             }


### PR DESCRIPTION
### This PR will...
Prevent playlistComplete from firing when related.autoplay is configured
### Why is this Pull Request needed?
playlistComplete was firing for each playlist item when it should only fire when the whole playlist has played.

For my fix, I added a conditional around when to trigger `PLAYLIST_COMPLETE` in the `_completeHandler` function. I am checking to see that there is no related playlist OR if the current playlist item is the last one before firing the `PLAYLIST_COMPLETE` event.
### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-12177

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
