### PR TITLE
[JW8-12120] Continue ad playback when floating player is dismissed with autoPause false

### DIFF
--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -548,6 +548,9 @@ function View(_api, _model) {
 
         controls.on('dismissFloating', () => {
             this.stopFloating(true);
+            if (_model.get('autoPause') && !_model.get('autoPause').pauseAds) {
+                return;
+            }
             _api.pause({ reason: 'interaction' });
         });
 


### PR DESCRIPTION
### This PR will...
Add logic to prevent ads from pausing when floating player is closed with autoPause.pauseAds set to false. I am adding logic to return before the pause if `autoPause` config is detected WITH `autoPause.pauseAds` set to false.
### Why is this Pull Request needed?
This will help increase ad complete rate for customers
### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-12120

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
