### PR TITLE
[JW8-12216] [JW8-12217] Fix beforePlay always triggers, fix oldstate value always 'buffering'

### DIFF
--- a/src/js/controller/controller.js
+++ b/src/js/controller/controller.js
@@ -331,6 +331,10 @@ Object.assign(Controller.prototype, {
             _model.change('playlistItem', function(model, playlistItem) {
                 if (playlistItem) {
                     const { title, image } = playlistItem;
+
+                    _beforePlay = false;
+                    _interruptPlay = false;
+
                     if ('mediaSession' in navigator && window.MediaMetadata && (title || image)) {
                         try {
                             navigator.mediaSession.metadata = new window.MediaMetadata({
@@ -617,7 +621,6 @@ Object.assign(Controller.prototype, {
                     playReason,
                     startTime: meta && meta.startTime ? meta.startTime : _model.get('playlistItem').starttime
                 });
-                _beforePlay = false;
 
                 if (inInteraction() && !mediaPool.primed()) {
                     mediaPool.prime();

--- a/src/js/providers/video-listener-mixin.ts
+++ b/src/js/providers/video-listener-mixin.ts
@@ -39,7 +39,7 @@ const VideoListenerMixin: VideoListenerInt = {
 
     play(this: ProviderWithMixins): void {
         this.stallTime = -1;
-        if (!this.video.paused && this.state !== STATE_PLAYING) {
+        if (!this.video.paused && this.state !== STATE_PAUSED && this.state !== STATE_PLAYING) {
             this.setState(STATE_LOADING);
         }
     },


### PR DESCRIPTION
### This PR will...
- Fix a bug where `beforePlay` is triggered on every play event on a playlistItem
- Fix a bug where `oldstate` in `play` event is always `buffering` for HLS media.
- 
### Why is this Pull Request needed?
Fixes two state bugs.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-12216
JW8-12217

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
