### PR TITLE
[JW8-12213] Fixing autopause + floating dismiss behavior when ad is not playing

### DIFF
--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -215,6 +215,7 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
         const { newstate } = event;
         if (newstate === STATE_PLAYING) {
             _controller.trigger(AD_PLAY, event);
+            _model.set('isAdPlaying', true);
         } else if (newstate === STATE_PAUSED) {
             _controller.trigger(AD_PAUSE, event);
         }
@@ -275,6 +276,7 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
             data.tag = _options.tag;
         }
         this.trigger(MEDIA_COMPLETE, data);
+        _model.set('isAdPlaying', false);
         _instreamItemNext.call(this, e);
     }
 

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -448,6 +448,7 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
         _skipAd.call(this, {
             type: skipAdType
         });
+        _model.set('isAdPlaying', false);
     };
 
     function _instreamMeta(evt) {

--- a/src/js/controller/instream-adapter.js
+++ b/src/js/controller/instream-adapter.js
@@ -215,7 +215,6 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
         const { newstate } = event;
         if (newstate === STATE_PLAYING) {
             _controller.trigger(AD_PLAY, event);
-            _model.set('isAdPlaying', true);
         } else if (newstate === STATE_PAUSED) {
             _controller.trigger(AD_PAUSE, event);
         }
@@ -276,7 +275,6 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
             data.tag = _options.tag;
         }
         this.trigger(MEDIA_COMPLETE, data);
-        _model.set('isAdPlaying', false);
         _instreamItemNext.call(this, e);
     }
 
@@ -448,7 +446,6 @@ const InstreamAdapter = function(_controller, _model, _view, _mediaPool) {
         _skipAd.call(this, {
             type: skipAdType
         });
-        _model.set('isAdPlaying', false);
     };
 
     function _instreamMeta(evt) {

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -548,7 +548,7 @@ function View(_api, _model) {
 
         controls.on('dismissFloating', () => {
             this.stopFloating(true);
-            if (_model.get('autoPause') && !_model.get('autoPause').pauseAds) {
+            if (_model.get('autoPause') && !_model.get('autoPause').pauseAds && _model.get('isAdPlaying')) {
                 return;
             }
             _api.pause({ reason: 'interaction' });

--- a/src/js/view/view.js
+++ b/src/js/view/view.js
@@ -548,7 +548,7 @@ function View(_api, _model) {
 
         controls.on('dismissFloating', () => {
             this.stopFloating(true);
-            if (_model.get('autoPause') && !_model.get('autoPause').pauseAds && _model.get('isAdPlaying')) {
+            if (_model.get('autoPause') && !_model.get('autoPause').pauseAds && !!_model.get('instream')) {
                 return;
             }
             _api.pause({ reason: 'interaction' });


### PR DESCRIPTION
### This PR will...
Fixing unwanted behavior introduced by autoPause + floating player dismissal. I am now setting a new state on the model `isAdPlaying` which is being toggled by the `instream-adapter` when ad playback starts and ends. I am now checking for `model.get('isAdPlaying')` in the autoPause + floating logic to only prevent the pause when an ad is currently playing.
### Why is this Pull Request needed?
Playback was not being paused after dismissing floating player. 
### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-12213

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
