### PR TITLE
[JW8-12210] Add support for larger values in liveSyncDuration

### DIFF
--- a/src/js/api/Setup.js
+++ b/src/js/api/Setup.js
@@ -5,7 +5,8 @@ import {
     loadModules,
     loadSkin,
     loadTranslations,
-    loadPlugins
+    loadPlugins,
+    validateConfig
 } from 'api/setup-steps';
 import { PlayerError, SETUP_ERROR_TIMEOUT, MSG_CANT_LOAD_PLAYER } from 'api/errors';
 
@@ -34,12 +35,14 @@ const Setup = function(_model) {
         const setup = __HEADLESS__ ?
             Promise.all([
                 loadCore(_model),
+                validateConfig(_model),
                 pluginsPromise,
                 loadProvider(_model),
                 new Promise((resolve) => setTimeout(resolve, 0))
             ]) :
             Promise.all([
                 loadCoreBundle(_model),
+                validateConfig(_model),
                 pluginsPromise,
                 loadProvider(_model),
                 loadModules(_model, api),

--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -48,9 +48,6 @@ export function getLiveSyncDuration(liveSyncDuration) {
     if (liveSyncDuration < 5) {
         return 5;
     }
-    if (liveSyncDuration > 30) {
-        return 30;
-    } 
     return liveSyncDuration;
 }
 

--- a/src/js/api/errors.ts
+++ b/src/js/api/errors.ts
@@ -73,6 +73,11 @@ export const ASYNC_PLAYLIST_ITEM_REJECTED = 203700;
 export const ERROR_LOADING_PROVIDER = 204000;
 
 /**
+ * @enum {ErrorCode} The play attempt failed because no supported source was found.
+ */
+ export const SETUP_ERROR_LIVESYNCDURATION = 300100;
+
+/**
  * @enum {ErrorCode} The play attempt failed for unknown reasons.
  */
 const PLAY_ATTEMPT_FAILED_MISC = 303200;

--- a/src/js/api/errors.ts
+++ b/src/js/api/errors.ts
@@ -73,7 +73,7 @@ export const ASYNC_PLAYLIST_ITEM_REJECTED = 203700;
 export const ERROR_LOADING_PROVIDER = 204000;
 
 /**
- * @enum {ErrorCode} The play attempt failed because no supported source was found.
+ * @enum {ErrorCode} The LiveSyncDuration is higher than 45
  */
  export const SETUP_ERROR_LIVESYNCDURATION = 300100;
 

--- a/src/js/api/setup-steps.js
+++ b/src/js/api/setup-steps.js
@@ -2,7 +2,7 @@ import { PLAYLIST_LOADED, ERROR } from 'events/events';
 import PlaylistLoader from 'playlist/loader';
 import Playlist, { filterPlaylist, validatePlaylist, wrapPlaylistIndex } from 'playlist/playlist';
 import ScriptLoader from 'utils/scriptloader';
-import { composePlayerError, convertToPlayerError, PlayerError,
+import { composePlayerError, PlayerError,
     SETUP_ERROR_LOADING_PLAYLIST, SETUP_ERROR_LOADING_PROVIDER, SETUP_ERROR_LIVESYNCDURATION,
     ERROR_LOADING_TRANSLATIONS, ERROR_LOADING_TRANSLATIONS_EMPTY_RESPONSE } from 'api/errors';
 import { getCustomLocalization, isLocalizationComplete, loadJsonTranslation, isTranslationAvailable, applyTranslation } from 'utils/language';
@@ -10,11 +10,10 @@ import { bundleContainsProviders } from 'api/core-loader';
 import pluginsPromise from 'plugins/plugins';
 
 export const validateConfig = (model) => {
-    return new Promise((accept, reject) => {
+    return new Promise((resolve, reject) => {
         if (model.attributes.liveSyncDuration > 45) {
-            accept(composePlayerError(new Error(), SETUP_ERROR_LIVESYNCDURATION));
+            return resolve(composePlayerError(new Error(), SETUP_ERROR_LIVESYNCDURATION));
         }
-        accept();
     });
 };
 

--- a/src/js/api/setup-steps.js
+++ b/src/js/api/setup-steps.js
@@ -2,12 +2,23 @@ import { PLAYLIST_LOADED, ERROR } from 'events/events';
 import PlaylistLoader from 'playlist/loader';
 import Playlist, { filterPlaylist, validatePlaylist, wrapPlaylistIndex } from 'playlist/playlist';
 import ScriptLoader from 'utils/scriptloader';
-import { composePlayerError, PlayerError,
-    SETUP_ERROR_LOADING_PLAYLIST, SETUP_ERROR_LOADING_PROVIDER,
+import { composePlayerError, convertToPlayerError, PlayerError,
+    SETUP_ERROR_LOADING_PLAYLIST, SETUP_ERROR_LOADING_PROVIDER, SETUP_ERROR_LIVESYNCDURATION,
     ERROR_LOADING_TRANSLATIONS, ERROR_LOADING_TRANSLATIONS_EMPTY_RESPONSE } from 'api/errors';
 import { getCustomLocalization, isLocalizationComplete, loadJsonTranslation, isTranslationAvailable, applyTranslation } from 'utils/language';
 import { bundleContainsProviders } from 'api/core-loader';
 import pluginsPromise from 'plugins/plugins';
+
+export const validateConfig = (model) => {
+    return new Promise((accept, reject) => {
+        if (model.attributes.liveSyncDuration > 45) {
+            // console.log('validateConfig model if lsd > 45', model);
+            // accept(model.set('errorEvent', convertToPlayerError(null, SETUP_ERROR_LIVESYNCDURATION, null)));
+            accept(composePlayerError(new Error(), SETUP_ERROR_LIVESYNCDURATION));
+        }
+        accept();
+    });
+};
 
 export function loadPlaylist(_model) {
     const playlist = _model.get('playlist');

--- a/src/js/api/setup-steps.js
+++ b/src/js/api/setup-steps.js
@@ -12,8 +12,6 @@ import pluginsPromise from 'plugins/plugins';
 export const validateConfig = (model) => {
     return new Promise((accept, reject) => {
         if (model.attributes.liveSyncDuration > 45) {
-            // console.log('validateConfig model if lsd > 45', model);
-            // accept(model.set('errorEvent', convertToPlayerError(null, SETUP_ERROR_LIVESYNCDURATION, null)));
             accept(composePlayerError(new Error(), SETUP_ERROR_LIVESYNCDURATION));
         }
         accept();


### PR DESCRIPTION
### This PR will...
will remove the upper clamp on LiveSyncDuration and add a warning if a user sets LiveSyncDuration above 45 with validateConfig.
### Why is this Pull Request needed?
Removing the upper clamp on LiveSyncDuration will give users more control over config settings.
### Are there any points in the code the reviewer needs to double check?
Nope
### Are there any Pull Requests open in other repos which need to be merged with this?
I made another PR in jwplayer-commercial to add validateConfig there also
#### Addresses Issue(s):

https://jwplayer.atlassian.net/browse/JW8-12210

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
