### PR TITLE
[JW8-12115] Fixing menu redirect behavior after editing caption styles

### DIFF
--- a/src/js/view/controls/components/menu/menu.js
+++ b/src/js/view/controls/components/menu/menu.js
@@ -352,7 +352,9 @@ export default class Menu extends Events {
             if (mainMenu.backButton) {
                 mainMenu.backButton.hide();
             }
-            this.mainMenu.backButtonTarget = null;
+            if (this.mainMenu.backButtonTarget) {
+                this.mainMenu.backButtonTarget = null;
+            }
         }
         this.el.classList.add('jw-settings-submenu-active');
         if (mainMenuVisible && isKeydown) {

--- a/src/js/view/controls/components/menu/menu.js
+++ b/src/js/view/controls/components/menu/menu.js
@@ -352,6 +352,7 @@ export default class Menu extends Events {
             if (mainMenu.backButton) {
                 mainMenu.backButton.hide();
             }
+            this.mainMenu.backButtonTarget = null;
         }
         this.el.classList.add('jw-settings-submenu-active');
         if (mainMenuVisible && isKeydown) {


### PR DESCRIPTION
### This PR will...
Fix the menu redirect behavior after editing captions. It seems that at some point, the code to set the `backButtonTarget` to null was removed, which caused logic in `menuItemClick` to open the captions menu. 
### Why is this Pull Request needed?
To fix unwanted menu redirect behavior 
### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-12115

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
