### PR TITLE
[JW-11320]<Teaching Channel 9: No confirmation message is provided it on selecting captions styles 'Reset' button>

### DIFF
--- a/src/js/view/controls/components/menu/menu-item.js
+++ b/src/js/view/controls/components/menu/menu-item.js
@@ -45,6 +45,5 @@ export class ResetMenuItem extends MenuItem {
         this.statusEl.setAttribute('role', 'status');
         this.el.appendChild(this.statusEl);
         this.el.setAttribute('aria-controls', 'reset-status-message');
-        console.trace(this.statusEl);
     }
 }

--- a/src/js/view/controls/components/menu/menu-item.js
+++ b/src/js/view/controls/components/menu/menu-item.js
@@ -35,3 +35,16 @@ export class ButtonMenuItem extends MenuItem {
         this.active = false;
     }
 }
+
+export class ResetMenuItem extends MenuItem {
+    constructor(_content, _action, _template = itemButtonTemplate) {
+        super(_content, _action, _template);
+        this.statusEl = document.createElement('span');
+        this.statusEl.id = 'reset-status-message';
+        this.statusEl.style = 'font-size: 0;';
+        this.statusEl.setAttribute('role', 'status');
+        this.el.appendChild(this.statusEl);
+        this.el.setAttribute('aria-controls', 'reset-status-message');
+        console.trace(this.statusEl);
+    }
+}

--- a/src/js/view/controls/components/menu/settings-menu.js
+++ b/src/js/view/controls/components/menu/settings-menu.js
@@ -149,12 +149,23 @@ class SettingsMenu extends Menu {
             this.model.set('captions', newStyles);
         };
         const persistedOptions = model.get('captions');
+        
+        const resetItem = new MenuItem(this.localization.reset, () => {
+            this.model.set('captions', Object.assign({}, CaptionsDefaults));
+            renderCaptionsSettings(true);
+        });
         const renderCaptionsSettings = (isReset) => {
-            const resetItem = new MenuItem(this.localization.reset, () => {
-                this.model.set('captions', Object.assign({}, CaptionsDefaults));
-                renderCaptionsSettings(true);
-            });
             resetItem.el.classList.add('jw-settings-reset');
+            resetItem.el.setAttribute('aria-live', 'polite');
+            resetItem.el.addEventListener('blur', () => resetItem.el.setAttribute('aria-label', 'Reset Caption Styles'));
+            resetItem.el.addEventListener('click', () => resetItem.el.setAttribute('aria-label', 'Reset Captions Successful'));
+            resetItem.el.onkeyup = (e) => {
+                if (e.key === 'Enter') {
+                    resetItem.el.setAttribute('aria-label', 'Reset Captions Successful');
+                    resetItem.el.focus();
+                }
+            };
+
             const captionsSettingsItems = [];
             captionStyleItems(captionsLocalization).forEach(captionItem => {
                 if (!isReset && persistedOptions && persistedOptions[captionItem.name]) {
@@ -190,7 +201,7 @@ class SettingsMenu extends Menu {
             captionsSettingsMenu.setMenuItems(captionsSettingsItems);
         };
         renderCaptionsSettings();
-    
+        
     }
 
     onPlaylistItem() {

--- a/src/js/view/controls/components/menu/settings-menu.js
+++ b/src/js/view/controls/components/menu/settings-menu.js
@@ -1,5 +1,5 @@
 import Menu from 'view/controls/components/menu/menu';
-import { MenuItem } from 'view/controls/components/menu/menu-item';
+import { MenuItem, ResetMenuItem } from 'view/controls/components/menu/menu-item';
 import { itemMenuTemplate } from 'view/controls/templates/menu/menu-item';
 import { _defaults as CaptionsDefaults } from 'view/captionsrenderer';
 import { captionStyleItems } from './utils';
@@ -149,23 +149,14 @@ class SettingsMenu extends Menu {
             this.model.set('captions', newStyles);
         };
         const persistedOptions = model.get('captions');
-        
-        const resetItem = new MenuItem(this.localization.reset, () => {
-            this.model.set('captions', Object.assign({}, CaptionsDefaults));
-            renderCaptionsSettings(true);
-        });
-        const renderCaptionsSettings = (isReset) => {
-            resetItem.el.classList.add('jw-settings-reset');
-            resetItem.el.setAttribute('aria-live', 'polite');
-            resetItem.el.addEventListener('blur', () => resetItem.el.setAttribute('aria-label', 'Reset Caption Styles'));
-            resetItem.el.addEventListener('click', () => resetItem.el.setAttribute('aria-label', 'Reset Captions Successful'));
-            resetItem.el.onkeyup = (e) => {
-                if (e.key === 'Enter') {
-                    resetItem.el.setAttribute('aria-label', 'Reset Captions Successful');
-                    resetItem.el.focus();
-                }
-            };
 
+
+        const renderCaptionsSettings = (isReset) => {
+            const resetItem = new ResetMenuItem(this.localization.reset, () => {
+                this.model.set('captions', Object.assign({}, CaptionsDefaults));
+                renderCaptionsSettings(true);
+            });
+            resetItem.el.classList.add('jw-settings-reset');
             const captionsSettingsItems = [];
             captionStyleItems(captionsLocalization).forEach(captionItem => {
                 if (!isReset && persistedOptions && persistedOptions[captionItem.name]) {
@@ -199,6 +190,12 @@ class SettingsMenu extends Menu {
             });
             captionsSettingsItems.push(resetItem);
             captionsSettingsMenu.setMenuItems(captionsSettingsItems);
+            if (isReset) {
+                resetItem.statusEl.innerHTML = 'Reset Captions Successful';
+                resetItem.el.focus();
+            } else {
+                resetItem.statusEl.innerHTML = '';
+            }
         };
         renderCaptionsSettings();
         

--- a/src/js/view/controls/components/menu/settings-menu.js
+++ b/src/js/view/controls/components/menu/settings-menu.js
@@ -149,8 +149,6 @@ class SettingsMenu extends Menu {
             this.model.set('captions', newStyles);
         };
         const persistedOptions = model.get('captions');
-
-
         const renderCaptionsSettings = (isReset) => {
             const resetItem = new ResetMenuItem(this.localization.reset, () => {
                 this.model.set('captions', Object.assign({}, CaptionsDefaults));
@@ -198,7 +196,7 @@ class SettingsMenu extends Menu {
             }
         };
         renderCaptionsSettings();
-        
+
     }
 
     onPlaylistItem() {

--- a/src/js/view/controls/components/menu/settings-menu.js
+++ b/src/js/view/controls/components/menu/settings-menu.js
@@ -196,7 +196,6 @@ class SettingsMenu extends Menu {
             }
         };
         renderCaptionsSettings();
-
     }
 
     onPlaylistItem() {


### PR DESCRIPTION
### This PR will...
Add confirmation message "Reset Captions Successful" when the reset button in the captions menu is pressed
### Why is this Pull Request needed?
If the screen reader does not notify anything after selecting "Reset" button non-sighted users will not be able to confirm or notice that the information has been reset
### Are there any points in the code the reviewer needs to double check?
Nope
### Are there any Pull Requests open in other repos which need to be merged with this?
Nope
#### Addresses Issue(s):

https://jwplayer.atlassian.net/browse/JW8-11320

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
