### PR TITLE
[JW8-12182] WebPlayer - When opening any menu inside player, stream is not paused

### DIFF
--- a/src/js/view/controls/components/menu/settings-menu.js
+++ b/src/js/view/controls/components/menu/settings-menu.js
@@ -314,6 +314,12 @@ class SettingsMenu extends Menu {
             gearButton.setAttribute('aria-expanded', true);
         }
 
+        if (document.querySelector('.jw-breakpoint-0') || document.querySelector('.jw-breakpoint-1')) {
+            const mediaState = this.model._mediaModel.attributes.mediaState;
+            this.mediaStateWhenOpened = mediaState;
+            this.api.pause()
+        }
+
         this.el.parentNode.classList.add('jw-settings-open');
         this.trigger('visibility', { visible: true, evt });
         document.addEventListener('click', this.onDocumentClick);
@@ -329,6 +335,12 @@ class SettingsMenu extends Menu {
             gearButton.setAttribute('aria-expanded', false);
         }
         
+        if (document.querySelector('.jw-breakpoint-0') || document.querySelector('.jw-breakpoint-1')) {
+            if (this.mediaStateWhenOpened === 'playing') {
+                this.api.play();
+            }
+        }
+
         this.el.setAttribute('aria-expanded', 'false');
         this.el.parentNode.classList.remove('jw-settings-open');
         

--- a/src/js/view/controls/components/menu/settings-menu.js
+++ b/src/js/view/controls/components/menu/settings-menu.js
@@ -7,6 +7,7 @@ import button from 'view/controls/components/button';
 import { cloneIcon } from 'view/controls/icons';
 import { normalizeKey, destroyMenu, selectMenuItem } from './utils';
 import UI from 'utils/ui';
+import { getBreakpoint } from 'view/utils/breakpoint';
 import { 
     nextSibling, 
     previousSibling,
@@ -314,8 +315,8 @@ class SettingsMenu extends Menu {
             gearButton.setAttribute('aria-expanded', true);
         }
 
-        if (document.querySelector('.jw-breakpoint-0') || document.querySelector('.jw-breakpoint-1')) {
-            const mediaState = this.model._mediaModel.attributes.mediaState;
+        if (getBreakpoint(this.model.get('containerWidth')) === 0 || getBreakpoint(this.model.get('containerWidth')) === 1) {
+            const mediaState = this.model.get('state')
             this.mediaStateWhenOpened = mediaState;
             this.api.pause()
         }
@@ -335,7 +336,7 @@ class SettingsMenu extends Menu {
             gearButton.setAttribute('aria-expanded', false);
         }
         
-        if (document.querySelector('.jw-breakpoint-0') || document.querySelector('.jw-breakpoint-1')) {
+        if (getBreakpoint(this.model.get('containerWidth')) === 0 || getBreakpoint(this.model.get('containerWidth')) === 1) {
             if (this.mediaStateWhenOpened === 'playing') {
                 this.api.play();
             }

--- a/src/js/view/controls/components/menu/settings-menu.js
+++ b/src/js/view/controls/components/menu/settings-menu.js
@@ -316,8 +316,7 @@ class SettingsMenu extends Menu {
         }
 
         if (getBreakpoint(this.model.get('containerWidth')) === 0 || getBreakpoint(this.model.get('containerWidth')) === 1) {
-            const mediaState = this.model.get('state')
-            this.mediaStateWhenOpened = mediaState;
+            this.mediaStateWhenOpened = this.model.get('state')
             this.api.pause()
         }
 

--- a/src/js/view/controls/components/menu/settings-menu.js
+++ b/src/js/view/controls/components/menu/settings-menu.js
@@ -306,6 +306,8 @@ class SettingsMenu extends Menu {
     }
 
     open(evt) {
+        const currentBreakpoint = getBreakpoint(this.model.get('containerWidth'));
+
         if (this.visible) {
             return;
         }
@@ -315,7 +317,7 @@ class SettingsMenu extends Menu {
             gearButton.setAttribute('aria-expanded', true);
         }
 
-        if (getBreakpoint(this.model.get('containerWidth')) === 0 || getBreakpoint(this.model.get('containerWidth')) === 1) {
+        if (currentBreakpoint < 2) {
             this.mediaStateWhenOpened = this.model.get('state')
             this.api.pause()
         }
@@ -330,12 +332,13 @@ class SettingsMenu extends Menu {
     close(evt) {
         const key = normalizeKey(evt && evt.sourceEvent && evt.sourceEvent.key);
         const gearButton = this.controlbar.elements.settingsButton.element();
-        
+        const currentBreakpoint = getBreakpoint(this.model.get('containerWidth'));
+
         if (gearButton) {
             gearButton.setAttribute('aria-expanded', false);
         }
         
-        if (getBreakpoint(this.model.get('containerWidth')) === 0 || getBreakpoint(this.model.get('containerWidth')) === 1) {
+        if (currentBreakpoint < 2) {
             if (this.mediaStateWhenOpened === 'playing') {
                 this.api.play();
             }
@@ -350,7 +353,7 @@ class SettingsMenu extends Menu {
         if (this.openMenus.length) {
             this.closeChildren();
         }
-        
+
         // If closed by keypress, focus appropriate element.
         let focusEl;
 


### PR DESCRIPTION
### This PR will...
add the functionality of pausing the player when any menu is opened when using breakpoint 0 or 1. Closing the menu will continue the player at the same point before opening the menu.  If the player is paused before opening a menu the player will be paused after closing the menu.
### Why is this Pull Request needed?
This PR is needed because the player should pause while on any menu, and continue playing after closing any menu. On breakpoint 0 or 1 the open menu covers the player fully, so if a user can't see the player, it shouldn't be playing.
### Are there any points in the code the reviewer needs to double check?
Nope
### Are there any Pull Requests open in other repos which need to be merged with this?
Nope
#### Addresses Issue(s):

https://jwplayer.atlassian.net/browse/JW8-12182

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
