### PR TITLE
[JW8-12755] Update documentation to mention jwplayer-react

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,11 +117,11 @@ grunt hooks
 
 ## Framework Integration
 
-While the JW team does not maintain any framework integrations of our own, there are developers in our community who do. We recommend the following libraries:
+The JW team officially maintains and supports framework integration for React.
 
 | Framework | Link |
 | --------- | ---- |
-| React |  https://github.com/micnews/react-jw-player |
+| React |  https://github.com/jwplayer/jwplayer-react |
 
 If you have a library which you believe is good enough to meet the needs of other developers using a certain framework, please open a pull request modifying the above table.
 


### PR DESCRIPTION
### This PR will...
Update Framework Integration section to link to our official `jwplayer-react` package instead of the unofficial one.

### Why is this Pull Request needed?
Currently it is linking to an unofficial react package for `jwplayer`.

### Are there any points in the code the reviewer needs to double check?
I removed the old react package but should I still have that and just mention that we have an official one above what was there previously?

### Are there any Pull Requests open in other repos which need to be merged with this?
Nope

#### Addresses Issue(s):

https://jwplayer.atlassian.net/browse/JW8-12755

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results
