### PR TITLE
[JW8-12112] <PiP button on Firefox is preventing the next up display to work properly>

### DIFF
--- a/src/css/controls/imports/nextup.less
+++ b/src/css/controls/imports/nextup.less
@@ -165,5 +165,5 @@
 }
 
 .jw-nextup-firefox-pip-fix {
-    background: rgba(38, 38, 38, 1);
+    background: fade(@overlay-background-color, 100%);
 }

--- a/src/css/controls/imports/nextup.less
+++ b/src/css/controls/imports/nextup.less
@@ -163,3 +163,7 @@
         visibility: visible;
     }
 }
+
+.jw-nextup-firefox-pip-fix {
+    background: rgba(38, 38, 38, 1);
+}

--- a/src/js/view/controls/templates/nextup.ts
+++ b/src/js/view/controls/templates/nextup.ts
@@ -1,9 +1,12 @@
 import type { HTMLTemplateString } from 'types/generic.type';
+import { Browser } from 'environment/environment';
 
 export default (header = '', title = '', duration = '', closeAriaLabel = ''): HTMLTemplateString => {
+    let firefoxPipFix = Browser.firefox ? ' jw-nextup-firefox-pip-fix' : '';
+
     return (
-        `<div class="jw-nextup jw-background-color jw-reset">` +
-             `<div class="jw-nextup-tooltip jw-reset">` +
+        `<div class="jw-nextup jw-background-color jw-reset${firefoxPipFix}">` +
+                `<div class="jw-nextup-tooltip jw-reset">` +
                 `<div class="jw-nextup-thumbnail jw-reset"></div>` +
                 `<div class="jw-nextup-body jw-reset">` +
                     `<div class="jw-nextup-header jw-reset">${header}</div>` +

--- a/src/js/view/controls/templates/nextup.ts
+++ b/src/js/view/controls/templates/nextup.ts
@@ -2,6 +2,7 @@ import type { HTMLTemplateString } from 'types/generic.type';
 import { Browser } from 'environment/environment';
 
 export default (header = '', title = '', duration = '', closeAriaLabel = ''): HTMLTemplateString => {
+    // When using firefox this adds opacity to stop the firefox PiP button getting clicked instead of the next up div
     const firefoxPipFix = Browser.firefox ? ' jw-nextup-firefox-pip-fix' : '';
 
     return (

--- a/src/js/view/controls/templates/nextup.ts
+++ b/src/js/view/controls/templates/nextup.ts
@@ -2,7 +2,7 @@ import type { HTMLTemplateString } from 'types/generic.type';
 import { Browser } from 'environment/environment';
 
 export default (header = '', title = '', duration = '', closeAriaLabel = ''): HTMLTemplateString => {
-    let firefoxPipFix = Browser.firefox ? ' jw-nextup-firefox-pip-fix' : '';
+    const firefoxPipFix = Browser.firefox ? ' jw-nextup-firefox-pip-fix' : '';
 
     return (
         `<div class="jw-nextup jw-background-color jw-reset${firefoxPipFix}">` +


### PR DESCRIPTION
### This PR will...
Add opacity to the next up button when using firefox to prevent the PiP button getting clicked through the next up tooltip. 
### Why is this Pull Request needed?
The PiP button being clicked instead of the next up button ruins the functionality of the next up button.
### Are there any points in the code the reviewer needs to double check?
Nope
### Are there any Pull Requests open in other repos which need to be merged with this?
Nope
#### Addresses Issue(s):

https://jwplayer.atlassian.net/browse/JW8-12112

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
